### PR TITLE
Lsp7compat proxy and erc20 events

### DIFF
--- a/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
+++ b/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
@@ -2,9 +2,10 @@
 
 pragma solidity ^0.8.0;
 
+import "@erc725/smart-contracts/contracts/ERC725Y.sol";
 import "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
 
-contract LSP4CompatibilityTester is LSP4Compatibility {
+contract LSP4CompatibilityTester is ERC725Y, LSP4Compatibility {
     constructor(
         string memory name,
         string memory symbol,

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
@@ -3,16 +3,16 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol";
+import "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol";
 import "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
 
-contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20Init {
+contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20InitAbstract {
     function initialize(
         string memory name,
         string memory symbol,
         address newOwner
     ) public virtual override initializer{ 
-        LSP7CompatibilityForERC20Init.initialize(name, symbol, newOwner);
+        LSP7CompatibilityForERC20InitAbstract.initialize(name, symbol, newOwner);
     }
 
     function mint(

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+// modules
+import "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol";
+import "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+
+contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20Init {
+    function initialize(
+        string memory name,
+        string memory symbol,
+        address newOwner
+    ) public virtual override initializer{ 
+        LSP7CompatibilityForERC20Init.initialize(name, symbol, newOwner);
+    }
+
+    function mint(
+        address to,
+        uint256 amount,
+        bytes calldata data
+    ) public {
+        // using force=true so we can send to EOA in test
+        _mint(to, amount, true, data);
+    }
+}

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
@@ -23,4 +23,12 @@ contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20Init {
         // using force=true so we can send to EOA in test
         _mint(to, amount, true, data);
     }
+
+    function burn(
+        address from,
+        uint256 amount,
+        bytes calldata data
+    ) public {
+        _burn(from, amount, data);
+    }
 }

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20Tester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20Tester.sol
@@ -22,4 +22,12 @@ contract LSP7CompatibilityForERC20Tester is LSP7CompatibilityForERC20 {
         // using force=true so we can send to EOA in test
         _mint(to, amount, true, data);
     }
+
+    function burn(
+        address from,
+        uint256 amount,
+        bytes calldata data
+    ) public {
+        _burn(from, amount, data);
+    }
 }

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 
 // interfaces
 import "./ILSP4Compatibility.sol";
@@ -18,7 +18,7 @@ import "./LSP4Constants.sol";
  * @author Matthew Stevens
  * @dev LSP4 extension, for compatibility with clients & tools that expect ERC20/721.
  */
-abstract contract LSP4Compatibility is ERC725Y, ILSP4Compatibility {
+abstract contract LSP4Compatibility is ERC725YCore, ILSP4Compatibility {
     // --- Token queries
 
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -15,7 +15,7 @@ import "@erc725/smart-contracts/contracts/ERC725Y.sol";
  * @author Matthew Stevens
  * @dev Implementation of a LSP7 compliant contract.
  */
-contract LSP7DigitalAsset is LSP4DigitalAssetMetadata, LSP7DigitalAssetCore {
+contract LSP7DigitalAsset is LSP7DigitalAssetCore, LSP4DigitalAssetMetadata {
     /**
      * @notice Sets the token-Metadata and register LSP7InterfaceId
      * @param name_ The name of the token

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -25,8 +25,6 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
  * @dev Core Implementation of a LSP7 compliant contract.
  */
 abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
-    using EnumerableSet for EnumerableSet.AddressSet;
-    using EnumerableSet for EnumerableSet.Bytes32Set;
     using Address for address;
 
     // --- Storage

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -15,9 +15,9 @@ import "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
  * @dev Proxy Implementation of a LSP7 compliant contract.
  */
 abstract contract LSP7DigitalAssetInitAbstract is
+    LSP7DigitalAssetCore,
     Initializable,
-    LSP4DigitalAssetMetadataInitAbstract,
-    LSP7DigitalAssetCore
+    LSP4DigitalAssetMetadataInitAbstract
 {
     /**
      * @notice Sets the token-Metadata and register LSP7InterfaceId

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
@@ -10,7 +10,8 @@ import "../ILSP7DigitalAsset.sol";
  */
 interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
     /**
-     * @dev To provide compatibility with indexing ERC20 events.
+     * @notice To provide compatibility with indexing ERC20 events.
+     * @dev Emitted when `amount` tokens is transferred from `from` to `to`.
      * @param from The sending address
      * @param to The receiving address
      * @param value The amount of tokens transfered.
@@ -18,7 +19,8 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
     event Transfer(address indexed from, address indexed to, uint256 value);
 
     /**
-     * @dev To provide compatibility with indexing ERC20 events.
+     * @notice To provide compatibility with indexing ERC20 events.
+     * @dev Emitted when `owner` enables `spender` for `value` tokens.
      * @param owner The account giving approval
      * @param spender The account receiving approval
      * @param value The amount of tokens `spender` has access to from `owner`
@@ -26,14 +28,14 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
     /*
-     * @dev Compatible with ERC20 tranfer
+     * @dev Compatible with ERC20 transfer
      * @param to The receiving address
      * @param amount The amount of tokens to transfer
      */
     function transfer(address to, uint256 amount) external;
 
     /*
-     * @dev Compatible with ERC20 tranferFrom
+     * @dev Compatible with ERC20 transferFrom
      * @param from The sending address
      * @param to The receiving address
      * @param amount The amount of tokens to transfer

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
@@ -9,6 +9,22 @@ import "../ILSP7DigitalAsset.sol";
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC20.
  */
 interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
+    /**
+     * @dev To provide compatibility with indexing ERC20 events.
+     * @param from The sending address
+     * @param to The receiving address
+     * @param value The amount of tokens transfered.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev To provide compatibility with indexing ERC20 events.
+     * @param owner The account giving approval
+     * @param spender The account receiving approval
+     * @param value The amount of tokens `spender` has access to from `owner`
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
     /*
      * @dev Compatible with ERC20 tranfer
      * @param to The receiving address

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+// modules
+import "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+import "../LSP7DigitalAssetCore.sol";
+
+// interfaces
+import "./ILSP7CompatibilityForERC20.sol";
+
+/**
+ * @dev LSP7 extension, for compatibility for clients / tools that expect ERC20.
+ */
+abstract contract LSP7CompatibilityForERC20Core is
+    LSP7DigitalAssetCore,
+    LSP4Compatibility,
+    ILSP7CompatibilityForERC20
+{
+    /**
+     * @inheritdoc ILSP7CompatibilityForERC20
+     */
+    function approve(address operator, uint256 amount)
+        external
+        virtual
+        override
+    {
+        return authorizeOperator(operator, amount);
+    }
+
+    /**
+     * @inheritdoc ILSP7CompatibilityForERC20
+     */
+    function allowance(address tokenOwner, address operator)
+        external
+        view
+        virtual
+        override
+        returns (uint256)
+    {
+        return isOperatorFor(operator, tokenOwner);
+    }
+
+    /**
+     * @inheritdoc ILSP7CompatibilityForERC20
+     * @dev Compatible with ERC20 transfer.
+     * Using force=true so that EOA and any contract may receive the tokens.
+     */
+    function transfer(address to, uint256 amount) external virtual override {
+        return transfer(_msgSender(), to, amount, true, "compat-transfer");
+    }
+
+    /**
+     * @inheritdoc ILSP7CompatibilityForERC20
+     * @dev Compatible with ERC20 transferFrom.
+     * Using force=true so that EOA and any contract may receive the tokens.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external virtual override {
+        return transfer(from, to, amount, true, "compat-transferFrom");
+    }
+
+    // --- Overrides
+
+    function authorizeOperator(address operator, uint256 amount)
+        public
+        virtual
+        override(ILSP7DigitalAsset, LSP7DigitalAssetCore)
+    {
+        super.authorizeOperator(operator, amount);
+
+        emit Approval(
+            _msgSender(),
+            operator,
+            amount
+        );
+    }
+
+    function _transfer(
+        address from,
+        address to,
+        uint256 amount,
+        bool force,
+        bytes memory data
+    ) internal virtual override {
+        super._transfer(from, to, amount, force, data);
+
+        emit Transfer(
+            from,
+            to,
+            amount
+        );
+    }
+
+    function _mint(
+        address to,
+        uint256 amount,
+        bool force,
+        bytes memory data
+    ) internal virtual override {
+        super._mint(to, amount, force, data);
+
+        emit Transfer(
+            address(0),
+            to,
+            amount
+        );
+    }
+
+    function _burn(address from, uint256 amount, bytes memory data)
+        internal
+        virtual
+        override
+    {
+        super._burn(from, amount, data);
+
+        emit Transfer(
+            from,
+            address(0),
+            amount
+        );
+    }
+}

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
@@ -3,10 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../LSP7DigitalAssetInit.sol";
-import "./LSP7CompatibilityForERC20Core.sol";
+import "./LSP7CompatibilityForERC20InitAbstract.sol";
 
-contract LSP7CompatibilityForERC20Init is LSP7DigitalAssetInit, LSP7CompatibilityForERC20Core {
+contract LSP7CompatibilityForERC20Init is LSP7CompatibilityForERC20InitAbstract {
     /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
@@ -18,38 +17,6 @@ contract LSP7CompatibilityForERC20Init is LSP7DigitalAssetInit, LSP7Compatibilit
         string memory symbol_,
         address newOwner_
     ) public virtual override initializer {
-        LSP7DigitalAssetInit.initialize(name_, symbol_, newOwner_, false);
-    }
-
-    // --- Overrides
-
-    function authorizeOperator(address operator, uint256 amount)
-    public
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
-        super.authorizeOperator(operator, amount);
-    }
-
-    function _burn(address from, uint256 amount, bytes memory data)
-        internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
-        super._burn(from, amount, data);
-    }
-
-    function _mint(address to, uint256 amount, bool force, bytes memory data)
-    internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
-            super._mint(to, amount, force, data);
-    }
-
-    function _transfer(address from, address to, uint256 amount, bool force, bytes memory data)
-    internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
-            super._transfer(from, to, amount, force, data);
+        LSP7CompatibilityForERC20InitAbstract.initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
@@ -3,23 +3,22 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../LSP7DigitalAsset.sol";
+import "../LSP7DigitalAssetInit.sol";
 import "./LSP7CompatibilityForERC20Core.sol";
 
-contract LSP7CompatibilityForERC20 is LSP7DigitalAsset, LSP7CompatibilityForERC20Core {
-    /* solhint-disable no-empty-blocks */
+contract LSP7CompatibilityForERC20Init is LSP7DigitalAssetInit, LSP7CompatibilityForERC20Core {
     /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the token
      */
-    constructor(
+    function initialize(
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) LSP7DigitalAsset(name_, symbol_, newOwner_, false) {
-
+    ) public virtual override initializer {
+        LSP7DigitalAssetInit.initialize(name_, symbol_, newOwner_, false);
     }
 
     // --- Overrides

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+// modules
+import "../LSP7DigitalAssetInitAbstract.sol";
+import "./LSP7CompatibilityForERC20Core.sol";
+
+contract LSP7CompatibilityForERC20InitAbstract is LSP7DigitalAssetInitAbstract, LSP7CompatibilityForERC20Core {
+    /**
+     * @notice Sets the name, the symbol and the owner of the token
+     * @param name_ The name of the token
+     * @param symbol_ The symbol of the token
+     * @param newOwner_ The owner of the token
+     */
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_
+    ) public virtual override onlyInitializing {
+        LSP7DigitalAssetInitAbstract.initialize(name_, symbol_, newOwner_, false);
+    }
+
+    // --- Overrides
+
+    function authorizeOperator(address operator, uint256 amount)
+    public
+        virtual
+        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
+    {
+        super.authorizeOperator(operator, amount);
+    }
+
+    function _burn(address from, uint256 amount, bytes memory data)
+        internal
+        virtual
+        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
+    {
+        super._burn(from, amount, data);
+    }
+
+    function _mint(address to, uint256 amount, bool force, bytes memory data)
+    internal
+        virtual
+        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
+            super._mint(to, amount, force, data);
+    }
+
+    function _transfer(address from, address to, uint256 amount, bool force, bytes memory data)
+    internal
+        virtual
+        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
+            super._transfer(from, to, amount, force, data);
+    }
+}

--- a/docs/ILSP7CompatibilityForERC20.md
+++ b/docs/ILSP7CompatibilityForERC20.md
@@ -282,6 +282,24 @@ function transferFrom(address from, address to, uint256 amount) external nonpaya
 
 ## Events
 
+### Approval
+
+```solidity
+event Approval(address indexed owner, address indexed spender, uint256 value)
+```
+
+
+
+*To provide compatibility with indexing ERC20 events.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | The account giving approval |
+| spender `indexed` | address | The account receiving approval |
+| value  | uint256 | The amount of tokens `spender` has access to from `owner` |
+
 ### AuthorizedOperator
 
 ```solidity
@@ -342,15 +360,15 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 
 
 
-
+*To provide compatibility with indexing ERC20 events.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | operator `indexed` | address | undefined |
-| from `indexed` | address | undefined |
-| to `indexed` | address | undefined |
+| from `indexed` | address | The sending address |
+| to `indexed` | address | The receiving address |
 | amount  | uint256 | undefined |
 | force  | bool | undefined |
 | data  | bytes | undefined |

--- a/docs/ILSP7CompatibilityForERC20.md
+++ b/docs/ILSP7CompatibilityForERC20.md
@@ -288,9 +288,9 @@ function transferFrom(address from, address to, uint256 amount) external nonpaya
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
+To provide compatibility with indexing ERC20 events.
 
-
-*To provide compatibility with indexing ERC20 events.*
+*Emitted when `owner` enables `spender` for `value` tokens.*
 
 #### Parameters
 
@@ -358,9 +358,9 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
+To provide compatibility with indexing ERC20 events.
 
-
-*To provide compatibility with indexing ERC20 events.*
+*Emitted when `amount` tokens is transferred from `from` to `to`.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20.md
+++ b/docs/LSP7CompatibilityForERC20.md
@@ -366,7 +366,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -453,7 +453,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/LSP7CompatibilityForERC20Core.md
+++ b/docs/LSP7CompatibilityForERC20Core.md
@@ -1,4 +1,4 @@
-# LSP7CompatibilityForERC20
+# LSP7CompatibilityForERC20Core
 
 
 
@@ -6,7 +6,7 @@
 
 
 
-
+*LSP7 extension, for compatibility for clients / tools that expect ERC20.*
 
 ## Methods
 

--- a/docs/LSP7CompatibilityForERC20Core.md
+++ b/docs/LSP7CompatibilityForERC20Core.md
@@ -366,7 +366,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -453,7 +453,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/LSP7CompatibilityForERC20Init.md
+++ b/docs/LSP7CompatibilityForERC20Init.md
@@ -1,4 +1,4 @@
-# LSP7CompatibilityForERC20
+# LSP7CompatibilityForERC20Init
 
 
 
@@ -127,6 +127,22 @@ Gets array of data at multiple given keys
 | Name | Type | Description |
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
+
+### initialize
+
+```solidity
+function initialize(address _newOwner) external nonpayable
+```
+
+Sets the token-Metadata and register LSP7InterfaceId
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _newOwner | address | the owner of the contract
 
 ### isOperatorFor
 

--- a/docs/LSP7CompatibilityForERC20Init.md
+++ b/docs/LSP7CompatibilityForERC20Init.md
@@ -382,7 +382,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -469,7 +469,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/LSP7CompatibilityForERC20InitAbstract.md
+++ b/docs/LSP7CompatibilityForERC20InitAbstract.md
@@ -382,7 +382,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -469,7 +469,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/LSP7CompatibilityForERC20InitAbstract.md
+++ b/docs/LSP7CompatibilityForERC20InitAbstract.md
@@ -1,4 +1,4 @@
-# LSP7CompatibilityForERC20
+# LSP7CompatibilityForERC20InitAbstract
 
 
 
@@ -127,6 +127,22 @@ Gets array of data at multiple given keys
 | Name | Type | Description |
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
+
+### initialize
+
+```solidity
+function initialize(address _newOwner) external nonpayable
+```
+
+Sets the token-Metadata and register LSP7InterfaceId
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _newOwner | address | the owner of the contract
 
 ### isOperatorFor
 

--- a/docs/LSP7CompatibilityForERC20InitTester.md
+++ b/docs/LSP7CompatibilityForERC20InitTester.md
@@ -1,4 +1,4 @@
-# LSP7CompatibilityForERC20
+# LSP7CompatibilityForERC20InitTester
 
 
 
@@ -89,6 +89,24 @@ function balanceOf(address tokenOwner) external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | The number of tokens owned by this address
 
+### burn
+
+```solidity
+function burn(address from, uint256 amount, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined
+| amount | uint256 | undefined
+| data | bytes | undefined
+
 ### decimals
 
 ```solidity
@@ -128,6 +146,22 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
+### initialize
+
+```solidity
+function initialize(address _newOwner) external nonpayable
+```
+
+Sets the token-Metadata and register LSP7InterfaceId
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _newOwner | address | the owner of the contract
+
 ### isOperatorFor
 
 ```solidity
@@ -150,6 +184,24 @@ function isOperatorFor(address operator, address tokenOwner) external view retur
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The amount of tokens `operator` address has access to from `tokenOwner`.
+
+### mint
+
+```solidity
+function mint(address to, uint256 amount, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined
+| amount | uint256 | undefined
+| data | bytes | undefined
 
 ### name
 

--- a/docs/LSP7CompatibilityForERC20InitTester.md
+++ b/docs/LSP7CompatibilityForERC20InitTester.md
@@ -418,7 +418,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -505,7 +505,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/LSP7CompatibilityForERC20Tester.md
+++ b/docs/LSP7CompatibilityForERC20Tester.md
@@ -58,14 +58,14 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
-| operator | address | The address to authorize as an operator.
-| amount | uint256 | The amount of tokens operator has access to.
+| operator | address | undefined
+| amount | uint256 | undefined
 
 ### balanceOf
 
@@ -88,6 +88,24 @@ function balanceOf(address tokenOwner) external view returns (uint256)
 | Name | Type | Description |
 |---|---|---|
 | _0 | uint256 | The number of tokens owned by this address
+
+### burn
+
+```solidity
+function burn(address from, uint256 amount, bytes data) external nonpayable
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined
+| amount | uint256 | undefined
+| data | bytes | undefined
 
 ### decimals
 
@@ -168,6 +186,23 @@ function mint(address to, uint256 amount, bytes data) external nonpayable
 | to | address | undefined
 | amount | uint256 | undefined
 | data | bytes | undefined
+
+### name
+
+```solidity
+function name() external view returns (string)
+```
+
+
+
+*Returns the name of the token.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | The name of the token
 
 ### owner
 
@@ -251,6 +286,23 @@ function supportsInterface(bytes4 interfaceId) external view returns (bool)
 | Name | Type | Description |
 |---|---|---|
 | _0 | bool | undefined
+
+### symbol
+
+```solidity
+function symbol() external view returns (string)
+```
+
+
+
+*Returns the symbol of the token, usually a shorter version of the name.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | The symbol of the token
 
 ### totalSupply
 
@@ -343,6 +395,24 @@ function transferOwnership(address newOwner) external nonpayable
 
 
 ## Events
+
+### Approval
+
+```solidity
+event Approval(address indexed owner, address indexed spender, uint256 value)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| owner `indexed` | address | undefined |
+| spender `indexed` | address | undefined |
+| value  | uint256 | undefined |
 
 ### AuthorizedOperator
 

--- a/docs/LSP7CompatibilityForERC20Tester.md
+++ b/docs/LSP7CompatibilityForERC20Tester.md
@@ -402,7 +402,7 @@ function transferOwnership(address newOwner) external nonpayable
 event Approval(address indexed owner, address indexed spender, uint256 value)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 
@@ -489,7 +489,7 @@ event RevokedOperator(address indexed operator, address indexed tokenOwner)
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data)
 ```
 
-
+To provide compatibility with indexing ERC20 events.
 
 
 

--- a/docs/SignatureValidator.md
+++ b/docs/SignatureValidator.md
@@ -1,0 +1,60 @@
+# SignatureValidator
+
+
+
+
+
+
+
+*sample contract that implements ERC1271 (Standard Signature Validation Method for Contracts)  used to test the permission ALLOWEDSTANDARDS implementation code taken from: https://eips.ethereum.org/EIPS/eip-1271*
+
+## Methods
+
+### isValidSignature
+
+```solidity
+function isValidSignature(bytes32 _hash, bytes _signature) external pure returns (bytes4)
+```
+
+Verifies that the signer is the owner of the signing contract.
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _hash | bytes32 | undefined
+| _signature | bytes | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+*See {IERC165-supportsInterface}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined
+
+
+
+

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.behaviour.ts
@@ -1,15 +1,13 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import { INTERFACE_IDS, SupportedStandards } from "../../../constants";
 import {
-  LSP7CompatibilityForERC20Tester,
-  LSP7CompatibilityForERC20Tester__factory,
   TokenReceiverWithLSP1,
   TokenReceiverWithLSP1__factory,
   TokenReceiverWithoutLSP1,
   TokenReceiverWithoutLSP1__factory,
 } from "../../../types";
-
-import type { BigNumber, ContractTransaction } from "ethers";
 
 type LSP7CompatibilityForERC20TestAccounts = {
   owner: SignerWithAddress;
@@ -19,54 +17,39 @@ type LSP7CompatibilityForERC20TestAccounts = {
   anyone: SignerWithAddress;
 };
 
-const getNamedAccounts =
+export const getNamedAccounts =
   async (): Promise<LSP7CompatibilityForERC20TestAccounts> => {
     const [owner, tokenReceiver, operator, anotherOperator, anyone] =
       await ethers.getSigners();
     return { owner, tokenReceiver, operator, anotherOperator, anyone };
   };
 
-type LSP7CompatibilityForERC20TestContext = {
+export type LSP7CompatibilityForERC20DeployParams = {
+  name: string;
+  symbol: string;
+  newOwner: string;
+};
+
+export type LSP7CompatibilityForERC20TestContext = {
   accounts: LSP7CompatibilityForERC20TestAccounts;
   lsp7CompatibilityForERC20: LSP7CompatibilityForERC20Tester;
-  deployParams: {
-    name: string;
-    symbol: string;
-    newOwner: string;
-  };
+  deployParams: LSP7CompatibilityForERC20DeployParams;
   initialSupply: BigNumber;
 };
 
-const buildTestContext =
-  async (): Promise<LSP7CompatibilityForERC20TestContext> => {
-    const accounts = await getNamedAccounts();
-    const initialSupply = ethers.BigNumber.from("3");
-    const deployParams = {
-      name: "Compat for ERC20",
-      symbol: "NFT",
-      newOwner: accounts.owner.address,
-    };
+export const shouldBehaveLikeLSP7CompatibilityForERC20 = (
+  buildContext: () => Promise<LSP7CompatibilityForERC20TestContext>
+) => {
+  let context: LSP7CompatibilityForERC20TestContext;
 
-    const lsp7CompatibilityForERC20 =
-      await new LSP7CompatibilityForERC20Tester__factory(accounts.owner).deploy(
-        deployParams.name,
-        deployParams.symbol,
-        deployParams.newOwner
-      );
+  beforeEach(async () => {
+    context = await buildContext();
 
-    await lsp7CompatibilityForERC20.mint(
-      accounts.owner.address,
-      initialSupply,
+    await context.lsp7CompatibilityForERC20.mint(
+      context.accounts.owner.address,
+      context.initialSupply,
       ethers.utils.toUtf8Bytes("mint tokens for the owner")
     );
-
-    return { accounts, lsp7CompatibilityForERC20, deployParams, initialSupply };
-  };
-
-describe("LSP7CompatibilityForERC20", () => {
-  let context: LSP7CompatibilityForERC20TestContext;
-  beforeEach(async () => {
-    context = await buildTestContext();
   });
 
   describe("approve", () => {
@@ -119,6 +102,11 @@ describe("LSP7CompatibilityForERC20", () => {
             "AuthorizedOperator",
             [operator, tokenOwner, authorizedAmount]
           );
+          await expect(tx).toHaveEmittedWith(
+            context.lsp7CompatibilityForERC20,
+            "Approval",
+            [tokenOwner, operator, authorizedAmount]
+          );
 
           const postAllowance =
             await context.lsp7CompatibilityForERC20.allowance(
@@ -130,40 +118,90 @@ describe("LSP7CompatibilityForERC20", () => {
       });
 
       describe("when the operator had an authorized amount", () => {
-        it("should succeed by replacing the existing amount with the given amount", async () => {
-          const operator = context.accounts.operator.address;
-          const tokenOwner = context.accounts.owner.address;
-          const previouslyAuthorizedAmount = "20";
-          const authorizedAmount = "1";
+        describe("when the operator authorized amount is changed to another non-zero value", () => {
+          it("should succeed by replacing the existing amount with the given amount", async () => {
+            const operator = context.accounts.operator.address;
+            const tokenOwner = context.accounts.owner.address;
+            const previouslyAuthorizedAmount = "20";
+            const authorizedAmount = "1";
 
-          await context.lsp7CompatibilityForERC20.approve(
-            operator,
-            previouslyAuthorizedAmount
-          );
-
-          const preAllowance =
-            await context.lsp7CompatibilityForERC20.allowance(
-              tokenOwner,
-              operator
+            await context.lsp7CompatibilityForERC20.approve(
+              operator,
+              previouslyAuthorizedAmount
             );
-          expect(preAllowance.toString()).toEqual(previouslyAuthorizedAmount);
 
-          const tx = await context.lsp7CompatibilityForERC20.approve(
-            operator,
-            authorizedAmount
-          );
-          await expect(tx).toHaveEmittedWith(
-            context.lsp7CompatibilityForERC20,
-            "AuthorizedOperator",
-            [operator, tokenOwner, authorizedAmount]
-          );
+            const preAllowance =
+              await context.lsp7CompatibilityForERC20.allowance(
+                tokenOwner,
+                operator
+              );
+            expect(preAllowance.toString()).toEqual(previouslyAuthorizedAmount);
 
-          const postAllowance =
-            await context.lsp7CompatibilityForERC20.allowance(
-              tokenOwner,
-              operator
+            const tx = await context.lsp7CompatibilityForERC20.approve(
+              operator,
+              authorizedAmount
             );
-          expect(postAllowance.toString()).toEqual(authorizedAmount);
+            await expect(tx).toHaveEmittedWith(
+              context.lsp7CompatibilityForERC20,
+              "AuthorizedOperator",
+              [operator, tokenOwner, authorizedAmount]
+            );
+            await expect(tx).toHaveEmittedWith(
+              context.lsp7CompatibilityForERC20,
+              "Approval",
+              [tokenOwner, operator, authorizedAmount]
+            );
+
+            const postAllowance =
+              await context.lsp7CompatibilityForERC20.allowance(
+                tokenOwner,
+                operator
+              );
+            expect(postAllowance.toString()).toEqual(authorizedAmount);
+          });
+        });
+
+        describe("when the operator authorized amount is changed to zero", () => {
+          it("should succeed by replacing the existing amount with the given amount", async () => {
+            const operator = context.accounts.operator.address;
+            const tokenOwner = context.accounts.owner.address;
+            const previouslyAuthorizedAmount = "20";
+            const authorizedAmount = "0";
+
+            await context.lsp7CompatibilityForERC20.approve(
+              operator,
+              previouslyAuthorizedAmount
+            );
+
+            const preAllowance =
+              await context.lsp7CompatibilityForERC20.allowance(
+                tokenOwner,
+                operator
+              );
+            expect(preAllowance.toString()).toEqual(previouslyAuthorizedAmount);
+
+            const tx = await context.lsp7CompatibilityForERC20.approve(
+              operator,
+              authorizedAmount
+            );
+            await expect(tx).toHaveEmittedWith(
+              context.lsp7CompatibilityForERC20,
+              "RevokedOperator",
+              [operator, tokenOwner]
+            );
+            await expect(tx).toHaveEmittedWith(
+              context.lsp7CompatibilityForERC20,
+              "Approval",
+              [tokenOwner, operator, authorizedAmount]
+            );
+
+            const postAllowance =
+              await context.lsp7CompatibilityForERC20.allowance(
+                tokenOwner,
+                operator
+              );
+            expect(postAllowance.toString()).toEqual(authorizedAmount);
+          });
         });
       });
     });
@@ -247,9 +285,9 @@ describe("LSP7CompatibilityForERC20", () => {
 
       // effect
       const tx = await sendTransaction();
-      expect(tx).toHaveEmittedWith(
+      await expect(tx).toHaveEmittedWith(
         context.lsp7CompatibilityForERC20,
-        "Transfer",
+        "Transfer(address,address,address,uint256,bool,bytes)",
         [
           operator,
           from,
@@ -258,6 +296,12 @@ describe("LSP7CompatibilityForERC20", () => {
           true, // Using force=true so that EOA and any contract may receive the tokens.
           expectedData,
         ]
+      );
+
+      await expect(tx).toHaveEmittedWith(
+        context.lsp7CompatibilityForERC20,
+        "Transfer(address,address,uint256)",
+        [from, to, amount]
       );
 
       // post-conditions
@@ -415,4 +459,74 @@ describe("LSP7CompatibilityForERC20", () => {
       });
     });
   });
-});
+};
+
+export type LSP7InitializeTestContext = {
+  lsp7CompatibilityForERC20: LSP7CompatibilityForERC20;
+  deployParams: LSP7CompatibilityForERC20DeployParams;
+  initializeTransaction: TransactionResponse;
+};
+
+export const shouldInitializeLikeLSP7CompatibilityForERC20 = (
+  buildContext: () => Promise<LSP7InitializeTestContext>
+) => {
+  let context: LSP7InitializeTestContext;
+
+  beforeEach(async () => {
+    context = await buildContext();
+  });
+
+  describe("when the contract was initialized", () => {
+    it("should have registered its ERC165 interface", async () => {
+      expect(
+        await context.lsp7CompatibilityForERC20.supportsInterface(
+          INTERFACE_IDS.LSP7
+        )
+      );
+    });
+
+    it("should have set expected entries with ERC725Y.setData", async () => {
+      await expect(context.initializeTransaction).toHaveEmittedWith(
+        context.lsp7CompatibilityForERC20,
+        "DataChanged",
+        [
+          SupportedStandards.LSP4DigitalAsset.key,
+          SupportedStandards.LSP4DigitalAsset.value,
+        ]
+      );
+      expect(
+        await context.lsp7CompatibilityForERC20.getData([
+          SupportedStandards.LSP4DigitalAsset.key,
+        ])
+      ).toEqual([SupportedStandards.LSP4DigitalAsset.value]);
+
+      const nameKey =
+        "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1";
+      const expectedNameValue = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes(context.deployParams.name)
+      );
+      await expect(context.initializeTransaction).toHaveEmittedWith(
+        context.lsp7CompatibilityForERC20,
+        "DataChanged",
+        [nameKey, expectedNameValue]
+      );
+      expect(
+        await context.lsp7CompatibilityForERC20.getData([nameKey])
+      ).toEqual([expectedNameValue]);
+
+      const symbolKey =
+        "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756";
+      const expectedSymbolValue = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes(context.deployParams.symbol)
+      );
+      await expect(context.initializeTransaction).toHaveEmittedWith(
+        context.lsp7CompatibilityForERC20,
+        "DataChanged",
+        [symbolKey, expectedSymbolValue]
+      );
+      expect(
+        await context.lsp7CompatibilityForERC20.getData([symbolKey])
+      ).toEqual([expectedSymbolValue]);
+    });
+  });
+};

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.spec.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.spec.ts
@@ -1,0 +1,156 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
+import { deployProxy } from "../../utils/proxy";
+import {
+  LSP7CompatibilityForERC20Tester,
+  LSP7CompatibilityForERC20Tester__factory,
+  LSP7CompatibilityForERC20InitTester,
+  LSP7CompatibilityForERC20InitTester__factory,
+} from "../../../types";
+import {
+  getNamedAccounts,
+  LSP7CompatibilityForERC20TestContext,
+  shouldInitializeLikeLSP7CompatibilityForERC20,
+  shouldBehaveLikeLSP7CompatibilityForERC20,
+} from "./LSP7CompatibilityForERC20.behaviour";
+
+describe("LSP7CompatibilityForERC20", () => {
+  describe("when using LSP7 contract with constructor", () => {
+    const buildTestContext =
+      async (): Promise<LSP7CompatibilityForERC20TestContext> => {
+        const accounts = await getNamedAccounts();
+        const initialSupply = ethers.BigNumber.from("3");
+        const deployParams = {
+          name: "Compat for ERC20",
+          symbol: "NFT",
+          newOwner: accounts.owner.address,
+        };
+
+        const lsp7CompatibilityForERC20 =
+          await new LSP7CompatibilityForERC20Tester__factory(
+            accounts.owner
+          ).deploy(
+            deployParams.name,
+            deployParams.symbol,
+            deployParams.newOwner
+          );
+
+        return {
+          accounts,
+          lsp7CompatibilityForERC20,
+          deployParams,
+          initialSupply,
+        };
+      };
+
+    describe("when deploying the contract", () => {
+      let context: LSP7CompatibilityForERC20TestContext;
+
+      beforeEach(async () => {
+        context = await buildTestContext();
+      });
+
+      describe("when initializing the contract", () => {
+        shouldInitializeLikeLSP7CompatibilityForERC20(async () => {
+          const { lsp7CompatibilityForERC20, deployParams } = context;
+          return {
+            lsp7CompatibilityForERC20,
+            deployParams,
+            initializeTransaction:
+              context.lsp7CompatibilityForERC20.deployTransaction,
+          };
+        });
+      });
+    });
+
+    describe("when testing deployed contract", () => {
+      shouldBehaveLikeLSP7CompatibilityForERC20(buildTestContext);
+    });
+  });
+
+  describe("when using LSP7 contract with proxy", () => {
+    const buildTestContext =
+      async (): Promise<LSP7CompatibilityForERC20TestContext> => {
+        const accounts = await getNamedAccounts();
+        const initialSupply = ethers.BigNumber.from("3");
+        const deployParams = {
+          name: "LSP7 - deployed with constructor",
+          symbol: "NFT",
+          newOwner: accounts.owner.address,
+        };
+
+        const lsp7CompatibilityForERC20TesterInit =
+          await new LSP7CompatibilityForERC20InitTester__factory(
+            accounts.owner
+          ).deploy();
+        const lsp7CompatibilityForERC20Proxy = await deployProxy(
+          lsp7CompatibilityForERC20TesterInit.address,
+          accounts.owner
+        );
+        const lsp7CompatibilityForERC20 =
+          lsp7CompatibilityForERC20TesterInit.attach(
+            lsp7CompatibilityForERC20Proxy
+          );
+
+        return {
+          accounts,
+          lsp7CompatibilityForERC20,
+          deployParams,
+          initialSupply,
+        };
+      };
+
+    const initializeProxy = async (
+      context: LSP7CompatibilityForERC20TestContext
+    ) => {
+      return context.lsp7CompatibilityForERC20[
+        "initialize(string,string,address)"
+      ](
+        context.deployParams.name,
+        context.deployParams.symbol,
+        context.deployParams.newOwner
+      );
+    };
+
+    describe("when deploying the contract as proxy", () => {
+      let context: LSP7CompatibilityForERC20TestContext;
+
+      beforeEach(async () => {
+        context = await buildTestContext();
+      });
+
+      describe("when initializing the contract", () => {
+        shouldInitializeLikeLSP7CompatibilityForERC20(async () => {
+          const { lsp7CompatibilityForERC20, deployParams } = context;
+          const initializeTransaction = await initializeProxy(context);
+
+          return {
+            lsp7CompatibilityForERC20,
+            deployParams,
+            initializeTransaction,
+          };
+        });
+      });
+
+      describe("when calling initialize more than once", () => {
+        it("should revert", async () => {
+          await initializeProxy(context);
+
+          await expect(initializeProxy(context)).toBeRevertedWith(
+            "Initializable: contract is already initialized"
+          );
+        });
+      });
+    });
+
+    describe("when testing deployed contract", () => {
+      shouldBehaveLikeLSP7CompatibilityForERC20(() =>
+        buildTestContext().then(async (context) => {
+          await initializeProxy(context);
+
+          return context;
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds a contract LSP7CompatabilityForERC20Init for the proxy version. This was left out after the change from an abstract contract to a constructor version, and is being implemented this way to support the pattern to have a constructor and proxy version.