### PR TITLE
fix: import path for KeyManager

### DIFF
--- a/contracts/TestHelpers/calculateSelectors.sol
+++ b/contracts/TestHelpers/calculateSelectors.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../../submodules/ERC725/implementations/contracts/IERC1271.sol";
-import "../_LSPs/KeyManager/KeyManager.sol";
+import "../KeyManager/KeyManager.sol";
 import "../_LSPs/ILSP1_UniversalReceiver.sol";
 import "../_LSPs/ILSP1_UniversalReceiverDelegate.sol";
 


### PR DESCRIPTION
## Description
The current `develop` branch fails when building the contracts using `npm run build`.

## Tasks
- [x] fix import path