### PR TITLE
feat: add ErrorHandlerLib in LSP6

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -15,6 +15,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {ErrorHandlerLib} from "@erc725/smart-contracts/contracts/utils/ErrorHandlerLib.sol";
 import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 import {LSP6Utils} from "./LSP6Utils.sol";
@@ -91,14 +92,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         );
 
         if (!success) {
-            // solhint-disable reason-string
-            if (result.length < 68) revert();
-
-            // solhint-disable no-inline-assembly
-            assembly {
-                result := add(result, 0x04)
-            }
-            revert(abi.decode(result, (string)));
+            ErrorHandlerLib.revertWithParsedError(result);
         }
 
         emit Executed(msg.value, bytes4(_calldata));
@@ -133,14 +127,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         (bool success, bytes memory result) = target.call{value: 0, gas: gasleft()}(_calldata);
 
         if (!success) {
-            // solhint-disable reason-string
-            if (result.length < 68) revert();
-
-            // solhint-disable no-inline-assembly
-            assembly {
-                result := add(result, 0x04)
-            }
-            revert(abi.decode(result, (string)));
+            ErrorHandlerLib.revertWithParsedError(result);
         }
 
         emit Executed(msg.value, bytes4(_calldata));

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -86,24 +86,23 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         _verifyPermissions(msg.sender, _calldata);
 
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory result_) = address(target).call{
-            value: msg.value,
-            gas: gasleft()
-        }(_calldata);
+        (bool success, bytes memory result) = target.call{value: msg.value, gas: gasleft()}(
+            _calldata
+        );
 
         if (!success) {
             // solhint-disable reason-string
-            if (result_.length < 68) revert();
+            if (result.length < 68) revert();
 
             // solhint-disable no-inline-assembly
             assembly {
-                result_ := add(result_, 0x04)
+                result := add(result, 0x04)
             }
-            revert(abi.decode(result_, (string)));
+            revert(abi.decode(result, (string)));
         }
 
         emit Executed(msg.value, bytes4(_calldata));
-        return result_.length != 0 ? abi.decode(result_, (bytes)) : result_;
+        return result.length != 0 ? abi.decode(result, (bytes)) : result;
     }
 
     /**
@@ -131,23 +130,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         _verifyPermissions(signer, _calldata);
 
         // solhint-disable avoid-low-level-calls
-        (bool success, bytes memory result_) = address(target).call{value: 0, gas: gasleft()}(
-            _calldata
-        );
+        (bool success, bytes memory result) = target.call{value: 0, gas: gasleft()}(_calldata);
 
         if (!success) {
             // solhint-disable reason-string
-            if (result_.length < 68) revert();
+            if (result.length < 68) revert();
 
             // solhint-disable no-inline-assembly
             assembly {
-                result_ := add(result_, 0x04)
+                result := add(result, 0x04)
             }
-            revert(abi.decode(result_, (string)));
+            revert(abi.decode(result, (string)));
         }
 
         emit Executed(msg.value, bytes4(_calldata));
-        return result_.length != 0 ? abi.decode(result_, (bytes)) : result_;
+        return result.length != 0 ? abi.decode(result, (bytes)) : result;
     }
 
     /**


### PR DESCRIPTION
## What does this PR introduce?
- Introducing `ErrorHandlerLib` in `execute(...)` and `executeRelayCall(..)` to support custom errors.