### PR TITLE
fix: admin caller with `ALL_PERMISSIONS` can call any functions part of the Universal Profile's ABI

### DIFF
--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -101,6 +101,17 @@ export const testSecurityScenarios = (
     }
   });
 
+  it("should revert when admin with ALL PERMISSIONS try to call `renounceOwnership(...)`", async () => {
+    let payload =
+      context.universalProfile.interface.encodeFunctionData(
+        "renounceOwnership"
+      );
+
+    await expect(
+      context.keyManager.connect(context.owner).execute(payload)
+    ).toBeRevertedWith("_validateERC725Selector: invalid ERC725 selector");
+  });
+
   describe("when sending LYX to a contract", () => {
     it("Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant fallback() function.", async () => {
       // the Universal Profile wants to send 1 x LYX from its UP to another smart contract


### PR DESCRIPTION
# What does this PR introduce?

## What is the current behaviour?

Since PR #123, the function selector in the payload sent to `execute(...)` or `executeRelayCall(...)` is not checked
for callers with `ALL_PERMISSIONS`.

This introduces a bug as callers with ALL_PERMISSIONS can now call functions like `revokeOwnership` on the Universal Profile.

## What is the expected behaviour?

Caller should be allowed to interact with only the 3 functions below on the Universal Profile, regardless of their permissions (admin or not).

- `setData(...)`
- `execute(...)`
- `transferOwnership(...)`

## Fix

Introduces an internal function to validate the function being called on the linked Universal Profile.