### PR TITLE
SetData + Send 1 Lyx via Executor > KM > UP

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,3 @@
-printWidth: 100
+{
+    "printWidth": 100
+}

--- a/contracts/TestHelpers/Executor.sol
+++ b/contracts/TestHelpers/Executor.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../UniversalProfileCore.sol";
+import "../KeyManager/KeyManager.sol";
+
+contract Executor {
+
+    KeyManager keyManager;
+
+    constructor(address _keyManager) {
+        keyManager = KeyManager(_keyManager);
+    }
+
+    function setHardcodedKey() public returns (bool) {
+        bytes32[] memory keys = new bytes32[](1);
+        bytes[] memory values = new bytes[](1);
+
+        // keccak256('MyFirstKey')
+        keys[0] = 0x00b76b597620a89621ab37aedc4220d553ad6145a885461350e5990372b906f5;
+        values[0] = 'Hello Lukso';
+
+        bytes memory erc725Payload = abi.encodeWithSelector(
+            UniversalProfileCore.setData.selector,
+            keys,
+            values
+        );
+
+        return keyManager.execute(erc725Payload);
+    }
+
+    // setHardcodedKey (raw / low-level call)
+    function setHardcodedKeyRawCall() public returns (bool) {
+        bytes32[] memory keys = new bytes32[](1);
+        bytes[] memory values = new bytes[](1);
+
+        // keccak256('MyFirstKey')
+        keys[0] = 0x00b76b597620a89621ab37aedc4220d553ad6145a885461350e5990372b906f5;
+        values[0] = 'Hello Lukso';
+
+        bytes memory erc725Payload = abi.encodeWithSelector(
+            UniversalProfileCore.setData.selector,
+            keys,
+            values
+        );
+
+        bytes memory keyManagerPayload = abi.encodeWithSelector(
+            keyManager.execute.selector,
+            erc725Payload
+        );
+
+        (bool success, ) = address(keyManager).call(keyManagerPayload);
+        return success;
+    }
+
+    // set computed keys
+    function setComputedKey() public returns (bool) {
+        bytes32[] memory keys = new bytes32[](1);
+        bytes[] memory values = new bytes[](1);
+
+        keys[0] = keccak256(abi.encodePacked('MyFirstKey'));
+        values[0] = abi.encodePacked('Hello Lukso');
+
+        bytes memory erc725Payload = abi.encodeWithSelector(
+            UniversalProfileCore.setData.selector,
+            keys,
+            values
+        );
+
+        return keyManager.execute(erc725Payload);
+    }
+
+    // set computed keys (raw call)
+
+    // set computed keys (as params)
+    function setComputedKeyFromParams(bytes32 _key, bytes memory _value) public returns (bool) {
+        bytes32[] memory keys = new bytes32[](1);
+        bytes[] memory values = new bytes[](1);
+
+        keys[0] = keccak256(abi.encodePacked('MyFirstKey'));
+        values[0] = abi.encodePacked(_value);
+
+        bytes memory erc725Payload = abi.encodeWithSelector(
+            UniversalProfileCore.setData.selector,
+            keys,
+            values
+        );
+
+        return keyManager.execute(erc725Payload);
+    }
+
+    // set computed keys (as params) (raw call)
+}

