### PR TITLE
Lsp7 8 solidity errors

### DIFF
--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -88,7 +88,6 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *
      * Requirements
      *
-     * - `operator` cannot be calling address.
      * - `operator` cannot be the zero address.
      *
      * Emits an {AuthorizedOperator} event.
@@ -103,7 +102,6 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *
      * Requirements
      *
-     * - `operator` cannot be calling address.
      * - `operator` cannot be the zero address.
      *
      * Emits a {RevokedOperator} event.

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -186,7 +186,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         address operator,
         uint256 amount
     ) internal virtual {
-        if(operator == address(0)) {
+        if (operator == address(0)) {
             revert LSP7CannotUseAddressZeroAsOperator();
         }
 
@@ -219,7 +219,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        if(to == address(0)){
+        if (to == address(0)){
             revert LSP7CannotSendWithAddressZero();
         }
 
@@ -303,7 +303,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         }
 
         uint256 balance = _tokenOwnerBalances[from];
-        if(amount > balance) {
+        if (amount > balance) {
             revert LSP7AmountExceedsBalance(balance, from, amount);
         }
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -27,6 +27,16 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     using Address for address;
 
+    // --- Errors
+
+    error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
+    error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount);
+    error LSP7CannotUseAddressZeroAsOperator();
+    error LSP7CannotSendWithAddressZero();
+    error LSP7InvalidTransferBatch();
+    error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
+    error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
+
     // --- Storage
 
     bool internal _isNFT;
@@ -122,14 +132,14 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         address operator = _msgSender();
         if (operator != from) {
             uint256 operatorAmount = _operatorAuthorizedAmount[from][operator];
-            require(
-                operatorAmount >= amount,
-                "LSP7: transfer amount exceeds operator authorized amount"
-            );
+            if (amount > operatorAmount) {
+                revert LSP7AmountExceedsAuthorizedAmount(from, operatorAmount, operator, amount);
+            }
+
             _updateOperator(
                 from,
                 operator,
-                _operatorAuthorizedAmount[from][operator] - amount
+                operatorAmount - amount
             );
         }
 
@@ -146,12 +156,11 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes[] memory data
     ) external virtual override {
-        require(
-            from.length == to.length &&
-                from.length == amount.length &&
-                from.length == data.length,
-            "LSP7: transferBatch list length mismatch"
-        );
+        if (from.length != to.length ||
+                from.length != amount.length ||
+                from.length != data.length) {
+            revert LSP7InvalidTransferBatch();
+        }
 
         for (uint256 i = 0; i < from.length; i++) {
             // using the public transfer function to handle updates to operator authorized amounts
@@ -170,7 +179,6 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
      *
      * Requirements
      *
-     * - `operator` cannot be calling address.
      * - `operator` cannot be the zero address.
      */
     function _updateOperator(
@@ -178,18 +186,14 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         address operator,
         uint256 amount
     ) internal virtual {
-        require(
-            operator != tokenOwner,
-            "LSP7: updating operator failed, can not use token owner as operator"
-        );
-        require(
-            operator != address(0),
-            "LSP7: updating operator failed, operator can not be zero address"
-        );
-        require(
-            tokenOwner != address(0),
-            "LSP7: updating operator failed, can not set operator for zero address"
-        );
+        if(operator == address(0)) {
+            revert LSP7CannotUseAddressZeroAsOperator();
+        }
+
+        // tokenOwner is always their own operator, no update required
+        if (operator == tokenOwner) {
+            return;
+        }
 
         _operatorAuthorizedAmount[tokenOwner][operator] = amount;
 
@@ -215,7 +219,9 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        require(to != address(0), "LSP7: mint to the zero address not allowed");
+        if(to == address(0)){
+            revert LSP7CannotSendWithAddressZero();
+        }
 
         address operator = _msgSender();
 
@@ -245,18 +251,21 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         uint256 amount,
         bytes memory data
     ) internal virtual {
-        require(from != address(0), "LSP7: burn from the zero address");
-        require(
-            _tokenOwnerBalances[from] >= amount,
-            "LSP7: burn amount exceeds tokenOwner balance"
-        );
+        if (from == address(0)) {
+            revert LSP7CannotSendWithAddressZero();
+        }
+
+        uint256 balance = _tokenOwnerBalances[from];
+        if (amount > balance) {
+            revert LSP7AmountExceedsBalance(balance, from, amount);
+        }
 
         address operator = _msgSender();
         if (operator != from) {
-            require(
-                _operatorAuthorizedAmount[from][operator] >= amount,
-                "LSP7: burn amount exceeds operator authorized amount"
-            );
+            uint256 authorizedAmount = _operatorAuthorizedAmount[from][operator];
+            if (amount > authorizedAmount) {
+                revert LSP7AmountExceedsAuthorizedAmount(from, authorizedAmount, operator, amount);
+            }
             _operatorAuthorizedAmount[from][operator] -= amount;
         }
 
@@ -289,12 +298,14 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        require(from != address(0), "LSP7: transfer from the zero address");
-        require(to != address(0), "LSP7: transfer to the zero address");
-        require(
-            _tokenOwnerBalances[from] >= amount,
-            "LSP7: transfer amount exceeds tokenOwner balance"
-        );
+        if (from == address(0) || to == address(0)) {
+            revert LSP7CannotSendWithAddressZero();
+        }
+
+        uint256 balance = _tokenOwnerBalances[from];
+        if(amount > balance) {
+            revert LSP7AmountExceedsBalance(balance, from, amount);
+        }
 
         address operator = _msgSender();
 
@@ -383,9 +394,9 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
             );
         } else if (!force) {
             if (to.isContract()) {
-                revert("LSP7: token receiver contract missing LSP1 interface");
+                revert LSP7NotifyTokenReceiverContractMissingLSP1Interface(to);
             } else {
-                revert("LSP7: token receiver is EOA");
+                revert LSP7NotifyTokenReceiverIsEOA(to);
             }
         }
     }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -15,10 +15,10 @@ abstract contract LSP7CappedSupply is LSP7CappedSupplyCore, LSP7DigitalAsset {
      * @param tokenSupplyCap_ The Token max supply
      */
     constructor(uint256 tokenSupplyCap_) {
-        require(
-            tokenSupplyCap_ > 0,
-            "LSP7CappedSupply: tokenSupplyCap is zero"
-        );
+        if (tokenSupplyCap_ == 0) {
+            revert LSP7CappedSupplyRequired();
+        }
+
         _tokenSupplyCap = tokenSupplyCap_;
     }
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
@@ -15,6 +15,11 @@ abstract contract LSP7CappedSupplyCore is
     ILSP7CappedSupply,
     LSP7DigitalAssetCore
 {
+    // --- Errors
+
+    error LSP7CappedSupplyRequired();
+    error LSP7CappedSupplyCannotMintOverCap();
+
     // --- Storage
 
     uint256 internal _tokenSupplyCap;
@@ -46,10 +51,10 @@ abstract contract LSP7CappedSupplyCore is
         bool force,
         bytes memory data
     ) internal virtual override {
-        require(
-            totalSupply() + amount <= tokenSupplyCap(),
-            "LSP7CappedSupply: tokenSupplyCap reached"
-        );
+        if (totalSupply() + amount > tokenSupplyCap()) {
+            revert LSP7CappedSupplyCannotMintOverCap();
+        }
+
         super._mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -23,7 +23,10 @@ abstract contract LSP7CappedSupplyInitAbstract is
         virtual
         onlyInitializing
     {
-        require(tokenSupplyCap_ > 0, "LSP7Capped: tokenSupplyCap is zero");
+        if (tokenSupplyCap_ == 0) {
+            revert LSP7CappedSupplyRequired();
+        }
+
         _tokenSupplyCap = tokenSupplyCap_;
     }
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -47,7 +47,7 @@ abstract contract LSP7CompatibilityForERC20Core is
      * Using force=true so that EOA and any contract may receive the tokens.
      */
     function transfer(address to, uint256 amount) external virtual override {
-        return transfer(_msgSender(), to, amount, true, "compat-transfer");
+        return transfer(_msgSender(), to, amount, true, "");
     }
 
     /**
@@ -60,7 +60,7 @@ abstract contract LSP7CompatibilityForERC20Core is
         address to,
         uint256 amount
     ) external virtual override {
-        return transfer(from, to, amount, true, "compat-transferFrom");
+        return transfer(from, to, amount, true, "");
     }
 
     // --- Overrides

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -108,7 +108,6 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `tokenId` must exist.
      * - caller must be current `tokenOwner` of `tokenId`.
-     * - `operator` cannot be calling address.
      * - `operator` cannot be the zero address.
      *
      * Emits an {AuthorizedOperator} event.
@@ -126,7 +125,6 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `tokenId` must exist.
      * - caller must be current `tokenOwner` of `tokenId`.
-     * - `operator` cannot be calling address.
      * - `operator` cannot be the zero address.
      *
      * Emits a {RevokedOperator} event.

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -224,7 +224,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) public virtual override {
         address operator = _msgSender();
 
-        if(!_isOperatorOrOwner(operator, tokenId)) {
+        if (!_isOperatorOrOwner(operator, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, operator);
         }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -33,6 +33,18 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using Address for address;
 
+    // --- Errors
+
+    error LSP8NonExistentTokenId(bytes32 tokenId);
+    error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
+    error LSP8NotTokenOperator(bytes32 tokenId, address caller);
+    error LSP8CannotUseAddressZeroAsOperator();
+    error LSP8CannotSendToAddressZero();
+    error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
+    error LSP8InvalidTransferBatch();
+    error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
+    error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
+
     // --- Storage
 
     uint256 internal _existingTokens;
@@ -79,10 +91,10 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         returns (address)
     {
         address tokenOwner = _tokenOwners[tokenId];
-        require(
-            tokenOwner != address(0),
-            "LSP8: can not query non existent token"
-        );
+
+        if (tokenOwner == address(0)) {
+            revert LSP8NonExistentTokenId(tokenId);
+        }
 
         return tokenOwner;
     }
@@ -96,11 +108,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         override
         returns (bytes32[] memory)
     {
-        require(
-            tokenOwner != address(0),
-            "LSP8: can not query token for zero address"
-        );
-
         return _ownedTokens[tokenOwner].values();
     }
 
@@ -115,16 +122,20 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         override
     {
         address tokenOwner = tokenOwnerOf(tokenId);
-        require(
-            tokenOwner == _msgSender(),
-            "LSP8: caller can not authorize operator for token id"
-        );
+        address caller = _msgSender();
 
-        require(
-            tokenOwner != operator,
-            "LSP8: can not authorize token owner as operator"
-        );
-        require(operator != address(0), "LSP8: can not authorize zero address");
+        if (tokenOwner != caller) {
+            revert LSP8NotTokenOwner(tokenOwner, tokenId, caller);
+        }
+
+        if (operator == address(0)) {
+            revert LSP8CannotUseAddressZeroAsOperator();
+        }
+
+        // tokenOwner is always their own operator, no update required
+        if (tokenOwner == operator) {
+            return;
+        }
 
         _operators[tokenId].add(operator);
 
@@ -140,19 +151,20 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         override
     {
         address tokenOwner = tokenOwnerOf(tokenId);
-        require(
-            tokenOwner == _msgSender(),
-            "LSP8: caller can not revoke operator for token id"
-        );
+        address caller = _msgSender();
 
-        require(
-            operator != tokenOwner,
-            "LSP8: can not revoke token owner as operator"
-        );
-        require(
-            operator != address(0),
-            "LSP8: can not revoke zero address as operator"
-        );
+        if (tokenOwner != caller) {
+            revert LSP8NotTokenOwner(tokenOwner, tokenId, caller);
+        }
+
+        if (operator == address(0)) {
+            revert LSP8CannotUseAddressZeroAsOperator();
+        }
+
+        // tokenOwner is always their own operator, no update required
+        if (tokenOwner == operator) {
+            return;
+        }
 
         _revokeOperator(operator, tokenOwner, tokenId);
     }
@@ -167,10 +179,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         override
         returns (bool)
     {
-        require(
-            _exists(tokenId),
-            "LSP8: can not query operator for non existent token"
-        );
+        _existsOrError(tokenId);
 
         return _isOperatorOrOwner(operator, tokenId);
     }
@@ -185,10 +194,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         override
         returns (address[] memory)
     {
-        require(
-            _exists(tokenId),
-            "LSP8: can not query operator for non existent token"
-        );
+        _existsOrError(tokenId);
 
         return _operators[tokenId].values();
     }
@@ -216,10 +222,12 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes memory data
     ) public virtual override {
-        require(
-            _isOperatorOrOwner(_msgSender(), tokenId),
-            "LSP8: can not transfer, caller is not the owner or operator of token"
-        );
+        address operator = _msgSender();
+
+        if(!_isOperatorOrOwner(operator, tokenId)) {
+            revert LSP8NotTokenOperator(tokenId, operator);
+        }
+
         _transfer(from, to, tokenId, force, data);
     }
 
@@ -233,12 +241,11 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes[] memory data
     ) external virtual override {
-        require(
-            from.length == to.length &&
-                from.length == tokenId.length &&
-                from.length == data.length,
-            "LSP8: transferBatch list length mismatch"
-        );
+        if (from.length != to.length ||
+                from.length != tokenId.length ||
+                from.length != data.length) {
+            revert LSP8InvalidTransferBatch();
+        }
 
         for (uint256 i = 0; i < from.length; i++) {
             transfer(from[i], to[i], tokenId[i], force, data[i]);
@@ -287,6 +294,15 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     }
 
     /**
+     * @dev When `tokenId` does not exist then revert with an error.
+     */
+    function _existsOrError(bytes32 tokenId) internal view {
+        if (!_exists(tokenId)) {
+            revert LSP8NonExistentTokenId(tokenId);
+        }
+    }
+
+    /**
      * @dev Mints `tokenId` and transfers it to `to`.
      *
      * Requirements:
@@ -302,8 +318,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes memory data
     ) internal virtual {
-        require(to != address(0), "LSP8: can not mint to zero address");
-        require(!_exists(tokenId), "LSP8: tokenId already minted");
+        if (to == address(0)) {
+            revert LSP8CannotSendToAddressZero();
+        }
+
+        if (_exists(tokenId)) {
+            revert LSP8TokenIdAlreadyMinted(tokenId);
+        }
 
         address operator = _msgSender();
 
@@ -318,8 +339,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     }
 
     /**
-     * @dev Destroys `tokenId`.
-     * The approval is cleared when the token is burned.
+     * @dev Destroys `tokenId`, clearing authorized operators.
      *
      * Requirements:
      *
@@ -335,7 +355,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         _beforeTokenTransfer(tokenOwner, address(0), tokenId);
 
-        // Clear operators
         _clearOperators(tokenOwner, tokenId);
 
         _ownedTokens[tokenOwner].remove(tokenId);
@@ -361,11 +380,14 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes memory data
     ) internal virtual {
-        require(
-            tokenOwnerOf(tokenId) == from,
-            "LSP8: transfer of tokenId from incorrect owner"
-        );
-        require(to != address(0), "LSP8: can not transfer to zero address");
+        address tokenOwner = tokenOwnerOf(tokenId);
+        if (tokenOwner != from) {
+            revert LSP8NotTokenOwner(tokenOwner, tokenId, from);
+        }
+
+        if (to == address(0)) {
+            revert LSP8CannotSendToAddressZero();
+        }
 
         address operator = _msgSender();
 
@@ -373,7 +395,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         _beforeTokenTransfer(from, to, tokenId);
 
-        // Clear operators from the previous owner
         _clearOperators(from, tokenId);
 
         _ownedTokens[from].remove(tokenId);
@@ -461,9 +482,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             );
         } else if (!force) {
             if (to.isContract()) {
-                revert("LSP8: token receiver contract missing LSP1 interface");
+                revert LSP8NotifyTokenReceiverContractMissingLSP1Interface(to);
             } else {
-                revert("LSP8: token receiver is EOA");
+                revert LSP8NotifyTokenReceiverIsEOA(to);
             }
         }
     }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -18,10 +18,10 @@ abstract contract LSP8CappedSupply is
      * @param tokenSupplyCap_ The Token max supply
      */
     constructor(uint256 tokenSupplyCap_) {
-        require(
-            tokenSupplyCap_ > 0,
-            "LSP8CappedSupply: tokenSupplyCap is zero"
-        );
+        if (tokenSupplyCap_ == 0) {
+            revert LSP8CappedSupplyRequired();
+        }
+
         _tokenSupplyCap = tokenSupplyCap_;
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
@@ -15,6 +15,11 @@ abstract contract LSP8CappedSupplyCore is
     ILSP8CappedSupply,
     LSP8IdentifiableDigitalAssetCore
 {
+    // --- Errors
+
+    error LSP8CappedSupplyRequired();
+    error LSP8CappedSupplyCannotMintOverCap();
+
     // --- Storage
 
     uint256 internal _tokenSupplyCap;
@@ -47,10 +52,10 @@ abstract contract LSP8CappedSupplyCore is
         bool force,
         bytes memory data
     ) internal virtual override {
-        require(
-            totalSupply() + 1 <= tokenSupplyCap(),
-            "LSP8CappedSupply: tokenSupplyCap reached"
-        );
+        if (totalSupply() + 1 > tokenSupplyCap()) {
+            revert LSP8CappedSupplyCannotMintOverCap();
+        }
+
         super._mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -23,7 +23,10 @@ abstract contract LSP8CappedSupplyInitAbstract is
         virtual
         onlyInitializing
     {
-        require(tokenSupplyCap_ > 0, "LSP8Capped: tokenSupplyCap is zero");
+        if (tokenSupplyCap_ == 0) {
+            revert LSP8CappedSupplyRequired();
+        }
+
         _tokenSupplyCap = tokenSupplyCap_;
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
@@ -89,13 +89,11 @@ abstract contract LSP8CompatibilityForERC721Core is
         override
         returns (address)
     {
-        require(
-            _exists(bytes32(tokenId)),
-            "LSP8: can not query operator for non existent token"
-        );
+        bytes32 tokenIdAsBytes32 = bytes32(tokenId);
+        _existsOrError(tokenIdAsBytes32);
 
         EnumerableSet.AddressSet storage operatorsForTokenId = _operators[
-            bytes32(tokenId)
+            tokenIdAsBytes32
         ];
         uint256 operatorListLength = operatorsForTokenId.length();
 
@@ -140,7 +138,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         uint256 tokenId
     ) external virtual override {
         return
-            transfer(from, to, bytes32(tokenId), true, "compat-transferFrom");
+            transfer(from, to, bytes32(tokenId), true, "");
     }
 
     /**
@@ -159,7 +157,7 @@ abstract contract LSP8CompatibilityForERC721Core is
                 to,
                 bytes32(tokenId),
                 false,
-                "compat-safeTransferFrom"
+                ""
             );
     }
 

--- a/docs/CalculateERCInterfaces.md
+++ b/docs/CalculateERCInterfaces.md
@@ -1,0 +1,134 @@
+# CalculateERCInterfaces
+
+
+
+
+
+
+
+*Calculate the ERC165 interface IDs (for backward compatibility)*
+
+## Methods
+
+### calculateInterfaceERC1155
+
+```solidity
+function calculateInterfaceERC1155() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC1271
+
+```solidity
+function calculateInterfaceERC1271() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC20
+
+```solidity
+function calculateInterfaceERC20() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC223
+
+```solidity
+function calculateInterfaceERC223() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC721
+
+```solidity
+function calculateInterfaceERC721() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC721Metadata
+
+```solidity
+function calculateInterfaceERC721Metadata() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceERC777
+
+```solidity
+function calculateInterfaceERC777() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+
+
+

--- a/docs/CalculateLSPInterfaces.md
+++ b/docs/CalculateLSPInterfaces.md
@@ -1,0 +1,117 @@
+# CalculateLSPInterfaces
+
+
+
+
+
+
+
+*This contract calculates the ERC165 interface IDs of each LSP contract      and ensure that these values are correctly stored as hardcoded      Solidity constants.*
+
+## Methods
+
+### calculateInterfaceLSP1
+
+```solidity
+function calculateInterfaceLSP1() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceLSP1Delegate
+
+```solidity
+function calculateInterfaceLSP1Delegate() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceLSP6KeyManager
+
+```solidity
+function calculateInterfaceLSP6KeyManager() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceLSP7
+
+```solidity
+function calculateInterfaceLSP7() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateInterfaceLSP8
+
+```solidity
+function calculateInterfaceLSP8() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+### calculateLSP9VaultInterfaceID
+
+```solidity
+function calculateLSP9VaultInterfaceID() external pure returns (bytes4)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bytes4 | undefined
+
+
+
+

--- a/docs/IERC1155.md
+++ b/docs/IERC1155.md
@@ -1,0 +1,241 @@
+# IERC1155
+
+
+
+
+
+
+
+*Required interface of an ERC1155 compliant contract, as defined in the https://eips.ethereum.org/EIPS/eip-1155[EIP]. _Available since v3.1._*
+
+## Methods
+
+### balanceOf
+
+```solidity
+function balanceOf(address account, uint256 id) external view returns (uint256)
+```
+
+
+
+*Returns the amount of tokens of token type `id` owned by `account`. Requirements: - `account` cannot be the zero address.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined
+| id | uint256 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+### balanceOfBatch
+
+```solidity
+function balanceOfBatch(address[] accounts, uint256[] ids) external view returns (uint256[])
+```
+
+
+
+*xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {balanceOf}. Requirements: - `accounts` and `ids` must have the same length.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| accounts | address[] | undefined
+| ids | uint256[] | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256[] | undefined
+
+### isApprovedForAll
+
+```solidity
+function isApprovedForAll(address account, address operator) external view returns (bool)
+```
+
+
+
+*Returns true if `operator` is approved to transfer ``account``&#39;s tokens. See {setApprovalForAll}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account | address | undefined
+| operator | address | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined
+
+### safeBatchTransferFrom
+
+```solidity
+function safeBatchTransferFrom(address from, address to, uint256[] ids, uint256[] amounts, bytes data) external nonpayable
+```
+
+
+
+*xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {safeTransferFrom}. Emits a {TransferBatch} event. Requirements: - `ids` and `amounts` must have the same length. - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155BatchReceived} and return the acceptance magic value.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined
+| to | address | undefined
+| ids | uint256[] | undefined
+| amounts | uint256[] | undefined
+| data | bytes | undefined
+
+### safeTransferFrom
+
+```solidity
+function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes data) external nonpayable
+```
+
+
+
+*Transfers `amount` tokens of token type `id` from `from` to `to`. Emits a {TransferSingle} event. Requirements: - `to` cannot be the zero address. - If the caller is not `from`, it must be have been approved to spend ``from``&#39;s tokens via {setApprovalForAll}. - `from` must have a balance of tokens of type `id` of at least `amount`. - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155Received} and return the acceptance magic value.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from | address | undefined
+| to | address | undefined
+| id | uint256 | undefined
+| amount | uint256 | undefined
+| data | bytes | undefined
+
+### setApprovalForAll
+
+```solidity
+function setApprovalForAll(address operator, bool approved) external nonpayable
+```
+
+
+
+*Grants or revokes permission to `operator` to transfer the caller&#39;s tokens, according to `approved`, Emits an {ApprovalForAll} event. Requirements: - `operator` cannot be the caller.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator | address | undefined
+| approved | bool | undefined
+
+### supportsInterface
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool)
+```
+
+
+
+*Returns true if this contract implements the interface defined by `interfaceId`. See the corresponding https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section] to learn more about how these ids are created. This function call must use less than 30 000 gas.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| interfaceId | bytes4 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | bool | undefined
+
+
+
+## Events
+
+### ApprovalForAll
+
+```solidity
+event ApprovalForAll(address indexed account, address indexed operator, bool approved)
+```
+
+
+
+*Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to `approved`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| account `indexed` | address | undefined |
+| operator `indexed` | address | undefined |
+| approved  | bool | undefined |
+
+### TransferBatch
+
+```solidity
+event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)
+```
+
+
+
+*Equivalent to multiple {TransferSingle} events, where `operator`, `from` and `to` are the same for all transfers.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator `indexed` | address | undefined |
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| ids  | uint256[] | undefined |
+| values  | uint256[] | undefined |
+
+### TransferSingle
+
+```solidity
+event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)
+```
+
+
+
+*Emitted when `value` tokens of token type `id` are transferred from `from` to `to` by `operator`.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| operator `indexed` | address | undefined |
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| id  | uint256 | undefined |
+| value  | uint256 | undefined |
+
+### URI
+
+```solidity
+event URI(string value, uint256 indexed id)
+```
+
+
+
+*Emitted when the URI for token type `id` changes to `value`, if it is a non-programmatic URI. If an {URI} event was emitted for `id`, the standard https://eips.ethereum.org/EIPS/eip-1155#metadata-extensions[guarantees] that `value` will equal the value returned by {IERC1155MetadataURI-uri}.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| value  | string | undefined |
+| id `indexed` | uint256 | undefined |
+
+
+

--- a/docs/IERC223.md
+++ b/docs/IERC223.md
@@ -1,0 +1,183 @@
+# IERC223
+
+
+
+
+
+
+
+*Interface of the ERC223 standard token as defined in the EIP.      see: https://github.com/Dexaran/ERC223-token-standard/blob/development/token/ERC223/IERC223.sol*
+
+## Methods
+
+### balanceOf
+
+```solidity
+function balanceOf(address who) external view returns (uint256)
+```
+
+
+
+*Returns the balance of the `who` address.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| who | address | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+### decimals
+
+```solidity
+function decimals() external view returns (uint8)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint8 | undefined
+
+### name
+
+```solidity
+function name() external view returns (string)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined
+
+### standard
+
+```solidity
+function standard() external view returns (string)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined
+
+### symbol
+
+```solidity
+function symbol() external view returns (string)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined
+
+### totalSupply
+
+```solidity
+function totalSupply() external view returns (uint256)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+### transfer
+
+```solidity
+function transfer(address to, uint256 value, bytes data) external nonpayable returns (bool success)
+```
+
+
+
+*Transfers `value` tokens from `msg.sender` to `to` address with `data` parameter and returns `true` on success.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| to | address | undefined
+| value | uint256 | undefined
+| data | bytes | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| success | bool | undefined
+
+
+
+## Events
+
+### Transfer
+
+```solidity
+event Transfer(address indexed from, address indexed to, uint256 value)
+```
+
+
+
+*Event that is fired on successful transfer.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| from `indexed` | address | undefined |
+| to `indexed` | address | undefined |
+| value  | uint256 | undefined |
+
+### TransferData
+
+```solidity
+event TransferData(bytes data)
+```
+
+
+
+*Additional event that is fired on successful transfer and logs transfer metadata,      this event is implemented to keep Transfer event compatible with ERC20.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| data  | bytes | undefined |
+
+
+

--- a/docs/ILSP7CappedSupply.md
+++ b/docs/ILSP7CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7CompatibilityForERC20.md
+++ b/docs/ILSP7CompatibilityForERC20.md
@@ -58,7 +58,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -159,7 +159,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7DigitalAsset.md
+++ b/docs/ILSP7DigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7Mintable.md
+++ b/docs/ILSP7Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -138,7 +138,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP8CappedSupply.md
+++ b/docs/ILSP8CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -124,7 +124,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP8CompatibilityForERC721.md
+++ b/docs/ILSP8CompatibilityForERC721.md
@@ -35,7 +35,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -208,7 +208,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP8IdentifiableDigitalAsset.md
+++ b/docs/ILSP8IdentifiableDigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -124,7 +124,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP8Mintable.md
+++ b/docs/ILSP8Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -143,7 +143,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupply.md
+++ b/docs/LSP7CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -147,7 +147,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -378,5 +378,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CappedSupplyCore.md
+++ b/docs/LSP7CappedSupplyCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -317,5 +317,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CappedSupplyInit.md
+++ b/docs/LSP7CappedSupplyInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -394,5 +394,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CappedSupplyInitAbstract.md
+++ b/docs/LSP7CappedSupplyInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -394,5 +394,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CappedSupplyInitTester.md
+++ b/docs/LSP7CappedSupplyInitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -197,7 +197,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -428,5 +428,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CappedSupplyTester.md
+++ b/docs/LSP7CappedSupplyTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -181,7 +181,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -412,5 +412,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20.md
+++ b/docs/LSP7CompatibilityForERC20.md
@@ -204,7 +204,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -468,5 +468,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20Core.md
+++ b/docs/LSP7CompatibilityForERC20Core.md
@@ -204,7 +204,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -468,5 +468,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20Init.md
+++ b/docs/LSP7CompatibilityForERC20Init.md
@@ -220,7 +220,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -484,5 +484,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20InitAbstract.md
+++ b/docs/LSP7CompatibilityForERC20InitAbstract.md
@@ -220,7 +220,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -484,5 +484,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20InitTester.md
+++ b/docs/LSP7CompatibilityForERC20InitTester.md
@@ -256,7 +256,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -520,5 +520,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7CompatibilityForERC20Tester.md
+++ b/docs/LSP7CompatibilityForERC20Tester.md
@@ -240,7 +240,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -504,5 +504,110 @@ To provide compatibility with indexing ERC20 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7DigitalAsset.md
+++ b/docs/LSP7DigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -147,7 +147,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -361,5 +361,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7DigitalAssetCore.md
+++ b/docs/LSP7DigitalAssetCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -300,5 +300,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7DigitalAssetInit.md
+++ b/docs/LSP7DigitalAssetInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -377,5 +377,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7DigitalAssetInitAbstract.md
+++ b/docs/LSP7DigitalAssetInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -377,5 +377,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7InitTester.md
+++ b/docs/LSP7InitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -200,7 +200,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -414,5 +414,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7Mintable.md
+++ b/docs/LSP7Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -166,7 +166,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -380,5 +380,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7MintableCore.md
+++ b/docs/LSP7MintableCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -138,7 +138,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -319,5 +319,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7MintableInit.md
+++ b/docs/LSP7MintableInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -182,7 +182,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -396,5 +396,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7MintableInitAbstract.md
+++ b/docs/LSP7MintableInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -182,7 +182,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -396,5 +396,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP7Tester.md
+++ b/docs/LSP7Tester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -184,7 +184,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -398,5 +398,110 @@ event Transfer(address indexed operator, address indexed from, address indexed t
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP7AmountExceedsAuthorizedAmount
+
+```solidity
+error LSP7AmountExceedsAuthorizedAmount(address tokenOwner, uint256 authorizedAmount, address operator, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| authorizedAmount | uint256 | undefined |
+| operator | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7AmountExceedsBalance
+
+```solidity
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| balance | uint256 | undefined |
+| tokenOwner | address | undefined |
+| amount | uint256 | undefined |
+
+### LSP7CannotSendWithAddressZero
+
+```solidity
+error LSP7CannotSendWithAddressZero()
+```
+
+
+
+
+
+
+### LSP7CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP7CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP7InvalidTransferBatch
+
+```solidity
+error LSP7InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP7NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP7NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
 
 

--- a/docs/LSP8CappedSupply.md
+++ b/docs/LSP8CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -152,7 +152,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -429,5 +429,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CappedSupplyCore.md
+++ b/docs/LSP8CappedSupplyCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -124,7 +124,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -368,5 +368,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CappedSupplyInit.md
+++ b/docs/LSP8CappedSupplyInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -168,7 +168,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -445,5 +445,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CappedSupplyInitAbstract.md
+++ b/docs/LSP8CappedSupplyInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -168,7 +168,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -445,5 +445,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CappedSupplyInitTester.md
+++ b/docs/LSP8CappedSupplyInitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -201,7 +201,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -478,5 +478,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CappedSupplyTester.md
+++ b/docs/LSP8CappedSupplyTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -185,7 +185,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -462,5 +462,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721.md
+++ b/docs/LSP8CompatibilityForERC721.md
@@ -253,7 +253,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -607,5 +607,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721Core.md
+++ b/docs/LSP8CompatibilityForERC721Core.md
@@ -253,7 +253,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -607,5 +607,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721Init.md
+++ b/docs/LSP8CompatibilityForERC721Init.md
@@ -269,7 +269,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -623,5 +623,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721InitAbstract.md
+++ b/docs/LSP8CompatibilityForERC721InitAbstract.md
@@ -269,7 +269,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -623,5 +623,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721InitTester.md
+++ b/docs/LSP8CompatibilityForERC721InitTester.md
@@ -304,7 +304,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -658,5 +658,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8CompatibilityForERC721Tester.md
+++ b/docs/LSP8CompatibilityForERC721Tester.md
@@ -288,7 +288,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -642,5 +642,140 @@ To provide compatibility with indexing ERC721 events.
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8IdentifiableDigitalAsset.md
+++ b/docs/LSP8IdentifiableDigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -152,7 +152,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -412,5 +412,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8IdentifiableDigitalAssetCore.md
+++ b/docs/LSP8IdentifiableDigitalAssetCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -124,7 +124,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -351,5 +351,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8IdentifiableDigitalAssetInit.md
+++ b/docs/LSP8IdentifiableDigitalAssetInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -168,7 +168,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -428,5 +428,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8IdentifiableDigitalAssetInitAbstract.md
+++ b/docs/LSP8IdentifiableDigitalAssetInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -168,7 +168,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -428,5 +428,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8InitTester.md
+++ b/docs/LSP8InitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -204,7 +204,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -464,5 +464,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8Mintable.md
+++ b/docs/LSP8Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -171,7 +171,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -431,5 +431,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8MintableCore.md
+++ b/docs/LSP8MintableCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -143,7 +143,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -370,5 +370,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8MintableInit.md
+++ b/docs/LSP8MintableInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -187,7 +187,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -447,5 +447,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8MintableInitAbstract.md
+++ b/docs/LSP8MintableInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -187,7 +187,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -447,5 +447,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/LSP8Tester.md
+++ b/docs/LSP8Tester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, bytes32 tokenId) external nonpayabl
 
 
 
-*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Makes `operator` address an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -188,7 +188,7 @@ function revokeOperator(address operator, bytes32 tokenId) external nonpayable
 
 
 
-*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be calling address. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of `tokenId`. See {isOperatorFor}. Requirements - `tokenId` must exist. - caller must be current `tokenOwner` of `tokenId`. - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 
@@ -448,5 +448,140 @@ event Transfer(address operator, address indexed from, address indexed to, bytes
 | force  | bool | undefined |
 | data  | bytes | undefined |
 
+
+
+## Events
+
+### LSP8CannotSendToAddressZero
+
+```solidity
+error LSP8CannotSendToAddressZero()
+```
+
+
+
+
+
+
+### LSP8CannotUseAddressZeroAsOperator
+
+```solidity
+error LSP8CannotUseAddressZeroAsOperator()
+```
+
+
+
+
+
+
+### LSP8InvalidTransferBatch
+
+```solidity
+error LSP8InvalidTransferBatch()
+```
+
+
+
+
+
+
+### LSP8NonExistentTokenId
+
+```solidity
+error LSP8NonExistentTokenId(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+
+### LSP8NotTokenOperator
+
+```solidity
+error LSP8NotTokenOperator(bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotTokenOwner
+
+```solidity
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenOwner | address | undefined |
+| tokenId | bytes32 | undefined |
+| caller | address | undefined |
+
+### LSP8NotifyTokenReceiverContractMissingLSP1Interface
+
+```solidity
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8NotifyTokenReceiverIsEOA
+
+```solidity
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenReceiver | address | undefined |
+
+### LSP8TokenIdAlreadyMinted
+
+```solidity
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| tokenId | bytes32 | undefined |
 
 

--- a/docs/UniversalProfile.md
+++ b/docs/UniversalProfile.md
@@ -10,45 +10,6 @@
 
 ## Methods
 
-### allDataKeys
-
-```solidity
-function allDataKeys() external view returns (bytes32[])
-```
-
-
-
-*Returns all the keys set on the account*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32[] | The array of keys set on the account
-
-### dataKeys
-
-```solidity
-function dataKeys(uint256) external view returns (bytes32)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32 | undefined
-
 ### execute
 
 ```solidity
@@ -155,7 +116,7 @@ function setData(bytes32[] _keys, bytes[] _values) external nonpayable
 
 
 
-*Sets array of data at multiple given `key` Push all the keys to the `dataKeys` array SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
+*Sets array of data at multiple given `key` SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
 
 #### Parameters
 

--- a/docs/UniversalProfileInit.md
+++ b/docs/UniversalProfileInit.md
@@ -10,45 +10,6 @@
 
 ## Methods
 
-### allDataKeys
-
-```solidity
-function allDataKeys() external view returns (bytes32[])
-```
-
-
-
-*Returns all the keys set on the account*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32[] | The array of keys set on the account
-
-### dataKeys
-
-```solidity
-function dataKeys(uint256) external view returns (bytes32)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32 | undefined
-
 ### execute
 
 ```solidity
@@ -171,7 +132,7 @@ function setData(bytes32[] _keys, bytes[] _values) external nonpayable
 
 
 
-*Sets array of data at multiple given `key` Push all the keys to the `dataKeys` array SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
+*Sets array of data at multiple given `key` SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
 
 #### Parameters
 

--- a/docs/UniversalProfileInitAbstract.md
+++ b/docs/UniversalProfileInitAbstract.md
@@ -10,45 +10,6 @@
 
 ## Methods
 
-### allDataKeys
-
-```solidity
-function allDataKeys() external view returns (bytes32[])
-```
-
-
-
-*Returns all the keys set on the account*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32[] | The array of keys set on the account
-
-### dataKeys
-
-```solidity
-function dataKeys(uint256) external view returns (bytes32)
-```
-
-
-
-
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | bytes32 | undefined
-
 ### execute
 
 ```solidity
@@ -171,7 +132,7 @@ function setData(bytes32[] _keys, bytes[] _values) external nonpayable
 
 
 
-*Sets array of data at multiple given `key` Push all the keys to the `dataKeys` array SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
+*Sets array of data at multiple given `key` SHOULD only be callable by the owner of the contract set via ERC173 Emits a {DataChanged} event.*
 
 #### Parameters
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,7 @@ import "@nomiclabs/hardhat-web3";
 import "@typechain/hardhat";
 import "@primitivefi/hardhat-dodoc";
 import "hardhat-packager";
+import "hardhat-contract-sizer";
 
 import "hardhat-deploy";
 

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,15 @@
 import { waffleJest } from "@ethereum-waffle/jest";
 
 jest.setTimeout(20000);
-expect.extend(waffleJest);
+expect.extend({
+  ...waffleJest,
+  toBeRevertedWith: async (promise: Promise<any>, revertReason: string) => {
+    // The matcher is using `String.search(regExp)` whose parameter is always a RegExp.
+    // To correctly match custom errors, we must escape any parens as they are otherwise interpreted
+    // as capture groups.
+    return waffleJest.toBeRevertedWith(
+      promise,
+      revertReason.replace(/[()]/g, "\\$&")
+    );
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eth-create2-calculator": "^1.1.5",
         "ethers": "5.4.6",
         "hardhat": "^2.6.2",
+        "hardhat-contract-sizer": "^2.4.0",
         "hardhat-deploy": "^0.9.4",
         "hardhat-deploy-ethers": "^0.3.0-beta.11",
         "hardhat-packager": "^1.1.0",
@@ -3564,6 +3565,15 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@solidity-parser/parser": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
+      "dev": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
@@ -5403,6 +5413,71 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "1.4.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-table3/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-width": {
       "version": "2.2.1",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
@@ -5471,6 +5546,16 @@
     "node_modules/colorette": {
       "version": "1.3.0",
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -18853,6 +18938,68 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/hardhat-contract-sizer": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.4.0.tgz",
+      "integrity": "sha512-ww+Fw5Fq+q6gkVxB8KFvicqZFH5pH9HGZwV4ZSTxd0QrxA162qzLdbScJseUP30VvIBPYN9wpdj0cWlz6M9j6g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "cli-table3": "^0.6.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/hardhat-contract-sizer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/hardhat-contract-sizer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/hardhat-contract-sizer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/hardhat-contract-sizer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/hardhat-deploy": {
       "version": "0.9.8",
       "integrity": "sha512-f7s3mG4wHnZuQWR+W4QVnPIE0OshgBrf19gvqRBqMbH9cDw4IxBXKWYSVTPXHXNITjwE3CA9Rqx+52Ee1ovtAA==",
@@ -26906,14 +27053,6 @@
         "prettier": "^2.3.0"
       }
     },
-    "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
-      "version": "0.14.0",
-      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
-      "dev": true,
-      "dependencies": {
-        "antlr4ts": "^0.5.0-alpha.4"
-      }
-    },
     "node_modules/prettier-plugin-solidity/node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
@@ -33993,6 +34132,15 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@solidity-parser/parser": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.14.0.tgz",
+      "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
+      "dev": true,
+      "requires": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
@@ -35459,6 +35607,56 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
+      "dev": true,
+      "requires": {
+        "colors": "1.4.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.1",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
@@ -35514,6 +35712,13 @@
     "colorette": {
       "version": "1.3.0",
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w=="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -46180,6 +46385,52 @@
         }
       }
     },
+    "hardhat-contract-sizer": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.4.0.tgz",
+      "integrity": "sha512-ww+Fw5Fq+q6gkVxB8KFvicqZFH5pH9HGZwV4ZSTxd0QrxA162qzLdbScJseUP30VvIBPYN9wpdj0cWlz6M9j6g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "cli-table3": "^0.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "hardhat-deploy": {
       "version": "0.9.8",
       "integrity": "sha512-f7s3mG4wHnZuQWR+W4QVnPIE0OshgBrf19gvqRBqMbH9cDw4IxBXKWYSVTPXHXNITjwE3CA9Rqx+52Ee1ovtAA==",
@@ -52029,14 +52280,6 @@
         "string-width": "^4.2.3"
       },
       "dependencies": {
-        "@solidity-parser/parser": {
-          "version": "0.14.0",
-          "integrity": "sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==",
-          "dev": true,
-          "requires": {
-            "antlr4ts": "^0.5.0-alpha.4"
-          }
-        },
         "ansi-regex": {
           "version": "5.0.1",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eth-create2-calculator": "^1.1.5",
     "ethers": "5.4.6",
     "hardhat": "^2.6.2",
+    "hardhat-contract-sizer": "^2.4.0",
     "hardhat-deploy": "^0.9.4",
     "hardhat-deploy-ethers": "^0.3.0-beta.11",
     "hardhat-packager": "^1.1.0",

--- a/tests/LSP7DigitalAsset/extensions/LSP7CappedSupply.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CappedSupply.behaviour.ts
@@ -81,7 +81,7 @@ export const shouldBehaveLikeLSP7CappedSupply = (
             context.accounts.tokenReceiver.address,
             1
           )
-        ).toBeRevertedWith("LSP7CappedSupply: tokenSupplyCap reached");
+        ).toBeRevertedWith("LSP7CappedSupplyCannotMintOverCap()");
       });
 
       it("should allow minting after burning", async () => {

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -76,7 +76,7 @@ export const shouldBehaveLikeLSP8 = (
             txParams.force,
             txParams.data
           )
-        ).toBeRevertedWith("LSP8: tokenId already minted");
+        ).toBeRevertedWith(`LSP8TokenIdAlreadyMinted("${txParams.tokenId}")`);
       });
     });
 
@@ -99,7 +99,7 @@ export const shouldBehaveLikeLSP8 = (
               txParams.force,
               txParams.data
             )
-          ).toBeRevertedWith("LSP8: can not mint to zero address");
+          ).toBeRevertedWith("LSP8CannotSendToAddressZero()");
         });
       });
 
@@ -169,7 +169,7 @@ export const shouldBehaveLikeLSP8 = (
         it("should revert", async () => {
           await expect(
             context.lsp8.tokenOwnerOf(neverMintedTokenId)
-          ).toBeRevertedWith("LSP8: can not query non existent token");
+          ).toBeRevertedWith(`LSP8NonExistentTokenId("${neverMintedTokenId}")`);
         });
       });
 
@@ -198,14 +198,6 @@ export const shouldBehaveLikeLSP8 = (
           ).toEqual([]);
         });
       });
-
-      describe("when the given address is the zero address", () => {
-        it("should revert", async () => {
-          await expect(
-            context.lsp8.tokenIdsOf(ethers.constants.AddressZero)
-          ).toBeRevertedWith("LSP8: can not query token for zero address");
-        });
-      });
     });
 
     describe("authorizeOperator", () => {
@@ -216,7 +208,7 @@ export const shouldBehaveLikeLSP8 = (
               context.accounts.operator.address,
               neverMintedTokenId
             )
-          ).toBeRevertedWith("LSP8: can not query non existent token");
+          ).toBeRevertedWith(`LSP8NonExistentTokenId("${neverMintedTokenId}")`);
         });
       });
 
@@ -230,31 +222,45 @@ export const shouldBehaveLikeLSP8 = (
                 mintedTokenId
               )
           ).toBeRevertedWith(
-            "LSP8: caller can not authorize operator for token id"
+            `LSP8NotTokenOwner("${context.accounts.owner.address}", "${mintedTokenId}", "${context.accounts.anyone.address}")`
           );
         });
       });
 
       describe("when caller is owner of tokenId", () => {
-        describe("when given operator is the tokenOwner", () => {
-          it("should revert", async () => {
-            await expect(
-              context.lsp8.authorizeOperator(
-                context.accounts.owner.address,
-                mintedTokenId
-              )
-            ).toBeRevertedWith(
-              "LSP8: can not authorize token owner as operator"
+        describe("when operator is not the zero address", () => {
+          it("should succeed", async () => {
+            const operator = context.accounts.operator.address;
+            const tokenOwner = context.accounts.owner.address;
+            const tokenId = mintedTokenId;
+
+            const tx = await context.lsp8.authorizeOperator(operator, tokenId);
+
+            await expect(tx).toHaveEmittedWith(
+              context.lsp8,
+              "AuthorizedOperator",
+              [operator, tokenOwner, tokenId]
+            );
+
+            expect(await context.lsp8.isOperatorFor(operator, tokenId)).toEqual(
+              true
             );
           });
-        });
 
-        describe("when given operator is different than tokenOwner", () => {
-          describe("when operator is not the zero address", () => {
+          describe("when operator is already authorized", () => {
+            beforeEach(async () => {
+              await context.lsp8.authorizeOperator(
+                context.accounts.operator.address,
+                mintedTokenId
+              );
+            });
+
             it("should succeed", async () => {
               const operator = context.accounts.operator.address;
               const tokenOwner = context.accounts.owner.address;
               const tokenId = mintedTokenId;
+
+              await context.lsp8.authorizeOperator(operator, tokenId);
 
               const tx = await context.lsp8.authorizeOperator(
                 operator,
@@ -271,48 +277,16 @@ export const shouldBehaveLikeLSP8 = (
                 await context.lsp8.isOperatorFor(operator, tokenId)
               ).toEqual(true);
             });
+          });
 
-            describe("when operator is already authorized", () => {
-              beforeEach(async () => {
-                await context.lsp8.authorizeOperator(
-                  context.accounts.operator.address,
-                  mintedTokenId
-                );
-              });
+          describe("when operator is the zero address", () => {
+            it("should revert", async () => {
+              const operator = ethers.constants.AddressZero;
+              const tokenId = mintedTokenId;
 
-              it("should succeed", async () => {
-                const operator = context.accounts.operator.address;
-                const tokenOwner = context.accounts.owner.address;
-                const tokenId = mintedTokenId;
-
-                await context.lsp8.authorizeOperator(operator, tokenId);
-
-                const tx = await context.lsp8.authorizeOperator(
-                  operator,
-                  tokenId
-                );
-
-                await expect(tx).toHaveEmittedWith(
-                  context.lsp8,
-                  "AuthorizedOperator",
-                  [operator, tokenOwner, tokenId]
-                );
-
-                expect(
-                  await context.lsp8.isOperatorFor(operator, tokenId)
-                ).toEqual(true);
-              });
-            });
-
-            describe("when operator is the zero address", () => {
-              it("should revert", async () => {
-                const operator = ethers.constants.AddressZero;
-                const tokenId = mintedTokenId;
-
-                await expect(
-                  context.lsp8.authorizeOperator(operator, tokenId)
-                ).toBeRevertedWith("LSP8: can not authorize zero address");
-              });
+              await expect(
+                context.lsp8.authorizeOperator(operator, tokenId)
+              ).toBeRevertedWith("LSP8CannotUseAddressZeroAsOperator()");
             });
           });
         });
@@ -327,7 +301,7 @@ export const shouldBehaveLikeLSP8 = (
               context.accounts.operator.address,
               neverMintedTokenId
             )
-          ).toBeRevertedWith("LSP8: can not query non existent token");
+          ).toBeRevertedWith(`LSP8NonExistentTokenId("${neverMintedTokenId}")`);
         });
       });
 
@@ -338,62 +312,47 @@ export const shouldBehaveLikeLSP8 = (
               .connect(context.accounts.anyone)
               .revokeOperator(context.accounts.operator.address, mintedTokenId)
           ).toBeRevertedWith(
-            "LSP8: caller can not revoke operator for token id"
+            `LSP8NotTokenOwner("${context.accounts.owner.address}", "${mintedTokenId}", "${context.accounts.anyone.address}")`
           );
         });
       });
 
       describe("when caller is owner of tokenId", () => {
-        describe("when given operator is the tokenOwner", () => {
-          it("should revert", async () => {
-            await expect(
-              context.lsp8.revokeOperator(
-                context.accounts.owner.address,
-                mintedTokenId
-              )
-            ).toBeRevertedWith("LSP8: can not revoke token owner as operator");
+        describe("when operator is not the zero address", () => {
+          it("should succeed", async () => {
+            const operator = context.accounts.operator.address;
+            const tokenOwner = context.accounts.owner.address;
+            const tokenId = mintedTokenId;
+
+            // pre-conditions
+            await context.lsp8.authorizeOperator(operator, tokenId);
+            expect(await context.lsp8.isOperatorFor(operator, tokenId)).toEqual(
+              true
+            );
+
+            // effects
+            const tx = await context.lsp8.revokeOperator(operator, tokenId);
+            await expect(tx).toHaveEmittedWith(
+              context.lsp8,
+              "RevokedOperator",
+              [operator, tokenOwner, tokenId]
+            );
+
+            // post-conditions
+            expect(await context.lsp8.isOperatorFor(operator, tokenId)).toEqual(
+              false
+            );
           });
         });
 
-        describe("when given operator is different than tokenOwner", () => {
-          describe("when operator is not the zero address", () => {
-            it("should succeed", async () => {
-              const operator = context.accounts.operator.address;
-              const tokenOwner = context.accounts.owner.address;
-              const tokenId = mintedTokenId;
+        describe("when operator is the zero address", () => {
+          it("should revert", async () => {
+            const operator = ethers.constants.AddressZero;
+            const tokenId = mintedTokenId;
 
-              // pre-conditions
-              await context.lsp8.authorizeOperator(operator, tokenId);
-              expect(
-                await context.lsp8.isOperatorFor(operator, tokenId)
-              ).toEqual(true);
-
-              // effects
-              const tx = await context.lsp8.revokeOperator(operator, tokenId);
-              await expect(tx).toHaveEmittedWith(
-                context.lsp8,
-                "RevokedOperator",
-                [operator, tokenOwner, tokenId]
-              );
-
-              // post-conditions
-              expect(
-                await context.lsp8.isOperatorFor(operator, tokenId)
-              ).toEqual(false);
-            });
-          });
-
-          describe("when operator is the zero address", () => {
-            it("should revert", async () => {
-              const operator = ethers.constants.AddressZero;
-              const tokenId = mintedTokenId;
-
-              await expect(
-                context.lsp8.revokeOperator(operator, tokenId)
-              ).toBeRevertedWith(
-                "LSP8: can not revoke zero address as operator"
-              );
-            });
+            await expect(
+              context.lsp8.revokeOperator(operator, tokenId)
+            ).toBeRevertedWith("LSP8CannotUseAddressZeroAsOperator()");
           });
         });
       });
@@ -407,9 +366,7 @@ export const shouldBehaveLikeLSP8 = (
               context.accounts.operator.address,
               neverMintedTokenId
             )
-          ).toBeRevertedWith(
-            "LSP8: can not query operator for non existent token"
-          );
+          ).toBeRevertedWith(`LSP8NonExistentTokenId("${neverMintedTokenId}")`);
         });
       });
 
@@ -474,9 +431,7 @@ export const shouldBehaveLikeLSP8 = (
         it("should revert", async () => {
           await expect(
             context.lsp8.getOperatorsOf(neverMintedTokenId)
-          ).toBeRevertedWith(
-            "LSP8: can not query operator for non existent token"
-          );
+          ).toBeRevertedWith(`LSP8NonExistentTokenId("${neverMintedTokenId}")`);
         });
       });
 
@@ -668,8 +623,7 @@ export const shouldBehaveLikeLSP8 = (
                     force,
                     data,
                   };
-                  const expectedError =
-                    "LSP8: can not transfer to zero address";
+                  const expectedError = "LSP8CannotSendToAddressZero()";
 
                   await transferFailScenario(txParams, operator, expectedError);
                 });
@@ -754,7 +708,7 @@ export const shouldBehaveLikeLSP8 = (
                   force,
                   data,
                 };
-                const expectedError = "LSP8: token receiver is EOA";
+                const expectedError = `LSP8NotifyTokenReceiverIsEOA("${txParams.to}")`;
 
                 await transferFailScenario(txParams, operator, expectedError);
               });
@@ -804,8 +758,7 @@ export const shouldBehaveLikeLSP8 = (
                     force,
                     data,
                   };
-                  const expectedError =
-                    "LSP8: token receiver contract missing LSP1 interface";
+                  const expectedError = `LSP8NotifyTokenReceiverContractMissingLSP1Interface("${txParams.to}")`;
 
                   await transferFailScenario(txParams, operator, expectedError);
                 });
@@ -833,8 +786,7 @@ export const shouldBehaveLikeLSP8 = (
                   ethers.utils.toUtf8Bytes("should revert")
                 ),
               };
-              const expectedError =
-                "LSP8: can not transfer, caller is not the owner or operator of token";
+              const expectedError = `LSP8NotTokenOperator("${txParams.tokenId}", "${operator.address}")`;
 
               await transferFailScenario(txParams, operator, expectedError);
             });
@@ -853,8 +805,7 @@ export const shouldBehaveLikeLSP8 = (
                 ethers.utils.toUtf8Bytes("should revert")
               ),
             };
-            const expectedError =
-              "LSP8: transfer of tokenId from incorrect owner";
+            const expectedError = `LSP8NotTokenOwner("${context.accounts.owner.address}", "${txParams.tokenId}", "${txParams.from}")`;
 
             await transferFailScenario(txParams, operator, expectedError);
           });
@@ -872,7 +823,7 @@ export const shouldBehaveLikeLSP8 = (
                 ethers.utils.toUtf8Bytes("should revert")
               ),
             };
-            const expectedError = "LSP8: can not query non existent token";
+            const expectedError = `LSP8NonExistentTokenId("${txParams.tokenId}")`;
 
             await transferFailScenario(txParams, operator, expectedError);
           });
@@ -1046,8 +997,7 @@ export const shouldBehaveLikeLSP8 = (
                     force,
                     data: [data, data],
                   };
-                  const expectedError =
-                    "LSP8: can not transfer to zero address";
+                  const expectedError = "LSP8CannotSendToAddressZero()";
 
                   await transferBatchFailScenario(
                     txParams,
@@ -1159,13 +1109,13 @@ export const shouldBehaveLikeLSP8 = (
                   ],
                   to: [
                     context.accounts.tokenReceiver.address,
-                    context.accounts.tokenReceiver.address,
+                    helperContracts.tokenReceiverWithLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
                   force,
                   data: [data, data],
                 };
-                const expectedError = "LSP8: token receiver is EOA";
+                const expectedError = `LSP8NotifyTokenReceiverIsEOA("${txParams.to[0]}")`;
 
                 await transferBatchFailScenario(
                   txParams,
@@ -1205,14 +1155,13 @@ export const shouldBehaveLikeLSP8 = (
                     ],
                     to: [
                       helperContracts.tokenReceiverWithoutLSP1.address,
-                      helperContracts.tokenReceiverWithoutLSP1.address,
+                      helperContracts.tokenReceiverWithLSP1.address,
                     ],
                     tokenId: [mintedTokenId, anotherMintedTokenId],
                     force,
                     data: [data, data],
                   };
-                  const expectedError =
-                    "LSP8: token receiver contract missing LSP1 interface";
+                  const expectedError = `LSP8NotifyTokenReceiverContractMissingLSP1Interface("${txParams.to[0]}")`;
 
                   await transferBatchFailScenario(
                     txParams,
@@ -1237,8 +1186,7 @@ export const shouldBehaveLikeLSP8 = (
                   ),
                 ],
               };
-              const expectedError =
-                "LSP8: transfer of tokenId from incorrect owner";
+              const expectedError = `LSP8NotTokenOwner("${context.accounts.owner.address}", "${txParams.tokenId[0]}", "${txParams.from[0]}")`;
 
               await transferBatchFailScenario(
                 txParams,
@@ -1261,7 +1209,7 @@ export const shouldBehaveLikeLSP8 = (
                   ),
                 ],
               };
-              const expectedError = "LSP8: can not query non existent token";
+              const expectedError = `LSP8NonExistentTokenId("${txParams.tokenId[0]}")`;
 
               await transferBatchFailScenario(
                 txParams,
@@ -1298,7 +1246,7 @@ export const shouldBehaveLikeLSP8 = (
                       [`${arrayParam}`]: [validTxParams[arrayParam][0]],
                     },
                     operator,
-                    "LSP8: transferBatch list length mismatch"
+                    "LSP8InvalidTransferBatch()"
                   );
                 })
               );
@@ -1327,8 +1275,7 @@ export const shouldBehaveLikeLSP8 = (
                   ),
                 ],
               };
-              const expectedError =
-                "LSP8: can not transfer, caller is not the owner or operator of token";
+              const expectedError = `LSP8NotTokenOperator("${txParams.tokenId[0]}", "${operator.address}")`;
 
               await transferBatchFailScenario(
                 txParams,

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.behaviour.ts
@@ -103,7 +103,7 @@ export const shouldBehaveLikeLSP8CappedSupply = (
             context.accounts.tokenReceiver.address,
             anotherTokenId
           )
-        ).toBeRevertedWith("LSP8CappedSupply: tokenSupplyCap reached");
+        ).toBeRevertedWith("LSP8CappedSupplyCannotMintOverCap()");
       });
 
       it("should allow minting after burning", async () => {


### PR DESCRIPTION
# Description
Use solidity custom errors instead of strings in order to reduce contract size, and have more specific errors in some scenarios by having parameters for the custom errors.

- in all LSP7 and LSP8 contracts, switch from error strings to custom errors
- added hardhat plugin to report contract size
- remove invariant in LSP7 and LSP8 when tokenOwner authorizes / revokes their own address as operator
- remove invariant in LSP7 when calling `balanceOf` for address zero

## Contract size difference
Using `npx hardhat size-contract` before and after and formatting to show LSP7/8 contract changes

```json
{
  "LSP7DigitalAsset": 0.742,
  "LSP7Mintable": 0.852,
  "LSP7Tester": 1.057,
  "LSP7CompatibilityForERC20": 0.818,
  "LSP7CappedSupplyTester": 1.057,
  "LSP7DigitalAssetInit": 0.742,
  "LSP7MintableInit": 0.852,
  "LSP7CompatibilityForERC20InitAbstract": 0.818,
  "LSP7InitTester": 1.057,
  "LSP7CompatibilityForERC20Tester": 1.133,
  "LSP7CompatibilityForERC20Init": 0.818,
  "LSP7CappedSupplyInitTester": 1.057,
  "LSP7CompatibilityForERC20InitTester": 1.133,
  "LSP8IdentifiableDigitalAsset": 1.155,
  "LSP8Mintable": 1.284,
  "LSP8Tester": 1.284,
  "LSP8CappedSupplyTester": 1.284,
  "LSP8IdentifiableDigitalAssetInit": 1.155,
  "LSP8MintableInit": 1.284,
  "LSP8InitTester": 1.284,
  "LSP8CompatibilityForERC721": 1.356,
  "LSP8CappedSupplyInitTester": 1.29,
  "LSP8CompatibilityForERC721InitAbstract": 1.3559,
  "LSP8CompatibilityForERC721Tester": 1.485,
  "LSP8CompatibilityForERC721Init": 1.356,
  "LSP8CompatibilityForERC721InitTester": 1.485
}
```