### PR TITLE
ci: remove .only in LSP6 tests

### DIFF
--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -35,7 +35,7 @@ export const shouldBehaveLikeLSP6 = (
     shouldBehaveLikePermissionChangeOwner(buildContext);
   });
 
-  describe.only("CHANGE / ADD permissions", () => {
+  describe("CHANGE / ADD permissions", () => {
     shouldBehaveLikePermissionChangeOrAddPermissions(buildContext);
   });
 


### PR DESCRIPTION
A `.only` was not removed in PR #152 for the LSP6 test suite, skipping all the other LSP6 tests apart from ADD / CHANGE permission.