### PR TITLE
fix: security + gas optimization

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -12,12 +12,25 @@ import "@erc725/smart-contracts/contracts/ERC725.sol";
  */
 contract LSP0ERC725Account is LSP0ERC725AccountCore, ERC725 {
     /**
-     * @notice Sets the owner of the contract and register ERC725Account, ERC1271 and LSP1UniversalReceiver interfacesId
+     * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract
      */
-    constructor(address _newOwner) ERC725(_newOwner) {
-        _registerInterface(_INTERFACEID_LSP0);
-        _registerInterface(_INTERFACEID_ERC1271);
-        _registerInterface(_INTERFACEID_LSP1);
+    constructor(address _newOwner) ERC725(_newOwner) {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC1271 ||
+            interfaceId == _INTERFACEID_LSP0 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -96,9 +96,7 @@ abstract contract LSP0ERC725AccountCore is
         override
         returns (bytes memory returnValue)
     {
-        bytes memory data = IERC725Y(this).getDataSingle(
-            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
-        );
+        bytes memory data = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
         if (data.length >= 20) {
             address universalReceiverAddress = BytesLib.toAddress(data, 0);

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -11,7 +11,7 @@ import "./LSP0ERC725AccountInitAbstract.sol";
  */
 contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
     /**
-     * @notice Sets the owner of the contract and register ERC725Account, ERC1271 and LSP1UniversalReceiver interfacesId
+     * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract
      */
     function initialize(address _newOwner) public virtual override initializer {

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -16,9 +16,22 @@ abstract contract LSP0ERC725AccountInitAbstract is
 {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
         ERC725InitAbstract.initialize(_newOwner);
+    }
 
-        _registerInterface(_INTERFACEID_LSP0);
-        _registerInterface(_INTERFACEID_ERC1271);
-        _registerInterface(_INTERFACEID_LSP1);
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC1271 ||
+            interfaceId == _INTERFACEID_LSP0 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
@@ -26,10 +26,7 @@ abstract contract LSP4Compatibility is ILSP4Compatibility, ERC725YCore {
      * @return The name of the token
      */
     function name() public view virtual override returns (string memory) {
-        bytes memory data = ERC725Utils.getDataSingle(
-            this,
-            _LSP4_TOKEN_NAME_KEY
-        );
+        bytes memory data = _getData(_LSP4_TOKEN_NAME_KEY);
         return string(data);
     }
 
@@ -38,10 +35,7 @@ abstract contract LSP4Compatibility is ILSP4Compatibility, ERC725YCore {
      * @return The symbol of the token
      */
     function symbol() public view virtual override returns (string memory) {
-        bytes memory data = ERC725Utils.getDataSingle(
-            this,
-            _LSP4_TOKEN_SYMBOL_KEY
-        );
+        bytes memory data = _getData(_LSP4_TOKEN_SYMBOL_KEY);
         return string(data);
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.6;
 
 // modules
 import "./LSP6KeyManagerCore.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -17,7 +17,7 @@ import "@erc725/smart-contracts/contracts/ERC725Y.sol";
  */
 contract LSP7DigitalAsset is LSP7DigitalAssetCore, LSP4DigitalAssetMetadata {
     /**
-     * @notice Sets the token-Metadata and register LSP7InterfaceId
+     * @notice Sets the token-Metadata
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata
@@ -30,6 +30,20 @@ contract LSP7DigitalAsset is LSP7DigitalAssetCore, LSP4DigitalAssetMetadata {
         bool isNFT_
     ) LSP4DigitalAssetMetadata(name_, symbol_, newOwner_) {
         _isNFT = isNFT_;
-        _registerInterface(_INTERFACEID_LSP7);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165Storage)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP7 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -11,7 +11,7 @@ import "./LSP7DigitalAssetInitAbstract.sol";
  */
 contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
     /**
-     * @notice Sets the token-Metadata and register LSP7InterfaceId
+     * @notice Sets the token-Metadata
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -31,7 +31,20 @@ abstract contract LSP7DigitalAssetInitAbstract is
             symbol_,
             newOwner_
         );
+    }
 
-        _registerInterface(_INTERFACEID_LSP7);
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165Storage)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP7 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -20,7 +20,7 @@ contract LSP8IdentifiableDigitalAsset is
     LSP4DigitalAssetMetadata
 {
     /**
-     * @notice Sets the token-Metadata and register LSP8InterfaceId
+     * @notice Sets the token-Metadata
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata
@@ -29,7 +29,20 @@ contract LSP8IdentifiableDigitalAsset is
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) LSP4DigitalAssetMetadata(name_, symbol_, newOwner_) {
-        _registerInterface(_INTERFACEID_LSP8);
+    ) LSP4DigitalAssetMetadata(name_, symbol_, newOwner_) {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165Storage)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP8 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
@@ -13,7 +13,7 @@ contract LSP8IdentifiableDigitalAssetInit is
     LSP8IdentifiableDigitalAssetInitAbstract
 {
     /**
-     * @notice Sets the token-Metadata and register LSP8InterfaceId
+     * @notice Sets the token-Metadata
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -29,7 +29,20 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
             symbol_,
             newOwner_
         );
+    }
 
-        _registerInterface(_INTERFACEID_LSP8);
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC165Storage)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP8 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
@@ -28,10 +28,7 @@ contract LSP8CompatibilityForERC721 is
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_) {
-        _registerInterface(_INTERFACEID_ERC721);
-        _registerInterface(_INTERFACEID_ERC721METADATA);
-    }
+    ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_) {}
 
     // --- Overrides
 
@@ -88,5 +85,21 @@ contract LSP8CompatibilityForERC721 is
         )
     {
         super._burn(tokenId, data);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, LSP8IdentifiableDigitalAsset)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC721 ||
+            interfaceId == _INTERFACEID_ERC721METADATA ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
@@ -40,7 +40,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         // silence compiler warning about unused variable
         tokenId;
 
-        bytes memory data = IERC725Y(this).getDataSingle(_LSP4_METADATA_KEY);
+        bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36
         uint256 offset = 36;
@@ -137,8 +137,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         address to,
         uint256 tokenId
     ) external virtual override {
-        return
-            transfer(from, to, bytes32(tokenId), true, "");
+        return transfer(from, to, bytes32(tokenId), true, "");
     }
 
     /**
@@ -151,14 +150,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         address to,
         uint256 tokenId
     ) external virtual override {
-        return
-            transfer(
-                from,
-                to,
-                bytes32(tokenId),
-                false,
-                ""
-            );
+        return transfer(from, to, bytes32(tokenId), false, "");
     }
 
     /*

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
@@ -26,9 +26,6 @@ contract LSP8CompatibilityForERC721InitAbstract is
             symbol_,
             newOwner_
         );
-
-        _registerInterface(_INTERFACEID_ERC721);
-        _registerInterface(_INTERFACEID_ERC721METADATA);
     }
 
     function authorizeOperator(address operator, bytes32 tokenId)
@@ -84,5 +81,21 @@ contract LSP8CompatibilityForERC721InitAbstract is
         )
     {
         super._burn(tokenId, data);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, LSP8IdentifiableDigitalAssetInitAbstract)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC721 ||
+            interfaceId == _INTERFACEID_ERC721METADATA ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -15,21 +15,17 @@ import "../LSP1UniversalReceiver/LSP1Constants.sol";
  */
 contract LSP9Vault is LSP9VaultCore, ERC725 {
     /**
-     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key and register
-     * LSP1UniversalReceiver and LSP9Vault InterfaceId
+     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param _newOwner the owner of the contract
      */
     constructor(address _newOwner) ERC725(_newOwner) {
         // set key SupportedStandards:LSP9Vault
         _setData(
-            _LSP9_SUPPORTED_STANDARDS_KEY, 
+            _LSP9_SUPPORTED_STANDARDS_KEY,
             _LSP9_SUPPORTED_STANDARDS_VALUE
         );
 
         _notifyVaultReceiver(_newOwner);
-
-        _registerInterface(_INTERFACEID_LSP1);
-        _registerInterface(_INTERFACEID_LSP9);
     }
 
     /**
@@ -53,5 +49,21 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
         onlyAllowed
     {
         LSP9VaultCore.setData(_keys, _values);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP9 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -40,11 +40,7 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
     modifier onlyAllowed() {
         if (msg.sender != owner()) {
             address universalReceiverAddress = address(
-                bytes20(
-                    IERC725Y(this).getDataSingle(
-                        _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
-                    )
-                )
+                bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY))
             );
             require(
                 ERC165Checker.supportsInterface(
@@ -105,9 +101,7 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
         override
         returns (bytes memory returnValue)
     {
-        bytes memory data = IERC725Y(this).getDataSingle(
-            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
-        );
+        bytes memory data = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
         if (data.length >= 20) {
             address universalReceiverAddress = BytesLib.toAddress(data, 0);

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -131,10 +131,9 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
         override
         onlyOwner
     {
-        _notifyVaultSender(msg.sender);
-
         OwnableUnset.transferOwnership(newOwner);
 
+        _notifyVaultSender(msg.sender);
         _notifyVaultReceiver(newOwner);
     }
 

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -11,8 +11,7 @@ import "./LSP9VaultInitAbstract.sol";
  */
 contract LSP9VaultInit is LSP9VaultInitAbstract {
     /**
-     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key and register
-     * LSP1UniversalReceiver and LSP9Vault InterfaceId
+     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param _newOwner the owner of the contract
      */
     function initialize(address _newOwner) public override initializer {

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -21,9 +21,6 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
         );
 
         _notifyVaultReceiver(_newOwner);
-
-        _registerInterface(_INTERFACEID_LSP1);
-        _registerInterface(_INTERFACEID_LSP9);
     }
 
     /**
@@ -47,5 +44,21 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
         onlyAllowed
     {
         LSP9VaultCore.setData(_keys, _values);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP9 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- [x] Apply checks-effects-interactions pattern for the vault transfer.
- [x] override `supportsInterface(...)` function instead of writing to the storage. (Big deployment gas saving)
- [x] Use internal `_getData` instead of `getDataSingle` when possible **(3,428 gas optimized)**.

These steps made an LSP7 token transfer cheaper by **10,658 gas units.** 