### PR TITLE
tests: add tests for UP to UP interaction + use explicit names for contracts that test internal functions

### DIFF
--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -6,7 +6,7 @@ import "../../LSP6KeyManager/LSP6KeyManager.sol";
 /**
  * Helper contract to test internal functions of the KeyManager
  */
-contract KeyManagerHelper is LSP6KeyManager {
+contract KeyManagerInternalTester is LSP6KeyManager {
     using LSP6Utils for *;
 
     /* solhint-disable no-empty-blocks */

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -5,7 +5,7 @@ import {
   LSP6KeyManager__factory,
   UniversalProfileInit__factory,
   LSP6KeyManagerInit__factory,
-  KeyManagerHelper__factory,
+  KeyManagerInternalTester__factory,
 } from "../../types";
 
 import { LSP6TestContext } from "../utils/context";
@@ -65,11 +65,12 @@ describe("LSP6KeyManager", () => {
         const universalProfile = await new UniversalProfile__factory(
           owner
         ).deploy(owner.address);
-        const keyManagerHelper = await new KeyManagerHelper__factory(
-          owner
-        ).deploy(universalProfile.address);
+        const keyManagerInternalTester =
+          await new KeyManagerInternalTester__factory(owner).deploy(
+            universalProfile.address
+          );
 
-        return { owner, accounts, universalProfile, keyManagerHelper };
+        return { owner, accounts, universalProfile, keyManagerInternalTester };
       });
     });
   });

