### PR TITLE
build: increase number of runs for Solidity optimizer

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -49,7 +49,7 @@ const config: HardhatUserConfig = {
          * values will optimize more for high-frequency usage.
          * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
          */
-        runs: 1000,
+        runs: 10000,
       },
     },
   },


### PR DESCRIPTION
# What does this PR introduce?

Increase number of runs to **`10,000`** in the Solidity optimizer, so to optimize for contract interactions rather than deployment.

**gas costs LYX transfer:**
- everything allowed: -147 gas
- one allowed address: -240 gas
- one allowed address + one allowed standard: -348 gas