### PR TITLE
fix: include `chainId` in signed message in `executeRelayCall(..)`

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -20,7 +20,7 @@ export const enum INTERFACE_IDS {
   ERC725Account = "0x481e0fe8",
   LSP1 = "0x6bb56a14",
   LSP1Delegate = "0xc2d7bcc1",
-  LSP6 = "0xbbf5cd19",
+  LSP6 = "0xc403d48f",
   LSP7 = "0xe33f65c3",
   LSP8 = "0x49399145",
   LSP9 = "0x5e38b596",

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -42,16 +42,14 @@ interface ILSP6KeyManager is
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor
-     * @param _signedFor this KeyManager
+     * @param _signature bytes32 ethereum signature
      * @param _nonce the address' nonce (in a specific `_channel`), obtained via `getNonce(...)`. Used to prevent replay attack
      * @param _calldata obtained via encodeABI() in web3
-     * @param _signature bytes32 ethereum signature
      * @return result_ the data being returned by the ERC725 Account
      */
     function executeRelayCall(
-        address _signedFor,
+        bytes memory _signature,
         uint256 _nonce,
-        bytes calldata _calldata,
-        bytes memory _signature
+        bytes calldata _calldata
     ) external payable returns (bytes memory);
 }

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -33,25 +33,25 @@ interface ILSP6KeyManager is
     function getNonce(address _address, uint256 _channel) external view returns (uint256);
 
     /**
-     * @notice execute the following payload on the ERC725Account: `_data`
+     * @notice execute the following payload on the ERC725Account: `_calldata`
      * @dev the ERC725Account will return some data on successful call, or revert on failure
-     * @param _data the payload to execute. Obtained in web3 via encodeABI()
+     * @param _calldata the payload to execute. Obtained in web3 via encodeABI()
      * @return result_ the data being returned by the ERC725 Account
      */