--- a/tests/LSP6KeyManager/internals/AllowedAddresses.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedAddresses.internal.ts
@@ -67,9 +67,10 @@ export const testAllowedAddressesInternals = (
 
   describe("`getAllowedAddressesFor(...)`", () => {
     it("should return the same list of allowed addresses", async () => {
-      let bytesResult = await context.keyManagerHelper.getAllowedAddressesFor(
-        canCallOnlyTwoAddresses.address
-      );
+      let bytesResult =
+        await context.keyManagerInternalTester.getAllowedAddressesFor(
+          canCallOnlyTwoAddresses.address
+        );
 
       let decodedResult = abiCoder.decode(["address[]"], bytesResult);
 
@@ -82,9 +83,10 @@ export const testAllowedAddressesInternals = (
     });
 
     it("should return no bytes when no allowed addresses are set", async () => {
-      let bytesResult = await context.keyManagerHelper.getAllowedAddressesFor(
-        context.owner.address
-      );
+      let bytesResult =
+        await context.keyManagerInternalTester.getAllowedAddressesFor(
+          context.owner.address
+        );
       expect([bytesResult]).toEqual(["0x"]);
 
       let resultFromAccount = await context.universalProfile[
@@ -99,11 +101,11 @@ export const testAllowedAddressesInternals = (
 
   describe("`verifyAllowedAddressesFor(...)`", () => {
     it("should not revert for address listed in allowed addresses list", async () => {
-      await context.keyManagerHelper.verifyAllowedAddress(
+      await context.keyManagerInternalTester.verifyAllowedAddress(
         canCallOnlyTwoAddresses.address,
         allowedEOA.address
       );
-      await context.keyManagerHelper.verifyAllowedAddress(
+      await context.keyManagerInternalTester.verifyAllowedAddress(
         canCallOnlyTwoAddresses.address,
         allowedTargetContract.address
       );
@@ -115,7 +117,7 @@ export const testAllowedAddressesInternals = (
       );
 
       try {
-        await context.keyManagerHelper.verifyAllowedAddress(
+        await context.keyManagerInternalTester.verifyAllowedAddress(
           canCallOnlyTwoAddresses.address,
           disallowedAddress
         );
@@ -132,7 +134,7 @@ export const testAllowedAddressesInternals = (
     it("should not revert when user has no address listed (= all addresses whitelisted)", async () => {
       let randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
-      await context.keyManagerHelper.verifyAllowedAddress(
+      await context.keyManagerInternalTester.verifyAllowedAddress(
         context.owner.address,
         randomAddress
       );

--- a/tests/LSP6KeyManager/internals/AllowedFunctions.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedFunctions.internal.ts
@@ -54,7 +54,7 @@ export const testAllowedFunctionsInternals = (
 
   it("should return the right list of allowed functions", async () => {
     let bytesResult =
-      await context.keyManagerHelper.callStatic.getAllowedFunctionsFor(
+      await context.keyManagerInternalTester.callStatic.getAllowedFunctionsFor(
         addressCanCallOnlyOneFunction.address
       );
     let decodedResult = abiCoder.decode(["bytes4[]"], bytesResult);
@@ -81,9 +81,10 @@ export const testAllowedFunctionsInternals = (
   });
 
   it("should return an empty byte when address has no allowed functions listed", async () => {
-    let bytesResult = await context.keyManagerHelper.getAllowedFunctionsFor(
-      context.owner.address
-    );
+    let bytesResult =
+      await context.keyManagerInternalTester.getAllowedFunctionsFor(
+        context.owner.address
+      );
     expect([bytesResult]).toEqual(["0x"]);
 
     let resultFromAccount = await context.universalProfile["getData(bytes32)"](

--- a/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
+++ b/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
@@ -50,13 +50,15 @@ export const testReadingPermissionsInternals = (
 
     it("Should return ALL_PERMISSIONS for owner", async () => {
       expect(
-        await context.keyManagerHelper.getPermissionsFor(context.owner.address)
+        await context.keyManagerInternalTester.getPermissionsFor(
+          context.owner.address
+        )
       ).toEqual(ALL_PERMISSIONS_SET); // ALL_PERMISSIONS = "0xffff..."
     });
 
     it("Should return SETDATA", async () => {
       expect(
-        await context.keyManagerHelper.getPermissionsFor(
+        await context.keyManagerInternalTester.getPermissionsFor(
           addressCanSetData.address
         )
       ).toEqual(ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32));
@@ -64,7 +66,7 @@ export const testReadingPermissionsInternals = (
 
     it("Should return SETDATA + CALL", async () => {
       expect(
-        await context.keyManagerHelper.getPermissionsFor(
+        await context.keyManagerInternalTester.getPermissionsFor(
           addressCanSetDataAndCall.address
         )
       ).toEqual(
@@ -112,21 +114,21 @@ export const testReadingPermissionsInternals = (
     });
 
     it("should cast permissions to 32 bytes when reading permissions stored as more than 32 empty bytes", async () => {
-      const result = await context.keyManagerHelper.getPermissionsFor(
+      const result = await context.keyManagerInternalTester.getPermissionsFor(
         moreThan32EmptyBytes.address
       );
       expect(result).toEqual(expectedEmptyPermission);
     });
 
     it("should cast permissions to 32 bytes when reading permissions stored as less than 32 empty bytes", async () => {
-      const result = await context.keyManagerHelper.getPermissionsFor(
+      const result = await context.keyManagerInternalTester.getPermissionsFor(
         lessThan32EmptyBytes.address
       );
       expect(result).toEqual(expectedEmptyPermission);
     });
 
     it("should cast permissions to 32 bytes when reading permissions stored as one empty byte", async () => {
-      const result = await context.keyManagerHelper.getPermissionsFor(
+      const result = await context.keyManagerInternalTester.getPermissionsFor(
         oneEmptyByte.address
       );
       expect(result).toEqual(expectedEmptyPermission);
@@ -157,12 +159,13 @@ export const testReadingPermissionsInternals = (
     });
 
     it("Should return true when checking if has permission SETDATA", async () => {
-      let appPermissions = await context.keyManagerHelper.getPermissionsFor(
-        addressCanSetData.address
-      );
+      let appPermissions =
+        await context.keyManagerInternalTester.getPermissionsFor(
+          addressCanSetData.address
+        );
 
       expect(
-        await context.keyManagerHelper.includesPermissions(
+        await context.keyManagerInternalTester.includesPermissions(
           appPermissions,
           ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32)
         )

--- a/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
+++ b/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
@@ -135,7 +135,7 @@ export const testReadingPermissionsInternals = (
     });
   });
 
-  describe("`hasPermissions(...)`", () => {
+  describe("`includesPermissions(...)`", () => {
     let addressCanSetData: SignerWithAddress;
 
     beforeAll(async () => {

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -114,9 +114,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await context.keyManager.connect(context.owner).execute(payload);
 
-          const result = await context.universalProfile.callStatic[
-            "getData(bytes32)"
-          ](key);
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(
             ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32)
           );
@@ -136,9 +135,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await context.keyManager.connect(context.owner).execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -153,9 +151,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await context.keyManager.connect(context.owner).execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -170,9 +167,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await context.keyManager.connect(context.owner).execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -192,9 +188,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await context.keyManager.connect(context.owner).execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(ethers.utils.getAddress(result)).toEqual(value);
         });
       });
@@ -218,9 +213,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canOnlyAddPermissions)
             .execute(payload);
 
-          const result = await context.universalProfile.callStatic[
-            "getData(bytes32)"
-          ](key);
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -263,9 +257,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canOnlyAddPermissions)
             .execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -391,9 +384,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canOnlyChangePermissions)
             .execute(payload);
 
-          const result = await context.universalProfile.callStatic[
-            "getData(bytes32)"
-          ](key);
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -433,9 +425,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canOnlyChangePermissions)
             .execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(result).toEqual(value);
         });
 
@@ -457,9 +448,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canOnlyChangePermissions)
             .execute(payload);
 
-          const result = await context.universalProfile["getData(bytes32)"](
-            key
-          );
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
           expect(ethers.utils.getAddress(result)).toEqual(value);
         });
       });
@@ -590,7 +580,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       /**
-       *  @todo should test that an address with only the permisssion SETDATA
+       *  @todo should test that an address with only the permission SETDATA
        * cannot add or edit permissions
        */
     });
@@ -679,9 +669,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
 
@@ -716,9 +706,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
 
@@ -752,9 +742,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
       });
@@ -793,9 +783,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .connect(canSetDataAndAddPermissions)
             .execute(payload);
 
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
 
@@ -960,9 +949,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           await context.keyManager
             .connect(canSetDataAndChangePermissions)
             .execute(payload);
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
 
@@ -999,9 +988,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           await context.keyManager
             .connect(canSetDataAndChangePermissions)
             .execute(payload);
-          const fetchedResult = await context.universalProfile[
-            "getData(bytes32[])"
-          ](keys);
+
+          // prettier-ignore
+          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
           expect(fetchedResult).toEqual(values);
         });
 

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -575,7 +575,7 @@ export const shouldBehaveLikePermissionSetData = (
     });
   });
 
-  describe.only("when caller is another UniversalProfile (with a KeyManager attached as owner)", () => {
+  describe("when caller is another UniversalProfile (with a KeyManager attached as owner)", () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -614,6 +614,7 @@ export const shouldBehaveLikePermissionSetData = (
         alicePermissionKeys,
         alicePermissionValues
       );
+
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
     });
 
@@ -622,7 +623,9 @@ export const shouldBehaveLikePermissionSetData = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         alice.address.substring(2);
 
-      const [result] = await aliceContext.universalProfile.getData([key]);
+      const result = await aliceContext.universalProfile["getData(bytes32)"](
+        key
+      );
       expect(result).toEqual(ALL_PERMISSIONS_SET);
     });
 
@@ -631,7 +634,7 @@ export const shouldBehaveLikePermissionSetData = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         bob.address.substring(2);
 
-      const [result] = await bobContext.universalProfile.getData([key]);
+      const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(ALL_PERMISSIONS_SET);
     });
 
@@ -640,7 +643,7 @@ export const shouldBehaveLikePermissionSetData = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         aliceContext.universalProfile.address.substring(2);
 
-      const [result] = await bobContext.universalProfile.getData([key]);
+      const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32));
     });
 
@@ -651,10 +654,10 @@ export const shouldBehaveLikePermissionSetData = (
       );
 
       let finalSetDataPayload =
-        bobContext.universalProfile.interface.encodeFunctionData("setData", [
-          [key],
-          [value],
-        ]);
+        bobContext.universalProfile.interface.encodeFunctionData(
+          "setData(bytes32[],bytes[])",
+          [[key], [value]]
+        );
 
       let bobKeyManagerPayload =
         bobContext.keyManager.interface.encodeFunctionData("execute", [
@@ -675,7 +678,7 @@ export const shouldBehaveLikePermissionSetData = (
       let receipt = await tx.wait();
       console.log("gas used: ", receipt.gasUsed.toNumber());
 
-      const [result] = await bobContext.universalProfile.getData([key]);
+      const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(value);
     });
   });

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -10,6 +10,7 @@ import {
   ALL_PERMISSIONS_SET,
   PERMISSIONS,
   BasicUPSetup_Schema,
+  OPERATIONS,
 } from "../../../constants";
 
 // setup
@@ -22,6 +23,7 @@ import {
   getRandomAddresses,
   NotAuthorisedError,
 } from "../../utils/helpers";
+import { Signer } from "ethers";
 
 export const shouldBehaveLikePermissionSetData = (
   buildContext: () => Promise<LSP6TestContext>
@@ -570,6 +572,111 @@ export const shouldBehaveLikePermissionSetData = (
         ](key);
         expect(newStorage).toEqual(value);
       });
+    });
+  });
+
+  describe.only("when caller is another UniversalProfile (with a KeyManager attached as owner)", () => {
+    // UP making the call
+    let alice: SignerWithAddress;
+    let aliceContext: LSP6TestContext;
+
+    // UP being called
+    let bob: SignerWithAddress;
+    let bobContext: LSP6TestContext;
+
+    beforeAll(async () => {
+      aliceContext = await buildContext();
+      alice = aliceContext.accounts[0];
+
+      bobContext = await buildContext();
+      bob = bobContext.accounts[1];
+
+      const alicePermissionKeys = [
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          alice.address.substring(2),
+      ];
+      const alicePermissionValues = [ALL_PERMISSIONS_SET];
+
+      const bobPermissionKeys = [
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          bob.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          aliceContext.universalProfile.address.substring(2),
+      ];
+
+      const bobPermissionValues = [
+        ALL_PERMISSIONS_SET,
+        ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+      ];
+
+      await setupKeyManager(
+        aliceContext,
+        alicePermissionKeys,
+        alicePermissionValues
+      );
+      await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
+    });
+
+    it("Alice should have ALL PERMISSIONS in her UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        alice.address.substring(2);
+
+      const [result] = await aliceContext.universalProfile.getData([key]);
+      expect(result).toEqual(ALL_PERMISSIONS_SET);
+    });
+
+    it("Bob should have ALL PERMISSIONS in his UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        bob.address.substring(2);
+
+      const [result] = await bobContext.universalProfile.getData([key]);
+      expect(result).toEqual(ALL_PERMISSIONS_SET);
+    });
+
+    it("Alice's UP should have permission SETDATA on Bob's UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        aliceContext.universalProfile.address.substring(2);
+
+      const [result] = await bobContext.universalProfile.getData([key]);
+      expect(result).toEqual(ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32));
+    });
+
+    it("Alice's UP should be able to `setData(...)` on Bob's UP", async () => {
+      let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Alice's Key"));
+      let value = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("Alice's Value")
+      );
+
+      let finalSetDataPayload =
+        bobContext.universalProfile.interface.encodeFunctionData("setData", [
+          [key],
+          [value],
+        ]);
+
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalSetDataPayload,
+        ]);
+
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATIONS.CALL,
+          bobContext.keyManager.address,
+          0,
+          bobKeyManagerPayload,
+        ]);
+
+      let tx = await aliceContext.keyManager
+        .connect(alice)
+        .execute(aliceUniversalProfilePayload);
+      let receipt = await tx.wait();
+      console.log("gas used: ", receipt.gasUsed.toNumber());
+
+      const [result] = await bobContext.universalProfile.getData([key]);
+      expect(result).toEqual(value);
     });
   });
 };

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -311,4 +311,135 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
   });
