### PR TITLE
fix: add sender code length check in UniversalReceiverDelegate

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -29,6 +29,8 @@ abstract contract TokenAndVaultHandling {
         internal
         returns (bytes memory result)
     {
+        if (sender.code.length == 0) return "";
+
         address keyManager = ERC725Y(msg.sender).owner();
         if (!ERC165Checker.supportsInterface(keyManager, _INTERFACEID_LSP6))
             return "";

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -29,6 +29,8 @@ abstract contract TokenHandling {
         internal
         returns (bytes memory result)
     {
+        if (sender.code.length == 0) return "";
+
         if (!ERC165Checker.supportsInterface(msg.sender, _INTERFACEID_LSP9))
             return "";
 


### PR DESCRIPTION
## What does this PR introduce?
- Calling the `universalReceiver` function in LSP0, LSP9 with a specific `typeId` related to token hooks will allow making the caller address registered as an asset or vault in the LSP5/LSP10 array keys.

This will prevent spamming the storage of vaults and UPs by EOAs. 
Will add 288 gas unit.