### PR TITLE
refactor: re-structure import statements

### DIFF
--- a/contracts/Helpers/ERC165CheckerCustomTest.sol
+++ b/contracts/Helpers/ERC165CheckerCustomTest.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../Utils/ERC165CheckerCustom.sol";
+// libraries
+import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 
 /**
  * @dev Contract used to test the custom implementation of ERC165Checker
@@ -12,7 +13,6 @@ contract ERC165CheckerCustomTest {
         view
         returns (bool)
     {
-        return
-            ERC165CheckerCustom.supportsERC165Interface(account, interfaceId);
+        return ERC165CheckerCustom.supportsERC165Interface(account, interfaceId);
     }
 }

--- a/contracts/Helpers/ERC165Interfaces.sol
+++ b/contracts/Helpers/ERC165Interfaces.sol
@@ -1,8 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+// ERC interfaces
+import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import {IERC777} from "@openzeppelin/contracts/token/ERC777/IERC777.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {IERC223} from "./Tokens/IERC223.sol";
 
 // LSPs interfaces
 import {ILSP1UniversalReceiver as ILSP1} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
@@ -10,15 +18,6 @@ import {ILSP1UniversalReceiverDelegate as ILSP1Delegate} from "../LSP1UniversalR
 import {ILSP6KeyManager as ILSP6} from "../LSP6KeyManager/ILSP6KeyManager.sol";
 import {ILSP7DigitalAsset as ILSP7} from "../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
 import {ILSP8IdentifiableDigitalAsset as ILSP8} from "../LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol";
-
-// ERC interfaces
-import "./Tokens/IERC223.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import "@openzeppelin/contracts/token/ERC777/IERC777.sol";
-import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 // constants
 import {_INTERFACEID_LSP0} from "../LSP0ERC725Account/LSP0Constants.sol";

--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "../UniversalProfile.sol";
-import "../LSP6KeyManager/LSP6KeyManager.sol";
+// modules
+import {UniversalProfile} from "../UniversalProfile.sol";
+import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";
+
+// constants
 import {setDataMultipleSelector} from "../LSP6KeyManager/LSP6Constants.sol";
 
 contract Executor {
@@ -32,11 +35,7 @@ contract Executor {
         keys[0] = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         values[0] = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -48,11 +47,7 @@ contract Executor {
         keys[0] = keccak256(abi.encodePacked("Some Key"));
         values[0] = abi.encodePacked("Some value");
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -67,11 +62,7 @@ contract Executor {
         keys[0] = _key;
         values[0] = _value;
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -90,10 +81,7 @@ contract Executor {
         return _keyManager.execute(erc725Payload);
     }
 
-    function sendOneLyxToRecipient(address _recipient)
-        public
-        returns (bytes memory)
-    {
+    function sendOneLyxToRecipient(address _recipient) public returns (bytes memory) {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(
@@ -118,11 +106,7 @@ contract Executor {
         keys[0] = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         values[0] = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -141,11 +125,7 @@ contract Executor {
         keys[0] = keccak256(abi.encodePacked("Some Key"));
         values[0] = abi.encodePacked("Some value");
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -167,11 +147,7 @@ contract Executor {
         keys[0] = _key;
         values[0] = _value;
 
-        bytes memory erc725Payload = abi.encodeWithSelector(
-            setDataMultipleSelector,
-            keys,
-            values
-        );
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -204,10 +180,7 @@ contract Executor {
         return success;
     }
 
-    function sendOneLyxToRecipientRawCall(address _recipient)
-        public
-        returns (bool)
-    {
+    function sendOneLyxToRecipientRawCall(address _recipient) public returns (bool) {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(

--- a/contracts/Helpers/KeyManager/KeyManagerHelper.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerHelper.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../../LSP6KeyManager/LSP6KeyManager.sol";
+// libraries
+import {LSP6Utils} from "../../LSP6KeyManager/LSP6Utils.sol";
+
+// modules
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {LSP6KeyManager} from "../../LSP6KeyManager/LSP6KeyManager.sol";
 
 /**
  * Helper contract to test internal functions of the KeyManager
@@ -16,40 +21,27 @@ contract KeyManagerHelper is LSP6KeyManager {
         return ERC725Y(account).getPermissionsFor(_address);
     }
 
-    function getAllowedAddressesFor(address _address)
-        public
-        view
-        returns (bytes memory)
-    {
+    function getAllowedAddressesFor(address _address) public view returns (bytes memory) {
         return ERC725Y(account).getAllowedAddressesFor(_address);
     }
 
-    function getAllowedFunctionsFor(address _address)
-        public
-        view
-        returns (bytes memory)
-    {
+    function getAllowedFunctionsFor(address _address) public view returns (bytes memory) {
         return ERC725Y(account).getAllowedFunctionsFor(_address);
     }
 
-    function verifyAllowedAddress(address _sender, address _recipient)
-        public
-        view
-    {
+    function verifyAllowedAddress(address _sender, address _recipient) public view {
         super._verifyAllowedAddress(_sender, _recipient);
     }
 
-    function verifyAllowedFunction(address _sender, bytes4 _function)
-        public
-        view
-    {
+    function verifyAllowedFunction(address _sender, bytes4 _function) public view {
         super._verifyAllowedFunction(_sender, _function);
     }
 
-    function includesPermissions(
-        bytes32 _addressPermission,
-        bytes32 _permissions
-    ) public pure returns (bool) {
+    function includesPermissions(bytes32 _addressPermission, bytes32 _permissions)
+        public
+        pure
+        returns (bool)
+    {
         return _addressPermission.includesPermissions(_permissions);
     }
 }

--- a/contracts/Helpers/NFTStorage.sol
+++ b/contracts/Helpers/NFTStorage.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+// libraries
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 contract NFTStorageMerkle {
     function verifyMerkleProof(

--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+// interfaces
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+
+// modules
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 /**
  * @dev sample contract that implements ERC1271 (Standard Signature Validation Method for Contracts)

--- a/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
+++ b/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
@@ -2,8 +2,12 @@
 
 pragma solidity ^0.8.0;
 
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-import "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+// modules
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {LSP4Compatibility} from "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+
+// constants
+import {_LSP4_TOKEN_NAME_KEY, _LSP4_TOKEN_SYMBOL_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 
 contract LSP4CompatibilityTester is ERC725Y, LSP4Compatibility {
     constructor(

--- a/contracts/Helpers/Tokens/LSP7CappedSupplyInitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CappedSupplyInitTester.sol
@@ -3,7 +3,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol";
+import {LSP7DigitalAssetInitAbstract} from "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
+import {LSP7CappedSupplyInitAbstract} from "../../LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol";
 
 contract LSP7CappedSupplyInitTester is LSP7CappedSupplyInitAbstract {
     function initialize(

--- a/contracts/Helpers/Tokens/LSP7CappedSupplyTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CappedSupplyTester.sol
@@ -3,7 +3,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP7DigitalAsset/extensions/LSP7CappedSupply.sol";
+import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+import {LSP7CappedSupply} from "../../LSP7DigitalAsset/extensions/LSP7CappedSupply.sol";
 
 contract LSP7CappedSupplyTester is LSP7CappedSupply {
     /* solhint-disable no-empty-blocks */