+
+  describe.only("when caller is another UP (with a KeyManager as owner)", () => {
+    // UP making the call
+    let alice: SignerWithAddress;
+    let aliceContext: LSP6TestContext;
+
+    // UP being called
+    let bob: SignerWithAddress;
+    let bobContext: LSP6TestContext;
+
+    beforeAll(async () => {
+      aliceContext = await buildContext();
+      alice = aliceContext.accounts[0];
+
+      bobContext = await buildContext();
+      bob = bobContext.accounts[1];
+
+      const alicePermissionKeys = [
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          alice.address.substring(2),
+      ];
+      const alicePermissionValues = [ALL_PERMISSIONS_SET];
+
+      const bobPermissionKeys = [
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          bob.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          aliceContext.universalProfile.address.substring(2),
+      ];
+
+      const bobPermissionValues = [
+        ALL_PERMISSIONS_SET,
+        ethers.utils.hexZeroPad(
+          PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE,
+          32
+        ),
+      ];
+
+      await setupKeyManager(
+        aliceContext,
+        alicePermissionKeys,
+        alicePermissionValues
+      );
+      await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
+
+      // fund Bob's Up with some LYX to be transfered
+      await bob.sendTransaction({
+        to: bobContext.universalProfile.address,
+        value: ethers.utils.parseEther("5"),
+      });
+    });
+
+    it("Alice should have ALL PERMISSIONS in her UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        alice.address.substring(2);
+
+      const [result] = await aliceContext.universalProfile.getData([key]);
+      expect(result).toEqual(ALL_PERMISSIONS_SET);
+    });
+
+    it("Bob should have ALL PERMISSIONS in his UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        bob.address.substring(2);
+
+      const [result] = await bobContext.universalProfile.getData([key]);
+      expect(result).toEqual(ALL_PERMISSIONS_SET);
+    });
+
+    it("Alice's UP should have permission SETDATA on Bob's UP", async () => {
+      let key =
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        aliceContext.universalProfile.address.substring(2);
+
+      const [result] = await bobContext.universalProfile.getData([key]);
+      expect(result).toEqual(
+        ethers.utils.hexZeroPad(
+          PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE,
+          32
+        )
+      );
+    });
+
+    it("Alice should be able to send 5 LYX from Bob's UP to her UP", async () => {
+      let aliceUPBalanceBefore = await provider.getBalance(
+        aliceContext.universalProfile.address
+      );
+      let bobUPBalanceBefore = await provider.getBalance(
+        bobContext.universalProfile.address
+      );
+      expect(aliceUPBalanceBefore).toEqBN(0);
+      expect(bobUPBalanceBefore).toEqBN(ethers.utils.parseEther("5"));
+
+      let finalTransferLyxPayload =
+        bobContext.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATIONS.CALL,
+          aliceContext.universalProfile.address,
+          ethers.utils.parseEther("5"),
+          "0x",
+        ]);
+
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalTransferLyxPayload,
+        ]);
+
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATIONS.CALL,
+          bobContext.keyManager.address,
+          0,
+          bobKeyManagerPayload,
+        ]);
+
+      let tx = await aliceContext.keyManager
+        .connect(alice)
+        .execute(aliceUniversalProfilePayload);
+      let receipt = await tx.wait();
+      console.log("gas used: ", receipt.gasUsed.toNumber());
+
+      let aliceUPBalanceAfter = await provider.getBalance(
+        aliceContext.universalProfile.address
+      );
+      let bobUPBalanceAfter = await provider.getBalance(
+        bobContext.universalProfile.address
+      );
+      expect(aliceUPBalanceAfter).toEqBN(ethers.utils.parseEther("5"));
+      expect(bobUPBalanceAfter).toEqBN(0);
+    });
+  });
 };

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -312,7 +312,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe.only("when caller is another UP (with a KeyManager as owner)", () => {
+  describe("when caller is another UP (with a KeyManager as owner)", () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -368,7 +368,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         alice.address.substring(2);
 
-      const [result] = await aliceContext.universalProfile.getData([key]);
+      // prettier-ignore
+      const result = await aliceContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(ALL_PERMISSIONS_SET);
     });
 
@@ -377,7 +378,7 @@ export const shouldBehaveLikePermissionTransferValue = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         bob.address.substring(2);
 
-      const [result] = await bobContext.universalProfile.getData([key]);
+      const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(ALL_PERMISSIONS_SET);
     });
 
