### PR TITLE
chore: linter warnings

### DIFF
--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
  *
  * implementation code taken from: https://eips.ethereum.org/EIPS/eip-1271
  */
-contract SignatureValidatorContract is IERC1271, ERC165Storage {
+contract SignatureValidator is IERC1271, ERC165Storage {
     constructor() {
         _registerInterface(type(IERC1271).interfaceId);
     }

--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -15,6 +15,7 @@ contract SignatureValidator is IERC1271, ERC165Storage {
         _registerInterface(type(IERC1271).interfaceId);
     }
 
+    // solhint-disable no-unused-vars
     /**
      * @notice Verifies that the signer is the owner of the signing contract.
      */

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
@@ -42,6 +42,7 @@ contract LSP8CompatibilityForERC721 is
         _registerInterface(_INTERFACEID_ERC721METADATA);
     }
 
+    // solhint-disable no-unused-vars
     /*
      * @inheritdoc ILSP8CompatibilityForERC721
      */
@@ -124,6 +125,7 @@ contract LSP8CompatibilityForERC721 is
         }
     }
 
+    // solhint-disable no-unused-vars
     /*
      * @inheritdoc ILSP8CompatibilityForERC721
      */

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -12,8 +12,8 @@ import {
   LSP6KeyManager__factory,
   TargetContract,
   TargetContract__factory,
-  SignatureValidatorContract,
-  SignatureValidatorContract__factory,
+  SignatureValidator,
+  SignatureValidator__factory,
   Reentrancy,
   Reentrancy__factory,
 } from "../../types";
@@ -2717,7 +2717,7 @@ describe("ALLOWEDSTANDARDS", () => {
   let universalProfile: UniversalProfile,
     keyManager: LSP6KeyManager,
     targetContract: TargetContract,
-    signatureValidatorContract: SignatureValidatorContract;
+    SignatureValidator: SignatureValidator;
 
   let otherUniversalProfile: UniversalProfile;
 
@@ -2736,9 +2736,7 @@ describe("ALLOWEDSTANDARDS", () => {
       universalProfile.address
     );
     targetContract = await new TargetContract__factory(owner).deploy();
-    signatureValidatorContract = await new SignatureValidatorContract__factory(
-      owner
-    ).deploy();
+    SignatureValidator = await new SignatureValidator__factory(owner).deploy();
 
     // test to interact with an other UniversalProfile (e.g.: transfer LYX)
     otherUniversalProfile = await new UniversalProfile__factory(
@@ -2812,14 +2810,14 @@ describe("ALLOWEDSTANDARDS", () => {
         );
         let sampleSignature = await owner.signMessage("Sample Message");
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData(
+        let payload = SignatureValidator.interface.encodeFunctionData(
           "isValidSignature",
           [sampleHash, sampleSignature]
         );
 
         let upPayload = universalProfile.interface.encodeFunctionData(
           "execute",
-          [OPERATIONS.CALL, signatureValidatorContract.address, 0, payload]
+          [OPERATIONS.CALL, SignatureValidator.address, 0, payload]
         );
 
         let data = await keyManager
@@ -2862,14 +2860,14 @@ describe("ALLOWEDSTANDARDS", () => {
         );
         let sampleSignature = await caller.signMessage("Sample Message");
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData(
+        let payload = SignatureValidator.interface.encodeFunctionData(
           "isValidSignature",
           [sampleHash, sampleSignature]
         );
 
         let upPayload = universalProfile.interface.encodeFunctionData(
           "execute",
-          [OPERATIONS.CALL, signatureValidatorContract.address, 0, payload]
+          [OPERATIONS.CALL, SignatureValidator.address, 0, payload]
         );
 
         let data = await keyManager
@@ -2932,14 +2930,14 @@ describe("ALLOWEDSTANDARDS", () => {
         );
         let sampleSignature = await caller.signMessage("Sample Message");
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData(
+        let payload = SignatureValidator.interface.encodeFunctionData(
           "isValidSignature",
           [sampleHash, sampleSignature]
         );
 
         let upPayload = universalProfile.interface.encodeFunctionData(
           "execute",
-          [OPERATIONS.CALL, signatureValidatorContract.address, 0, payload]
+          [OPERATIONS.CALL, SignatureValidator.address, 0, payload]
         );
 
         await expect(


### PR DESCRIPTION
- Dismissed all the linter warnings with solhint comments, so that they don't display anymore on future PRs

These warnings were related to unused function variables in `LSP8CompatibilityForERC721` + `SignatureValidator` (helper) contracts