### PR TITLE
refactor!: change function `account()` -> `target()` in LSP6

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -20,7 +20,7 @@ export const enum INTERFACE_IDS {
   ERC725Account = "0x481e0fe8",
   LSP1 = "0x6bb56a14",
   LSP1Delegate = "0xc2d7bcc1",
-  LSP6 = "0x32e6d0ab",
+  LSP6 = "0xbbf5cd19",
   LSP7 = "0xe33f65c3",
   LSP8 = "0x49399145",
   LSP9 = "0x5e38b596",

--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -13,66 +13,42 @@ contract KeyManagerInternalTester is LSP6KeyManager {
     constructor(address _account) LSP6KeyManager(_account) {}
 
     function getPermissionsFor(address _address) public view returns (bytes32) {
-        return ERC725Y(account).getPermissionsFor(_address);
+        return ERC725Y(target).getPermissionsFor(_address);
     }
 
-    function getAllowedAddressesFor(address _address)
-        public
-        view
-        returns (bytes memory)
-    {
-        return ERC725Y(account).getAllowedAddressesFor(_address);
+    function getAllowedAddressesFor(address _address) public view returns (bytes memory) {
+        return ERC725Y(target).getAllowedAddressesFor(_address);
     }
 
-    function getAllowedFunctionsFor(address _address)
-        public
-        view
-        returns (bytes memory)
-    {
-        return ERC725Y(account).getAllowedFunctionsFor(_address);
+    function getAllowedFunctionsFor(address _address) public view returns (bytes memory) {
+        return ERC725Y(target).getAllowedFunctionsFor(_address);
     }
 
-    function getAllowedERC725YKeysFor(address _address)
-        public
-        view
-        returns (bytes memory)
-    {
-        return ERC725Y(account).getAllowedERC725YKeysFor(_address);
+    function getAllowedERC725YKeysFor(address _address) public view returns (bytes memory) {
+        return ERC725Y(target).getAllowedERC725YKeysFor(_address);
     }
 
-    function verifyAllowedAddress(address _sender, address _recipient)
-        public
-        view
-    {
+    function verifyAllowedAddress(address _sender, address _recipient) public view {
         super._verifyAllowedAddress(_sender, _recipient);
     }
 
-    function verifyAllowedFunction(address _sender, bytes4 _function)
-        public
-        view
-    {
+    function verifyAllowedFunction(address _sender, bytes4 _function) public view {
         super._verifyAllowedFunction(_sender, _function);
     }
 
-    function verifyAllowedERC725YKeys(
-        address _from,
-        bytes32[] memory _inputKeys
-    ) public view {
+    function verifyAllowedERC725YKeys(address _from, bytes32[] memory _inputKeys) public view {
         super._verifyAllowedERC725YKeys(_from, _inputKeys);
     }
 
-    function includesPermissions(
-        bytes32 _addressPermission,
-        bytes32 _permissions
-    ) public pure returns (bool) {
+    function includesPermissions(bytes32 _addressPermission, bytes32 _permissions)
+        public
+        pure
+        returns (bool)
+    {
         return _addressPermission.includesPermissions(_permissions);
     }
 
-    function countZeroBytes(bytes32 _key)
-        public
-        pure
-        returns (uint256 zeroBytesCount_)
-    {
+    function countZeroBytes(bytes32 _key) public pure returns (uint256 zeroBytesCount_) {
         return super._countZeroBytes(_key);
     }
 }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -29,21 +29,12 @@ abstract contract TokenAndVaultHandling {
         if (sender.code.length == 0) return "";
 
         address keyManager = ERC725Y(msg.sender).owner();
-        if (
-            !ERC165CheckerCustom.supportsERC165Interface(
-                keyManager,
-                _INTERFACEID_LSP6
-            )
-        ) return "";
-        address accountAddress = address(LSP6KeyManager(keyManager).account());
+        if (!ERC165CheckerCustom.supportsERC165Interface(keyManager, _INTERFACEID_LSP6)) return "";
+        address accountAddress = address(LSP6KeyManager(keyManager).target());
         // check if the caller is the same account controlled by the keyManager
         if (msg.sender != accountAddress) return "";
-        (
-            bool senderHook,
-            bytes32 arrayKey,
-            bytes12 mapPrefix,
-            bytes4 interfaceID
-        ) = LSP1Utils.getTransferDetails(typeId);
+        (bool senderHook, bytes32 arrayKey, bytes12 mapPrefix, bytes4 interfaceID) = LSP1Utils
+            .getTransferDetails(typeId);
 
         bytes32 mapKey = LSP2Utils.generateBytes20MappingWithGroupingKey(
             mapPrefix,
@@ -66,9 +57,7 @@ abstract contract TokenAndVaultHandling {
             // if there is no map for the asset to remove, then do nothing
             if (bytes12(mapValue) == bytes12(0)) return "";
             if (typeId != _TYPEID_LSP9_VAULTSENDER) {
-                uint256 balance = ILSP7DigitalAsset(sender).balanceOf(
-                    msg.sender
-                );
+                uint256 balance = ILSP7DigitalAsset(sender).balanceOf(msg.sender);
                 // if the amount sent is not the full balance, then do nothing
                 if (balance != 0) return "";
             }

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -22,7 +22,7 @@ interface ILSP6KeyManager is
      *
      * @return the address of the linked account
      */
-    function account() external view returns (address);
+    function target() external view returns (address);
 
     /**
      * @notice get latest nonce for `_from` for channel ID: `_channel`
@@ -30,10 +30,7 @@ interface ILSP6KeyManager is
      * @param _address caller address
      * @param _channel channel id
      */
-    function getNonce(address _address, uint256 _channel)
-        external
-        view
-        returns (uint256);
+    function getNonce(address _address, uint256 _channel) external view returns (uint256);
 
     /**
      * @notice execute the following payload on the ERC725Account: `_data`
@@ -41,10 +38,7 @@ interface ILSP6KeyManager is
      * @param _data the payload to execute. Obtained in web3 via encodeABI()
      * @return result_ the data being returned by the ERC725 Account
      */
-    function execute(bytes calldata _data)
-        external
-        payable
-        returns (bytes memory);
+    function execute(bytes calldata _data) external payable returns (bytes memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = 0x32e6d0ab;
+bytes4 constant _INTERFACEID_LSP6 = 0xbbf5cd19;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -15,6 +15,6 @@ contract LSP6KeyManager is LSP6KeyManagerCore {
      * @param _account The address of the ER725Account to control
      */
     constructor(address _account) {
-        account = _account;
+        target = _account;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -34,19 +34,13 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     using ECDSA for bytes32;
     using ERC165CheckerCustom for address;
 
-    address public override account;
+    address public override target;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
 
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return
             interfaceId == _INTERFACEID_LSP6 ||
             interfaceId == _INTERFACEID_ERC1271 ||
@@ -56,12 +50,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address _from, uint256 _channel)
-        public
-        view
-        override
-        returns (uint256)
-    {
+    function getNonce(address _from, uint256 _channel) public view override returns (uint256) {
         uint128 nonceId = uint128(_nonceStore[_from][_channel]);
         return (uint256(_channel) << 128) | nonceId;
     }
@@ -78,9 +67,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         address recoveredAddress = ECDSA.recover(_hash, _signature);
 
         return (
-            ERC725Y(account)
-                .getPermissionsFor(recoveredAddress)
-                .includesPermissions(_PERMISSION_SIGN)
+            ERC725Y(target).getPermissionsFor(recoveredAddress).includesPermissions(
+                _PERMISSION_SIGN
+            )
                 ? _ERC1271_MAGICVALUE
                 : _ERC1271_FAILVALUE
         );
@@ -89,16 +78,11 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function execute(bytes calldata _data)
-        external
-        payable
-        override
-        returns (bytes memory)
-    {
+    function execute(bytes calldata _data) external payable override returns (bytes memory) {
         _verifyPermissions(msg.sender, _data);
 
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory result_) = address(account).call{
+        (bool success, bytes memory result_) = address(target).call{
             value: msg.value,
             gas: gasleft()
         }(_data);
@@ -138,14 +122,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
             _data
         );
 
-        address signer = keccak256(blob).toEthSignedMessageHash().recover(
-            _signature
-        );
+        address signer = keccak256(blob).toEthSignedMessageHash().recover(_signature);
 
-        require(
-            _isValidNonce(signer, _nonce),
-            "executeRelayCall: Invalid nonce"
-        );
+        require(_isValidNonce(signer, _nonce), "executeRelayCall: Invalid nonce");
 
         // increase nonce after successful verification
         _nonceStore[signer][_nonce >> 128]++;
@@ -153,10 +132,9 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         _verifyPermissions(signer, _data);
 
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory result_) = address(account).call{
-            value: 0,
-            gas: gasleft()
-        }(_data);
+        (bool success, bytes memory result_) = address(target).call{value: 0, gas: gasleft()}(
+            _data
+        );
 
         if (!success) {
             // solhint-disable reason-string
@@ -181,11 +159,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @param _from caller address
      * @param _idx (channel id + nonce within the channel)
      */
-    function _isValidNonce(address _from, uint256 _idx)
-        internal
-        view
-        returns (bool)
-    {
+    function _isValidNonce(address _from, uint256 _idx) internal view returns (bool) {
         // idx % (1 << 128) = nonce
         // (idx >> 128) = channel
         // equivalent to: return (nonce == _nonceStore[_from][channel]
@@ -193,18 +167,15 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     }
 
     /**
-     * @dev verify the permissions of the _from address that want to interact with the `account`
+     * @dev verify the permissions of the _from address that want to interact with the `target`
      * @param _from the address making the request
-     * @param _data the payload that will be run on `account`
+     * @param _data the payload that will be run on `target`
      */
-    function _verifyPermissions(address _from, bytes calldata _data)
-        internal
-        view
-    {
+    function _verifyPermissions(address _from, bytes calldata _data) internal view {
         bytes4 erc725Function = bytes4(_data[:4]);
 
         // get the permissions of the caller
-        bytes32 permissions = ERC725Y(account).getPermissionsFor(_from);
+        bytes32 permissions = ERC725Y(target).getPermissionsFor(_from);
 
         // skip permissions check if caller has all permissions (except SIGN as not required)
         if (permissions.includesPermissions(_ALL_EXECUTION_PERMISSIONS)) {
@@ -242,7 +213,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @dev verify if `_from` has the required permissions to set some keys
      * on the linked ERC725Account
      * @param _from the address who want to set the keys
-     * @param _data the ABI encoded payload `account.setData(keys, values)`
+     * @param _data the ABI encoded payload `target.setData(keys, values)`
      * containing a list of keys-value pairs
      */
     function _verifyCanSetData(
@@ -271,7 +242,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
                 inputKeys[ii] = bytes32(0);
 
             } else if (key == _LSP6_ADDRESS_PERMISSIONS_ARRAY_KEY) {
-                uint256 arrayLength = uint256(bytes32(ERC725Y(account).getData(key)));
+                uint256 arrayLength = uint256(bytes32(ERC725Y(target).getData(key)));
                 uint256 newLength = uint256(bytes32(inputValues[ii]));
 
                 if (newLength > arrayLength) {
@@ -308,7 +279,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
     ) internal view {
         // prettier-ignore
         // check if some permissions are already stored under this key
-        if (bytes32(ERC725Y(account).getData(_key)) == bytes32(0)) {
+        if (bytes32(ERC725Y(target).getData(_key)) == bytes32(0)) {
             // if nothing is stored under this key,
             // we are trying to ADD permissions for a NEW address
             if (!_callerPermissions.includesPermissions(_PERMISSION_ADDPERMISSIONS))
@@ -322,20 +293,13 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         }
     }
 
-    function _verifyAllowedERC725YKeys(
-        address _from,
-        bytes32[] memory _inputKeys
-    ) internal view {
-        bytes memory allowedERC725YKeysEncoded = ERC725Y(account)
-            .getAllowedERC725YKeysFor(_from);
+    function _verifyAllowedERC725YKeys(address _from, bytes32[] memory _inputKeys) internal view {
+        bytes memory allowedERC725YKeysEncoded = ERC725Y(target).getAllowedERC725YKeysFor(_from);
 
         // whitelist any ERC725Y key if nothing in the list
         if (allowedERC725YKeysEncoded.length == 0) return;
 
-        bytes32[] memory allowedERC725YKeys = abi.decode(
-            allowedERC725YKeysEncoded,
-            (bytes32[])
-        );
+        bytes32[] memory allowedERC725YKeys = abi.decode(allowedERC725YKeysEncoded, (bytes32[]));
 
         uint256 zeroBytesCount;
         bytes32 mask;
@@ -382,8 +346,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         }
 
         for (uint256 ii = 0; ii < _inputKeys.length; ii++) {
-            if (_inputKeys[ii] != bytes32(0))
-                revert NotAllowedERC725YKey(_from, _inputKeys[ii]);
+            if (_inputKeys[ii] != bytes32(0)) revert NotAllowedERC725YKey(_from, _inputKeys[ii]);
         }
     }
 
@@ -391,7 +354,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @dev verify if `_from` has the required permissions to make an external call
      * via the linked ERC725Account
      * @param _from the address who want to run the execute function on the ERC725Account
-     * @param _data the ABI encoded payload `account.execute(...)`
+     * @param _data the ABI encoded payload `target.execute(...)`
      */
     function _verifyCanExecute(
         address _from,
@@ -402,23 +365,16 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         uint256 value = uint256(bytes32(_data[68:100]));
 
         // TODO: to be removed, as delegatecall should be allowed in the future
-        require(
-            operationType != 4,
-            "_verifyCanExecute: operation 4 `DELEGATECALL` not supported"
-        );
+        require(operationType != 4, "_verifyCanExecute: operation 4 `DELEGATECALL` not supported");
 
-        (
-            bytes32 permissionRequired,
-            string memory operationName
-        ) = _extractPermissionFromOperation(operationType);
+        (bytes32 permissionRequired, string memory operationName) = _extractPermissionFromOperation(
+            operationType
+        );
 
         if (!_permissions.includesPermissions(permissionRequired))
             revert NotAuthorised(_from, operationName);
 
-        if (
-            (value > 0) &&
-            !_permissions.includesPermissions(_PERMISSION_TRANSFERVALUE)
-        ) {
+        if ((value > 0) && !_permissions.includesPermissions(_PERMISSION_TRANSFERVALUE)) {
             revert NotAuthorised(_from, "TRANSFERVALUE");
         }
     }
@@ -429,17 +385,12 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @param _to the address to interact with
      */
     function _verifyAllowedAddress(address _from, address _to) internal view {
-        bytes memory allowedAddresses = ERC725Y(account).getAllowedAddressesFor(
-            _from
-        );
+        bytes memory allowedAddresses = ERC725Y(target).getAllowedAddressesFor(_from);
 
         // whitelist any address if nothing in the list
         if (allowedAddresses.length == 0) return;
 
-        address[] memory allowedAddressesList = abi.decode(
-            allowedAddresses,
-            (address[])
-        );
+        address[] memory allowedAddressesList = abi.decode(allowedAddresses, (address[]));
 
         for (uint256 ii = 0; ii < allowedAddressesList.length; ii++) {
             if (_to == allowedAddressesList[ii]) return;
@@ -454,7 +405,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @param _to the address of the contract to interact with
      */
     function _verifyAllowedStandard(address _from, address _to) internal view {
-        bytes memory allowedStandards = ERC725Y(account).getData(
+        bytes memory allowedStandards = ERC725Y(target).getData(
             LSP2Utils.generateBytes20MappingWithGroupingKey(
                 _LSP6_ADDRESS_ALLOWEDSTANDARDS_MAP_KEY_PREFIX,
                 bytes20(_from)
@@ -464,10 +415,7 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
         // whitelist any standard interface (ERC165) if nothing in the list
         if (allowedStandards.length == 0) return;
 
-        bytes4[] memory allowedStandardsList = abi.decode(
-            allowedStandards,
-            (bytes4[])
-        );
+        bytes4[] memory allowedStandardsList = abi.decode(allowedStandards, (bytes4[]));
 
         for (uint256 ii = 0; ii < allowedStandardsList.length; ii++) {
             if (_to.supportsERC165Interface(allowedStandardsList[ii])) return;
@@ -482,21 +430,13 @@ abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
      * @param _functionSelector the bytes4 function selector of the function to run
      * at the target contract
      */
-    function _verifyAllowedFunction(address _from, bytes4 _functionSelector)
-        internal
-        view
-    {
-        bytes memory allowedFunctions = ERC725Y(account).getAllowedFunctionsFor(
-            _from
-        );
+    function _verifyAllowedFunction(address _from, bytes4 _functionSelector) internal view {
+        bytes memory allowedFunctions = ERC725Y(target).getAllowedFunctionsFor(_from);
 
         // whitelist any function if nothing in the list
         if (allowedFunctions.length == 0) return;
 
-        bytes4[] memory allowedFunctionsList = abi.decode(
-            allowedFunctions,
-            (bytes4[])
-        );
+        bytes4[] memory allowedFunctionsList = abi.decode(allowedFunctions, (bytes4[]));
 
         for (uint256 ii = 0; ii < allowedFunctionsList.length; ii++) {
             if (_functionSelector == allowedFunctionsList[ii]) return;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -11,11 +11,8 @@ import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
  * @author Fabian Vogelsteller, Jean Cavallera
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
-abstract contract LSP6KeyManagerInitAbstract is
-    Initializable,
-    LSP6KeyManagerCore
-{
+abstract contract LSP6KeyManagerInitAbstract is Initializable, LSP6KeyManagerCore {
     function _initialize(address _account) internal virtual onlyInitializing {
-        account = _account;
+        target = _account;
     }
 }

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -128,7 +128,7 @@ export const shouldInitializeLikeLSP6 = (
     });
 
     it("should be linked to the right ERC725 account contract", async () => {
-      let account = await context.keyManager.account();
+      let account = await context.keyManager.target();
       expect(account).toEqual(context.universalProfile.address);
     });
   });


### PR DESCRIPTION
# What does this PR introduce?

## Refactor - BREAKING CHANGE

Edit the LSP6 interface function from `account()` -> `target()`

This make the LSP6 interface ID change from:
- **before:** `0x32e6d0ab `
- **after:** `0xbbf5cd19 `