### PR TITLE
fix: security check in UniversalReceiverDelegateUP contract

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import "../../../LSP6KeyManager/LSP6KeyManager.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 // interfaces
@@ -31,6 +32,8 @@ abstract contract TokenAndVaultHandlingContract {
         bytes memory data
     ) internal returns (bytes memory result) {
         address keyManagerAddress = ERC725Y(msg.sender).owner();
+        _profileChecker(keyManagerAddress);
+
         if (
             ERC165Checker.supportsInterface(
                 keyManagerAddress,
@@ -185,5 +188,12 @@ abstract contract TokenAndVaultHandlingContract {
         } else {
             amount = 1;
         }
+    }
+
+    function _profileChecker(address keyManagerAddress) private {
+        address profileAddress = address(
+            LSP6KeyManager(keyManagerAddress).account()
+        );
+        require(profileAddress == msg.sender, "Not the same Profile");
     }
 }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -194,6 +194,6 @@ abstract contract TokenAndVaultHandlingContract {
         address profileAddress = address(
             LSP6KeyManager(keyManagerAddress).account()
         );
-        require(profileAddress == msg.sender, "Not the same Profile");
+        require(profileAddress == msg.sender, "Incorrect KeyManager");
     }
 }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -194,6 +194,9 @@ abstract contract TokenAndVaultHandlingContract {
         address profileAddress = address(
             LSP6KeyManager(keyManagerAddress).account()
         );
-        require(profileAddress == msg.sender, "Incorrect KeyManager");
+        require(
+            profileAddress == msg.sender,
+            "Security: The called Key Manager belongs to a different account"
+        );
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- Add a security check to confirm that the profile(msg.sender) is the same profile linked to the extracted Key Manager.