### PR TITLE
fix: `isValidSignature(...)` on LSP6 revert on empty permissions

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -24,6 +24,13 @@ import "../LSP0ERC725Account/LSP0Constants.sol";
 import "@erc725/smart-contracts/contracts/constants.sol";
 
 /**
+ * @dev revert when address `from` does not have any permissions set
+ * on the account linked to this Key Manager
+ * @param from the address that does not have permissions
+ */
+error NoPermissionsSet(address from);
+
+/**
  * @dev address `from` is not authorised to `permission`
  * @param permission permission required
  * @param from address not-authorised
@@ -248,6 +255,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             }
         } else if (erc725Function == account.transferOwnership.selector) {
             bytes32 permissions = account.getPermissionsFor(_from);
+            if (permissions == bytes32(0)) revert NoPermissionsSet(_from);
 
             if (!_hasPermission(_PERMISSION_CHANGEOWNER, permissions))
                 revert NotAuthorised(_from, "TRANSFEROWNERSHIP");
@@ -268,6 +276,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         view
     {
         bytes32 permissions = account.getPermissionsFor(_from);
+        if (permissions == bytes32(0)) revert NoPermissionsSet(_from);
 
         (bytes32[] memory inputKeys, ) = abi.decode(
             _data[4:],
@@ -403,6 +412,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         view
     {
         bytes32 permissions = account.getPermissionsFor(_from);
+        if (permissions == bytes32(0)) revert NoPermissionsSet(_from);
 
         uint256 operationType = uint256(bytes32(_data[4:36]));
         uint256 value = uint256(bytes32(_data[68:100]));

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -24,12 +24,6 @@ library LSP6Utils {
             )
         );
 
-        if (bytes32(permissions) == bytes32(0)) {
-            revert(
-                "LSP6Utils:getPermissionsFor: no permissions set for this address"
-            );
-        }
-
         return bytes32(permissions);
     }
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -1,5 +1,4 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { loadFixture } from "@nomiclabs/hardhat-waffle";
 import { ethers } from "hardhat";
 import { encodeData, flattenEncodedData } from "@erc725/erc725.js";
 import { solidityKeccak256 } from "ethers/lib/utils";
@@ -36,6 +35,7 @@ import {
   NotAllowedAddressError,
   NotAllowedFunctionError,
   NotAllowedERC725YKeyError,
+  NoPermissionsSetError,
   EMPTY_PAYLOAD,
   DUMMY_PAYLOAD,
   DUMMY_PRIVATEKEY,
@@ -43,7 +43,6 @@ import {
   getRandomAddresses,
   generateKeysAndValues,
   getRandomString,
-  NoPermissionsSetError,
 } from "../utils/helpers";
 import { Signer } from "ethers";
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -28,7 +28,6 @@ import {
   BasicUPSetup_Schema,
   ERC725YKeys,
   ERC1271,
-  SupportedStandards,
 } from "../../constants";
 
 // helpers
@@ -44,6 +43,7 @@ import {
   getRandomAddresses,
   generateKeysAndValues,
   getRandomString,
+  NoPermissionsSetError,
 } from "../utils/helpers";
 import { Signer } from "ethers";
 
@@ -1512,7 +1512,7 @@ describe("KeyManager", () => {
     let provider = ethers.provider;
     let channelId = 0;
 
-    it("Should revert because caller has no permissions set", async () => {
+    it("Should revert when caller has no permissions set", async () => {
       let targetContractPayload = targetContract.interface.encodeFunctionData(
         "setName",
         ["New Contract Name"]
@@ -1523,11 +1523,13 @@ describe("KeyManager", () => {
         [OPERATIONS.CALL, targetContract.address, 0, targetContractPayload]
       );
 
-      await expect(
-        keyManager.connect(accounts[6]).execute(executePayload)
-      ).toBeRevertedWith(
-        "LSP6Utils:getPermissionsFor: no permissions set for this address"
-      );
+      try {
+        await keyManager.connect(app).execute(executePayload);
+      } catch (error) {
+        expect(error.message).toMatch(
+          NoPermissionsSetError(accounts[6].address)
+        );
+      }
     });
 
     it("Should revert if STATICCALL tries to change state", async () => {
@@ -2694,27 +2696,36 @@ describe("Testing permissions of multiple empty bytes length", () => {
 
   describe("reading permissions", () => {
     it("should revert when reading permissions stored as more than 32 empty bytes", async () => {
-      await expect(
-        keyManagerHelper.getAddressPermissions(moreThan32EmptyBytes.address)
-      ).toBeRevertedWith(
-        "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      const result = await keyManagerHelper.getAddressPermissions(
+        moreThan32EmptyBytes.address
       );
+      console.log("result (more than 32 empty bytes): ", result);
+      //   await expect(
+      //   ).toBeRevertedWith(
+      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      //   );
     });
 
     it("should revert when reading permissions stored as less than 32 empty bytes", async () => {
-      await expect(
-        keyManagerHelper.getAddressPermissions(lessThan32EmptyBytes.address)
-      ).toBeRevertedWith(
-        "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      const result = await keyManagerHelper.getAddressPermissions(
+        lessThan32EmptyBytes.address
       );
+      console.log("result (less than 32 empty bytes): ", result);
+      //   await expect(
+      //   ).toBeRevertedWith(
+      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      //   );
     });
 
     it("should revert when reading permissions stored as one empty byte", async () => {
-      await expect(
-        keyManagerHelper.getAddressPermissions(oneEmptyByte.address)
-      ).toBeRevertedWith(
-        "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      const result = await keyManagerHelper.getAddressPermissions(
+        oneEmptyByte.address
       );
+      console.log("result (one empty byte): ", result);
+
+      //   await expect().toBeRevertedWith(
+      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
+      //   );
     });
   });
 });
@@ -4637,9 +4648,11 @@ describe("SIGN (ERC1271)", () => {
 
   let keyManager: LSP6KeyManager;
   let UniversalProfile: UniversalProfile;
+
   let owner: SignerWithAddress;
   let signer: SignerWithAddress;
   let thirdParty: SignerWithAddress;
+  let noPermissionsSet: SignerWithAddress;
 
   beforeAll(async () => {
     accounts = await ethers.getSigners();
@@ -4647,6 +4660,8 @@ describe("SIGN (ERC1271)", () => {
     owner = accounts[6];
     signer = accounts[7];
     thirdParty = accounts[8];
+    noPermissionsSet = accounts[9];
+
     UniversalProfile = await new UniversalProfile__factory(owner).deploy(
       owner.address
     );
@@ -4654,26 +4669,18 @@ describe("SIGN (ERC1271)", () => {
       UniversalProfile.address
     );
 
-    // give all permissions to owner
     await UniversalProfile.connect(owner).setData(
       [
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-          owner.address.substr(2),
-      ],
-      [ALL_PERMISSIONS_SET]
-    );
-
-    // give SIGN permission to signer
-    await UniversalProfile.connect(owner).setData(
-      [
+          owner.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           signer.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           thirdParty.address.substring(2),
       ],
       [
+        ALL_PERMISSIONS_SET,
         ethers.utils.hexZeroPad(PERMISSIONS.SIGN, 32),
-        // give CALL permission to non-signer
         ethers.utils.hexZeroPad(PERMISSIONS.CALL, 32),
       ]
     );
@@ -4681,7 +4688,7 @@ describe("SIGN (ERC1271)", () => {
     await UniversalProfile.connect(owner).transferOwnership(keyManager.address);
   });
 
-  it("Can verify signature from owner on KeyManager", async () => {
+  it("can verify signature from owner on KeyManager", async () => {
     const dataToSign = "0xcafecafe";
     const messageHash = ethers.utils.hashMessage(dataToSign);
     const signature = await owner.signMessage(dataToSign);
@@ -4693,7 +4700,7 @@ describe("SIGN (ERC1271)", () => {
     expect(result).toEqual(ERC1271.MAGIC_VALUE);
   });
 
-  it("Can verify signature from signer on KeyManager", async () => {
+  it("can verify signature from signer on KeyManager", async () => {
     const dataToSign = "0xbeefbeef";
     const messageHash = ethers.utils.hashMessage(dataToSign);
     const signature = await signer.signMessage(dataToSign);
@@ -4705,10 +4712,22 @@ describe("SIGN (ERC1271)", () => {
     expect(result).toEqual(ERC1271.MAGIC_VALUE);
   });
 
-  it("Should fail when verifying signature from address with no SIGN permission", async () => {
+  it("should fail when verifying signature from address with no SIGN permission", async () => {
     const dataToSign = "0xabcdabcd";
     const messageHash = ethers.utils.hashMessage(dataToSign);
     const signature = await thirdParty.signMessage(dataToSign);
+
+    const result = await keyManager.callStatic.isValidSignature(
+      messageHash,
+      signature
+    );
+    expect(result).toEqual(ERC1271.FAIL_VALUE);
+  });
+
+  it("should fail when verifying signature from address with no permissions set", async () => {
+    const dataToSign = "0xabcdabcd";
+    const messageHash = ethers.utils.hashMessage(dataToSign);
+    const signature = await noPermissionsSet.signMessage(dataToSign);
 
     const result = await keyManager.callStatic.isValidSignature(
       messageHash,

--- a/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.spec.ts
@@ -2695,37 +2695,36 @@ describe("Testing permissions of multiple empty bytes length", () => {
   });
 
   describe("reading permissions", () => {
-    it("should revert when reading permissions stored as more than 32 empty bytes", async () => {
+    let abiCoder;
+    let expectedEmptyPermission;
+
+    beforeAll(async () => {
+      abiCoder = await ethers.utils.defaultAbiCoder;
+      expectedEmptyPermission = abiCoder.encode(
+        ["bytes32"],
+        ["0x0000000000000000000000000000000000000000000000000000000000000000"]
+      );
+    });
+
+    it("should cast permissions to 32 bytes when reading permissions stored as more than 32 empty bytes", async () => {
       const result = await keyManagerHelper.getAddressPermissions(
         moreThan32EmptyBytes.address
       );
-      console.log("result (more than 32 empty bytes): ", result);
-      //   await expect(
-      //   ).toBeRevertedWith(
-      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
-      //   );
+      expect(result).toEqual(expectedEmptyPermission);
     });
 
     it("should revert when reading permissions stored as less than 32 empty bytes", async () => {
       const result = await keyManagerHelper.getAddressPermissions(
         lessThan32EmptyBytes.address
       );
-      console.log("result (less than 32 empty bytes): ", result);
-      //   await expect(
-      //   ).toBeRevertedWith(
-      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
-      //   );
+      expect(result).toEqual(expectedEmptyPermission);
     });
 
     it("should revert when reading permissions stored as one empty byte", async () => {
       const result = await keyManagerHelper.getAddressPermissions(
         oneEmptyByte.address
       );
-      console.log("result (one empty byte): ", result);
-
-      //   await expect().toBeRevertedWith(
-      //     "LSP6Utils:getPermissionsFor: no permissions set for this address"
-      //   );
+      expect(result).toEqual(expectedEmptyPermission);
     });
   });
 });

--- a/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerProxy.spec.ts
@@ -38,6 +38,7 @@ import {
   NotAuthorisedError,
   NotAllowedAddressError,
   NotAllowedFunctionError,
+  NoPermissionsSetError,
 } from "../utils/helpers";
 
 describe("KeyManager + LSP3 Account as Proxies", () => {
@@ -1511,11 +1512,13 @@ describe("KeyManager + LSP3 Account as Proxies", () => {
         [OPERATIONS.CALL, targetContract.address, 0, targetContractPayload]
       );
 
-      await expect(
-        proxyKeyManager.connect(accounts[6]).execute(executePayload)
-      ).toBeRevertedWith(
-        "LSP6Utils:getPermissionsFor: no permissions set for this address"
-      );
+      try {
+        await proxyKeyManager.connect(app).execute(executePayload);
+      } catch (error) {
+        expect(error.message).toMatch(
+          NoPermissionsSetError(accounts[6].address)
+        );
+      }
     });
 
     it("Should revert if STATICCALL tries to change state", async () => {

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -134,6 +134,10 @@ export function getRandomString() {
 const customRevertErrorMessage =
   "VM Exception while processing transaction: reverted with custom error";
 
+export const NoPermissionsSetError = (_from) => {
+  return `${customRevertErrorMessage} 'NoPermissionsSet("${_from}")'`;
+};
+
 export const NotAuthorisedError = (_from, _permission) => {
   return `${customRevertErrorMessage} 'NotAuthorised("${_from}", "${_permission}")'`;
 };


### PR DESCRIPTION
# What does this PR introduce?

## Expected behaviour

When calling the function `isValidSignature(...)` with a message signed by an `address` that has no permissions set on the `account` linked to the Key Manager, the output / returned value should be the **ERC1271 FAIL VALUE** (`0xffffffff`).

## Current behaviour

The function `isValidSignature(...)` on the Key Manager reverts with the error message `no permission set for this user` when the signed message comes from an address that has no permission set.

## Fix

- [x] extract the revert error message outside of the `getPermissionsFor(...)` function on the `LSP6Utils`.
- [x] do not revert on the `isValidSignature(...)` function.
- **new feature:**  use custom Solidity `error` called `NoPermissionsSet` 