### PR TITLE
docs: change `UniversalProfile` -> `LSP0ERC725Account` in README + fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # lsp-smart-contracts
 
-The reference implementation for universal profiles smart contracts.
+The smart contracts reference implementation of the [LUKSO Standard Proposals (LSPs)](https://github.com/lukso-network/LIPs/tree/main/LSPs).
 
 For more information see [Documentation](https://docs.lukso.tech/standards/smart-contracts/introduction) on *[docs.lukso.tech](https://docs.lukso.tech/standards/introduction).*
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 The reference implementation for universal profiles smart contracts.
 
-For more information see [Documentation](https://docs.lukso.tech/standards/Universal-Profiles)
+For more information see [Documentation](https://docs.lukso.tech/standards/smart-contracts/introduction) on *[docs.lukso.tech](https://docs.lukso.tech/standards/introduction).*
 
 | :warning: | _This package is currently in early stages of development,<br/> use for testing or experimentation purposes only._ |
 | :-------: | :----------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information see [Documentation](https://docs.lukso.tech/standards/smart
 
 #### npm
 
-Universal Profile smart contracts are available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts).
+LSP smart contracts are available as a [npm package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts).
 
 ```bash
 npm install @lukso/lsp-smart-contracts
@@ -43,18 +43,18 @@ $ npm install
 You can use the contracts JSON ABI by importing them as follow:
 
 ```javascript
-import UniversalProfile from "@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json";
+import LSP0ERC725Account from "@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json";
 
-const myContract = new this.web3.eth.Contract(UniversalProfile.abi, "", defaultOptions);
+const myContract = new this.web3.eth.Contract(LSP0ERC725Account.abi, "", defaultOptions);
 ```
 
 #### in Solidity
 
 ```sol
-import "@lukso/lsp-smart-contracts/contracts/UniversalProfile.sol";
+import "@lukso/lsp-smart-contracts/contracts/LSP0ERC725Account/LSP0ERC725Account.sol";
 
-contract MyUP is UniversalProfile {
-  constructor(address _newOwner) UniversalProfile(_newOwner) {
+contract MyAccount is LSP0ERC725Account {
+  constructor(address _newOwner) LSP0ERC725Account(_newOwner) {
     
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -74,7 +74,7 @@ const config: HardhatUserConfig = {
       // Proxy version
       // ------------------
       "UniversalProfileInit",
-      "LSP0ERC725Account",
+      "LSP0ERC725AccountInit",
       "LSP4DigitalAssetMetadataInit",
       "LSP6KeyManagerInit",
       "LSP7DigitalAssetInit",


### PR DESCRIPTION
# What does this PR introduce?

## Build

LSP0 was already in the list of artifacts, but as duplicate in the standard and proxy section of the artifacts list
- add proxy version of LSP0 (= `LSP0ERC725AccountInit`) in artifacts list.


## Docs

- [x] change occurrences of `UniversalProfile` -> `LSP0ERC725Account` in Usage guides.
- [x] fix broken links to docs + add more visible links to:
    - _docs.lukso.tech_ ([Standard](https://docs.lukso.tech/standards/introduction) + [contract API](https://docs.lukso.tech/standards/smart-contracts/introduction) docs)
    - [LSP](https://github.com/lukso-network/LIPs) repository.