### PR TITLE
refactor(lsp6): use bytes4 selector in `Executed` event

### DIFF
--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -11,7 +11,7 @@ interface ILSP6KeyManager is
     IERC1271
     /* is ERC165 */
 {
-    event Executed(uint256 indexed _value, bytes _data);
+    event Executed(uint256 indexed _value, bytes4 _selector);
 
     /**
      * @notice returns the address of the account linked to this KeyManager

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -148,7 +148,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             revert(abi.decode(result_, (string)));
         }
 
-        emit Executed(msg.value, _data);
+        emit Executed(msg.value, bytes4(_data));
         return result_.length > 0 ? abi.decode(result_, (bytes)) : result_;
     }
 
@@ -203,7 +203,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             revert(abi.decode(result_, (string)));
         }
 
-        emit Executed(msg.value, _data);
+        emit Executed(msg.value, bytes4(_data));
         return result_.length > 0 ? abi.decode(result_, (bytes)) : result_;
     }
 


### PR DESCRIPTION
# What does this PR introduce?

Similar to https://github.com/ERC725Alliance/ERC725/pull/98

Save gas by only use the first 4 bytes of the `_data` payload (= function selector) in the `Executed` event in LSP6.