@@ -386,7 +387,7 @@ export const shouldBehaveLikePermissionTransferValue = (
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         aliceContext.universalProfile.address.substring(2);
 
-      const [result] = await bobContext.universalProfile.getData([key]);
+      const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).toEqual(
         ethers.utils.hexZeroPad(
           PERMISSIONS.CALL + PERMISSIONS.TRANSFERVALUE,

--- a/tests/utils/context.ts
+++ b/tests/utils/context.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import {
-  KeyManagerHelper,
+  KeyManagerInternalTester,
   LSP6KeyManager,
   UniversalProfile,
 } from "../../types";
@@ -16,5 +16,5 @@ export type LSP6InternalsTestContext = {
   accounts: SignerWithAddress[];
   owner: SignerWithAddress;
   universalProfile: UniversalProfile;
-  keyManagerHelper: KeyManagerHelper;
+  keyManagerInternalTester: KeyManagerInternalTester;
 };

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -69,7 +69,7 @@ export async function setupKeyManagerHelper(
 
   await _context.universalProfile
     .connect(_context.owner)
-    .transferOwnership(_context.keyManagerHelper.address);
+    .transferOwnership(_context.keyManagerInternalTester.address);
 }
 
 /**

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -163,11 +163,14 @@ export async function getMapAndArrayKeyValues(
   arrayKey: string,
   elementInArray: string
 ) {
-  let [mapValue, arrayLength, elementAddress] = await account.getData([
-    vaultMapKey,
-    arrayKey,
-    elementInArray,
-  ]);
+  // prettier-ignore
+  let [mapValue, arrayLength, elementAddress] = await account["getData(bytes32[])"](
+        [
+            vaultMapKey, 
+            arrayKey, 
+            elementInArray
+        ]
+    );
 
   return [mapValue, arrayLength, elementAddress];
 }


### PR DESCRIPTION
# What does this PR introduce?

- [x] add tests for UP to UP interactions for `setData(...)' + transfer LYX via `execute(...)`
- [x] use more explicit name for Helper contract that test internal functions: ~~`KeyManagerHelper`~~ :x: `KeyManagerInternalTester` ✅ 