### PR TITLE
feat: use custom version of `ERC165Checker`

### DIFF
--- a/contracts/Helpers/ERC165CheckerCustomTest.sol
+++ b/contracts/Helpers/ERC165CheckerCustomTest.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../Utils/ERC165CheckerCustom.sol";
+
+/**
+ * @dev Contract used to test the custom implementation of ERC165Checker
+ */
+contract ERC165CheckerCustomTest {
+    function supportsERC165Interface(address account, bytes4 interfaceId)
+        public
+        view
+        returns (bool)
+    {
+        return
+            ERC165CheckerCustom.supportsERC165Interface(account, interfaceId);
+    }
+}

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -13,8 +13,7 @@ import "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 
 // libraries
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-
+import "../Utils/ERC165CheckerCustom.sol";
 // constants
 import "../LSP0ERC725Account/LSP0Constants.sol";
 import "../LSP1UniversalReceiver/LSP1Constants.sol";
@@ -69,7 +68,10 @@ abstract contract LSP0ERC725AccountCore is
         // if OWNER is a contract
         if (_owner.code.length != 0) {
             return
-                ERC165Checker.supportsInterface(_owner, _INTERFACEID_ERC1271)
+                ERC165CheckerCustom.supportsERC165Interface(
+                    _owner,
+                    _INTERFACEID_ERC1271
+                )
                     ? IERC1271(_owner).isValidSignature(_hash, _signature)
                     : _ERC1271_FAILVALUE;
             // if OWNER is a key
@@ -98,7 +100,7 @@ abstract contract LSP0ERC725AccountCore is
         if (data.length >= 20) {
             address universalReceiverDelegate = BytesLib.toAddress(data, 0);
             if (
-                ERC165Checker.supportsInterface(
+                ERC165CheckerCustom.supportsERC165Interface(
                     universalReceiverDelegate,
                     _INTERFACEID_LSP1_DELEGATE
                 )

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -9,7 +9,7 @@ import "../../../LSP6KeyManager/LSP6KeyManager.sol";
 import "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "../../../Utils/ERC165CheckerCustom.sol";
 import "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 import "../../../LSP5ReceivedAssets/LSP5Utils.sol";
 import "../../LSP1Utils.sol";
@@ -21,7 +21,6 @@ import "../../LSP1Constants.sol";
  * @dev Function logic to add and remove the MapAndArrayKey of incoming assets and vaults
  */
 abstract contract TokenAndVaultHandling {
-
     // internal functions
     function _tokenAndVaultHandling(address sender, bytes32 typeId)
         internal
@@ -30,8 +29,12 @@ abstract contract TokenAndVaultHandling {
         if (sender.code.length == 0) return "";
 
         address keyManager = ERC725Y(msg.sender).owner();
-        if (!ERC165Checker.supportsInterface(keyManager, _INTERFACEID_LSP6))
-            return "";
+        if (
+            !ERC165CheckerCustom.supportsERC165Interface(
+                keyManager,
+                _INTERFACEID_LSP6
+            )
+        ) return "";
         address accountAddress = address(LSP6KeyManager(keyManager).account());
         // check if the caller is the same account controlled by the keyManager
         if (msg.sender != accountAddress) return "";

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -9,7 +9,7 @@ import "../../../LSP6KeyManager/LSP6KeyManager.sol";
 import "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "../../../Utils/ERC165CheckerCustom.sol";
 import "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 import "../../../LSP5ReceivedAssets/LSP5Utils.sol";
 import "../../LSP1Utils.sol";
@@ -21,7 +21,6 @@ import "../../LSP1Constants.sol";
  * @dev Function logic to add and remove the MapAndArrayKey of incoming assets and vaults
  */
 abstract contract TokenHandling {
-
     // internal functions
     function _tokenHandling(address sender, bytes32 typeId)
         internal
@@ -29,8 +28,12 @@ abstract contract TokenHandling {
     {
         if (sender.code.length == 0) return "";
 
-        if (!ERC165Checker.supportsInterface(msg.sender, _INTERFACEID_LSP9))
-            return "";
+        if (
+            !ERC165CheckerCustom.supportsERC165Interface(
+                msg.sender,
+                _INTERFACEID_LSP9
+            )
+        ) return "";
 
         (
             bool senderHook,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -14,7 +14,7 @@ import "./LSP6Utils.sol";
 
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "../Utils/ERC165CheckerCustom.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 
 // constants
@@ -67,7 +67,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     using LSP6Utils for *;
     using Address for address;
     using ECDSA for bytes32;
-    using ERC165Checker for address;
+    using ERC165CheckerCustom for address;
 
     ERC725 public account;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
@@ -503,7 +503,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         );
 
         for (uint256 ii = 0; ii < allowedStandardsList.length; ii++) {
-            if (_to.supportsInterface(allowedStandardsList[ii])) return;
+            if (_to.supportsERC165Interface(allowedStandardsList[ii])) return;
         }
         revert("Not Allowed Standards");
     }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -17,7 +17,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
 // library
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import "../Utils/ERC165CheckerCustom.sol";
 
 /**
  * @title LSP7DigitalAsset contract
@@ -379,8 +379,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bytes memory data
     ) internal virtual {
         if (
-            ERC165Checker.supportsERC165(from) &&
-            ERC165Checker.supportsInterface(from, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)
         ) {
             bytes memory packedData = abi.encodePacked(from, to, amount, data);
             ILSP1UniversalReceiver(from).universalReceiver(
@@ -404,8 +403,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bytes memory data
     ) internal virtual {
         if (
-            ERC165Checker.supportsERC165(to) &&
-            ERC165Checker.supportsInterface(to, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)
         ) {
             bytes memory packedData = abi.encodePacked(from, to, amount, data);
             ILSP1UniversalReceiver(to).universalReceiver(

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -12,8 +12,7 @@ import "./ILSP8IdentifiableDigitalAsset.sol";
 
 // libraries
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-
+import "../Utils/ERC165CheckerCustom.sol";
 // constants
 import "./LSP8Constants.sol";
 import "../LSP1UniversalReceiver/LSP1Constants.sol";
@@ -453,8 +452,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes memory data
     ) internal virtual {
         if (
-            ERC165Checker.supportsERC165(from) &&
-            ERC165Checker.supportsInterface(from, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)
         ) {
             bytes memory packedData = abi.encodePacked(from, to, tokenId, data);
             ILSP1UniversalReceiver(from).universalReceiver(
@@ -478,8 +476,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes memory data
     ) internal virtual {
         if (
-            ERC165Checker.supportsERC165(to) &&
-            ERC165Checker.supportsInterface(to, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)
         ) {
             bytes memory packedData = abi.encodePacked(from, to, tokenId, data);
             ILSP1UniversalReceiver(to).universalReceiver(

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -10,8 +10,7 @@ import "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 import "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // library
-import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-
+import "../Utils/ERC165CheckerCustom.sol";
 // constants
 import "../LSP1UniversalReceiver/LSP1Constants.sol";
 import "./LSP9Constants.sol";
@@ -22,7 +21,6 @@ import "./LSP9Constants.sol";
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
 contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
-
     /**
      * @notice Emitted when a native token is received
      * @param sender The address of the sender
@@ -41,7 +39,7 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
                 bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY))
             );
             require(
-                ERC165Checker.supportsInterface(
+                ERC165CheckerCustom.supportsERC165Interface(
                     msg.sender,
                     _INTERFACEID_LSP1_DELEGATE
                 ) && msg.sender == universalReceiverAddress,
@@ -79,7 +77,7 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
         if (data.length >= 20) {
             address universalReceiverDelegate = BytesLib.toAddress(data, 0);
             if (
-                ERC165Checker.supportsInterface(
+                ERC165CheckerCustom.supportsERC165Interface(
                     universalReceiverDelegate,
                     _INTERFACEID_LSP1_DELEGATE
                 )
@@ -99,8 +97,10 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      */
     function _notifyVaultSender(address _sender) internal virtual {
         if (
-            ERC165Checker.supportsERC165(_sender) &&
-            ERC165Checker.supportsInterface(_sender, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(
+                _sender,
+                _INTERFACEID_LSP1
+            )
         ) {
             ILSP1UniversalReceiver(_sender).universalReceiver(
                 _TYPEID_LSP9_VAULTSENDER,
@@ -114,8 +114,10 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      */
     function _notifyVaultReceiver(address _receiver) internal virtual {
         if (
-            ERC165Checker.supportsERC165(_receiver) &&
-            ERC165Checker.supportsInterface(_receiver, _INTERFACEID_LSP1)
+            ERC165CheckerCustom.supportsERC165Interface(
+                _receiver,
+                _INTERFACEID_LSP1
+            )
         ) {
             ILSP1UniversalReceiver(_receiver).universalReceiver(
                 _TYPEID_LSP9_VAULTRECIPIENT,

--- a/contracts/Utils/ERC165CheckerCustom.sol
+++ b/contracts/Utils/ERC165CheckerCustom.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/introspection/ERC165Checker.sol)
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @dev Library used to query support of an interface declared via {IERC165}.
+ *
+ * Note that these functions return the actual result of the query: they do not
+ * `revert` if an interface is not supported. It is up to the caller to decide
+ * what to do in these cases.
+ */
+library ERC165CheckerCustom {
+    // As per the EIP-165 spec, no interface should ever match 0xffffffff
+    bytes4 private constant _INTERFACE_ID_INVALID = 0xffffffff;
+
+    /**
+     * @dev Returns true if `account` supports the {IERC165} interface,
+     */
+    function supportsERC165(address account) internal view returns (bool) {
+        // Any contract that implements ERC165 must explicitly indicate support of
+        // InterfaceId_ERC165 and explicitly indicate non-support of InterfaceId_Invalid
+        return
+            supportsERC165Interface(account, type(IERC165).interfaceId) &&
+            !supportsERC165Interface(account, _INTERFACE_ID_INVALID);
+    }
+
+    /**
+     * @dev Returns true if `account` supports the interface defined by
+     * `interfaceId`. Support for {IERC165} itself is queried automatically.
+     *
+     * See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(address account, bytes4 interfaceId)
+        internal
+        view
+        returns (bool)
+    {
+        // query support of both ERC165 as per the spec and support of _interfaceId
+        return
+            supportsERC165(account) &&
+            supportsERC165Interface(account, interfaceId);
+    }
+
+    /**
+     * @dev Returns a boolean array where each value corresponds to the
+     * interfaces passed in and whether they're supported or not. This allows
+     * you to batch check interfaces for a contract where your expectation
+     * is that some interfaces may not be supported.
+     *
+     * See {IERC165-supportsInterface}.
+     *
+     * _Available since v3.4._
+     */
+    function getSupportedInterfaces(
+        address account,
+        bytes4[] memory interfaceIds
+    ) internal view returns (bool[] memory) {
+        // an array of booleans corresponding to interfaceIds and whether they're supported or not
+        bool[] memory interfaceIdsSupported = new bool[](interfaceIds.length);
+
+        // query support of ERC165 itself
+        if (supportsERC165(account)) {
+            // query support of each interface in interfaceIds
+            for (uint256 i = 0; i < interfaceIds.length; i++) {
+                interfaceIdsSupported[i] = supportsERC165Interface(
+                    account,
+                    interfaceIds[i]
+                );
+            }
+        }
+
+        return interfaceIdsSupported;
+    }
+
+    /**
+     * @dev Returns true if `account` supports all the interfaces defined in
+     * `interfaceIds`. Support for {IERC165} itself is queried automatically.
+     *
+     * Batch-querying can lead to gas savings by skipping repeated checks for
+     * {IERC165} support.
+     *
+     * See {IERC165-supportsInterface}.
+     */
+    function supportsAllInterfaces(
+        address account,
+        bytes4[] memory interfaceIds
+    ) internal view returns (bool) {
+        // query support of ERC165 itself
+        if (!supportsERC165(account)) {
+            return false;
+        }
+
+        // query support of each interface in _interfaceIds
+        for (uint256 i = 0; i < interfaceIds.length; i++) {
+            if (!supportsERC165Interface(account, interfaceIds[i])) {
+                return false;
+            }
+        }
+
+        // all interfaces supported
+        return true;
+    }
+
+    /**
+     * @notice Query if a contract implements an interface, does not check ERC165 support
+     * @param account The address of the contract to query for support of an interface
+     * @param interfaceId The interface identifier, as specified in ERC-165
+     * @return true if the contract at account indicates support of the interface with
+     * identifier interfaceId, false otherwise
+     * @dev Assumes that account contains a contract that supports ERC165, otherwise
+     * the behavior of this method is undefined. This precondition can be checked
+     * with {supportsERC165}.
+     * Interface identification is specified in ERC-165.
+     */
+    function supportsERC165Interface(address account, bytes4 interfaceId)
+        internal
+        view
+        returns (bool)
+    {
+        bytes memory encodedParams = abi.encodeWithSelector(
+            IERC165.supportsInterface.selector,
+            interfaceId
+        );
+        (bool success, bytes memory result) = account.staticcall{gas: 30000}(
+            encodedParams
+        );
+        if (result.length < 32) return false;
+        return success && abi.decode(result, (bool));
+    }
+}

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -1,0 +1,81 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
+import {
+  ERC165CheckerCustomTest,
+  ERC165CheckerCustomTest__factory,
+  TargetContract,
+  TargetContract__factory,
+  ERC725,
+  ERC725__factory,
+  TokenReceiverWithoutLSP1,
+  TokenReceiverWithoutLSP1__factory,
+} from "../../types";
+
+// utils
+import { INTERFACE_IDS } from "../../constants";
+
+
+describe("Test Custom implementation of ERC165Checker", () => {
+  let accounts: SignerWithAddress[];
+  let contract: ERC165CheckerCustomTest;
+  let targetContract: TargetContract;
+  let erc725: ERC725;
+  let contractWithFallback: TokenReceiverWithoutLSP1;
+
+  beforeAll(async () => {
+    accounts = await ethers.getSigners();
+    contract = await new ERC165CheckerCustomTest__factory(accounts[0]).deploy();
+    targetContract = await new TargetContract__factory(accounts[0]).deploy();
+    contractWithFallback = await new TokenReceiverWithoutLSP1__factory(accounts[0]).deploy();
+    erc725 = await new ERC725__factory(accounts[0]).deploy(accounts[0].address);
+  });
+
+  it("Calling an EOA", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      accounts[1].address,
+      INTERFACE_IDS.ERC165
+    );
+    const result2 = await contract.supportsERC165Interface(
+      accounts[1].address,
+      INTERFACE_IDS.LSP8
+    );
+    expect(result1).toBeFalsy();
+    expect(result2).toBeFalsy();
+  });
+
+  it("Calling a contract without a fallback function that doesn't support ERC165", async () => {
+    const result = await contract.supportsERC165Interface(
+      targetContract.address,
+      INTERFACE_IDS.ERC165
+    );
+    expect(result).toBeFalsy();
+  });
+
+  it("Calling a contract with a fallback function that doesn't support ERC165", async () => {
+    const result = await contract.supportsERC165Interface(
+      contractWithFallback.address,
+      INTERFACE_IDS.ERC165
+    );
+    expect(result).toBeFalsy();
+  });
+
+  it("Calling a contract that support ERC165 and ERC725X but doesn't support LSP1", async () => {
+    const ERC165result = await contract.supportsERC165Interface(
+      erc725.address,
+      INTERFACE_IDS.ERC165
+    );
+    expect(ERC165result).toBeTruthy();
+
+    const ERC725Xresult = await contract.supportsERC165Interface(
+      erc725.address,
+      INTERFACE_IDS.ERC725X
+    );
+    expect(ERC725Xresult).toBeTruthy();
+
+    const LSP1result = await contract.supportsERC165Interface(
+      erc725.address,
+      INTERFACE_IDS.LSP1
+    );
+    expect(LSP1result).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## What does this PR introduce?
After discussing with @CJ42 about the gas cost of `ERC165Checker` which is approximately **~10k gas unit**, we decided to create a custom implementation of `ERC165Checker` that only checks for the InterfaceID we want to query and drop checking the ERC165 and `0xffffffff` InterfaceIDs. 

It will save **~3,1k gas unit** on each call, resulting in a **~31k gas unit** saving on a normal token transfer scenario.