### PR TITLE
feature: add check for `ALLOWEDSTANDARDS` in KeyManager

### DIFF
--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 /**
  * @dev sample contract that implements ERC1271 (Standard Signature Validation Method for Contracts)
@@ -9,7 +10,11 @@ import "@openzeppelin/contracts/interfaces/IERC1271.sol";
  *
  * implementation code taken from: https://eips.ethereum.org/EIPS/eip-1271
  */
-contract SignatureValidatorContract is IERC1271 {
+contract SignatureValidatorContract is IERC1271, ERC165Storage {
+    constructor() {
+        _registerInterface(type(IERC1271).interfaceId);
+    }
+
     /**
      * @notice Verifies that the signer is the owner of the signing contract.
      */

--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+/**
+ * @dev sample contract that implements ERC1271 (Standard Signature Validation Method for Contracts)
+ *  used to test the permission ALLOWEDSTANDARDS
+ *
+ * implementation code taken from: https://eips.ethereum.org/EIPS/eip-1271
+ */
+contract SignatureValidatorContract is IERC1271 {
+    /**
+     * @notice Verifies that the signer is the owner of the signing contract.
+     */
+    function isValidSignature(bytes32 _hash, bytes calldata _signature)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        // always return true (just for testing)
+        return 0x1626ba7e;
+    }
+}

--- a/contracts/Helpers/TargetContract.sol
+++ b/contracts/Helpers/TargetContract.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+/**
+ * @dev sample contract to test interaction + state changes:
+ *      - directly from Universal Profile
+ *      - via KeyManager > UniversalProfile
+ *
+ * also used to test permissions ALLOWEDADDRESS and ALLOWEDSTANDARDS
+ */
 contract TargetContract {
     /* solhint-disable */
     uint256 number = 5;

--- a/contracts/Utils/LSP6Utils.sol
+++ b/contracts/Utils/LSP6Utils.sol
@@ -60,4 +60,18 @@ library LSP6Utils {
                 )
             );
     }
+
+    function getAllowedStandardsFor(IERC725Y _account, address _address)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return
+            _account.getDataSingle(
+                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                    _ADDRESS_ALLOWEDSTANDARDS,
+                    bytes20(_address)
+                )
+            );
+    }
 }


### PR DESCRIPTION
# What does this PR introduce?

added feature + test for `ALLOWEDSTANDARDS`

- [x] added check for `ALLOWEDSTANDARDS` in KeyManager when interacting with contracts
- added check for `isContract` for `to` address