-    function execute(bytes calldata _data) external payable returns (bytes memory);
+    function execute(bytes calldata _calldata) external payable returns (bytes memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor
      * @param _signedFor this KeyManager
      * @param _nonce the address' nonce (in a specific `_channel`), obtained via `getNonce(...)`. Used to prevent replay attack
-     * @param _data obtained via encodeABI() in web3
+     * @param _calldata obtained via encodeABI() in web3
      * @param _signature bytes32 ethereum signature
      * @return result_ the data being returned by the ERC725 Account
      */
     function executeRelayCall(
         address _signedFor,
         uint256 _nonce,
-        bytes calldata _data,
+        bytes calldata _calldata,
         bytes memory _signature
     ) external payable returns (bytes memory);
 }

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = 0xbbf5cd19;
+bytes4 constant _INTERFACEID_LSP6 = 0xc403d48f;
 
 // 0x4b80742d00000000c6dd000054dD2f5A45C8e7C83248a5a9F3c67b001F6AcC05
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -115,6 +115,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes calldata _calldata
     ) external payable override returns (bytes memory) {
         bytes memory blob = abi.encodePacked(
+            block.chainid,
             address(this), // needs to be signed for this keyManager
             _nonce,
             _calldata

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -110,16 +110,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @inheritdoc ILSP6KeyManager
      */
     function executeRelayCall(
-        address _signedFor,
+        bytes memory _signature,
         uint256 _nonce,
-        bytes calldata _calldata,
-        bytes memory _signature
+        bytes calldata _calldata
     ) external payable override returns (bytes memory) {
-        require(
-            _signedFor == address(this),
-            "executeRelayCall: Message not signed for this keyManager"
-        );
-
         bytes memory blob = abi.encodePacked(
             address(this), // needs to be signed for this keyManager
             _nonce,

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -226,9 +226,16 @@ export const shouldBehaveLikeAllowedFunctions = (
               targetContractPayload,
             ]);
 
+          const HARDHAT_CHAINID = 31337;
+
           let hash = ethers.utils.solidityKeccak256(
-            ["address", "uint256", "bytes"],
-            [context.keyManager.address, nonce, executeRelayCallPayload]
+            ["uint256", "address", "uint256", "bytes"],
+            [
+              HARDHAT_CHAINID,
+              context.keyManager.address,
+              nonce,
+              executeRelayCallPayload,
+            ]
           );
 
           let signature = await addressCanCallOnlyOneFunction.signMessage(
@@ -236,10 +243,9 @@ export const shouldBehaveLikeAllowedFunctions = (
           );
 
           await context.keyManager.executeRelayCall(
-            context.keyManager.address,
+            signature,
             nonce,
-            executeRelayCallPayload,
-            signature
+            executeRelayCallPayload
           );
           let endResult = await targetContract.callStatic.getName();
           expect(endResult).toEqual(newName);
@@ -263,9 +269,16 @@ export const shouldBehaveLikeAllowedFunctions = (
               targetContractPayload,
             ]);
 
+          const HARDHAT_CHAINID = 31337;
+
           let hash = ethers.utils.solidityKeccak256(
-            ["address", "uint256", "bytes"],
-            [context.keyManager.address, nonce, executeRelayCallPayload]
+            ["uint256", "address", "uint256", "bytes"],
+            [
+              HARDHAT_CHAINID,
+              context.keyManager.address,
+              nonce,
+              executeRelayCallPayload,
+            ]
           );
 
           let signature = await addressCanCallOnlyOneFunction.signMessage(
@@ -274,10 +287,9 @@ export const shouldBehaveLikeAllowedFunctions = (
 
           await expect(
             context.keyManager.executeRelayCall(
-              context.keyManager.address,
+              signature,
               nonce,
-              executeRelayCallPayload,
-              signature
+              executeRelayCallPayload
             )
           ).toBeRevertedWith(
             NotAllowedFunctionError(

--- a/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
@@ -79,18 +79,24 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, latestNonce, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            latestNonce,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager.executeRelayCall(
-          context.keyManager.address,
+          signature,
           latestNonce,
-          executeRelayCallPayload,
-          signature
+          executeRelayCallPayload
         );
 
         let fetchedName = await targetContract.callStatic.getName();
@@ -133,21 +139,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -180,21 +188,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -232,21 +242,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -279,21 +291,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -331,21 +345,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -378,21 +394,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -426,21 +444,23 @@ export const shouldBehaveLikeMultiChannelNonce = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonceBefore, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonceBefore,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await signer.signMessage(ethers.utils.arrayify(hash));
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(
-            context.keyManager.address,
-            nonceBefore,
-            executeRelayCallPayload,
-            signature
-          );
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -209,9 +209,16 @@ export const shouldBehaveLikePermissionCall = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonce, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonce,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await context.owner.signMessage(
@@ -219,10 +226,9 @@ export const shouldBehaveLikePermissionCall = (
         );
 
         await context.keyManager.executeRelayCall(
-          context.keyManager.address,
+          signature,
           nonce,
-          executeRelayCallPayload,
-          signature
+          executeRelayCallPayload
         );
 
         const result = await targetContract.callStatic.getName();
@@ -251,9 +257,16 @@ export const shouldBehaveLikePermissionCall = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonce, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonce,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await addressCanMakeCall.signMessage(
@@ -261,10 +274,9 @@ export const shouldBehaveLikePermissionCall = (
         );
 
         await context.keyManager.executeRelayCall(
-          context.keyManager.address,
+          signature,
           nonce,
-          executeRelayCallPayload,
-          signature
+          executeRelayCallPayload
         );
 
         const result = await targetContract.callStatic.getName();
@@ -293,9 +305,16 @@ export const shouldBehaveLikePermissionCall = (
             targetContractPayload,
           ]);
 
+        const HARDHAT_CHAINID = 31337;
+
         let hash = ethers.utils.solidityKeccak256(
-          ["address", "uint256", "bytes"],
-          [context.keyManager.address, nonce, executeRelayCallPayload]
+          ["uint256", "address", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonce,
+            executeRelayCallPayload,
+          ]
         );
 
         let signature = await addressCannotMakeCall.signMessage(
@@ -304,10 +323,9 @@ export const shouldBehaveLikePermissionCall = (
 
         await expect(
           context.keyManager.executeRelayCall(
-            context.keyManager.address,
+            signature,
             nonce,
-            executeRelayCallPayload,
-            signature
+            executeRelayCallPayload
           )
         ).toBeRevertedWith(
           NotAuthorisedError(addressCannotMakeCall.address, "CALL")

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -205,9 +205,16 @@ export const testSecurityScenarios = (
           EMPTY_PAYLOAD,
         ]);
 
+      const HARDHAT_CHAINID = 31337;
+
       let hash = ethers.utils.solidityKeccak256(
-        ["address", "uint256", "bytes"],
-        [context.keyManager.address, nonce, executeRelayCallPayload]
+        ["uint256", "address", "uint256", "bytes"],
+        [
+          HARDHAT_CHAINID,
+          context.keyManager.address,
+          nonce,
+          executeRelayCallPayload,
+        ]
       );
 
       let signature = await signer.signMessage(ethers.utils.arrayify(hash));
@@ -215,12 +222,7 @@ export const testSecurityScenarios = (
       // first call
       await context.keyManager
         .connect(relayer)
-        .executeRelayCall(
-          context.keyManager.address,
-          nonce,
-          executeRelayCallPayload,
-          signature
-        );
+        .executeRelayCall(signature, nonce, executeRelayCallPayload);
 
       // 2nd call = replay attack
       await expect(


### PR DESCRIPTION
## What does this PR introduce?
- Include chainId in the signed message in `executeRelayCall(..)` as mentioned in issue [#151](https://github.com/lukso-network/lsp-smart-contracts/issues/151).
- Change all occurrences of `_data` to `_calldata` in LSP6.
- Remove unnecessary param in `executeRelayCall(...)`: `_signedFor` param as it will be included in the signed message.
- Re-order params in `executeRelayCall(..)` (dynamic param is the last one) to be able to extract the `_calldata`. 
- Change the interfaceId of LSP6 from `0xbbf5cd19` to `0xc403d48f` since function signature of `executeRelayCall(..)` changed.