### PR TITLE
test: add missing tests for `supportInterface`

### DIFF
--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.spec.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.spec.ts
@@ -152,6 +152,18 @@ describe("UniversalReceiverDelegateUP contract", () => {
   });
 
   describe("Testing Deployement", () => {
+    it("should support ERC165 interface", async () => {
+      let result = await universalReceiverDelegate.callStatic.supportsInterface(
+        INTERFACE_IDS.ERC165
+      );
+      expect(result).toBeTruthy();
+    });
+    it("should support LSP1Delegate interface", async () => {
+      let result = await universalReceiverDelegate.callStatic.supportsInterface(
+        INTERFACE_IDS.LSP1Delegate
+      );
+      expect(result).toBeTruthy();
+    });
     it("Deploys correctly, and compare owners", async () => {
       const idOwner = await universalProfile1.callStatic.owner();
       expect(idOwner).toEqual(keyManager1.address);

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.spec.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.spec.ts
@@ -53,6 +53,21 @@ describe("UniversalReceiverDelegateVault contract", () => {
     URDRevert = await new URDRevert__factory(owner1).deploy();
   });
 
+  describe("Universal Receiver Delegate (for Vault) deployment", () => {
+    it("should support ERC165 interface", async () => {
+      let result = await universalReceiverDelegate.callStatic.supportsInterface(
+        INTERFACE_IDS.ERC165
+      );
+      expect(result).toBeTruthy();
+    });
+    it("should support LSP1Delegate interface", async () => {
+      let result = await universalReceiverDelegate.callStatic.supportsInterface(
+        INTERFACE_IDS.LSP1Delegate
+      );
+      expect(result).toBeTruthy();
+    });
+  });
+
   describe("Vault deployement", () => {
     it("Deploys correctly, and compare owners", async () => {
       const idOwner = await VaultA.callStatic.owner();

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -1181,7 +1181,15 @@ export const shouldInitializeLikeLSP7 = (
   });
 
   describe("when the contract was initialized", () => {
-    it("should have registered its ERC165 interface", async () => {
+    it("should have registered the ERC165 interface", async () => {
+      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC165));
+    });
+
+    it("should have registered the ERC725Y interface", async () => {
+      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC725Y));
+    });
+
+    it("should have registered the LSP7 interface", async () => {
       expect(await context.lsp7.supportsInterface(INTERFACE_IDS.LSP7));
     });
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -1359,7 +1359,15 @@ export const shouldInitializeLikeLSP8 = (
   });
 
   describe("when the contract was initialized", () => {
-    it("should have registered its ERC165 interface", async () => {
+    it("should have registered the ERC165 interface", async () => {
+      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC165));
+    });
+
+    it("should have registered the ERC725Y interface", async () => {
+      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC725Y));
+    });
+
+    it("should have registered the LSP8 interface", async () => {
       expect(await context.lsp8.supportsInterface(INTERFACE_IDS.LSP8));
     });
 

--- a/tests/UniversalProfile.spec.ts
+++ b/tests/UniversalProfile.spec.ts
@@ -83,6 +83,15 @@ describe("UniversalProfile", () => {
       expect(result).toBeTruthy();
     });
 
+    it("Supports LSP0 (ERC725Account)", async () => {
+      const interfaceID = INTERFACE_IDS.ERC725Account;
+      const result = await UniversalProfile.callStatic.supportsInterface(
+        interfaceID
+      );
+
+      expect(result).toBeTruthy();
+    });
+
     it("Supports ERC1271", async () => {
       const interfaceID = INTERFACE_IDS.ERC1271;
       const result = await UniversalProfile.callStatic.supportsInterface(

--- a/tests/UniversalProfileProxy.spec.ts
+++ b/tests/UniversalProfileProxy.spec.ts
@@ -137,6 +137,13 @@ describe("UniversalProfile via EIP1167 Proxy + initializer", () => {
       expect(result).toBeTruthy(); // "does not support interface `ERC725Y`"
     });
 
+    it("Should support LSP0 (ERC725Account)", async () => {
+      let result = await proxy.callStatic.supportsInterface(
+        INTERFACE_IDS.ERC725Account
+      );
+      expect(result).toBeTruthy();
+    });
+
     it("Should support ERC1271", async () => {
       let result = await proxy.callStatic.supportsInterface(
         INTERFACE_IDS.ERC1271


### PR DESCRIPTION
# What does this PR introduce?

added tests to verify contracts support `ERC165` interface + the following interface:
- `ERC725Y` in LSP7 / 8
- `ILSP1Delegate` in URD (for Universal Profile and Vault)
- `ERC725Account` (LSP0) in Universal Profile  