### PR TITLE
fix: inherit from most base to most derived

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -14,7 +14,7 @@ import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
-contract LSP0ERC725Account is LSP0ERC725AccountCore, ERC725 {
+contract LSP0ERC725Account is ERC725, LSP0ERC725AccountCore {
     /**
      * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -24,7 +24,13 @@ contract LSP0ERC725Account is ERC725, LSP0ERC725AccountCore {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725, LSP0ERC725AccountCore)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -25,10 +25,10 @@ import {_INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from 
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
 abstract contract LSP0ERC725AccountCore is
-    IERC1271,
-    ILSP1UniversalReceiver,
     ERC725XCore,
-    ERC725YCore
+    ERC725YCore,
+    IERC1271,
+    ILSP1UniversalReceiver
 {
     event ValueReceived(address indexed sender, uint256 indexed value);
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -16,8 +16,8 @@ import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 
 // constants
-import {_INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
-import {_INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
+import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 
 /**
  * @title Core Implementation of ERC725Account
@@ -108,5 +108,22 @@ abstract contract LSP0ERC725AccountCore is
             }
         }
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC1271 ||
+            interfaceId == _INTERFACEID_LSP0 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -14,7 +14,7 @@ import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
-abstract contract LSP0ERC725AccountInitAbstract is LSP0ERC725AccountCore, ERC725InitAbstract {
+abstract contract LSP0ERC725AccountInitAbstract is ERC725InitAbstract, LSP0ERC725AccountCore {
     function _initialize(address _newOwner) internal virtual override onlyInitializing {
         ERC725InitAbstract._initialize(_newOwner);
     }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -22,7 +22,13 @@ abstract contract LSP0ERC725AccountInitAbstract is ERC725InitAbstract, LSP0ERC72
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725InitAbstract, LSP0ERC725AccountCore)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -25,8 +25,8 @@ import {_TYPEID_LSP9_VAULTSENDER, _TYPEID_LSP9_VAULTRECIPIENT} from "../../LSP9V
  *
  */
 contract LSP1UniversalReceiverDelegateUP is
-    ILSP1UniversalReceiverDelegate,
     ERC165,
+    ILSP1UniversalReceiverDelegate,
     TokenAndVaultHandling
 {
     /**

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -37,7 +37,7 @@ contract LSP1UniversalReceiverDelegateUP is
     function universalReceiverDelegate(
         address sender,
         bytes32 typeId,
-        bytes memory data
+        bytes memory data // solhint-disable no-unused-vars
     ) public virtual override returns (bytes memory result) {
         if (
             typeId == _TYPEID_LSP7_TOKENSSENDER ||

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -33,7 +33,7 @@ contract LSP1UniversalReceiverDelegateVault is
     function universalReceiverDelegate(
         address sender,
         bytes32 typeId,
-        bytes memory data
+        bytes memory data // solhint-disable no-unused-vars
     ) public virtual override returns (bytes memory result) {
         if (
             typeId == _TYPEID_LSP7_TOKENSSENDER ||

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -21,8 +21,8 @@ import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "../../LSP
  * @dev Delegate contract of the initial universal receiver
  */
 contract LSP1UniversalReceiverDelegateVault is
-    ILSP1UniversalReceiverDelegate,
     ERC165,
+    ILSP1UniversalReceiverDelegate,
     TokenHandling
 {
     /**

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -13,7 +13,7 @@ import "./LSP4Constants.sol";
  * @author Matthew Stevens
  * @dev Inheritable Proxy Implementation of a LSP8 compliant contract.
  */
-abstract contract LSP4DigitalAssetMetadataInitAbstract is Initializable, ERC725YInitAbstract {
+abstract contract LSP4DigitalAssetMetadataInitAbstract is ERC725YInitAbstract {
     function _initialize(
         string memory name_,
         string memory symbol_,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -31,7 +31,7 @@ import "./LSP6Constants.sol";
  * @author Fabian Vogelsteller <frozeman>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
-abstract contract LSP6KeyManagerCore is ILSP6KeyManager, ERC165 {
+abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     using LSP2Utils for ERC725Y;
     using LSP6Utils for *;
     using Address for address;

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
 import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
 
@@ -42,7 +42,7 @@ contract LSP7DigitalAsset is LSP4DigitalAssetMetadata, LSP7DigitalAssetCore {
         public
         view
         virtual
-        override(IERC165, ERC165Storage)
+        override(IERC165, ERC725YCore)
         returns (bool)
     {
         return interfaceId == _INTERFACEID_LSP7 || super.supportsInterface(interfaceId);

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -18,7 +18,7 @@ import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
  * @author Matthew Stevens
  * @dev Implementation of a LSP7 compliant contract.
  */
-contract LSP7DigitalAsset is LSP7DigitalAssetCore, LSP4DigitalAssetMetadata {
+contract LSP7DigitalAsset is LSP4DigitalAssetMetadata, LSP7DigitalAssetCore {
     /**
      * @notice Sets the token-Metadata
      * @param name_ The name of the token

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -19,8 +19,8 @@ import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
  * @dev Proxy Implementation of a LSP7 compliant contract.
  */
 abstract contract LSP7DigitalAssetInitAbstract is
-    LSP7DigitalAssetCore,
-    LSP4DigitalAssetMetadataInitAbstract
+    LSP4DigitalAssetMetadataInitAbstract,
+    LSP7DigitalAssetCore
 {
     function _initialize(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
 
@@ -39,7 +39,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         public
         view
         virtual
-        override(IERC165, ERC165Storage)
+        override(IERC165, ERC725YCore)
         returns (bool)
     {
         return interfaceId == _INTERFACEID_LSP7 || super.supportsInterface(interfaceId);

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -20,7 +20,6 @@ import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
  */
 abstract contract LSP7DigitalAssetInitAbstract is
     LSP7DigitalAssetCore,
-    Initializable,
     LSP4DigitalAssetMetadataInitAbstract
 {
     function _initialize(

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -10,7 +10,7 @@ import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupply is LSP7CappedSupplyCore, LSP7DigitalAsset {
+abstract contract LSP7CappedSupply is LSP7DigitalAsset, LSP7CappedSupplyCore {
     /**
      * @notice Sets the token max supply
      * @param tokenSupplyCap_ The Token max supply

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
@@ -11,7 +11,7 @@ import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupplyCore is ILSP7CappedSupply, LSP7DigitalAssetCore {
+abstract contract LSP7CappedSupplyCore is LSP7DigitalAssetCore, ILSP7CappedSupply {
     // --- Errors
 
     error LSP7CappedSupplyRequired();

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -11,7 +11,7 @@ import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupplyInitAbstract is LSP7CappedSupplyCore, LSP7DigitalAssetInit {
+abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInit, LSP7CappedSupplyCore {
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {
             revert LSP7CappedSupplyRequired();

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -11,11 +11,7 @@ import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupplyInitAbstract is
-    Initializable,
-    LSP7CappedSupplyCore,
-    LSP7DigitalAssetInit
-{
+abstract contract LSP7CappedSupplyInitAbstract is LSP7CappedSupplyCore, LSP7DigitalAssetInit {
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {
             revert LSP7CappedSupplyRequired();

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.sol
@@ -7,7 +7,7 @@ import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
 import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 import {LSP7CompatibilityForERC20Core} from "./LSP7CompatibilityForERC20Core.sol";
 
-contract LSP7CompatibilityForERC20 is LSP7CompatibilityForERC20Core, LSP7DigitalAsset {
+contract LSP7CompatibilityForERC20 is LSP7DigitalAsset, LSP7CompatibilityForERC20Core {
     /* solhint-disable no-empty-blocks */
     /**
      * @notice Sets the name, the symbol and the owner of the token

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -14,9 +14,9 @@ import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
  * @dev LSP7 extension, for compatibility for clients / tools that expect ERC20.
  */
 abstract contract LSP7CompatibilityForERC20Core is
-    ILSP7CompatibilityForERC20,
+    LSP4Compatibility,
     LSP7DigitalAssetCore,
-    LSP4Compatibility
+    ILSP7CompatibilityForERC20
 {
     /**
      * @inheritdoc ILSP7CompatibilityForERC20

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol
@@ -8,8 +8,8 @@ import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 import {LSP7CompatibilityForERC20Core} from "./LSP7CompatibilityForERC20Core.sol";
 
 contract LSP7CompatibilityForERC20InitAbstract is
-    LSP7CompatibilityForERC20Core,
-    LSP7DigitalAssetInitAbstract
+    LSP7DigitalAssetInitAbstract,
+    LSP7CompatibilityForERC20Core
 {
     function _initialize(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Mintable.sol
@@ -11,7 +11,7 @@ import {LSP7MintableCore} from "./LSP7MintableCore.sol";
  * @author Jean Cavallera, Yamen Merhi
  * @dev LSP7 extension, mintable.
  */
-contract LSP7Mintable is LSP7MintableCore, LSP7DigitalAsset {
+contract LSP7Mintable is LSP7DigitalAsset, LSP7MintableCore {
     // solhint-disable no-empty-blocks
 
     /**

--- a/contracts/LSP7DigitalAsset/extensions/LSP7MintableCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7MintableCore.sol
@@ -11,7 +11,7 @@ import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 /**
  * @dev LSP7 extension, mintable .
  */
-abstract contract LSP7MintableCore is ILSP7Mintable, LSP7DigitalAssetCore {
+abstract contract LSP7MintableCore is LSP7DigitalAssetCore, ILSP7Mintable {
     /**
      * @inheritdoc ILSP7Mintable
      */

--- a/contracts/LSP7DigitalAsset/extensions/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7MintableInitAbstract.sol
@@ -10,7 +10,7 @@ import {LSP7MintableCore} from "./LSP7MintableCore.sol";
 /**
  * @dev LSP7 extension, mintable.
  */
-abstract contract LSP7MintableInitAbstract is LSP7MintableCore, LSP7DigitalAssetInit {
+abstract contract LSP7MintableInitAbstract is LSP7DigitalAssetInit, LSP7MintableCore {
     function _initialize(
         string memory name_,
         string memory symbol_,

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -19,8 +19,8 @@ import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
  * @dev Implementation of a LSP8 compliant contract.
  */
 contract LSP8IdentifiableDigitalAsset is
-    LSP8IdentifiableDigitalAssetCore,
-    LSP4DigitalAssetMetadata
+    LSP4DigitalAssetMetadata,
+    LSP8IdentifiableDigitalAssetCore
 {
     /**
      * @notice Sets the token-Metadata

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
-import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
@@ -41,7 +41,7 @@ contract LSP8IdentifiableDigitalAsset is
         public
         view
         virtual
-        override(IERC165, ERC165Storage)
+        override(IERC165, ERC725YCore)
         returns (bool)
     {
         return interfaceId == _INTERFACEID_LSP8 || super.supportsInterface(interfaceId);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -20,7 +20,6 @@ import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
  */
 abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
     LSP8IdentifiableDigitalAssetCore,
-    Initializable,
     LSP4DigitalAssetMetadataInitAbstract
 {
     function _initialize(

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
-import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
@@ -37,7 +37,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         public
         view
         virtual
-        override(IERC165, ERC165Storage)
+        override(IERC165, ERC725YCore)
         returns (bool)
     {
         return interfaceId == _INTERFACEID_LSP8 || super.supportsInterface(interfaceId);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -19,8 +19,8 @@ import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
  * @dev Proxy Implementation of a LSP8 compliant contract.
  */
 abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
-    LSP8IdentifiableDigitalAssetCore,
-    LSP4DigitalAssetMetadataInitAbstract
+    LSP4DigitalAssetMetadataInitAbstract,
+    LSP8IdentifiableDigitalAssetCore
 {
     function _initialize(
         string memory name_,

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -10,7 +10,7 @@ import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
 /**
  * @dev LSP8 extension, adds token supply cap.
  */
-abstract contract LSP8CappedSupply is LSP8CappedSupplyCore, LSP8IdentifiableDigitalAsset {
+abstract contract LSP8CappedSupply is LSP8IdentifiableDigitalAsset, LSP8CappedSupplyCore {
     /**
      * @notice Sets the token max supply
      * @param tokenSupplyCap_ The Token max supply

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
@@ -11,7 +11,7 @@ import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetC
 /**
  * @dev LSP8 extension, adds token supply cap.
  */
-abstract contract LSP8CappedSupplyCore is ILSP8CappedSupply, LSP8IdentifiableDigitalAssetCore {
+abstract contract LSP8CappedSupplyCore is LSP8IdentifiableDigitalAssetCore, ILSP8CappedSupply {
     // --- Errors
 
     error LSP8CappedSupplyRequired();

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -12,7 +12,6 @@ import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
  * @dev LSP8 extension, adds token supply cap.
  */
 abstract contract LSP8CappedSupplyInitAbstract is
-    Initializable,
     LSP8CappedSupplyCore,
     LSP8IdentifiableDigitalAssetInit
 {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -12,8 +12,8 @@ import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
  * @dev LSP8 extension, adds token supply cap.
  */
 abstract contract LSP8CappedSupplyInitAbstract is
-    LSP8CappedSupplyCore,
-    LSP8IdentifiableDigitalAssetInit
+    LSP8IdentifiableDigitalAssetInit,
+    LSP8CappedSupplyCore
 {
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.sol
@@ -20,8 +20,8 @@ import {_INTERFACEID_ERC721, _INTERFACEID_ERC721METADATA} from "./LSP8Compatibil
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
  */
 contract LSP8CompatibilityForERC721 is
-    LSP8CompatibilityForERC721Core,
-    LSP8IdentifiableDigitalAsset
+    LSP8IdentifiableDigitalAsset,
+    LSP8CompatibilityForERC721Core
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
@@ -21,9 +21,9 @@ import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.s
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
  */
 abstract contract LSP8CompatibilityForERC721Core is
-    ILSP8CompatibilityForERC721,
+    LSP4Compatibility,
     LSP8IdentifiableDigitalAssetCore,
-    LSP4Compatibility
+    ILSP8CompatibilityForERC721
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721InitAbstract.sol
@@ -17,8 +17,8 @@ import {_INTERFACEID_ERC721, _INTERFACEID_ERC721METADATA} from "./LSP8Compatibil
  * @dev LSP8 extension, for compatibility for clients / tools that expect ERC721.
  */
 contract LSP8CompatibilityForERC721InitAbstract is
-    LSP8CompatibilityForERC721Core,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    LSP8CompatibilityForERC721Core
 {
     function _initialize(
         string memory name_,

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.sol
@@ -9,7 +9,7 @@ import {LSP8MintableCore} from "./LSP8MintableCore.sol";
 /**
  * @dev LSP8 extension.
  */
-contract LSP8Mintable is LSP8MintableCore, LSP8IdentifiableDigitalAsset {
+contract LSP8Mintable is LSP8IdentifiableDigitalAsset, LSP8MintableCore {
     // solhint-disable no-empty-blocks
     /**
      * @notice Sets the token-Metadata and register LSP8InterfaceId

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableCore.sol
@@ -11,7 +11,7 @@ import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetC
 /**
  * @dev LSP8 extension
  */
-abstract contract LSP8MintableCore is ILSP8Mintable, LSP8IdentifiableDigitalAssetCore {
+abstract contract LSP8MintableCore is LSP8IdentifiableDigitalAssetCore, ILSP8Mintable {
     /**
      * @inheritdoc ILSP8Mintable
      */

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8MintableInitAbstract.sol
@@ -10,8 +10,8 @@ import {LSP8MintableCore} from "./LSP8MintableCore.sol";
  * @dev LSP8 extension.
  */
 abstract contract LSP8MintableInitAbstract is
-    LSP8MintableCore,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    LSP8MintableCore
 {
     function _initialize(
         string memory name_,

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -18,7 +18,7 @@ import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDA
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-contract LSP9Vault is LSP9VaultCore, ERC725 {
+contract LSP9Vault is ERC725, LSP9VaultCore {
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param _newOwner the owner of the contract

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -76,7 +76,13 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725, LSP9VaultCore)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -15,7 +15,7 @@ import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 
 // constants
 import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Constants.sol";
+import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Constants.sol";
 
 /**
  * @title Core Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -109,5 +109,21 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ILSP1UniversalReceiver {
         if (ERC165CheckerCustom.supportsERC165Interface(_receiver, _INTERFACEID_LSP1)) {
             ILSP1UniversalReceiver(_receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
         }
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP9 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -22,7 +22,7 @@ import {_TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Const
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
+contract LSP9VaultCore is ERC725XCore, ERC725YCore, ILSP1UniversalReceiver {
     /**
      * @notice Emitted when a native token is received
      * @param sender The address of the sender
@@ -37,10 +37,14 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
      */
     modifier onlyAllowed() {
         if (msg.sender != owner()) {
-            address universalReceiverAddress = address(bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY)));
+            address universalReceiverAddress = address(
+                bytes20(_getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY))
+            );
             require(
-                ERC165CheckerCustom.supportsERC165Interface(msg.sender, _INTERFACEID_LSP1_DELEGATE) &&
-                    msg.sender == universalReceiverAddress,
+                ERC165CheckerCustom.supportsERC165Interface(
+                    msg.sender,
+                    _INTERFACEID_LSP1_DELEGATE
+                ) && msg.sender == universalReceiverAddress,
                 "Only Owner or Universal Receiver Delegate allowed"
             );
         }
@@ -74,12 +78,14 @@ contract LSP9VaultCore is ILSP1UniversalReceiver, ERC725XCore, ERC725YCore {
 
         if (data.length >= 20) {
             address universalReceiverDelegate = BytesLib.toAddress(data, 0);
-            if (ERC165CheckerCustom.supportsERC165Interface(universalReceiverDelegate, _INTERFACEID_LSP1_DELEGATE)) {
-                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate).universalReceiverDelegate(
-                    _msgSender(),
-                    _typeId,
-                    _data
-                );
+            if (
+                ERC165CheckerCustom.supportsERC165Interface(
+                    universalReceiverDelegate,
+                    _INTERFACEID_LSP1_DELEGATE
+                )
+            ) {
+                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                    .universalReceiverDelegate(_msgSender(), _typeId, _data);
             }
         }
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -74,7 +74,13 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
     /**
      * @dev See {IERC165-supportsInterface}.
      */
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725InitAbstract, LSP9VaultCore)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -18,7 +18,7 @@ import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDA
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-abstract contract LSP9VaultInitAbstract is LSP9VaultCore, ERC725InitAbstract {
+abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
     function _initialize(address _newOwner) internal virtual override onlyInitializing {
         ERC725InitAbstract._initialize(_newOwner);
 

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -10,7 +10,7 @@ import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725Account/LSP0ERC725Accou
  * @author Fabian Vogelsteller <fabian@lukso.network>
  * @dev Implementation of the ERC725Account + LSP1 universalReceiver
  */
-abstract contract UniversalProfileInitAbstract is Initializable, LSP0ERC725AccountInitAbstract {
+abstract contract UniversalProfileInitAbstract is LSP0ERC725AccountInitAbstract {
     function _initialize(address _newOwner) internal virtual override onlyInitializing {
         LSP0ERC725AccountInitAbstract._initialize(_newOwner);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^3.0.0",
+        "@erc725/smart-contracts": "^3.0.2",
         "@openzeppelin/contracts": "^4.3.1",
         "solidity-bytes-utils": "0.8.0"
       },
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.0.tgz",
-      "integrity": "sha512-AvVFHYIfupQ4FemXVe1KWzs4b/63FjjM36aMyA698tn89REoYbQHeW98WaG/X1oh2cag7CaSHakIatpD7aorDQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.2.tgz",
+      "integrity": "sha512-wjsxnzOx/l+BppXJ+Y/l+uRHNKYzk+eg+MCnA6sPe6BXMYn9538hzzdgPHCUfAyui4IpJ+dO+eDQRf6a4pnXTQ==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.3.1",
         "solidity-bytes-utils": "0.8.0"
@@ -32012,9 +32012,9 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.0.tgz",
-      "integrity": "sha512-AvVFHYIfupQ4FemXVe1KWzs4b/63FjjM36aMyA698tn89REoYbQHeW98WaG/X1oh2cag7CaSHakIatpD7aorDQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.2.tgz",
+      "integrity": "sha512-wjsxnzOx/l+BppXJ+Y/l+uRHNKYzk+eg+MCnA6sPe6BXMYn9538hzzdgPHCUfAyui4IpJ+dO+eDQRf6a4pnXTQ==",
       "requires": {
         "@openzeppelin/contracts": "^4.3.1",
         "solidity-bytes-utils": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^3.0.0",
+    "@erc725/smart-contracts": "^3.0.2",
     "@openzeppelin/contracts": "^4.3.1",
     "solidity-bytes-utils": "0.8.0"
   },


### PR DESCRIPTION
## What does this PR introduce?
- Inherit from most base to most derived: resolve issue #155 
- Fix inheritance problem in erc725 by upgrading erc725-smart-contracts to 3.0.2
- Override ERC165 `supportsInterface(...)` function In LSP0/LSP9/LSP7/LSP8 contracts.
- Resolve solhint warnings