@@ -12,10 +13,7 @@ contract LSP7CappedSupplyTester is LSP7CappedSupply {
         string memory symbol,
         address newOwner,
         uint256 tokenSupplyCap
-    )
-        LSP7DigitalAsset(name, symbol, newOwner, true)
-        LSP7CappedSupply(tokenSupplyCap)
-    {}
+    ) LSP7DigitalAsset(name, symbol, newOwner, true) LSP7CappedSupply(tokenSupplyCap) {}
 
     function mint(address to, uint256 amount) public {
         // using force=true so we can send to EOA in test

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
@@ -3,22 +3,16 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol";
-import "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+import {LSP7CompatibilityForERC20InitAbstract} from "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol";
 
-contract LSP7CompatibilityForERC20InitTester is
-    LSP7CompatibilityForERC20InitAbstract
-{
+contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20InitAbstract {
     function initialize(
         string memory name,
         string memory symbol,
         address newOwner
     ) public virtual initializer {
-        LSP7CompatibilityForERC20InitAbstract._initialize(
-            name,
-            symbol,
-            newOwner
-        );
+        LSP7CompatibilityForERC20InitAbstract._initialize(name, symbol, newOwner);
     }
 
     function mint(

--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20Tester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20Tester.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol";
-import "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+import {LSP7CompatibilityForERC20} from "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol";
+import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
 
 contract LSP7CompatibilityForERC20Tester is LSP7CompatibilityForERC20 {
     /* solhint-disable no-empty-blocks */

--- a/contracts/Helpers/Tokens/LSP7InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7InitTester.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
+// modules
+import {LSP7DigitalAssetInitAbstract} from "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
 
 contract LSP7InitTester is LSP7DigitalAssetInitAbstract {
     function initialize(

--- a/contracts/Helpers/Tokens/LSP7Tester.sol
+++ b/contracts/Helpers/Tokens/LSP7Tester.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
+// modules
+import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
 
 contract LSP7Tester is LSP7DigitalAsset {
     /* solhint-disable no-empty-blocks */

--- a/contracts/Helpers/Tokens/LSP8CappedSupplyInitTester.sol
+++ b/contracts/Helpers/Tokens/LSP8CappedSupplyInitTester.sol
@@ -3,7 +3,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol";
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {LSP8CappedSupplyInitAbstract} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol";
 
 contract LSP8CappedSupplyInitTester is LSP8CappedSupplyInitAbstract {
     function initialize(
@@ -12,11 +13,7 @@ contract LSP8CappedSupplyInitTester is LSP8CappedSupplyInitAbstract {
         address newOwner,
         uint256 tokenSupplyCap
     ) public virtual initializer {
-        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name,
-            symbol,
-            newOwner
-        );
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(name, symbol, newOwner);
         LSP8CappedSupplyInitAbstract._initialize(tokenSupplyCap);
     }
 

--- a/contracts/Helpers/Tokens/LSP8CappedSupplyTester.sol
+++ b/contracts/Helpers/Tokens/LSP8CappedSupplyTester.sol
@@ -3,7 +3,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol";
+import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {LSP8CappedSupply} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol";
 
 contract LSP8CappedSupplyTester is LSP8CappedSupply {
     /* solhint-disable no-empty-blocks */
@@ -12,10 +13,7 @@ contract LSP8CappedSupplyTester is LSP8CappedSupply {
         string memory symbol,
         address newOwner,
         uint256 tokenSupplyCap
-    )
-        LSP8IdentifiableDigitalAsset(name, symbol, newOwner)
-        LSP8CappedSupply(tokenSupplyCap)
-    {}
+    ) LSP8IdentifiableDigitalAsset(name, symbol, newOwner) LSP8CappedSupply(tokenSupplyCap) {}
 
     function mint(address to, bytes32 tokenId) public {
         _mint(to, tokenId, true, "token printer go brrr");

--- a/contracts/Helpers/Tokens/LSP8CompatibilityForERC721Tester.sol
+++ b/contracts/Helpers/Tokens/LSP8CompatibilityForERC721Tester.sol
@@ -3,8 +3,11 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol";
-import "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {LSP8CompatibilityForERC721} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol";
+
+// constants
+import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 
 contract LSP8CompatibilityForERC721Tester is LSP8CompatibilityForERC721 {
     constructor(
@@ -25,10 +28,7 @@ contract LSP8CompatibilityForERC721Tester is LSP8CompatibilityForERC721 {
         _mint(to, bytes32(tokenId), true, data);
     }
 
-    function burn(
-        uint256 tokenId,
-        bytes calldata data
-    ) public {
+    function burn(uint256 tokenId, bytes calldata data) public {
         _burn(bytes32(tokenId), data);
     }
 }

--- a/contracts/Helpers/Tokens/LSP8CompatibilityForERC721TesterInit.sol
+++ b/contracts/Helpers/Tokens/LSP8CompatibilityForERC721TesterInit.sol
@@ -3,23 +3,20 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol";
-import "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {LSP8CompatibilityForERC721InitAbstract} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol";
 
-contract LSP8CompatibilityForERC721InitTester is
-    LSP8CompatibilityForERC721InitAbstract
-{
+// constants
+import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+
+contract LSP8CompatibilityForERC721InitTester is LSP8CompatibilityForERC721InitAbstract {
     function initialize(
         string memory name,
         string memory symbol,
         address newOwner,
         bytes memory tokenURIValue
     ) public virtual initializer {
-        LSP8CompatibilityForERC721InitAbstract._initialize(
-            name,
-            symbol,
-            newOwner
-        );
+        LSP8CompatibilityForERC721InitAbstract._initialize(name, symbol, newOwner);
 
         _setData(_LSP4_METADATA_KEY, tokenURIValue);
     }

--- a/contracts/Helpers/Tokens/LSP8InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP8InitTester.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+// modules
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 contract LSP8InitTester is LSP8IdentifiableDigitalAssetInitAbstract {
     function initialize(
@@ -10,11 +11,7 @@ contract LSP8InitTester is LSP8IdentifiableDigitalAssetInitAbstract {
         string memory symbol,
         address newOwner
     ) public initializer {
-        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name,
-            symbol,
-            newOwner
-        );
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(name, symbol, newOwner);
     }
 
     function mint(

--- a/contracts/Helpers/Tokens/LSP8Tester.sol
+++ b/contracts/Helpers/Tokens/LSP8Tester.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+// modules
+import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
 
 contract LSP8Tester is LSP8IdentifiableDigitalAsset {
     /* solhint-disable no-empty-blocks */

--- a/contracts/Helpers/Tokens/TokenReceiverWithLSP1.sol
+++ b/contracts/Helpers/Tokens/TokenReceiverWithLSP1.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// constants
-import "../../LSP1UniversalReceiver/LSP1Constants.sol";
-
 // interfaces
-import "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP1UniversalReceiver} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 
 // modules
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// constants
+import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract TokenReceiverWithLSP1 is ERC165Storage, ILSP1UniversalReceiver {
     /* solhint-disable no-empty-blocks */

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-import "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
-import "../../LSP1UniversalReceiver/LSP1Constants.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+// interfaces
+import {ILSP1UniversalReceiverDelegate} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
-contract UniversalReceiverDelegateRevert is
-    ILSP1UniversalReceiverDelegate,
-    ERC165Storage
-{
+// modules
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// constants
+import {_INTERFACEID_LSP1_DELEGATE} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+contract UniversalReceiverDelegateRevert is ILSP1UniversalReceiverDelegate, ERC165Storage {
     constructor() {
         _registerInterface(_INTERFACEID_LSP1_DELEGATE);
     }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-import "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
-import "../../LSP1UniversalReceiver/LSP1Constants.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+// interfaces
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {ILSP1UniversalReceiverDelegate} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+
+// modules
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// constants
+import {_INTERFACEID_LSP1_DELEGATE} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract UniversalReceiverDelegateVaultSetter is ERC165Storage {
     constructor() {

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+// interfaces
+import {ILSP1UniversalReceiver} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 
 contract UniversalReceiverTester {
     function callImplementationAndReturn(address target, bytes32 typeId)
@@ -15,21 +16,12 @@ contract UniversalReceiverTester {
         ILSP1UniversalReceiver(_target).universalReceiver(_typeId, "");
     }
 
-    function checkImplementationLowLevelCall(address _target, bytes32 _typeId)
-        external
-    {
+    function checkImplementationLowLevelCall(address _target, bytes32 _typeId) external {
         // solhint-disable avoid-low-level-calls
         (bool success, ) = _target.call(
-            abi.encodeWithSelector(
-                ILSP1UniversalReceiver.universalReceiver.selector,
-                _typeId,
-                ""
-            )
+            abi.encodeWithSelector(ILSP1UniversalReceiver.universalReceiver.selector, _typeId, "")
         );
 
-        require(
-            success,
-            "low-level call to `universalReceiver(...)` function failed"
-        );
+        require(success, "low-level call to `universalReceiver(...)` function failed");
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -2,8 +2,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP0ERC725AccountCore.sol";
-import "@erc725/smart-contracts/contracts/ERC725.sol";
+import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
+import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
+
+// constants
+import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 
 /**
  * @title Implementation of ERC725Account
@@ -20,13 +24,7 @@ contract LSP0ERC725Account is LSP0ERC725AccountCore, ERC725 {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -2,21 +2,22 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
-
-// modules
-
-import "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import "@erc725/smart-contracts/contracts/ERC725XCore.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "../Utils/ERC165CheckerCustom.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
+import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
+
+// modules
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
+import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
+
 // constants
-import "../LSP0ERC725Account/LSP0Constants.sol";
-import "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
+import {_INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 
 /**
  * @title Core Implementation of ERC725Account
@@ -68,10 +69,7 @@ abstract contract LSP0ERC725AccountCore is
         // if OWNER is a contract
         if (_owner.code.length != 0) {
             return
-                ERC165CheckerCustom.supportsERC165Interface(
-                    _owner,
-                    _INTERFACEID_ERC1271
-                )
+                ERC165CheckerCustom.supportsERC165Interface(_owner, _INTERFACEID_ERC1271)
                     ? IERC1271(_owner).isValidSignature(_hash, _signature)
                     : _ERC1271_FAILVALUE;
             // if OWNER is a key
@@ -105,9 +103,8 @@ abstract contract LSP0ERC725AccountCore is
                     _INTERFACEID_LSP1_DELEGATE
                 )
             ) {
-                returnValue = ILSP1UniversalReceiverDelegate(
-                    universalReceiverDelegate
-                ).universalReceiverDelegate(_msgSender(), _typeId, _data);
+                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                    .universalReceiverDelegate(_msgSender(), _typeId, _data);
             }
         }
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP0ERC725AccountInitAbstract.sol";
+import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725AccountInitAbstract.sol";
 
 /**
  * @title Deployable Proxy Implementation of ERC725Account

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -2,37 +2,27 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
-import "./LSP0ERC725AccountCore.sol";
+import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
+import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
+
+// constants
+import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725Account
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
-abstract contract LSP0ERC725AccountInitAbstract is
-    LSP0ERC725AccountCore,
-    ERC725InitAbstract
-{
-    function _initialize(address _newOwner)
-        internal
-        virtual
-        override
-        onlyInitializing
-    {
+abstract contract LSP0ERC725AccountInitAbstract is LSP0ERC725AccountCore, ERC725InitAbstract {
+    function _initialize(address _newOwner) internal virtual override onlyInitializing {
         ERC725InitAbstract._initialize(_newOwner);
     }
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-import "../../../LSP6KeyManager/LSP6KeyManager.sol";
-
 // interfaces
-import "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {ILSP7DigitalAsset} from "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
 
 // libraries
-import "../../../Utils/ERC165CheckerCustom.sol";
-import "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
-import "../../../LSP5ReceivedAssets/LSP5Utils.sol";
-import "../../LSP1Utils.sol";
+import {ERC165CheckerCustom} from "../../../Utils/ERC165CheckerCustom.sol";
+import {LSP1Utils} from "../../LSP1Utils.sol";
+import {LSP2Utils} from "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
+import {LSP5Utils} from "../../../LSP5ReceivedAssets/LSP5Utils.sol";
+
+// modules
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {LSP6KeyManager} from "../../../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
-import "../../LSP1Constants.sol";
+import {_INTERFACEID_LSP6} from "../../../LSP6KeyManager/LSP6Constants.sol";
+import {_TYPEID_LSP9_VAULTSENDER} from "../../../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @dev Function logic to add and remove the MapAndArrayKey of incoming assets and vaults
@@ -29,21 +31,12 @@ abstract contract TokenAndVaultHandling {
         if (sender.code.length == 0) return "";
 
         address keyManager = ERC725Y(msg.sender).owner();
-        if (
-            !ERC165CheckerCustom.supportsERC165Interface(
-                keyManager,
-                _INTERFACEID_LSP6
-            )
-        ) return "";
+        if (!ERC165CheckerCustom.supportsERC165Interface(keyManager, _INTERFACEID_LSP6)) return "";
         address accountAddress = address(LSP6KeyManager(keyManager).account());
         // check if the caller is the same account controlled by the keyManager
         if (msg.sender != accountAddress) return "";
-        (
-            bool senderHook,
-            bytes32 arrayKey,
-            bytes12 mapPrefix,
-            bytes4 interfaceID
-        ) = LSP1Utils.getTransferDetails(typeId);
+        (bool senderHook, bytes32 arrayKey, bytes12 mapPrefix, bytes4 interfaceID) = LSP1Utils
+            .getTransferDetails(typeId);
 
         bytes32 mapKey = LSP2Utils.generateBytes20MappingWithGroupingKey(
             mapPrefix,
@@ -66,9 +59,7 @@ abstract contract TokenAndVaultHandling {
             // if there is no map for the asset to remove, then do nothing
             if (bytes12(mapValue) == bytes12(0)) return "";
             if (typeId != _TYPEID_LSP9_VAULTSENDER) {
-                uint256 balance = ILSP7DigitalAsset(sender).balanceOf(
-                    msg.sender
-                );
+                uint256 balance = ILSP7DigitalAsset(sender).balanceOf(msg.sender);
                 // if the amount sent is not the full balance, then do nothing
                 if (balance != 0) return "";
             }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-import "./Handling/TokenAndVaultHandling.sol";
+// interfaces
+import {ILSP1UniversalReceiverDelegate} from "../ILSP1UniversalReceiverDelegate.sol";
 
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+// modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {TokenAndVaultHandling} from "./Handling/TokenAndVaultHandling.sol";
 
-import "../ILSP1UniversalReceiverDelegate.sol";
+// constants
+import {_INTERFACEID_LSP1_DELEGATE} from "../LSP1Constants.sol";
+import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../../LSP7DigitalAsset/LSP7Constants.sol";
+import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+import {_TYPEID_LSP9_VAULTSENDER, _TYPEID_LSP9_VAULTRECIPIENT} from "../../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Core Implementation of contract writing the received Vaults and LSP7, LSP8 assets into your ERC725Account using
@@ -55,15 +62,7 @@ contract LSP1UniversalReceiverDelegateUP is
     /**
      * @inheritdoc ERC165
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_LSP1_DELEGATE ||
-            super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_LSP1_DELEGATE || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -1,46 +1,36 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-import "../../../LSP6KeyManager/LSP6KeyManager.sol";
-
 // interfaces
-import "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {ILSP7DigitalAsset} from "../../../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
 
 // libraries
-import "../../../Utils/ERC165CheckerCustom.sol";
-import "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
-import "../../../LSP5ReceivedAssets/LSP5Utils.sol";
-import "../../LSP1Utils.sol";
+import {ERC165CheckerCustom} from "../../../Utils/ERC165CheckerCustom.sol";
+import {LSP1Utils} from "../../LSP1Utils.sol";
+import {LSP2Utils} from "../../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
+import {LSP5Utils} from "../../../LSP5ReceivedAssets/LSP5Utils.sol";
+
+// modules
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {LSP6KeyManager} from "../../../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
 import "../../LSP1Constants.sol";
+import "../../../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @dev Function logic to add and remove the MapAndArrayKey of incoming assets and vaults
  */
 abstract contract TokenHandling {
     // internal functions
-    function _tokenHandling(address sender, bytes32 typeId)
-        internal
-        returns (bytes memory result)
-    {
+    function _tokenHandling(address sender, bytes32 typeId) internal returns (bytes memory result) {
         if (sender.code.length == 0) return "";
 
-        if (
-            !ERC165CheckerCustom.supportsERC165Interface(
-                msg.sender,
-                _INTERFACEID_LSP9
-            )
-        ) return "";
+        if (!ERC165CheckerCustom.supportsERC165Interface(msg.sender, _INTERFACEID_LSP9)) return "";
 
-        (
-            bool senderHook,
-            bytes32 arrayKey,
-            bytes12 mapPrefix,
-            bytes4 interfaceID
-        ) = LSP1Utils.getTransferDetails(typeId);
+        (bool senderHook, bytes32 arrayKey, bytes12 mapPrefix, bytes4 interfaceID) = LSP1Utils
+            .getTransferDetails(typeId);
 
         bytes32 mapKey = LSP2Utils.generateBytes20MappingWithGroupingKey(
             mapPrefix,
@@ -52,14 +42,13 @@ abstract contract TokenHandling {
             // if the map is already set, then do nothing
             if (bytes12(mapValue) != bytes12(0)) return "";
 
-            (bytes32[] memory keys, bytes[] memory values) = LSP5Utils
-                .addMapAndArrayKey(
-                    IERC725Y(msg.sender),
-                    arrayKey,
-                    mapKey,
-                    sender,
-                    interfaceID
-                );
+            (bytes32[] memory keys, bytes[] memory values) = LSP5Utils.addMapAndArrayKey(
+                IERC725Y(msg.sender),
+                arrayKey,
+                mapKey,
+                sender,
+                interfaceID
+            );
             IERC725Y(msg.sender).setData(keys, values);
         } else if (senderHook) {
             // if there is no map for the asset to remove, then do nothing
@@ -68,13 +57,12 @@ abstract contract TokenHandling {
             // if the amount sent is not the full balance, then do nothing
             if (balance != 0) return "";
 
-            (bytes32[] memory keys, bytes[] memory values) = LSP5Utils
-                .removeMapAndArrayKey(
-                    IERC725Y(msg.sender),
-                    arrayKey,
-                    mapPrefix,
-                    mapKey
-                );
+            (bytes32[] memory keys, bytes[] memory values) = LSP5Utils.removeMapAndArrayKey(
+                IERC725Y(msg.sender),
+                arrayKey,
+                mapPrefix,
+                mapKey
+            );
             IERC725Y(msg.sender).setData(keys, values);
         }
     }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "./Handling/TokenHandling.sol";
-
 // interfaces
-import "../ILSP1UniversalReceiverDelegate.sol";
+import {ILSP1UniversalReceiverDelegate} from "../ILSP1UniversalReceiverDelegate.sol";
+
+// modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {TokenHandling} from "./Handling/TokenHandling.sol";
+
+// constants
+import {_INTERFACEID_LSP1_DELEGATE} from "../LSP1Constants.sol";
+import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../../LSP7DigitalAsset/LSP7Constants.sol";
+import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
 
 /**
  * @title Core Implementation of contract writing the received LSP7 and LSP8 assets into your Vault using
@@ -45,15 +50,7 @@ contract LSP1UniversalReceiverDelegateVault is
     /**
      * @inheritdoc ERC165
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_LSP1_DELEGATE ||
-            super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_LSP1_DELEGATE || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP1UniversalReceiver/LSP1Utils.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Utils.sol
@@ -2,13 +2,11 @@
 pragma solidity ^0.8.0;
 
 // constants
-
-import "../LSP5ReceivedAssets/LSP5Constants.sol";
-import "../LSP7DigitalAsset/LSP7Constants.sol";
-import "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
-import "../LSP9Vault/LSP9Constants.sol";
-import "../LSP5ReceivedAssets/LSP5Constants.sol";
-import "../LSP10ReceivedVaults/LSP10Constants.sol";
+import {_LSP5_RECEIVED_ASSETS_ARRAY_KEY, _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX} from "../LSP5ReceivedAssets/LSP5Constants.sol";
+import {_INTERFACEID_LSP7, _TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../LSP7DigitalAsset/LSP7Constants.sol";
+import {_INTERFACEID_LSP8, _TYPEID_LSP8_TOKENSRECIPIENT, _TYPEID_LSP8_TOKENSSENDER} from "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTSENDER} from "../LSP9Vault/LSP9Constants.sol";
+import {_LSP10_VAULTS_ARRAY_KEY, _LSP10_VAULTS_MAP_KEY_PREFIX} from "../LSP10ReceivedVaults/LSP10Constants.sol";
 
 library LSP1Utils {
     /**
@@ -36,8 +34,7 @@ library LSP1Utils {
                 typeId == _TYPEID_LSP7_TOKENSRECIPIENT
                 ? _INTERFACEID_LSP7
                 : _INTERFACEID_LSP8;
-            senderHook = typeId == _TYPEID_LSP7_TOKENSSENDER ||
-                typeId == _TYPEID_LSP8_TOKENSSENDER
+            senderHook = typeId == _TYPEID_LSP7_TOKENSSENDER || typeId == _TYPEID_LSP8_TOKENSSENDER
                 ? true
                 : false;
         } else {

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import "../Utils/UtilsLib.sol";
+// libraries
+import {UtilsLib} from "../Utils/UtilsLib.sol";
 
 /**
  * @title ERC725 Utility library to encode key types
@@ -12,30 +13,18 @@ import "../Utils/UtilsLib.sol";
 library LSP2Utils {
     /* solhint-disable no-inline-assembly */
 
-    function generateBytes32Key(bytes memory _rawKey)
-        internal
-        pure
-        returns (bytes32 key)
-    {
+    function generateBytes32Key(bytes memory _rawKey) internal pure returns (bytes32 key) {
         // solhint-disable-next-line
         assembly {
             key := mload(add(_rawKey, 32))
         }
     }
 
-    function generateSingletonKey(string memory _keyName)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function generateSingletonKey(string memory _keyName) internal pure returns (bytes32) {
         return keccak256(bytes(_keyName));
     }
 
-    function generateArrayKey(string memory _keyName)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function generateArrayKey(string memory _keyName) internal pure returns (bytes32) {
         bytes memory keyName = bytes(_keyName);
 
         // prettier-ignore
@@ -60,10 +49,11 @@ library LSP2Utils {
         return generateBytes32Key(elementInArray);
     }
 
-    function generateMappingKey(
-        string memory _firstWord,
-        string memory _lastWord
-    ) internal pure returns (bytes32) {
+    function generateMappingKey(string memory _firstWord, string memory _lastWord)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
         bytes32 lastWordHash = keccak256(bytes(_lastWord));
 
@@ -76,17 +66,14 @@ library LSP2Utils {
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateBytes20MappingKey(
-        string memory _firstWord,
-        address _address
-    ) internal pure returns (bytes32) {
+    function generateBytes20MappingKey(string memory _firstWord, address _address)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
 
-        bytes memory temporaryBytes = abi.encodePacked(
-            bytes8(firstWordHash),
-            bytes4(0),
-            _address
-        );
+        bytes memory temporaryBytes = abi.encodePacked(bytes8(firstWordHash), bytes4(0), _address);
 
         return generateBytes32Key(temporaryBytes);
     }
@@ -110,10 +97,11 @@ library LSP2Utils {
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateBytes20MappingWithGroupingKey(
-        bytes12 _keyPrefix,
-        bytes20 _bytes20
-    ) internal pure returns (bytes32) {
+    function generateBytes20MappingWithGroupingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+        internal
+        pure
+        returns (bytes32)
+    {
         bytes memory generatedKey = bytes.concat(_keyPrefix, _bytes20);
         return generateBytes32Key(generatedKey);
     }

--- a/contracts/LSP4DigitalAssetMetadata/ILSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/ILSP4Compatibility.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
  * @dev LSP4 extension, for compatibility with clients & tools that expect ERC20/721.

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// modules
-import "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-
 // interfaces
-import "./ILSP4Compatibility.sol";
+import {ILSP4Compatibility} from "./ILSP4Compatibility.sol";
+
+// modules
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 
 // constants
 import "./LSP4Constants.sol";

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
 // constants
 import "./LSP4Constants.sol";
@@ -25,10 +25,7 @@ abstract contract LSP4DigitalAssetMetadata is ERC725Y {
         address newOwner_
     ) ERC725Y(newOwner_) {
         // set key SupportedStandards:LSP4DigitalAsset
-        _setData(
-            _LSP4_SUPPORTED_STANDARDS_KEY,
-            _LSP4_SUPPORTED_STANDARDS_VALUE
-        );
+        _setData(_LSP4_SUPPORTED_STANDARDS_KEY, _LSP4_SUPPORTED_STANDARDS_VALUE);
 
         _setData(_LSP4_TOKEN_NAME_KEY, bytes(name_));
         _setData(_LSP4_TOKEN_SYMBOL_KEY, bytes(symbol_));

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInit.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInit.sol
@@ -1,18 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-// constants
-import "./LSP4Constants.sol";
-import "./LSP4DigitalAssetMetadataInitAbstract.sol";
+// modules
+import {LSP4DigitalAssetMetadataInitAbstract} from "./LSP4DigitalAssetMetadataInitAbstract.sol";
 
 /**
  * @title LSP4DigitalAssetMetadata
  * @author Matthew Stevens
  * @dev Deployable Proxy Implementation of a LSP8 compliant contract.
  */
-abstract contract LSP4DigitalAssetMetadataInit is
-    LSP4DigitalAssetMetadataInitAbstract
-{
+abstract contract LSP4DigitalAssetMetadataInit is LSP4DigitalAssetMetadataInitAbstract {
     /**
      * @notice Sets the name, symbol of the token and the owner, and sets the SupportedStandards:LSP4DigitalAsset key
      * @param name_ The name of the token
@@ -24,10 +21,6 @@ abstract contract LSP4DigitalAssetMetadataInit is
         string memory symbol_,
         address newOwner_
     ) public virtual initializer {
-        LSP4DigitalAssetMetadataInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP4DigitalAssetMetadataInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC725YInitAbstract} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
 
 // constants
 import "./LSP4Constants.sol";
@@ -12,10 +13,7 @@ import "./LSP4Constants.sol";
  * @author Matthew Stevens
  * @dev Inheritable Proxy Implementation of a LSP8 compliant contract.
  */
-abstract contract LSP4DigitalAssetMetadataInitAbstract is
-    Initializable,
-    ERC725YInitAbstract
-{
+abstract contract LSP4DigitalAssetMetadataInitAbstract is Initializable, ERC725YInitAbstract {
     function _initialize(
         string memory name_,
         string memory symbol_,
@@ -24,10 +22,7 @@ abstract contract LSP4DigitalAssetMetadataInitAbstract is
         ERC725YInitAbstract._initialize(newOwner_);
 
         // set SupportedStandards:LSP4DigitalAsset
-        _setData(
-            _LSP4_SUPPORTED_STANDARDS_KEY,
-            _LSP4_SUPPORTED_STANDARDS_VALUE
-        );
+        _setData(_LSP4_SUPPORTED_STANDARDS_KEY, _LSP4_SUPPORTED_STANDARDS_VALUE);
 
         _setData(_LSP4_TOKEN_NAME_KEY, bytes(name_));
         _setData(_LSP4_TOKEN_SYMBOL_KEY, bytes(symbol_));

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
-import "solidity-bytes-utils/contracts/BytesLib.sol";
-import "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
-import "../LSP7DigitalAsset/LSP7Constants.sol";
-import "../LSP6KeyManager/LSP6Utils.sol";
-import "../Utils/UtilsLib.sol";
+// interfaces
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
+// libraries
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
+import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
+import {LSP6Utils} from "../LSP6KeyManager/LSP6Utils.sol";
+import {UtilsLib} from "../Utils/UtilsLib.sol";
+
+// constants
+import {_TYPEID_LSP7_TOKENSSENDER} from "../LSP7DigitalAsset/LSP7Constants.sol";
 
 library LSP5Utils {
     /**
@@ -39,10 +44,7 @@ library LSP5Utils {
             uint256 arrayLength = abi.decode(rawArrayLength, (uint256));
             uint256 newArrayLength = arrayLength + 1;
 
-            keys[1] = LSP2Utils.generateArrayKeyAtIndex(
-                _arrayKey,
-                newArrayLength - 1
-            );
+            keys[1] = LSP2Utils.generateArrayKeyAtIndex(_arrayKey, newArrayLength - 1);
 
             values[0] = UtilsLib.uint256ToBytes(newArrayLength);
             values[2] = bytes.concat(bytes8(uint64(arrayLength)), _appendix);
@@ -60,10 +62,7 @@ library LSP5Utils {
         bytes32 _mapKeyToRemove
     ) internal view returns (bytes32[] memory keys, bytes[] memory values) {
         uint64 index = extractIndexFromMap(_account, _mapKeyToRemove);
-        bytes32 arrayKeyToRemove = LSP2Utils.generateArrayKeyAtIndex(
-            _arrayKey,
-            index
-        );
+        bytes32 arrayKeyToRemove = LSP2Utils.generateArrayKeyAtIndex(_arrayKey, index);
 
         bytes memory rawArrayLength = _account.getData(_arrayKey);
 
@@ -92,18 +91,14 @@ library LSP5Utils {
             keys[1] = _mapKeyToRemove;
             values[1] = "";
 
-            bytes32 lastKey = LSP2Utils.generateArrayKeyAtIndex(
-                _arrayKey,
-                newLength
-            );
+            bytes32 lastKey = LSP2Utils.generateArrayKeyAtIndex(_arrayKey, newLength);
 
             bytes memory lastKeyValue = _account.getData(lastKey);
 
-            bytes32 mapOfLastkey = LSP2Utils
-                .generateBytes20MappingWithGroupingKey(
-                    mapPrefix,
-                    bytes20(lastKeyValue)
-                );
+            bytes32 mapOfLastkey = LSP2Utils.generateBytes20MappingWithGroupingKey(
+                mapPrefix,
+                bytes20(lastKeyValue)
+            );
 
             bytes memory mapValueOfLastkey = _account.getData(mapOfLastkey);
 
@@ -164,11 +159,7 @@ library LSP5Utils {
         return BytesLib.toUint64(val, 0);
     }
 
-    function extractTokenAmount(bytes32 typeId, bytes memory data)
-        internal
-        pure
-        returns (uint256)
-    {
+    function extractTokenAmount(bytes32 typeId, bytes memory data) internal pure returns (uint256) {
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             return uint256(bytes32(BytesLib.slice(data, 40, 32)));
         } else {

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
 /**
  * @dev Contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
@@ -30,10 +30,7 @@ interface ILSP6KeyManager is
      * @param _address caller address
      * @param _channel channel id
      */
-    function getNonce(address _address, uint256 _channel)
-        external
-        view
-        returns (uint256);
+    function getNonce(address _address, uint256 _channel) external view returns (uint256);
 
     /**
      * @notice execute the following payload on the ERC725Account: `_data`
@@ -41,10 +38,7 @@ interface ILSP6KeyManager is
      * @param _data the payload to execute. Obtained in web3 via encodeABI()
      * @return result_ the data being returned by the ERC725 Account
      */
-    function execute(bytes calldata _data)
-        external
-        payable
-        returns (bytes memory);
+    function execute(bytes calldata _data) external payable returns (bytes memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+/**
+ * @dev revert when address `from` does not have any permissions set
+ * on the account linked to this Key Manager
+ * @param from the address that does not have permissions
+ */
+error NoPermissionsSet(address from);
+
+/**
+ * @dev address `from` is not authorised to `permission`
+ * @param permission permission required
+ * @param from address not-authorised
+ */
+error NotAuthorised(address from, string permission);
+
+/**
+ * @dev address `from` is not authorised to interact with `disallowedAddress` via account
+ * @param from address making the request
+ * @param disallowedAddress address that `from` is not authorised to call
+ */
+error NotAllowedAddress(address from, address disallowedAddress);
+
+/**
+ * @dev address `from` is not authorised to run `disallowedFunction` via account
+ * @param from address making the request
+ * @param disallowedFunction bytes4 function selector that `from` is not authorised to run
+ */
+error NotAllowedFunction(address from, bytes4 disallowedFunction);
+
+/**
+ * @dev address `from` is not authorised to set the key `disallowedKey` on the account
+ * @param from address making the request
+ * @param disallowedKey a bytes32 key that `from` is not authorised to set on the ERC725Y storage
+ */
+error NotAllowedERC725YKey(address from, bytes32 disallowedKey);

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.6;
 
 // modules
-import "./LSP6KeyManagerCore.sol";
+import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
 
 /**
  * @title Implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.6;
 
 // modules
-import "./LSP6KeyManagerInitAbstract.sol";
+import {LSP6KeyManagerInitAbstract} from "./LSP6KeyManagerInitAbstract.sol";
 
 /**
  * @title Proxy implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -2,19 +2,16 @@
 pragma solidity ^0.8.6;
 
 // modules
-import "./LSP6KeyManagerCore.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
 
 /**
  * @title Proxy implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
  * @author Fabian Vogelsteller, Jean Cavallera
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
-abstract contract LSP6KeyManagerInitAbstract is
-    Initializable,
-    LSP6KeyManagerCore
-{
+abstract contract LSP6KeyManagerInitAbstract is Initializable, LSP6KeyManagerCore {
     function _initialize(address _account) internal virtual onlyInitializing {
         account = _account;
     }

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {ILSP6KeyManager} from "./ILSP6KeyManager.sol";
+
+// libraries
+import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
 import "../LSP6KeyManager/LSP6Constants.sol";
-
-// libraries
-import "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
-import "./ILSP6KeyManager.sol";
 
 library LSP6Utils {
     using LSP2Utils for bytes12;
@@ -65,12 +65,12 @@ library LSP6Utils {
      * @param _permissionsToCheck the permissions to check
      * @return true if `_addressPermissions` includes `_permissionToCheck`, false otherwise
      */
-    function includesPermissions(
-        bytes32 _addressPermissions,
-        bytes32 _permissionsToCheck
-    ) internal pure returns (bool) {
-        return
-            (_addressPermissions & _permissionsToCheck) == _permissionsToCheck;
+    function includesPermissions(bytes32 _addressPermissions, bytes32 _permissionsToCheck)
+        internal
+        pure
+        returns (bool)
+    {
+        return (_addressPermissions & _permissionsToCheck) == _permissionsToCheck;
     }
 
     function setDataViaKeyManager(
@@ -78,11 +78,7 @@ library LSP6Utils {
         bytes32[] memory keys,
         bytes[] memory values
     ) internal returns (bytes memory result) {
-        bytes memory payload = abi.encodeWithSelector(
-            hex"14a6e293",
-            keys,
-            values
-        );
+        bytes memory payload = abi.encodeWithSelector(hex"14a6e293", keys, values);
         result = ILSP6KeyManager(keyManagerAddress).execute(payload);
     }
 }

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
  * @dev Required interface of a LSP8 compliant contract.
@@ -116,10 +116,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * Operators can send and burn tokens on behalf of their owners. The tokenOwner is their own
      * operator.
      */
-    function isOperatorFor(address operator, address tokenOwner)
-        external
-        view
-        returns (uint256);
+    function isOperatorFor(address operator, address tokenOwner) external view returns (uint256);
 
     // --- Transfer functionality
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// constants
-import "./LSP7Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
-import "./LSP7DigitalAssetCore.sol";
-import "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
+import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
+
+// constants
+import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
 
 /**
  * @title LSP7DigitalAsset contract
@@ -42,8 +45,6 @@ contract LSP7DigitalAsset is LSP7DigitalAssetCore, LSP4DigitalAssetMetadata {
         override(IERC165, ERC165Storage)
         returns (bool)
     {
-        return
-            interfaceId == _INTERFACEID_LSP7 ||
-            super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_LSP7 || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -14,6 +14,9 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
+// errors
+import "./LSP7Errors.sol";
+
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Constants.sol";
@@ -25,21 +28,6 @@ import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Con
  */
 abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     using Address for address;
-
-    // --- Errors
-
-    error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
-    error LSP7AmountExceedsAuthorizedAmount(
-        address tokenOwner,
-        uint256 authorizedAmount,
-        address operator,
-        uint256 amount
-    );
-    error LSP7CannotUseAddressZeroAsOperator();
-    error LSP7CannotSendWithAddressZero();
-    error LSP7InvalidTransferBatch();
-    error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
-    error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 
     // --- Storage
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -1,23 +1,22 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// constants
-import "./LSP7Constants.sol";
-import "../LSP1UniversalReceiver/LSP1Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
-
 // interfaces
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import "./ILSP7DigitalAsset.sol";
+import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP7DigitalAsset} from "./ILSP7DigitalAsset.sol";
+
+// libraries
+import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 
 // modules
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
-// library
-import "../Utils/ERC165CheckerCustom.sol";
+// constants
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Constants.sol";
 
 /**
  * @title LSP7DigitalAsset contract
@@ -29,11 +28,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
 
     // --- Errors
 
-    error LSP7AmountExceedsBalance(
-        uint256 balance,
-        address tokenOwner,
-        uint256 amount
-    );
+    error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
     error LSP7AmountExceedsAuthorizedAmount(
         address tokenOwner,
         uint256 authorizedAmount,
@@ -43,9 +38,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     error LSP7CannotUseAddressZeroAsOperator();
     error LSP7CannotSendWithAddressZero();
     error LSP7InvalidTransferBatch();
-    error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
-        address tokenReceiver
-    );
+    error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
     error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 
     // --- Storage
@@ -58,8 +51,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     mapping(address => uint256) internal _tokenOwnerBalances;
 
     // Mapping a `tokenOwner` to an `operator` to `amount` of tokens.
-    mapping(address => mapping(address => uint256))
-        internal _operatorAuthorizedAmount;
+    mapping(address => mapping(address => uint256)) internal _operatorAuthorizedAmount;
 
     // --- Token queries
 
@@ -82,12 +74,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function balanceOf(address tokenOwner)
-        public
-        view
-        override
-        returns (uint256)
-    {
+    function balanceOf(address tokenOwner) public view override returns (uint256) {
         return _tokenOwnerBalances[tokenOwner];
     }
 
@@ -96,11 +83,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function authorizeOperator(address operator, uint256 amount)
-        public
-        virtual
-        override
-    {
+    function authorizeOperator(address operator, uint256 amount) public virtual override {
         _updateOperator(_msgSender(), operator, amount);
     }
 
@@ -144,12 +127,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         if (operator != from) {
             uint256 operatorAmount = _operatorAuthorizedAmount[from][operator];
             if (amount > operatorAmount) {
-                revert LSP7AmountExceedsAuthorizedAmount(
-                    from,
-                    operatorAmount,
-                    operator,
-                    amount
-                );
+                revert LSP7AmountExceedsAuthorizedAmount(from, operatorAmount, operator, amount);
             }
 
             _updateOperator(from, operator, operatorAmount - amount);
@@ -169,9 +147,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bytes[] memory data
     ) external virtual override {
         if (
-            from.length != to.length ||
-            from.length != amount.length ||
-            from.length != data.length
+            from.length != to.length || from.length != amount.length || from.length != data.length
         ) {
             revert LSP7InvalidTransferBatch();
         }
@@ -276,16 +252,9 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
 
         address operator = _msgSender();
         if (operator != from) {
-            uint256 authorizedAmount = _operatorAuthorizedAmount[from][
-                operator
-            ];
+            uint256 authorizedAmount = _operatorAuthorizedAmount[from][operator];
             if (amount > authorizedAmount) {
-                revert LSP7AmountExceedsAuthorizedAmount(
-                    from,
-                    authorizedAmount,
-                    operator,
-                    amount
-                );
+                revert LSP7AmountExceedsAuthorizedAmount(from, authorizedAmount, operator, amount);
             }
             _operatorAuthorizedAmount[from][operator] -= amount;
         }
@@ -378,14 +347,9 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         uint256 amount,
         bytes memory data
     ) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)
-        ) {
+        if (ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)) {
             bytes memory packedData = abi.encodePacked(from, to, amount, data);
-            ILSP1UniversalReceiver(from).universalReceiver(
-                _TYPEID_LSP7_TOKENSSENDER,
-                packedData
-            );
+            ILSP1UniversalReceiver(from).universalReceiver(_TYPEID_LSP7_TOKENSSENDER, packedData);
         }
     }
 
@@ -402,14 +366,9 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)
-        ) {
+        if (ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)) {
             bytes memory packedData = abi.encodePacked(from, to, amount, data);
-            ILSP1UniversalReceiver(to).universalReceiver(
-                _TYPEID_LSP7_TOKENSRECIPIENT,
-                packedData
-            );
+            ILSP1UniversalReceiver(to).universalReceiver(_TYPEID_LSP7_TOKENSRECIPIENT, packedData);
         } else if (!force) {
             if (to.code.length > 0) {
                 revert LSP7NotifyTokenReceiverContractMissingLSP1Interface(to);

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP7DigitalAssetInitAbstract.sol";
+import {LSP7DigitalAssetInitAbstract} from "./LSP7DigitalAssetInitAbstract.sol";
 
 /**
  * @title LSP7DigitalAsset contract
@@ -23,11 +23,6 @@ contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
         address newOwner_,
         bool isNFT_
     ) public virtual initializer {
-        LSP7DigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_,
-            isNFT_
-        );
+        LSP7DigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_, isNFT_);
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// constants
-import "./LSP7Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
-import "./LSP7DigitalAssetCore.sol";
-import "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
+import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
+
+// constants
+import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
 
 /**
  * @title LSP7DigitalAsset contract
@@ -26,11 +30,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         bool isNFT_
     ) internal virtual onlyInitializing {
         _isNFT = isNFT_;
-        LSP4DigitalAssetMetadataInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP4DigitalAssetMetadataInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 
     /**
@@ -43,8 +43,6 @@ abstract contract LSP7DigitalAssetInitAbstract is
         override(IERC165, ERC165Storage)
         returns (bool)
     {
-        return
-            interfaceId == _INTERFACEID_LSP7 ||
-            super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_LSP7 || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// --- Errors
+
+error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
+
+error LSP7AmountExceedsAuthorizedAmount(
+    address tokenOwner,
+    uint256 authorizedAmount,
+    address operator,
+    uint256 amount
+);
+
+error LSP7CannotUseAddressZeroAsOperator();
+
+error LSP7CannotSendWithAddressZero();
+
+error LSP7InvalidTransferBatch();
+
+error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
+
+error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CappedSupply.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP7DigitalAsset.sol";
+import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP7DigitalAsset.sol";
+import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC20.
@@ -59,7 +59,5 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
      * @param operator The address approved by the `tokenOwner`
      * @return The amount `operator` is approved by `tokenOwner`
      */
-    function allowance(address tokenOwner, address operator)
-        external
-        returns (uint256);
+    function allowance(address tokenOwner, address operator) external returns (uint256);
 }

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7Mintable.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP7DigitalAsset.sol";
+import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
 
 /**
  * @dev LSP7 extension, Mintable version.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -3,8 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP7CappedSupplyCore.sol";
-import "../LSP7DigitalAsset.sol";
+import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
+import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
@@ -2,19 +2,16 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "../LSP7DigitalAssetCore.sol";
-
 // interfaces
-import "./ILSP7CappedSupply.sol";
+import {ILSP7CappedSupply} from "./ILSP7CappedSupply.sol";
+
+// modules
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupplyCore is
-    ILSP7CappedSupply,
-    LSP7DigitalAssetCore
-{
+abstract contract LSP7CappedSupplyCore is ILSP7CappedSupply, LSP7DigitalAssetCore {
     // --- Errors
 
     error LSP7CappedSupplyRequired();

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInit.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP7CappedSupplyInitAbstract.sol";
+import {LSP7CappedSupplyInitAbstract} from "./LSP7CappedSupplyInitAbstract.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -3,8 +3,10 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP7CappedSupplyCore.sol";
-import "../LSP7DigitalAssetInit.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP7DigitalAssetInit} from "../LSP7DigitalAssetInit.sol";
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
+import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.
@@ -14,11 +16,7 @@ abstract contract LSP7CappedSupplyInitAbstract is
     LSP7CappedSupplyCore,
     LSP7DigitalAssetInit
 {
-    function _initialize(uint256 tokenSupplyCap_)
-        internal
-        virtual
-        onlyInitializing
-    {
+    function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {
             revert LSP7CappedSupplyRequired();
         }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol
@@ -3,8 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../LSP7DigitalAsset.sol";
-import "./LSP7CompatibilityForERC20Core.sol";
+import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
+import {LSP7CompatibilityForERC20Core} from "./LSP7CompatibilityForERC20Core.sol";
 
 contract LSP7CompatibilityForERC20 is LSP7CompatibilityForERC20Core, LSP7DigitalAsset {
     /* solhint-disable no-empty-blocks */
@@ -18,39 +19,42 @@ contract LSP7CompatibilityForERC20 is LSP7CompatibilityForERC20Core, LSP7Digital
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) LSP7DigitalAsset(name_, symbol_, newOwner_, false) {
-
-    }
+    ) LSP7DigitalAsset(name_, symbol_, newOwner_, false) {}
 
     // --- Overrides
 
     function authorizeOperator(address operator, uint256 amount)
-    public
+        public
         virtual
         override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
     {
         super.authorizeOperator(operator, amount);
     }
 
-    function _burn(address from, uint256 amount, bytes memory data)
-        internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
+    function _burn(
+        address from,
+        uint256 amount,
+        bytes memory data
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
         super._burn(from, amount, data);
     }
 
-    function _mint(address to, uint256 amount, bool force, bytes memory data)
-    internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
-            super._mint(to, amount, force, data);
+    function _mint(
+        address to,
+        uint256 amount,
+        bool force,
+        bytes memory data
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
+        super._mint(to, amount, force, data);
     }
 
-    function _transfer(address from, address to, uint256 amount, bool force, bytes memory data)
-    internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
-            super._transfer(from, to, amount, force, data);
+    function _transfer(
+        address from,
+        address to,
+        uint256 amount,
+        bool force,
+        bytes memory data
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
+        super._transfer(from, to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -2,12 +2,13 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
-import "../LSP7DigitalAssetCore.sol";
-
 // interfaces
-import "./ILSP7CompatibilityForERC20.sol";
+import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
+import {ILSP7CompatibilityForERC20} from "./ILSP7CompatibilityForERC20.sol";
+
+// modules
+import {LSP4Compatibility} from "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 
 /**
  * @dev LSP7 extension, for compatibility for clients / tools that expect ERC20.
@@ -20,11 +21,7 @@ abstract contract LSP7CompatibilityForERC20Core is
     /**
      * @inheritdoc ILSP7CompatibilityForERC20
      */
-    function approve(address operator, uint256 amount)
-        external
-        virtual
-        override
-    {
+    function approve(address operator, uint256 amount) external virtual override {
         return authorizeOperator(operator, amount);
     }
 
@@ -72,11 +69,7 @@ abstract contract LSP7CompatibilityForERC20Core is
     {
         super.authorizeOperator(operator, amount);
 
-        emit Approval(
-            _msgSender(),
-            operator,
-            amount
-        );
+        emit Approval(_msgSender(), operator, amount);
     }
 
     function _transfer(
@@ -88,11 +81,7 @@ abstract contract LSP7CompatibilityForERC20Core is
     ) internal virtual override {
         super._transfer(from, to, amount, force, data);
 
-        emit Transfer(
-            from,
-            to,
-            amount
-        );
+        emit Transfer(from, to, amount);
     }
 
     function _mint(
@@ -103,24 +92,16 @@ abstract contract LSP7CompatibilityForERC20Core is
     ) internal virtual override {
         super._mint(to, amount, force, data);
 
-        emit Transfer(
-            address(0),
-            to,
-            amount
-        );
+        emit Transfer(address(0), to, amount);
     }
 
-    function _burn(address from, uint256 amount, bytes memory data)
-        internal
-        virtual
-        override
-    {
+    function _burn(
+        address from,
+        uint256 amount,
+        bytes memory data
+    ) internal virtual override {
         super._burn(from, amount, data);
 
-        emit Transfer(
-            from,
-            address(0),
-            amount
-        );
+        emit Transfer(from, address(0), amount);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
@@ -3,11 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP7CompatibilityForERC20InitAbstract.sol";
+import {LSP7CompatibilityForERC20InitAbstract} from "./LSP7CompatibilityForERC20InitAbstract.sol";
 
-contract LSP7CompatibilityForERC20Init is
-    LSP7CompatibilityForERC20InitAbstract
-{
+contract LSP7CompatibilityForERC20Init is LSP7CompatibilityForERC20InitAbstract {
     /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
@@ -19,10 +17,6 @@ contract LSP7CompatibilityForERC20Init is
         string memory symbol_,
         address newOwner_
     ) public virtual initializer {
-        LSP7CompatibilityForERC20InitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP7CompatibilityForERC20InitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
@@ -3,8 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "../LSP7DigitalAssetInitAbstract.sol";
-import "./LSP7CompatibilityForERC20Core.sol";
+import {LSP7DigitalAssetInitAbstract} from "../LSP7DigitalAssetInitAbstract.sol";
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
+import {LSP7CompatibilityForERC20Core} from "./LSP7CompatibilityForERC20Core.sol";
 
 contract LSP7CompatibilityForERC20InitAbstract is
     LSP7CompatibilityForERC20Core,
@@ -15,12 +16,7 @@ contract LSP7CompatibilityForERC20InitAbstract is
         string memory symbol_,
         address newOwner_
     ) internal virtual override onlyInitializing {
-        LSP7DigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_,
-            false
-        );
+        LSP7DigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_, false);
     }
 
     // --- Overrides
@@ -37,11 +33,7 @@ contract LSP7CompatibilityForERC20InitAbstract is
         address from,
         uint256 amount,
         bytes memory data
-    )
-        internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
         super._burn(from, amount, data);
     }
 
@@ -50,11 +42,7 @@ contract LSP7CompatibilityForERC20InitAbstract is
         uint256 amount,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
         super._mint(to, amount, force, data);
     }
 
@@ -64,11 +52,7 @@ contract LSP7CompatibilityForERC20InitAbstract is
         uint256 amount,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core)
-    {
+    ) internal virtual override(LSP7DigitalAssetCore, LSP7CompatibilityForERC20Core) {
         super._transfer(from, to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP7MintableCore.sol";
-import "../LSP7DigitalAsset.sol";
+// modules
+import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
+import {LSP7MintableCore} from "./LSP7MintableCore.sol";
 
 /**
  * @title LSP7Mintable

--- a/contracts/LSP7DigitalAsset/extensions/LSP7MintableCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7MintableCore.sol
@@ -2,11 +2,11 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "../LSP7DigitalAssetCore.sol";
-
 // interfaces
-import "./ILSP7Mintable.sol";
+import {ILSP7Mintable} from "./ILSP7Mintable.sol";
+
+// modules
+import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 
 /**
  * @dev LSP7 extension, mintable .

--- a/contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7MintableInit.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP7MintableInitAbstract.sol";
+// modules
+import {LSP7MintableInitAbstract} from "./LSP7MintableInitAbstract.sol";
 
 /**
  * @dev LSP7 extension, mintable.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7MintableInitAbstract.sol
@@ -2,28 +2,22 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP7MintableCore.sol";
-import "../LSP7DigitalAssetInit.sol";
+// modules
+import {LSP7DigitalAssetInit} from "../LSP7DigitalAssetInit.sol";
+import {LSP7DigitalAssetInitAbstract} from "../LSP7DigitalAssetInitAbstract.sol";
+import {LSP7MintableCore} from "./LSP7MintableCore.sol";
 
 /**
  * @dev LSP7 extension, mintable.
  */
-abstract contract LSP7MintableInitAbstract is
-    LSP7MintableCore,
-    LSP7DigitalAssetInit
-{
+abstract contract LSP7MintableInitAbstract is LSP7MintableCore, LSP7DigitalAssetInit {
     function _initialize(
         string memory name_,
         string memory symbol_,
         address newOwner_,
         bool isNFT_
     ) internal virtual override onlyInitializing {
-        LSP7DigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_,
-            isNFT_
-        );
+        LSP7DigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_, isNFT_);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
  * @dev Required interface of a LSP8 compliant contract.
@@ -90,10 +90,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      * @param tokenOwner The address to query owned tokens
      * @return List of owned tokens by `tokenOwner` address
      */
-    function tokenIdsOf(address tokenOwner)
-        external
-        view
-        returns (bytes32[] memory);
+    function tokenIdsOf(address tokenOwner) external view returns (bytes32[] memory);
 
     // --- Operator functionality
 
@@ -143,10 +140,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `tokenId` must exist.
      */
-    function isOperatorFor(address operator, bytes32 tokenId)
-        external
-        view
-        returns (bool);
+    function isOperatorFor(address operator, bytes32 tokenId) external view returns (bool);
 
     /**
      * @param tokenId The tokenId to query
@@ -157,10 +151,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `tokenId` must exist.
      */
-    function getOperatorsOf(bytes32 tokenId)
-        external
-        view
-        returns (address[] memory);
+    function getOperatorsOf(bytes32 tokenId) external view returns (address[] memory);
 
     // --- Transfer functionality
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// --- Errors
+
+error LSP8NonExistentTokenId(bytes32 tokenId);
+
+error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
+
+error LSP8NotTokenOperator(bytes32 tokenId, address caller);
+
+error LSP8CannotUseAddressZeroAsOperator();
+
+error LSP8CannotSendToAddressZero();
+
+error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
+
+error LSP8InvalidTransferBatch();
+
+error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
+
+error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // modules
-import "./LSP8IdentifiableDigitalAssetCore.sol";
-import "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
 
 // constants
-import "./LSP8Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
 
 /**
  * @title LSP8IdentifiableDigitalAsset contract
@@ -41,8 +44,6 @@ contract LSP8IdentifiableDigitalAsset is
         override(IERC165, ERC165Storage)
         returns (bool)
     {
-        return
-            interfaceId == _INTERFACEID_LSP8 ||
-            super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_LSP8 || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -1,32 +1,30 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@openzeppelin/contracts/utils/Address.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-
 // interfaces
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import "./ILSP8IdentifiableDigitalAsset.sol";
+import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP8IdentifiableDigitalAsset} from "./ILSP8IdentifiableDigitalAsset.sol";
 
 // libraries
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "../Utils/ERC165CheckerCustom.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
+
+// modules
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+
 // constants
-import "./LSP8Constants.sol";
-import "../LSP1UniversalReceiver/LSP1Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+// import {} from "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "./LSP8Constants.sol";
 
 /**
  * @title LSP8IdentifiableDigitalAsset contract
  * @author Matthew Stevens
  * @dev Core Implementation of a LSP8 compliant contract.
  */
-abstract contract LSP8IdentifiableDigitalAssetCore is
-    Context,
-    ILSP8IdentifiableDigitalAsset
-{
+abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8IdentifiableDigitalAsset {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using Address for address;
@@ -34,19 +32,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     // --- Errors
 
     error LSP8NonExistentTokenId(bytes32 tokenId);
-    error LSP8NotTokenOwner(
-        address tokenOwner,
-        bytes32 tokenId,
-        address caller
-    );
+    error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
     error LSP8NotTokenOperator(bytes32 tokenId, address caller);
     error LSP8CannotUseAddressZeroAsOperator();
     error LSP8CannotSendToAddressZero();
     error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
     error LSP8InvalidTransferBatch();
-    error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
-        address tokenReceiver
-    );
+    error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
     error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 
     // --- Storage
@@ -76,24 +68,14 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function balanceOf(address tokenOwner)
-        public
-        view
-        override
-        returns (uint256)
-    {
+    function balanceOf(address tokenOwner) public view override returns (uint256) {
         return _ownedTokens[tokenOwner].length();
     }
 
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function tokenOwnerOf(bytes32 tokenId)
-        public
-        view
-        override
-        returns (address)
-    {
+    function tokenOwnerOf(bytes32 tokenId) public view override returns (address) {
         address tokenOwner = _tokenOwners[tokenId];
 
         if (tokenOwner == address(0)) {
@@ -106,12 +88,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function tokenIdsOf(address tokenOwner)
-        public
-        view
-        override
-        returns (bytes32[] memory)
-    {
+    function tokenIdsOf(address tokenOwner) public view override returns (bytes32[] memory) {
         return _ownedTokens[tokenOwner].values();
     }
 
@@ -120,11 +97,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function authorizeOperator(address operator, bytes32 tokenId)
-        public
-        virtual
-        override
-    {
+    function authorizeOperator(address operator, bytes32 tokenId) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
         address caller = _msgSender();
 
@@ -149,11 +122,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function revokeOperator(address operator, bytes32 tokenId)
-        public
-        virtual
-        override
-    {
+    function revokeOperator(address operator, bytes32 tokenId) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
         address caller = _msgSender();
 
@@ -246,9 +215,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes[] memory data
     ) external virtual override {
         if (
-            from.length != to.length ||
-            from.length != tokenId.length ||
-            from.length != data.length
+            from.length != to.length || from.length != tokenId.length || from.length != data.length
         ) {
             revert LSP8InvalidTransferBatch();
         }
@@ -267,19 +234,14 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         emit RevokedOperator(operator, tokenOwner, tokenId);
     }
 
-    function _clearOperators(address tokenOwner, bytes32 tokenId)
-        internal
-        virtual
-    {
+    function _clearOperators(address tokenOwner, bytes32 tokenId) internal virtual {
         // TODO: here is a good exmaple of why having multiple operators will be expensive.. we
         // need to clear them on token transfer
         //
         // NOTE: this may cause a tx to fail if there is too many operators to clear, in which case
         // the tokenOwner needs to call `revokeOperator` until there is less operators to clear and
         // the desired `transfer` or `burn` call can succeed.
-        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[
-            tokenId
-        ];
+        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[tokenId];
 
         uint256 operatorListLength = operatorsForTokenId.length();
         for (uint256 i = 0; i < operatorListLength; i++) {
@@ -451,14 +413,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes32 tokenId,
         bytes memory data
     ) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)
-        ) {
+        if (ERC165CheckerCustom.supportsERC165Interface(from, _INTERFACEID_LSP1)) {
             bytes memory packedData = abi.encodePacked(from, to, tokenId, data);
-            ILSP1UniversalReceiver(from).universalReceiver(
-                _TYPEID_LSP8_TOKENSSENDER,
-                packedData
-            );
+            ILSP1UniversalReceiver(from).universalReceiver(_TYPEID_LSP8_TOKENSSENDER, packedData);
         }
     }
 
@@ -475,14 +432,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes memory data
     ) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)
-        ) {
+        if (ERC165CheckerCustom.supportsERC165Interface(to, _INTERFACEID_LSP1)) {
             bytes memory packedData = abi.encodePacked(from, to, tokenId, data);
-            ILSP1UniversalReceiver(to).universalReceiver(
-                _TYPEID_LSP8_TOKENSRECIPIENT,
-                packedData
-            );
+            ILSP1UniversalReceiver(to).universalReceiver(_TYPEID_LSP8_TOKENSRECIPIENT, packedData);
         } else if (!force) {
             if (to.code.length > 0) {
                 revert LSP8NotifyTokenReceiverContractMissingLSP1Interface(to);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -14,6 +14,9 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {Context} from "@openzeppelin/contracts/utils/Context.sol";
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
+// errors
+import "./LSP8Errors.sol";
+
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 // import {} from "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
@@ -28,18 +31,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using Address for address;
-
-    // --- Errors
-
-    error LSP8NonExistentTokenId(bytes32 tokenId);
-    error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
-    error LSP8NotTokenOperator(bytes32 tokenId, address caller);
-    error LSP8CannotUseAddressZeroAsOperator();
-    error LSP8CannotSendToAddressZero();
-    error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
-    error LSP8InvalidTransferBatch();
-    error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
-    error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 
     // --- Storage
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
@@ -2,16 +2,14 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "./LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 /**
  * @title LSP8IdentifiableDigitalAsset contract
  * @author Matthew Stevens
  * @dev Proxy Implementation of a LSP8 compliant contract.
  */
-contract LSP8IdentifiableDigitalAssetInit is
-    LSP8IdentifiableDigitalAssetInitAbstract
-{
+contract LSP8IdentifiableDigitalAssetInit is LSP8IdentifiableDigitalAssetInitAbstract {
     /**
      * @notice Sets the token-Metadata
      * @param name_ The name of the token
@@ -23,10 +21,6 @@ contract LSP8IdentifiableDigitalAssetInit is
         string memory symbol_,
         address newOwner_
     ) public virtual initializer {
-        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // modules
-import "./LSP8IdentifiableDigitalAssetCore.sol";
-import "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 
 // constants
-import "./LSP8Constants.sol";
-import "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
 
 /**
  * @title LSP8IdentifiableDigitalAsset contract
@@ -24,11 +28,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         string memory symbol_,
         address newOwner_
     ) internal virtual override onlyInitializing {
-        LSP4DigitalAssetMetadataInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP4DigitalAssetMetadataInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 
     /**
@@ -41,8 +41,6 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         override(IERC165, ERC165Storage)
         returns (bool)
     {
-        return
-            interfaceId == _INTERFACEID_LSP8 ||
-            super.supportsInterface(interfaceId);
+        return interfaceId == _INTERFACEID_LSP8 || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CappedSupply.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP8IdentifiableDigitalAsset.sol";
+import {ILSP8IdentifiableDigitalAsset} from "../ILSP8IdentifiableDigitalAsset.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibilityForERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibilityForERC721.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP8IdentifiableDigitalAsset.sol";
+import {ILSP8IdentifiableDigitalAsset} from "../ILSP8IdentifiableDigitalAsset.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
@@ -16,11 +16,7 @@ interface ILSP8CompatibilityForERC721 is ILSP8IdentifiableDigitalAsset {
      * @param to The receiving address
      * @param tokenId The tokenId to transfer
      */
-    event Transfer(
-        address indexed from,
-        address indexed to,
-        uint256 indexed tokenId
-    );
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
 
     /**
      * @notice To provide compatibility with indexing ERC721 events.
@@ -29,11 +25,7 @@ interface ILSP8CompatibilityForERC721 is ILSP8IdentifiableDigitalAsset {
      * @param approved The address set as operator
      * @param tokenId The approved tokenId
      */
-    event Approval(
-        address indexed owner,
-        address indexed approved,
-        uint256 indexed tokenId
-    );
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
 
     /**
      * @dev Compatible with ERC721 transferFrom.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8Mintable.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../ILSP8IdentifiableDigitalAsset.sol";
+import {ILSP8IdentifiableDigitalAsset} from "../ILSP8IdentifiableDigitalAsset.sol";
 
 /**
  * @dev LSP8 extension, mintable.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -3,16 +3,14 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP8CappedSupplyCore.sol";
-import "../LSP8IdentifiableDigitalAsset.sol";
+import {LSP8IdentifiableDigitalAsset} from "../LSP8IdentifiableDigitalAsset.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.
  */
-abstract contract LSP8CappedSupply is
-    LSP8CappedSupplyCore,
-    LSP8IdentifiableDigitalAsset
-{
+abstract contract LSP8CappedSupply is LSP8CappedSupplyCore, LSP8IdentifiableDigitalAsset {
     /**
      * @notice Sets the token max supply
      * @param tokenSupplyCap_ The Token max supply
@@ -43,11 +41,7 @@ abstract contract LSP8CappedSupply is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(LSP8IdentifiableDigitalAssetCore, LSP8CappedSupplyCore)
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CappedSupplyCore) {
         super._mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
@@ -2,19 +2,16 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "../LSP8IdentifiableDigitalAssetCore.sol";
-
 // interfaces
-import "./ILSP8CappedSupply.sol";
+import {ILSP8CappedSupply} from "./ILSP8CappedSupply.sol";
+
+// modules
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.
  */
-abstract contract LSP8CappedSupplyCore is
-    ILSP8CappedSupply,
-    LSP8IdentifiableDigitalAssetCore
-{
+abstract contract LSP8CappedSupplyCore is ILSP8CappedSupply, LSP8IdentifiableDigitalAssetCore {
     // --- Errors
 
     error LSP8CappedSupplyRequired();

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInit.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP8CappedSupplyInitAbstract.sol";
+import {LSP8CappedSupplyInitAbstract} from "./LSP8CappedSupplyInitAbstract.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -3,8 +3,10 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP8CappedSupplyCore.sol";
-import "../LSP8IdentifiableDigitalAssetInit.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP8IdentifiableDigitalAssetInit} from "../LSP8IdentifiableDigitalAssetInit.sol";
+import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.
@@ -14,11 +16,7 @@ abstract contract LSP8CappedSupplyInitAbstract is
     LSP8CappedSupplyCore,
     LSP8IdentifiableDigitalAssetInit
 {
-    function _initialize(uint256 tokenSupplyCap_)
-        internal
-        virtual
-        onlyInitializing
-    {
+    function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {
             revert LSP8CappedSupplyRequired();
         }
@@ -44,11 +42,7 @@ abstract contract LSP8CappedSupplyInitAbstract is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(LSP8IdentifiableDigitalAssetCore, LSP8CappedSupplyCore)
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CappedSupplyCore) {
         super._mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
@@ -2,12 +2,19 @@
 
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+// libraries
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
 // modules
-import "../LSP8IdentifiableDigitalAsset.sol";
-import "./LSP8CompatibilityForERC721Core.sol";
+import {LSP8IdentifiableDigitalAsset} from "../LSP8IdentifiableDigitalAsset.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP8CompatibilityForERC721Core} from "./LSP8CompatibilityForERC721Core.sol";
 
 // constants
-import "./LSP8CompatibilityConstants.sol";
+import {_INTERFACEID_ERC721, _INTERFACEID_ERC721METADATA} from "./LSP8CompatibilityConstants.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
@@ -35,10 +42,7 @@ contract LSP8CompatibilityForERC721 is
     function authorizeOperator(address operator, bytes32 tokenId)
         public
         virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
+        override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core)
     {
         super.authorizeOperator(operator, tokenId);
     }
@@ -49,14 +53,7 @@ contract LSP8CompatibilityForERC721 is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core) {
         super._transfer(from, to, tokenId, force, data);
     }
 
@@ -65,24 +62,14 @@ contract LSP8CompatibilityForERC721 is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core) {
         super._mint(to, tokenId, force, data);
     }
 
     function _burn(bytes32 tokenId, bytes memory data)
         internal
         virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
+        override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core)
     {
         super._burn(tokenId, data);
     }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
@@ -2,19 +2,20 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import "../LSP8IdentifiableDigitalAssetCore.sol";
-import "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+// interfaces
+import {ILSP8IdentifiableDigitalAsset} from "../ILSP8IdentifiableDigitalAsset.sol";
+import {ILSP8CompatibilityForERC721} from "./ILSP8CompatibilityForERC721.sol";
 
 // libraries
-import "solidity-bytes-utils/contracts/BytesLib.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 
-// interfaces
-import "./ILSP8CompatibilityForERC721.sol";
+// modules
+import {LSP4Compatibility} from "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 
 // constants
-import "./LSP8CompatibilityConstants.sol";
+import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
@@ -29,13 +30,7 @@ abstract contract LSP8CompatibilityForERC721Core is
     /*
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function tokenURI(uint256 tokenId)
-        public
-        view
-        virtual
-        override
-        returns (string memory)
-    {
+    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
         // silence compiler warning about unused variable
         tokenId;
 
@@ -44,35 +39,21 @@ abstract contract LSP8CompatibilityForERC721Core is
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36
         uint256 offset = 36;
 
-        bytes memory uriBytes = BytesLib.slice(
-            data,
-            offset,
-            data.length - offset
-        );
+        bytes memory uriBytes = BytesLib.slice(data, offset, data.length - offset);
         return string(uriBytes);
     }
 
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function ownerOf(uint256 tokenId)
-        external
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function ownerOf(uint256 tokenId) external view virtual override returns (address) {
         return tokenOwnerOf(bytes32(tokenId));
     }
 
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function approve(address operator, uint256 tokenId)
-        external
-        virtual
-        override
-    {
+    function approve(address operator, uint256 tokenId) external virtual override {
         authorizeOperator(operator, bytes32(tokenId));
 
         emit Approval(tokenOwnerOf(bytes32(tokenId)), operator, tokenId);
@@ -81,19 +62,11 @@ abstract contract LSP8CompatibilityForERC721Core is
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function getApproved(uint256 tokenId)
-        external
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function getApproved(uint256 tokenId) external view virtual override returns (address) {
         bytes32 tokenIdAsBytes32 = bytes32(tokenId);
         _existsOrError(tokenIdAsBytes32);
 
-        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[
-            tokenIdAsBytes32
-        ];
+        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[tokenIdAsBytes32];
         uint256 operatorListLength = operatorsForTokenId.length();
 
         if (operatorListLength == 0) {
@@ -170,10 +143,7 @@ abstract contract LSP8CompatibilityForERC721Core is
     function authorizeOperator(address operator, bytes32 tokenId)
         public
         virtual
-        override(
-            ILSP8IdentifiableDigitalAsset,
-            LSP8IdentifiableDigitalAssetCore
-        )
+        override(ILSP8IdentifiableDigitalAsset, LSP8IdentifiableDigitalAssetCore)
     {
         super.authorizeOperator(operator, tokenId);
 
@@ -193,11 +163,7 @@ abstract contract LSP8CompatibilityForERC721Core is
     ) internal virtual override {
         super._transfer(from, to, tokenId, force, data);
 
-        emit Transfer(
-            from,
-            to,
-            abi.decode(abi.encodePacked(tokenId), (uint256))
-        );
+        emit Transfer(from, to, abi.decode(abi.encodePacked(tokenId), (uint256)));
     }
 
     function _mint(
@@ -208,26 +174,14 @@ abstract contract LSP8CompatibilityForERC721Core is
     ) internal virtual override {
         super._mint(to, tokenId, force, data);
 
-        emit Transfer(
-            address(0),
-            to,
-            abi.decode(abi.encodePacked(tokenId), (uint256))
-        );
+        emit Transfer(address(0), to, abi.decode(abi.encodePacked(tokenId), (uint256)));
     }
 
-    function _burn(bytes32 tokenId, bytes memory data)
-        internal
-        virtual
-        override
-    {
+    function _burn(bytes32 tokenId, bytes memory data) internal virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
         super._burn(tokenId, data);
 
-        emit Transfer(
-            tokenOwner,
-            address(0),
-            abi.decode(abi.encodePacked(tokenId), (uint256))
-        );
+        emit Transfer(tokenOwner, address(0), abi.decode(abi.encodePacked(tokenId), (uint256)));
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Init.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Init.sol
@@ -3,14 +3,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP8CompatibilityForERC721InitAbstract.sol";
+import {LSP8CompatibilityForERC721InitAbstract} from "./LSP8CompatibilityForERC721InitAbstract.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
  */
-contract LSP8CompatibilityForERC721Init is
-    LSP8CompatibilityForERC721InitAbstract
-{
+contract LSP8CompatibilityForERC721Init is LSP8CompatibilityForERC721InitAbstract {
     /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
@@ -22,10 +20,6 @@ contract LSP8CompatibilityForERC721Init is
         string memory symbol_,
         address newOwner_
     ) public virtual initializer {
-        LSP8CompatibilityForERC721InitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP8CompatibilityForERC721InitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
@@ -2,12 +2,16 @@
 
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 // modules
-import "./LSP8CompatibilityForERC721Core.sol";
-import "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
+import {LSP8CompatibilityForERC721Core} from "./LSP8CompatibilityForERC721Core.sol";
 
 // constants
-import "./LSP8CompatibilityConstants.sol";
+import {_INTERFACEID_ERC721, _INTERFACEID_ERC721METADATA} from "./LSP8CompatibilityConstants.sol";
 
 /**
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
@@ -21,20 +25,13 @@ contract LSP8CompatibilityForERC721InitAbstract is
         string memory symbol_,
         address newOwner_
     ) internal virtual override onlyInitializing {
-        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 
     function authorizeOperator(address operator, bytes32 tokenId)
         public
         virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
+        override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core)
     {
         super.authorizeOperator(operator, tokenId);
     }
@@ -45,14 +42,7 @@ contract LSP8CompatibilityForERC721InitAbstract is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core) {
         super._transfer(from, to, tokenId, force, data);
     }
 
@@ -61,24 +51,14 @@ contract LSP8CompatibilityForERC721InitAbstract is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    )
-        internal
-        virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
-    {
+    ) internal virtual override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core) {
         super._mint(to, tokenId, force, data);
     }
 
     function _burn(bytes32 tokenId, bytes memory data)
         internal
         virtual
-        override(
-            LSP8IdentifiableDigitalAssetCore,
-            LSP8CompatibilityForERC721Core
-        )
+        override(LSP8IdentifiableDigitalAssetCore, LSP8CompatibilityForERC721Core)
     {
         super._burn(tokenId, data);
     }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP8MintableCore.sol";
-import "../LSP8IdentifiableDigitalAsset.sol";
+// modules
+import {LSP8IdentifiableDigitalAsset} from "../LSP8IdentifiableDigitalAsset.sol";
+import {LSP8MintableCore} from "./LSP8MintableCore.sol";
 
 /**
  * @dev LSP8 extension.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableCore.sol
@@ -2,19 +2,16 @@
 
 pragma solidity ^0.8.0;
 
-// modules
-import "../LSP8IdentifiableDigitalAssetCore.sol";
-
 // interfaces
-import "./ILSP8Mintable.sol";
+import {ILSP8Mintable} from "./ILSP8Mintable.sol";
+
+// modules
+import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 
 /**
  * @dev LSP8 extension
  */
-abstract contract LSP8MintableCore is
-    ILSP8Mintable,
-    LSP8IdentifiableDigitalAssetCore
-{
+abstract contract LSP8MintableCore is ILSP8Mintable, LSP8IdentifiableDigitalAssetCore {
     /**
      * @inheritdoc ILSP8Mintable
      */

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInit.sol
@@ -2,7 +2,8 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP8MintableInitAbstract.sol";
+// modules
+import {LSP8MintableInitAbstract} from "./LSP8MintableInitAbstract.sol";
 
 /**
  * @dev LSP8 extension.
@@ -18,7 +19,7 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) public virtual override initializer {
+    ) public virtual initializer {
         LSP8MintableInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInitAbstract.sol
@@ -2,26 +2,23 @@
 
 pragma solidity ^0.8.0;
 
-import "./LSP8MintableCore.sol";
-import "../LSP8IdentifiableDigitalAssetInit.sol";
+// modules
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {LSP8MintableCore} from "./LSP8MintableCore.sol";
 
 /**
  * @dev LSP8 extension.
  */
 abstract contract LSP8MintableInitAbstract is
     LSP8MintableCore,
-    LSP8IdentifiableDigitalAssetInit
+    LSP8IdentifiableDigitalAssetInitAbstract
 {
     function _initialize(
         string memory name_,
         string memory symbol_,
         address newOwner_
     ) internal virtual override onlyInitializing {
-        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name_,
-            symbol_,
-            newOwner_
-        );
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
 // modules
-import "@erc725/smart-contracts/contracts/ERC725.sol";
-import "./LSP9VaultCore.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
+import {LSP9VaultCore} from "./LSP9VaultCore.sol";
 
 // constants
-import "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -20,10 +25,7 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
      */
     constructor(address _newOwner) ERC725(_newOwner) {
         // set key SupportedStandards:LSP9Vault
-        _setData(
-            _LSP9_SUPPORTED_STANDARDS_KEY,
-            _LSP9_SUPPORTED_STANDARDS_VALUE
-        );
+        _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
         _notifyVaultReceiver(_newOwner);
     }
@@ -32,12 +34,7 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
      * @inheritdoc OwnableUnset
      * @dev Transfer the ownership and notify the vault sender and vault receiver
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override
-        onlyOwner
-    {
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
         OwnableUnset.transferOwnership(newOwner);
 
         _notifyVaultSender(msg.sender);
@@ -52,12 +49,7 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 _key, bytes memory _value)
-        public
-        virtual
-        override
-        onlyAllowed
-    {
+    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
         _setData(_key, _value);
     }
 
@@ -75,10 +67,7 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
         override
         onlyAllowed
     {
-        require(
-            _keys.length == _values.length,
-            "Keys length not equal to values length"
-        );
+        require(_keys.length == _values.length, "Keys length not equal to values length");
         for (uint256 i = 0; i < _keys.length; i++) {
             _setData(_keys[i], _values[i]);
         }
@@ -87,13 +76,7 @@ contract LSP9Vault is LSP9VaultCore, ERC725 {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@erc725/smart-contracts/contracts/ERC725X.sol";
-import "@erc725/smart-contracts/contracts/ERC725Y.sol";
-
 // interfaces
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
-// library
-import "../Utils/ERC165CheckerCustom.sol";
+// libraries
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
+import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
+
+// modules
+import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
+
 // constants
-import "../LSP1UniversalReceiver/LSP1Constants.sol";
-import "./LSP9Constants.sol";
+import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Constants.sol";
 
 /**
  * @title Core Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -35,14 +37,10 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      */
     modifier onlyAllowed() {
         if (msg.sender != owner()) {
-            address universalReceiverAddress = address(
-                bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY))
-            );
+            address universalReceiverAddress = address(bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY)));
             require(
-                ERC165CheckerCustom.supportsERC165Interface(
-                    msg.sender,
-                    _INTERFACEID_LSP1_DELEGATE
-                ) && msg.sender == universalReceiverAddress,
+                ERC165CheckerCustom.supportsERC165Interface(msg.sender, _INTERFACEID_LSP1_DELEGATE) &&
+                    msg.sender == universalReceiverAddress,
                 "Only Owner or Universal Receiver Delegate allowed"
             );
         }
@@ -76,15 +74,12 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
 
         if (data.length >= 20) {
             address universalReceiverDelegate = BytesLib.toAddress(data, 0);
-            if (
-                ERC165CheckerCustom.supportsERC165Interface(
-                    universalReceiverDelegate,
-                    _INTERFACEID_LSP1_DELEGATE
-                )
-            ) {
-                returnValue = ILSP1UniversalReceiverDelegate(
-                    universalReceiverDelegate
-                ).universalReceiverDelegate(_msgSender(), _typeId, _data);
+            if (ERC165CheckerCustom.supportsERC165Interface(universalReceiverDelegate, _INTERFACEID_LSP1_DELEGATE)) {
+                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate).universalReceiverDelegate(
+                    _msgSender(),
+                    _typeId,
+                    _data
+                );
             }
         }
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);
@@ -96,16 +91,8 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      * @dev Calls the universalReceiver function of the sender if supports LSP1 InterfaceId
      */
     function _notifyVaultSender(address _sender) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(
-                _sender,
-                _INTERFACEID_LSP1
-            )
-        ) {
-            ILSP1UniversalReceiver(_sender).universalReceiver(
-                _TYPEID_LSP9_VAULTSENDER,
-                ""
-            );
+        if (ERC165CheckerCustom.supportsERC165Interface(_sender, _INTERFACEID_LSP1)) {
+            ILSP1UniversalReceiver(_sender).universalReceiver(_TYPEID_LSP9_VAULTSENDER, "");
         }
     }
 
@@ -113,16 +100,8 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      * @dev Calls the universalReceiver function of the recipient if supports LSP1 InterfaceId
      */
     function _notifyVaultReceiver(address _receiver) internal virtual {
-        if (
-            ERC165CheckerCustom.supportsERC165Interface(
-                _receiver,
-                _INTERFACEID_LSP1
-            )
-        ) {
-            ILSP1UniversalReceiver(_receiver).universalReceiver(
-                _TYPEID_LSP9_VAULTRECIPIENT,
-                ""
-            );
+        if (ERC165CheckerCustom.supportsERC165Interface(_receiver, _INTERFACEID_LSP1)) {
+            ILSP1UniversalReceiver(_receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
         }
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP9VaultInitAbstract.sol";
+import {LSP9VaultInitAbstract} from "./LSP9VaultInitAbstract.sol";
 
 /**
  * @title Deployable Proxy Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -1,9 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+// interfaces
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
 // modules
-import "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
-import "./LSP9VaultCore.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
+import {LSP9VaultCore} from "./LSP9VaultCore.sol";
+
+// constants
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -11,19 +19,11 @@ import "./LSP9VaultCore.sol";
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
 abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
-    function _initialize(address _newOwner)
-        internal
-        virtual
-        override
-        onlyInitializing
-    {
+    function _initialize(address _newOwner) internal virtual override onlyInitializing {
         ERC725InitAbstract._initialize(_newOwner);
 
         // set key SupportedStandards:LSP9Vault
-        _setData(
-            _LSP9_SUPPORTED_STANDARDS_KEY,
-            _LSP9_SUPPORTED_STANDARDS_VALUE
-        );
+        _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
         _notifyVaultReceiver(_newOwner);
     }
@@ -32,12 +32,7 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
      * @inheritdoc OwnableUnset
      * @dev Transfer the ownership and notify the vault sender and vault receiver
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override
-        onlyOwner
-    {
+    function transferOwnership(address newOwner) public virtual override onlyOwner {
         OwnableUnset.transferOwnership(newOwner);
 
         _notifyVaultSender(msg.sender);
@@ -52,12 +47,7 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 _key, bytes memory _value)
-        public
-        virtual
-        override
-        onlyAllowed
-    {
+    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
         _setData(_key, _value);
     }
 
@@ -75,10 +65,7 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
         override
         onlyAllowed
     {
-        require(
-            _keys.length == _values.length,
-            "Keys length not equal to values length"
-        );
+        require(_keys.length == _values.length, "Keys length not equal to values length");
         for (uint256 i = 0; i < _keys.length; i++) {
             _setData(_keys[i], _values[i]);
         }
@@ -87,13 +74,7 @@ abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||

--- a/contracts/Legacy/Registries/AddressRegistry.sol
+++ b/contracts/Legacy/Registries/AddressRegistry.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// modules
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
-
 // libraries
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
+// modules
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 contract AddressRegistry is ERC165Storage {
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -26,13 +25,8 @@ contract AddressRegistry is ERC165Storage {
     }
 
     function getIndex(address _address) public view returns (uint256) {
-        require(
-            _addressStore.contains(_address),
-            "EnumerableSet: Index not found"
-        );
-        return
-            _addressStore._inner._indexes[bytes32(uint256(uint160(_address)))] -
-            1;
+        require(_addressStore.contains(_address), "EnumerableSet: Index not found");
+        return _addressStore._inner._indexes[bytes32(uint256(uint160(_address)))] - 1;
     }
 
     function getAllRawValues() public view returns (bytes32[] memory) {

--- a/contracts/Legacy/Registries/AddressRegistryRequiresERC725.sol
+++ b/contracts/Legacy/Registries/AddressRegistryRequiresERC725.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-// modules
-import "./AddressRegistry.sol";
+// libraries
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
+// modules
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {AddressRegistry} from "./AddressRegistry.sol";
+
+// constants
 import {_INTERFACEID_ERC725Y} from "@erc725/smart-contracts/contracts/constants.sol";
 
 contract AddressRegistryRequiresERC725 is AddressRegistry {

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -2,11 +2,14 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+
+// libraries
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 // modules
-import "./Registries/AddressRegistry.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {AddressRegistry} from "./Registries/AddressRegistry.sol";
 
 contract UniversalReceiverAddressStore is
     ERC165Storage,
@@ -27,21 +30,11 @@ contract UniversalReceiverAddressStore is
         _registerInterface(_INTERFACE_ID_LSP1DELEGATE);
     }
 
-    function addAddress(address _address)
-        public
-        override
-        onlyAccount
-        returns (bool)
-    {
+    function addAddress(address _address) public override onlyAccount returns (bool) {
         return _addressStore.add(_address);
     }
 
-    function removeAddress(address _address)
-        public
-        override
-        onlyAccount
-        returns (bool)
-    {
+    function removeAddress(address _address) public override onlyAccount returns (bool) {
         return _addressStore.remove(_address);
     }
 
@@ -60,10 +53,7 @@ contract UniversalReceiverAddressStore is
 
     /* Modifers */
     modifier onlyAccount() {
-        require(
-            msg.sender == account,
-            "Only the connected account call this function"
-        );
+        require(msg.sender == account, "Only the connected account call this function");
         _;
     }
 }

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP0ERC725Account/LSP0ERC725Account.sol";
+import {LSP0ERC725Account} from "./LSP0ERC725Account/LSP0ERC725Account.sol";
 
 /**
  * @title implementation of a LUKSO's Universal Profile based on LSP3

--- a/contracts/UniversalProfileInit.sol
+++ b/contracts/UniversalProfileInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./UniversalProfileInitAbstract.sol";
+import {UniversalProfileInitAbstract} from "./UniversalProfileInitAbstract.sol";
 
 /**
  * @title Deployable Proxy implementation of a LUKSO's Universal Profile based on LSP3

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -2,23 +2,16 @@
 pragma solidity ^0.8.0;
 
 // modules
-import "./LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol";
 
 /**
  * @title Inheritable Proxy implementation of a LUKSO's Universal Profile based on LSP3
  * @author Fabian Vogelsteller <fabian@lukso.network>
  * @dev Implementation of the ERC725Account + LSP1 universalReceiver
  */
-abstract contract UniversalProfileInitAbstract is
-    Initializable,
-    LSP0ERC725AccountInitAbstract
-{
-    function _initialize(address _newOwner)
-        internal
-        virtual
-        override
-        onlyInitializing
-    {
+abstract contract UniversalProfileInitAbstract is Initializable, LSP0ERC725AccountInitAbstract {
+    function _initialize(address _newOwner) internal virtual override onlyInitializing {
         LSP0ERC725AccountInitAbstract._initialize(_newOwner);
 
         // set key SupportedStandards:LSP3UniversalProfile

--- a/contracts/Utils/ERC165CheckerCustom.sol
+++ b/contracts/Utils/ERC165CheckerCustom.sol
@@ -3,7 +3,8 @@
 
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+// interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @dev Library used to query support of an interface declared via {IERC165}.
@@ -33,15 +34,9 @@ library ERC165CheckerCustom {
      *
      * See {IERC165-supportsInterface}.
      */
-    function supportsInterface(address account, bytes4 interfaceId)
-        internal
-        view
-        returns (bool)
-    {
+    function supportsInterface(address account, bytes4 interfaceId) internal view returns (bool) {
         // query support of both ERC165 as per the spec and support of _interfaceId
-        return
-            supportsERC165(account) &&
-            supportsERC165Interface(account, interfaceId);
+        return supportsERC165(account) && supportsERC165Interface(account, interfaceId);
     }
 
     /**
@@ -54,10 +49,11 @@ library ERC165CheckerCustom {
      *
      * _Available since v3.4._
      */
-    function getSupportedInterfaces(
-        address account,
-        bytes4[] memory interfaceIds
-    ) internal view returns (bool[] memory) {
+    function getSupportedInterfaces(address account, bytes4[] memory interfaceIds)
+        internal
+        view
+        returns (bool[] memory)
+    {
         // an array of booleans corresponding to interfaceIds and whether they're supported or not
         bool[] memory interfaceIdsSupported = new bool[](interfaceIds.length);
 
@@ -65,10 +61,7 @@ library ERC165CheckerCustom {
         if (supportsERC165(account)) {
             // query support of each interface in interfaceIds
             for (uint256 i = 0; i < interfaceIds.length; i++) {
-                interfaceIdsSupported[i] = supportsERC165Interface(
-                    account,
-                    interfaceIds[i]
-                );
+                interfaceIdsSupported[i] = supportsERC165Interface(account, interfaceIds[i]);
             }
         }
 
@@ -84,10 +77,11 @@ library ERC165CheckerCustom {
      *
      * See {IERC165-supportsInterface}.
      */
-    function supportsAllInterfaces(
-        address account,
-        bytes4[] memory interfaceIds
-    ) internal view returns (bool) {
+    function supportsAllInterfaces(address account, bytes4[] memory interfaceIds)
+        internal
+        view
+        returns (bool)
+    {
         // query support of ERC165 itself
         if (!supportsERC165(account)) {
             return false;
@@ -124,9 +118,7 @@ library ERC165CheckerCustom {
             IERC165.supportsInterface.selector,
             interfaceId
         );
-        (bool success, bytes memory result) = account.staticcall{gas: 30000}(
-            encodedParams
-        );
+        (bool success, bytes memory result) = account.staticcall{gas: 30000}(encodedParams);
         if (result.length < 32) return false;
         return success && abi.decode(result, (bool));
     }


### PR DESCRIPTION
## What does this PR introduce?
- [x] Using the `import {Module} from "File";` format for import statements
- [x] Order the layout of import statements: `interfaces` > `libraries` > `modules` > `errors` > `constants`
- [x] Add Custom Errors in a separate file