--- a/tests/Executor.spec.ts
+++ b/tests/Executor.spec.ts
@@ -11,6 +11,7 @@ import {
 
 // custom helpers
 import { deployERC725Utils, deployUniversalProfile, deployKeyManager } from "./utils/deploy";
+import { ONE_ETH, DUMMY_RECIPIENT } from "./utils/helpers";
 import { KEYS, PERMISSIONS } from "./utils/keymanager";
 
 describe("Executor interacting with KeyManager", () => {
@@ -23,14 +24,27 @@ describe("Executor interacting with KeyManager", () => {
     keyManager: KeyManager,
     executor: Executor;
 
+  /**
+   * @dev this is necessary when the function being called in the contract
+   *  perform a raw / low-level call (in the function body)
+   *  otherwise, the deeper layer of interaction (UP.execute) fails
+   */
+  const GAS_PROVIDED = 200_000;
+
   beforeAll(async () => {
     accounts = await ethers.getSigners();
     owner = accounts[0];
 
     erc725Utils = await deployERC725Utils();
+  });
+
+  beforeEach(async () => {
     universalProfile = await deployUniversalProfile(erc725Utils.address, owner);
     keyManager = await deployKeyManager(erc725Utils.address, universalProfile);
-    executor = await new Executor__factory(owner).deploy(keyManager.address);
+    executor = await new Executor__factory(owner).deploy(
+      universalProfile.address,
+      keyManager.address
+    );
 
     // owner permissions
     let ownerPermissions = ethers.utils.hexZeroPad(PERMISSIONS.ALL, 2);
@@ -39,7 +53,10 @@ describe("Executor interacting with KeyManager", () => {
       .setData([KEYS.PERMISSIONS + owner.address.substr(2)], [ownerPermissions]);
 
     // executor permissions
-    let executorPermissions = ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.CALL, 2);
+    let executorPermissions = ethers.utils.hexZeroPad(
+      PERMISSIONS.SETDATA + PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE,
+      2
+    );
     await universalProfile
       .connect(owner)
       .setData([KEYS.PERMISSIONS + executor.address.substr(2)], [executorPermissions]);
@@ -53,11 +70,11 @@ describe("Executor interacting with KeyManager", () => {
       let [permissions] = await universalProfile.getData([
         KEYS.PERMISSIONS + executor.address.substr(2),
       ]);
-      expect(permissions).toEqual("0x000c");
+      expect(permissions).toEqual("0x008c");
     });
   });
 
-  describe("Interactions", () => {
+  describe("Interaction = `setData`", () => {
     // keccak256('MyFirstKey')
     const key = "0x00b76b597620a89621ab37aedc4220d553ad6145a885461350e5990372b906f5";
     const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso"));
@@ -69,7 +86,7 @@ describe("Executor interacting with KeyManager", () => {
     });
 
     describe("> contract calls", () => {
-      it("Should allow executor to `setHardcodedKey` on UP", async () => {
+      it("Should allow to `setHardcodedKey` on UP", async () => {
         // check that nothing is set at store[key]
         let [initialStorage] = await universalProfile.callStatic.getData([key]);
         expect(initialStorage).toEqual("0x");
@@ -82,7 +99,7 @@ describe("Executor interacting with KeyManager", () => {
         expect(newStorage).toEqual(value);
       });
 
-      it("Should allow executor to `setComputedKey` on UP", async () => {
+      it("Should allow to `setComputedKey` on UP", async () => {
         // check that nothing is set at store[key]
         let [initialStorage] = await universalProfile.callStatic.getData([key]);
         expect(initialStorage).toEqual("0x");
@@ -95,13 +112,13 @@ describe("Executor interacting with KeyManager", () => {
         expect(newStorage).toEqual(value);
       });
 
-      it("Should allow executor to `setComputedKeyFromParams` on UP", async () => {
+      it("Should allow to `setComputedKeyFromParams` on UP", async () => {
         // check that nothing is set at store[key]
         let [initialStorage] = await universalProfile.callStatic.getData([key]);
         expect(initialStorage).toEqual("0x");
 
         // make the executor call
-        await executor.setComputedKeyFromParams(key, value);
+        await executor.setComputedKeyFromParams(key, value, { gasLimit: GAS_PROVIDED });
 
         // check that store[key] is now set to value
         let [newStorage] = await universalProfile.callStatic.getData([key]);
@@ -110,24 +127,132 @@ describe("Executor interacting with KeyManager", () => {
     });
 
     describe("> Low-level calls", () => {
-      it("Should allow executor to `setHardcodedKeyRawCall` on UP", async () => {
+      it("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
         // check that nothing is set at store[key]
         let [initialStorage] = await universalProfile.callStatic.getData([key]);
         console.log("initialStorage (low level): ", initialStorage);
         expect(initialStorage).toEqual("0x");
 
         // check if low-level call succeeded
-        let result = await executor.callStatic.setHardcodedKeyRawCall();
+        let result = await executor.callStatic.setHardcodedKeyRawCall({
+          gasLimit: GAS_PROVIDED,
+        });
         console.log("result (low level): ", result);
         expect(result).toBeTruthy();
 
         // make the executor call
-        await executor.setHardcodedKeyRawCall();
+        await executor.setHardcodedKeyRawCall({ gasLimit: GAS_PROVIDED });
 
         // check that store[key] is now set to value
         let [newStorage] = await universalProfile.callStatic.getData([key]);
         console.log("newStorage (low level): ", newStorage);
         expect(newStorage).toEqual(value);
+      });
+
+      it("Should allow to `setComputedKeyRawCall` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        expect(initialStorage).toEqual("0x");
+
+        // make the executor call
+        await executor.setComputedKeyRawCall({ gasLimit: GAS_PROVIDED });
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        expect(newStorage).toEqual(value);
+      });
+
+      it("Should allow to `setComputedKeyFromParamsRawCall` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        expect(initialStorage).toEqual("0x");
+
+        // make the executor call
+        await executor.setComputedKeyFromParamsRawCall(key, value, {
+          gasLimit: GAS_PROVIDED,
+        });
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        expect(newStorage).toEqual(value);
+      });
+    });
+  });
+
+  describe("Interaction = transfering LYX", () => {
+    let provider = ethers.provider;
+
+    beforeEach(async () => {
+      let ownerBalance = await provider.getBalance(owner.address);
+      console.log(ethers.utils.formatUnits(ownerBalance));
+
+      await owner.sendTransaction({
+        to: universalProfile.address,
+        value: ethers.utils.parseEther("1"),
+      });
+    });
+
+    describe("> Contract calls", () => {
+      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcoded`)", async () => {
+        let initialUPBalance = await provider.getBalance(universalProfile.address);
+        let initialRecipientBalance = await provider.getBalance(DUMMY_RECIPIENT);
+        expect(initialUPBalance).toEqBN(ONE_ETH);
+
+        await executor.sendOneLyxHardcoded();
+
+        let newUPBalance = await provider.getBalance(universalProfile.address);
+        let newRecipientBalance = await provider.getBalance(DUMMY_RECIPIENT);
+
+        expect(newUPBalance).toEqBN(0);
+        expect(newRecipientBalance).toEqBN(initialRecipientBalance.add(ONE_ETH));
+      });
+
+      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)", async () => {
+        let recipient = accounts[1];
+
+        let initialUPBalance = await provider.getBalance(universalProfile.address);
+        let initialRecipientBalance = await provider.getBalance(recipient.address);
+        expect(initialUPBalance).toEqBN(ONE_ETH);
+
+        await executor.sendOneLyxToRecipient(recipient.address);
+
+        let newUPBalance = await provider.getBalance(universalProfile.address);
+        let newRecipientBalance = await provider.getBalance(recipient.address);
+
+        expect(newUPBalance).toEqBN(0);
+        expect(newRecipientBalance).toEqBN(initialRecipientBalance.add(ONE_ETH));
+      });
+    });
+
+    describe("> Low-level calls", () => {
+      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcodedRawCall`)", async () => {
+        let initialUPBalance = await provider.getBalance(universalProfile.address);
+        let initialRecipientBalance = await provider.getBalance(DUMMY_RECIPIENT);
+        expect(initialUPBalance).toEqBN(ONE_ETH);
+
+        await executor.sendOneLyxHardcodedRawCall({ gasLimit: GAS_PROVIDED });
+
+        let newUPBalance = await provider.getBalance(universalProfile.address);
+        let newRecipientBalance = await provider.getBalance(DUMMY_RECIPIENT);
+
+        expect(newUPBalance).toEqBN(0);
+        expect(newRecipientBalance).toEqBN(initialRecipientBalance.add(ONE_ETH));
+      });
+
+      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)", async () => {
+        let recipient = accounts[1];
+
+        let initialUPBalance = await provider.getBalance(universalProfile.address);
+        let initialRecipientBalance = await provider.getBalance(recipient.address);
+        expect(initialUPBalance).toEqBN(ONE_ETH);
+
+        await executor.sendOneLyxToRecipientRawCall(recipient.address, { gasLimit: GAS_PROVIDED });
+
+        let newUPBalance = await provider.getBalance(universalProfile.address);
+        let newRecipientBalance = await provider.getBalance(recipient.address);
+
+        expect(newUPBalance).toEqBN(0);
+        expect(newRecipientBalance).toEqBN(initialRecipientBalance.add(ONE_ETH));
       });
     });
   });

--- a/tests/Executor.spec.ts
+++ b/tests/Executor.spec.ts
@@ -1,0 +1,134 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
+
+import {
+  ERC725Utils,
+  UniversalProfile,
+  KeyManager,
+  Executor,
+  Executor__factory,
+} from "../build/types";
+
+// custom helpers
+import { deployERC725Utils, deployUniversalProfile, deployKeyManager } from "./utils/deploy";
+import { KEYS, PERMISSIONS } from "./utils/keymanager";
+
+describe("Executor interacting with KeyManager", () => {
+  let accounts: SignerWithAddress[] = [];
+
+  let owner: SignerWithAddress;
+
+  let erc725Utils: ERC725Utils,
+    universalProfile: UniversalProfile,
+    keyManager: KeyManager,
+    executor: Executor;
+
+  beforeAll(async () => {
+    accounts = await ethers.getSigners();
+    owner = accounts[0];
+
+    erc725Utils = await deployERC725Utils();
+    universalProfile = await deployUniversalProfile(erc725Utils.address, owner);
+    keyManager = await deployKeyManager(erc725Utils.address, universalProfile);
+    executor = await new Executor__factory(owner).deploy(keyManager.address);
+
+    // owner permissions
+    let ownerPermissions = ethers.utils.hexZeroPad(PERMISSIONS.ALL, 2);
+    await universalProfile
+      .connect(owner)
+      .setData([KEYS.PERMISSIONS + owner.address.substr(2)], [ownerPermissions]);
+
+    // executor permissions
+    let executorPermissions = ethers.utils.hexZeroPad(PERMISSIONS.SETDATA + PERMISSIONS.CALL, 2);
+    await universalProfile
+      .connect(owner)
+      .setData([KEYS.PERMISSIONS + executor.address.substr(2)], [executorPermissions]);
+
+    // switch account management to KeyManager
+    await universalProfile.connect(owner).transferOwnership(keyManager.address);
+  });
+
+  describe("Setup", () => {
+    it("Executor should have permission SETDATA + CALL", async () => {
+      let [permissions] = await universalProfile.getData([
+        KEYS.PERMISSIONS + executor.address.substr(2),
+      ]);
+      expect(permissions).toEqual("0x000c");
+    });
+  });
+
+  describe("Interactions", () => {
+    // keccak256('MyFirstKey')
+    const key = "0x00b76b597620a89621ab37aedc4220d553ad6145a885461350e5990372b906f5";
+    const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso"));
+
+    // always reset storage before each tests
+    beforeEach(async () => {
+      let resetPayload = universalProfile.interface.encodeFunctionData("setData", [[key], ["0x"]]);
+      await keyManager.connect(owner).execute(resetPayload);
+    });
+
+    describe("> contract calls", () => {
+      it("Should allow executor to `setHardcodedKey` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        expect(initialStorage).toEqual("0x");
+
+        // make the executor call
+        await executor.setHardcodedKey();
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        expect(newStorage).toEqual(value);
+      });
+
+      it("Should allow executor to `setComputedKey` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        expect(initialStorage).toEqual("0x");
+
+        // make the executor call
+        await executor.setComputedKey();
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        expect(newStorage).toEqual(value);
+      });
+
+      it("Should allow executor to `setComputedKeyFromParams` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        expect(initialStorage).toEqual("0x");
+
+        // make the executor call
+        await executor.setComputedKeyFromParams(key, value);
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        expect(newStorage).toEqual(value);
+      });
+    });
+
+    describe("> Low-level calls", () => {
+      it("Should allow executor to `setHardcodedKeyRawCall` on UP", async () => {
+        // check that nothing is set at store[key]
+        let [initialStorage] = await universalProfile.callStatic.getData([key]);
+        console.log("initialStorage (low level): ", initialStorage);
+        expect(initialStorage).toEqual("0x");
+
+        // check if low-level call succeeded
+        let result = await executor.callStatic.setHardcodedKeyRawCall();
+        console.log("result (low level): ", result);
+        expect(result).toBeTruthy();
+
+        // make the executor call
+        await executor.setHardcodedKeyRawCall();
+
+        // check that store[key] is now set to value
+        let [newStorage] = await universalProfile.callStatic.getData([key]);
+        console.log("newStorage (low level): ", newStorage);
+        expect(newStorage).toEqual(value);
+      });
+    });
+  });
+});

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -6,6 +6,9 @@ export const DUMMY_PAYLOAD = "0xaabbccdd123456780000000000";
 export const ONE_ETH = ethers.utils.parseEther("1");
 export const DUMMY_PRIVATEKEY =
   "0xcafecafe7D0F0EBcafeC2D7cafe84cafe3248DDcafe8B80C421CE4C55A26cafe";
+export const DUMMY_RECIPIENT = ethers.utils.getAddress(
+  "0xcafecafecafecafecafecafecafecafecafecafe"
+);
 
 export const SCHEMA: ERC725JSONSchema[] = [
   {


### PR DESCRIPTION
What does this PR introduce?

- [x] an `Executor` contract that creates payload to `setData` + send 1 Lyx (`execute` on a UP).

- [x]  tests that show the following interactions:
          `setData`: EOA -> Executor -> KM -> UP
          `execute` for sending 1 LYX: EOA1 -> Executor -> KM -> UP -> EOA2
          
Tests include contract calls via `keyManager.execute(...)` as well as low-level calls via `address(keyManager).call{gas: ...}(payload)`.

➡️  **Noticeable difference:** is that functions in the `Executor` that perform raw / low-level calls need to specify a gas parameter in ethers in order for the whole execution chain to go successfully.

