### PR TITLE
ci: add smart contract version number to commit msg in iOS workflow

### DIFF
--- a/.github/workflows/publish-ios-artifacts.yml
+++ b/.github/workflows/publish-ios-artifacts.yml
@@ -33,5 +33,6 @@ jobs:
           git checkout -b abi-update-release
           cp ../ios/UPContractsAbi.swift universalprofile-ios-sdk/UPContractsAbi.swift
           git add .
-          git commit -m "Automatic publish new contracts abis from lukso-network/lsp-smart-contracts"
+          current_version=$(git describe --tags --abbrev=0)
+          git commit -m "Automatic publish of new contracts ABIs ($current_version) from lukso-network/lsp-smart-contracts"
           git push --set-upstream origin abi-update-release


### PR DESCRIPTION
Command `git describe --tags --abbrev=0` will print version as `v0.5.0`. 
It is saved into the variable and that variable is used in the commit message.

Try this out in console:
```
test_var=$(git describe --tags --abbrev=0)
echo "Test var content: $test_var"
```