### PR TITLE
feat(lsp6)!: add `account()` function as part of the LSP6 interface

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -20,7 +20,7 @@ export const enum INTERFACE_IDS {
   ERC725Account = "0x481e0fe8",
   LSP1 = "0x6bb56a14",
   LSP1Delegate = "0xc2d7bcc1",
-  LSP6 = "0x6f4df48b",
+  LSP6 = "0x32e6d0ab",
   LSP7 = "0xe33f65c3",
   LSP8 = "0x49399145",
   LSP9 = "0x5e38b596",

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -13,7 +13,7 @@ contract KeyManagerHelper is LSP6KeyManager {
     constructor(address _account) LSP6KeyManager(_account) {}
 
     function getPermissionsFor(address _address) public view returns (bytes32) {
-        return account.getPermissionsFor(_address);
+        return ERC725Y(account).getPermissionsFor(_address);
     }
 
     function getAllowedAddressesFor(address _address)
@@ -21,7 +21,7 @@ contract KeyManagerHelper is LSP6KeyManager {
         view
         returns (bytes memory)
     {
-        return account.getAllowedAddressesFor(_address);
+        return ERC725Y(account).getAllowedAddressesFor(_address);
     }
 
     function getAllowedFunctionsFor(address _address)
@@ -29,7 +29,7 @@ contract KeyManagerHelper is LSP6KeyManager {
         view
         returns (bytes memory)
     {
-        return account.getAllowedFunctionsFor(_address);
+        return ERC725Y(account).getAllowedFunctionsFor(_address);
     }
 
     function verifyAllowedAddress(address _sender, address _recipient)

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -14,6 +14,17 @@ interface ILSP6KeyManager is
     event Executed(uint256 indexed _value, bytes _data);
 
     /**
+     * @notice returns the address of the account linked to this KeyManager
+     * @dev this can be a contract that implements
+     *  - ERC725X only
+     *  - ERC725Y only
+     *  - any ERC725 based contract (so implementing both ERC725X and ERC725Y)
+     *
+     * @return the address of the linked account
+     */
+    function account() external view returns (address);
+
+    /**
      * @notice get latest nonce for `_from` for channel ID: `_channel`
      * @dev use channel ID = 0 for sequential nonces, any other number for out-of-order execution (= execution in parallel)
      * @param _address caller address

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = 0x6f4df48b;
+bytes4 constant _INTERFACEID_LSP6 = 0x32e6d0ab;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -15,6 +15,6 @@ contract LSP6KeyManager is LSP6KeyManagerCore {
      * @param _account The address of the ER725Account to control
      */
     constructor(address _account) {
-        account = ERC725(_account);
+        account = _account;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.6;
 
 // modules
+import "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
 import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-import "@erc725/smart-contracts/contracts/ERC725.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 // interfaces
@@ -69,7 +69,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     using ECDSA for bytes32;
     using ERC165Checker for address;
 
-    ERC725 public account;
+    address public override account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
 
     /**
@@ -112,7 +112,8 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     {
         address recoveredAddress = ECDSA.recover(_hash, _signature);
         return
-            (_PERMISSION_SIGN & account.getPermissionsFor(recoveredAddress)) ==
+            (_PERMISSION_SIGN &
+                ERC725Y(account).getPermissionsFor(recoveredAddress)) ==
                 _PERMISSION_SIGN
                 ? _INTERFACEID_ERC1271
                 : _ERC1271_FAILVALUE;
@@ -236,7 +237,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         bytes4 erc725Function = bytes4(_data[:4]);
 
         // get the permissions of the caller
-        bytes32 permissions = account.getPermissionsFor(_from);
+        bytes32 permissions = ERC725Y(account).getPermissionsFor(_from);
 
         // skip permissions check if caller has all permissions (except SIGN as not required)
         if (permissions.includesPermissions(_ALL_EXECUTION_PERMISSIONS)) {
@@ -248,7 +249,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
 
         if (erc725Function == setDataMultipleSelector) {
             _verifyCanSetData(_from, permissions, _data);
-        } else if (erc725Function == account.execute.selector) {
+        } else if (erc725Function == IERC725X.execute.selector) {
             _verifyCanExecute(_from, permissions, _data);
 
             address to = address(bytes20(_data[48:68]));
@@ -262,7 +263,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
                     _verifyAllowedFunction(_from, bytes4(_data[164:168]));
                 }
             }
-        } else if (erc725Function == account.transferOwnership.selector) {
+        } else if (erc725Function == OwnableUnset.transferOwnership.selector) {
             if (!permissions.includesPermissions(_PERMISSION_CHANGEOWNER))
                 revert NotAuthorised(_from, "TRANSFEROWNERSHIP");
         } else {
@@ -464,7 +465,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @param _to the address to interact with
      */
     function _verifyAllowedAddress(address _from, address _to) internal view {
-        bytes memory allowedAddresses = account.getAllowedAddressesFor(_from);
+        bytes memory allowedAddresses = ERC725Y(account).getAllowedAddressesFor(
+            _from
+        );
 
         // whitelist any address if nothing in the list
         if (allowedAddresses.length == 0) return;
@@ -519,7 +522,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         internal
         view
     {
-        bytes memory allowedFunctions = account.getAllowedFunctionsFor(_from);
+        bytes memory allowedFunctions = ERC725Y(account).getAllowedFunctionsFor(
+            _from
+        );
 
         // whitelist any function if nothing in the list
         if (allowedFunctions.length == 0) return;
@@ -535,12 +540,12 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         revert NotAllowedFunction(_from, _functionSelector);
     }
 
-    function _validateERC725Selector(bytes4 _selector) internal view {
+    function _validateERC725Selector(bytes4 _selector) internal pure {
         // prettier-ignore
         require(
             _selector == setDataMultipleSelector ||
             _selector == IERC725X.execute.selector ||
-            _selector == account.transferOwnership.selector,
+            _selector == OwnableUnset.transferOwnership.selector,
             "_validateERC725Selector: invalid ERC725 selector"
         );
     }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -18,7 +18,7 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 
 // constants
-import {_INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
+import {_INTERFACEID_ERC1271, _ERC1271_MAGICVALUE, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
 import "./LSP6Constants.sol";
 
 /**
@@ -110,12 +110,14 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         returns (bytes4 magicValue)
     {
         address recoveredAddress = ECDSA.recover(_hash, _signature);
-        return
-            (_PERMISSION_SIGN &
-                ERC725Y(account).getPermissionsFor(recoveredAddress)) ==
-                _PERMISSION_SIGN
-                ? _INTERFACEID_ERC1271
-                : _ERC1271_FAILVALUE;
+
+        return (
+            ERC725Y(account)
+                .getPermissionsFor(recoveredAddress)
+                .includesPermissions(_PERMISSION_SIGN)
+                ? _ERC1271_MAGICVALUE
+                : _ERC1271_FAILVALUE
+        );
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -18,9 +18,8 @@ import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 
 // constants
+import {_INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
 import "./LSP6Constants.sol";
-import "../LSP0ERC725Account/LSP0Constants.sol";
-import "@erc725/smart-contracts/contracts/constants.sol";
 
 /**
  * @dev revert when address `from` does not have any permissions set

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -16,6 +16,6 @@ abstract contract LSP6KeyManagerInitAbstract is
     LSP6KeyManagerCore
 {
     function _initialize(address _account) internal virtual onlyInitializing {
-        account = ERC725(_account);
+        account = _account;
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces a breaking in the LSP6 interface. changing LSP6 interface ID.

- **LSP6 interface ID (before):** `0x6f4df48b `
- **LSP6 interface ID (after):**  `0x32e6d0ab `

## Features

- [x] add the standard `account()` function to return the `address` of the ERC725 account contract linked with this KeyManager.

## Refactoring

- [x] wrap contract calls to get permissions from storage within `ERC725Y(account)`.
- [x] use import statements with curly braces to import specific symbols from files.
- [x] improve readability of `isValidSignature(...)` function by using `LSP6Utils` library.