### PR TITLE
chore: decrease prettier `printWidth` to 100

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -14,7 +14,7 @@
       "files": "*.sol",
       "options": {
         "tabWidth": 4,
-        "printWidth": 120
+        "printWidth": 100
       }
     }
   ]


### PR DESCRIPTION
## What does this PR introduce?
- Decreasing the `printWidth` in prettier from 120 to 100 (recommended by solidity docs).