### PR TITLE
refactor: use `!= 0` instead of `> 0`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -115,7 +115,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         }
 
         emit Executed(msg.value, bytes4(_data));
-        return result_.length > 0 ? abi.decode(result_, (bytes)) : result_;
+        return result_.length != 0 ? abi.decode(result_, (bytes)) : result_;
     }
 
     /**
@@ -170,7 +170,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         }
 
         emit Executed(msg.value, bytes4(_data));
-        return result_.length > 0 ? abi.decode(result_, (bytes)) : result_;
+        return result_.length != 0 ? abi.decode(result_, (bytes)) : result_;
     }
 
     /**
@@ -222,7 +222,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             address to = address(bytes20(_data[48:68]));
             _verifyAllowedAddress(_from, to);
 
-            if (to.code.length > 0) {
+            if (to.code.length != 0) {
                 _verifyAllowedStandard(_from, to);
 
                 if (_data.length >= 168) {
@@ -416,7 +416,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             revert NotAuthorised(_from, operationName);
 
         if (
-            (value > 0) &&
+            (value != 0) &&
             !_permissions.includesPermissions(_PERMISSION_TRANSFERVALUE)
         ) {
             revert NotAuthorised(_from, "TRANSFERVALUE");

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -211,7 +211,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
 
         _operatorAuthorizedAmount[tokenOwner][operator] = amount;
 
-        if (amount > 0) {
+        if (amount != 0) {
             emit AuthorizedOperator(operator, tokenOwner, amount);
         } else {
             emit RevokedOperator(operator, tokenOwner);
@@ -411,7 +411,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
                 packedData
             );
         } else if (!force) {
-            if (to.code.length > 0) {
+            if (to.code.length != 0) {
                 revert LSP7NotifyTokenReceiverContractMissingLSP1Interface(to);
             } else {
                 revert LSP7NotifyTokenReceiverIsEOA(to);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -484,7 +484,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
                 packedData
             );
         } else if (!force) {
-            if (to.code.length > 0) {
+            if (to.code.length != 0) {
                 revert LSP8NotifyTokenReceiverContractMissingLSP1Interface(to);
             } else {
                 revert LSP8NotifyTokenReceiverIsEOA(to);


### PR DESCRIPTION
## What does this PR introduce?
- Changed all occurrences of `> 0` to `!= 0` because `!= 0` is cheaper than `> 0`.
These two statements are equivalent for uint values since they cannot be less than zero.
