### PR TITLE
feat!: add ClaimOwnership in LSP9 Vault

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -23,7 +23,7 @@ export const enum INTERFACE_IDS {
   LSP6 = "0xc403d48f",
   LSP7 = "0xe33f65c3",
   LSP8 = "0x49399145",
-  LSP9 = "0x5e38b596",
+  LSP9 = "0xf3456c26",
   ClaimOwnership = "0xad7dd9b0",
 }
 

--- a/contracts/Helpers/ERC165Interfaces.sol
+++ b/contracts/Helpers/ERC165Interfaces.sol
@@ -106,7 +106,8 @@ contract CalculateLSPInterfaces {
         bytes4 interfaceId = 
             type(IERC725X).interfaceId ^
             type(IERC725Y).interfaceId ^
-            type(ILSP1).interfaceId;
+            type(ILSP1).interfaceId ^
+            type(IClaimOwnership).interfaceId;
 
         require(
             interfaceId == _INTERFACEID_LSP9,

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
+import {LSP0ERC725AccountCore, ClaimOwnership} from "./LSP0ERC725AccountCore.sol";
 import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
 
 // constants
 import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Implementation of ERC725Account
@@ -36,6 +37,7 @@ contract LSP0ERC725Account is ERC725, LSP0ERC725AccountCore {
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
             interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
     }
 
@@ -45,6 +47,6 @@ contract LSP0ERC725Account is ERC725, LSP0ERC725AccountCore {
         override(LSP0ERC725AccountCore, OwnableUnset)
         onlyOwner
     {
-        super.transferOwnership(_newOwner);
+        ClaimOwnership._transferOwnership(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -114,15 +114,6 @@ abstract contract LSP0ERC725AccountCore is
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);
     }
 
-    function transferOwnership(address _newOwner)
-        public
-        virtual
-        override(ClaimOwnership, OwnableUnset)
-        onlyOwner
-    {
-        ClaimOwnership.transferOwnership(_newOwner);
-    }
-
     /**
      * @dev See {IERC165-supportsInterface}.
      */
@@ -139,5 +130,14 @@ abstract contract LSP0ERC725AccountCore is
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
+    }
+
+    function transferOwnership(address _newOwner)
+        public
+        virtual
+        override(ClaimOwnership, OwnableUnset)
+        onlyOwner
+    {
+        ClaimOwnership.transferOwnership(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -138,6 +138,6 @@ abstract contract LSP0ERC725AccountCore is
         override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        ClaimOwnership.transferOwnership(_newOwner);
+        ClaimOwnership._transferOwnership(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
+import {LSP0ERC725AccountCore, ClaimOwnership} from "./LSP0ERC725AccountCore.sol";
 import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
 
 // constants
 import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725Account
@@ -34,6 +35,7 @@ abstract contract LSP0ERC725AccountInitAbstract is ERC725InitAbstract, LSP0ERC72
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
             interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
     }
 
@@ -43,6 +45,6 @@ abstract contract LSP0ERC725AccountInitAbstract is ERC725InitAbstract, LSP0ERC72
         override(LSP0ERC725AccountCore, OwnableUnset)
         onlyOwner
     {
-        super.transferOwnership(_newOwner);
+        ClaimOwnership._transferOwnership(_newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9Constants.sol
+++ b/contracts/LSP9Vault/LSP9Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP9 = 0x5e38b596;
+bytes4 constant _INTERFACEID_LSP9 = 0xf3456c26;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -31,17 +31,6 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
     }
 
     /**
-     * @inheritdoc OwnableUnset
-     * @dev Transfer the ownership and notify the vault sender and vault receiver
-     */
-    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        super.transferOwnership(newOwner);
-
-        _notifyVaultSender(msg.sender);
-        _notifyVaultReceiver(newOwner);
-    }
-
-    /**
      * @inheritdoc IERC725Y
      * @dev Sets data as bytes in the vault storage for a single key.
      * SHOULD only be callable by the owner of the contract set via ERC173
@@ -87,5 +76,23 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
             super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc OwnableUnset
+     */
+    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
+        super.transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfer the ownership and notify the vault sender and vault receiver
+     */
+    function claimOwnership() public virtual override {
+        address previousOwner = owner();
+        super.claimOwnership();
+
+        _notifyVaultSender(previousOwner);
+        _notifyVaultReceiver(msg.sender);
     }
 }

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -7,11 +7,12 @@ import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.so
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
 import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
-import {LSP9VaultCore} from "./LSP9VaultCore.sol";
+import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
+import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -75,6 +76,7 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
     }
 
@@ -82,7 +84,7 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
      * @inheritdoc OwnableUnset
      */
     function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        super.transferOwnership(newOwner);
+        ClaimOwnership._transferOwnership(newOwner);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -34,8 +34,8 @@ contract LSP9Vault is ERC725, LSP9VaultCore {
      * @inheritdoc OwnableUnset
      * @dev Transfer the ownership and notify the vault sender and vault receiver
      */
-    function transferOwnership(address newOwner) public virtual override onlyOwner {
-        OwnableUnset.transferOwnership(newOwner);
+    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
+        super.transferOwnership(newOwner);
 
         _notifyVaultSender(msg.sender);
         _notifyVaultReceiver(newOwner);

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -12,6 +12,8 @@ import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 // modules
 import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {ClaimOwnership} from "../Utils/ClaimOwnership.sol";
 
 // constants
 import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
@@ -23,7 +25,7 @@ import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-contract LSP9VaultCore is ERC725XCore, ERC725YCore, ILSP1UniversalReceiver {
+contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1UniversalReceiver {
     /**
      * @notice Emitted when a native token is received
      * @param sender The address of the sender
@@ -127,5 +129,14 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ILSP1UniversalReceiver {
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
+    }
+
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(ClaimOwnership, OwnableUnset)
+        onlyOwner
+    {
+        ClaimOwnership.transferOwnership(newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -14,6 +14,7 @@ import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 
 // constants
+import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Constants.sol";
 
@@ -124,6 +125,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ILSP1UniversalReceiver {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -137,6 +137,6 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        ClaimOwnership.transferOwnership(newOwner);
+        ClaimOwnership._transferOwnership(newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -7,11 +7,12 @@ import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.so
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
 import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
-import {LSP9VaultCore} from "./LSP9VaultCore.sol";
+import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
+import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Inheritable Proxy Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -73,6 +74,7 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
             super.supportsInterface(interfaceId);
     }
 
@@ -80,7 +82,7 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
      * @inheritdoc OwnableUnset
      */
     function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        super.transferOwnership(newOwner);
+        ClaimOwnership._transferOwnership(newOwner);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -32,7 +32,7 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
      * @inheritdoc OwnableUnset
      * @dev Transfer the ownership and notify the vault sender and vault receiver
      */
-    function transferOwnership(address newOwner) public virtual override onlyOwner {
+    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
         OwnableUnset.transferOwnership(newOwner);
 
         _notifyVaultSender(msg.sender);

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -29,17 +29,6 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
     }
 
     /**
-     * @inheritdoc OwnableUnset
-     * @dev Transfer the ownership and notify the vault sender and vault receiver
-     */
-    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        OwnableUnset.transferOwnership(newOwner);
-
-        _notifyVaultSender(msg.sender);
-        _notifyVaultReceiver(newOwner);
-    }
-
-    /**
      * @inheritdoc IERC725Y
      * @dev Sets data as bytes in the vault storage for a single key.
      * SHOULD only be callable by the owner of the contract set via ERC173
@@ -85,5 +74,23 @@ abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
             super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @inheritdoc OwnableUnset
+     */
+    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
+        super.transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfer the ownership and notify the vault sender and vault receiver
+     */
+    function claimOwnership() public virtual override {
+        address previousOwner = owner();
+        super.claimOwnership();
+
+        _notifyVaultSender(previousOwner);
+        _notifyVaultReceiver(msg.sender);
     }
 }

--- a/contracts/Utils/ClaimOwnership.sol
+++ b/contracts/Utils/ClaimOwnership.sol
@@ -17,7 +17,7 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
         pendingOwner = address(0);
     }
 
-    function transferOwnership(address _newOwner) public virtual override(OwnableUnset) onlyOwner {
+    function transferOwnership(address _newOwner) public virtual override onlyOwner {
         pendingOwner = _newOwner;
     }
 }

--- a/contracts/Utils/ClaimOwnership.sol
+++ b/contracts/Utils/ClaimOwnership.sol
@@ -18,6 +18,10 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     }
 
     function transferOwnership(address _newOwner) public virtual override onlyOwner {
+        _transferOwnership(_newOwner);
+    }
+
+    function _transferOwnership(address _newOwner) internal virtual {
         pendingOwner = _newOwner;
     }
 }

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -10,6 +10,7 @@ export type ClaimOwnershipTestContext = {
   accounts: SignerWithAddress[];
   contract: LSP0ERC725Account | LSP9Vault;
   deployParams: { owner: SignerWithAddress };
+  onlyOwnerRevertString: string;
 };
 
 export const shouldBehaveLikeClaimOwnership = (
@@ -178,6 +179,7 @@ export const shouldBehaveLikeClaimOwnership = (
           .transferOwnership(newOwner.address);
         await context.contract.connect(newOwner).claimOwnership();
       });
+
       describe("previous owner should not be allowed anymore to call onlyOwner functions", () => {
         it("should revert when calling `setData(...)`", async () => {
           const key =
@@ -187,7 +189,7 @@ export const shouldBehaveLikeClaimOwnership = (
           // prettier-ignore
           await expect(
                 context.contract.connect(previousOwner)["setData(bytes32,bytes)"](key, value)
-              ).toBeRevertedWith("Ownable: caller is not the owner")
+              ).toBeRevertedWith(context.onlyOwnerRevertString)
         });
 
         it("should revert when calling `execute(...)`", async () => {

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -1,14 +1,14 @@
 import { ethers } from "hardhat";
 
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { LSP0ERC725Account } from "../types";
+import { LSP0ERC725Account, LSP9Vault } from "../types";
 
 import { provider } from "./utils/helpers";
 import { OPERATIONS } from "../constants";
 
 export type ClaimOwnershipTestContext = {
   accounts: SignerWithAddress[];
-  contract: LSP0ERC725Account /* | LSP9Vault */;
+  contract: LSP0ERC725Account | LSP9Vault;
   deployParams: { owner: SignerWithAddress };
 };
 

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -18,7 +18,7 @@ import {
 import { ARRAY_LENGTH, TOKEN_ID } from "../utils/helpers";
 
 // constants
-import { ERC725YKeys, INTERFACE_IDS } from "../../constants";
+import { ERC725YKeys, INTERFACE_IDS, OPERATIONS } from "../../constants";
 
 // fixtures
 import {
@@ -26,7 +26,6 @@ import {
   getLSP10MapAndArrayKeysValue,
   getLSP5MapAndArrayKeysValue,
 } from "../utils/fixtures";
-
 
 export type LSP1TestAccounts = {
   owner1: SignerWithAddress;
@@ -706,13 +705,13 @@ export const shouldBehaveLikeLSP1Delegate = (
           );
       });
       it("should remove all lsp5 keys on both UP", async () => {
-        const arrayLengthUP1 = await context.universalProfile1["getData(bytes32)"](
-          ERC725YKeys.LSP5["LSP5ReceivedAssets[]"],
-        );
+        const arrayLengthUP1 = await context.universalProfile1[
+          "getData(bytes32)"
+        ](ERC725YKeys.LSP5["LSP5ReceivedAssets[]"]);
 
-        const arrayLengthUP2 = await context.universalProfile2["getData(bytes32)"](
-          ERC725YKeys.LSP5["LSP5ReceivedAssets[]"],
-        );
+        const arrayLengthUP2 = await context.universalProfile2[
+          "getData(bytes32)"
+        ](ERC725YKeys.LSP5["LSP5ReceivedAssets[]"]);
 
         expect(arrayLengthUP1).toEqual(ARRAY_LENGTH.ZERO);
         expect(arrayLengthUP2).toEqual(ARRAY_LENGTH.ZERO);
@@ -1302,6 +1301,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
   describe("when testing LSP9-Vault", () => {
     let lsp9VaultA: LSP9Vault, lsp9VaultB: LSP9Vault, lsp9VaultC: LSP9Vault;
+
     beforeAll(async () => {
       lsp9VaultA = await new LSP9Vault__factory(context.accounts.random).deploy(
         context.accounts.random.address
@@ -1322,6 +1322,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           await lsp9VaultA
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
+
+          let executePayload =
+            context.universalProfile1.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultA.address,
+              0,
+              lsp9VaultA.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager1
+            .connect(context.accounts.owner1)
+            .execute(executePayload);
         });
 
         it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
@@ -1342,6 +1354,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           await lsp9VaultB
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
+
+          let executePayload =
+            context.universalProfile1.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultB.address,
+              0,
+              lsp9VaultB.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager1
+            .connect(context.accounts.owner1)
+            .execute(executePayload);
         });
 
         it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
@@ -1362,6 +1386,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           await lsp9VaultC
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
+
+          let executePayload =
+            context.universalProfile1.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultC.address,
+              0,
+              lsp9VaultC.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager1
+            .connect(context.accounts.owner1)
+            .execute(executePayload);
         });
 
         it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
@@ -1391,6 +1427,18 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(
               callPayload(context.universalProfile1, lsp9VaultA.address, abi)
             );
+
+          let executePayload =
+            context.universalProfile2.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultA.address,
+              0,
+              lsp9VaultA.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager2
+            .connect(context.accounts.owner2)
+            .execute(executePayload);
         });
 
         it("should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 2, index = 0, VaultC address in UP1", async () => {
@@ -1430,6 +1478,18 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(
               callPayload(context.universalProfile1, lsp9VaultB.address, abi)
             );
+
+          let executePayload =
+            context.universalProfile2.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultB.address,
+              0,
+              lsp9VaultB.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager2
+            .connect(context.accounts.owner2)
+            .execute(executePayload);
         });
 
         it("should update lsp10keys (no pop and swap as VaultB has the last index): arrayLength 1, no map, no VaultB address in UP1", async () => {
@@ -1471,6 +1531,18 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(
               callPayload(context.universalProfile1, lsp9VaultC.address, abi)
             );
+
+          let executePayload =
+            context.universalProfile2.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultC.address,
+              0,
+              lsp9VaultC.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager2
+            .connect(context.accounts.owner2)
+            .execute(executePayload);
         });
 
         it("should remove all lsp10keys : arrayLength 0, no map, no VaultC address in UP1", async () => {
@@ -1512,6 +1584,18 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(
               callPayload(context.universalProfile2, lsp9VaultB.address, abi)
             );
+
+          let executePayload =
+            context.universalProfile1.interface.encodeFunctionData("execute", [
+              OPERATIONS.CALL,
+              lsp9VaultB.address,
+              0,
+              lsp9VaultB.interface.getSighash("claimOwnership"),
+            ]);
+
+          await context.lsp6KeyManager1
+            .connect(context.accounts.owner1)
+            .execute(executePayload);
         });
         it("should register lsp10key (UP1 able to re-write) : arrayLength 1, index 0, VaultB address in UP1", async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
@@ -1540,6 +1624,8 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(
               callPayload(context.universalProfile2, lsp9VaultA.address, abi)
             );
+
+          await lsp9VaultA.connect(context.accounts.any).claimOwnership();
         });
 
         it("should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 1, index = 0, VaultC address in UP2", async () => {

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -26,6 +26,7 @@ import {
   INTERFACE_IDS,
   SupportedStandards,
   PERMISSIONS,
+  OPERATIONS,
 } from "../../constants";
 
 export type LSP9TestAccounts = {
@@ -118,6 +119,21 @@ export const shouldBehaveLikeLSP9 = (
         await context.lsp9Vault
           .connect(context.accounts.owner)
           .transferOwnership(context.universalProfile.address);
+
+        let claimOwnershipSelector =
+          context.universalProfile.interface.getSighash("claimOwnership");
+
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
+            OPERATIONS.CALL,
+            context.lsp9Vault.address,
+            0,
+            claimOwnershipSelector,
+          ]);
+
+        await context.lsp6KeyManager
+          .connect(context.accounts.owner)
+          .execute(executePayload);
       });
 
       it("should register lsp10 keys of the vault on the profile", async () => {

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -259,12 +259,12 @@ export const shouldInitializeLikeLSP9 = (
       expect(result).toBeTruthy();
     });
 
-    // it("should support ClaimOwnership interface", async () => {
-    //   const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ClaimOwnership)
-    //   expect(
-
-    //   ).toBe;
-    // });
+    it("should support ClaimOwnership interface", async () => {
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.ClaimOwnership
+      );
+      expect(result).toBeTruthy();
+    });
 
     it("should have set expected entries with ERC725Y.setData", async () => {
       await expect(context.initializeTransaction).toHaveEmittedWith(

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -1,6 +1,5 @@
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import type { BytesLike } from "ethers";
 import type { TransactionResponse } from "@ethersproject/abstract-provider";
 
 // types

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -225,24 +225,46 @@ export const shouldInitializeLikeLSP9 = (
 
   describe("when the contract was initialized", () => {
     it("should have registered the ERC165 interface", async () => {
-      expect(await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC165));
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.ERC165
+      );
+      expect(result).toBeTruthy();
     });
 
     it("should have registered the ERC725X interface", async () => {
-      expect(await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725X));
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.ERC725X
+      );
+      expect(result).toBeTruthy();
     });
 
     it("should have registered the ERC725Y interface", async () => {
-      expect(await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725Y));
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.ERC725Y
+      );
+      expect(result).toBeTruthy();
     });
 
     it("should have registered the LSP9 interface", async () => {
-      expect(await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP9));
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.LSP9
+      );
+      expect(result).toBeTruthy();
     });
 
     it("should have registered the LSP1 interface", async () => {
-      expect(await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP1));
+      const result = await context.lsp9Vault.supportsInterface(
+        INTERFACE_IDS.LSP1
+      );
+      expect(result).toBeTruthy();
     });
+
+    // it("should support ClaimOwnership interface", async () => {
+    //   const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ClaimOwnership)
+    //   expect(
+
+    //   ).toBe;
+    // });
 
     it("should have set expected entries with ERC725Y.setData", async () => {
       await expect(context.initializeTransaction).toHaveEmittedWith(

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -1,3 +1,10 @@
+import { ethers } from "hardhat";
+
+import {
+  ClaimOwnershipTestContext,
+  shouldBehaveLikeClaimOwnership,
+} from "../ClaimOwnership.behaviour";
+
 import {
   LSP9Vault__factory,
   LSP9VaultInit__factory,
@@ -43,6 +50,18 @@ describe("LSP9Vault", () => {
       };
     };
 
+    const buildClaimOwnershipTestContext =
+      async (): Promise<ClaimOwnershipTestContext> => {
+        const accounts = await ethers.getSigners();
+        const deployParams = { owner: accounts[0] };
+
+        const lsp9Vault = await new LSP9Vault__factory(accounts[0]).deploy(
+          deployParams.owner.address
+        );
+
+        return { accounts, contract: lsp9Vault, deployParams };
+      };
+
     describe("when deploying the contract", () => {
       let context: LSP9TestContext;
 
@@ -65,6 +84,7 @@ describe("LSP9Vault", () => {
 
     describe("when testing deployed contract", () => {
       shouldBehaveLikeLSP9(buildTestContext);
+      shouldBehaveLikeClaimOwnership(buildClaimOwnershipTestContext);
     });
   });
 
@@ -144,6 +164,18 @@ describe("LSP9Vault", () => {
           return context;
         })
       );
+
+      shouldBehaveLikeClaimOwnership(async () => {
+        let context = await buildTestContext();
+        let accounts = await ethers.getSigners();
+        await initializeProxy(context);
+
+        return {
+          accounts: accounts,
+          contract: context.lsp9Vault,
+          deployParams: { owner: context.accounts.owner },
+        };
+      });
     });
   });
 });

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -59,7 +59,15 @@ describe("LSP9Vault", () => {
           deployParams.owner.address
         );
 
-        return { accounts, contract: lsp9Vault, deployParams };
+        const onlyOwnerRevertString =
+          "Only Owner or Universal Receiver Delegate allowed";
+
+        return {
+          accounts,
+          contract: lsp9Vault,
+          deployParams,
+          onlyOwnerRevertString,
+        };
       };
 
     describe("when deploying the contract", () => {
@@ -170,10 +178,14 @@ describe("LSP9Vault", () => {
         let accounts = await ethers.getSigners();
         await initializeProxy(context);
 
+        const onlyOwnerRevertString =
+          "Only Owner or Universal Receiver Delegate allowed";
+
         return {
           accounts: accounts,
           contract: context.lsp9Vault,
           deployParams: { owner: context.accounts.owner },
+          onlyOwnerRevertString,
         };
       });
     });

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -98,10 +98,12 @@ describe("UniversalProfile", () => {
       const universalProfileInit = await new UniversalProfileInit__factory(
         accounts[0]
       ).deploy();
+
       const universalProfileProxy = await deployProxy(
         universalProfileInit.address,
         accounts[0]
       );
+
       const universalProfile = universalProfileInit.attach(
         universalProfileProxy
       );
@@ -136,6 +138,27 @@ describe("UniversalProfile", () => {
 
       return { accounts, lsp1Implementation, lsp1Checker };
     };
+
+    const buildClaimOwnershipTestContext =
+      async (): Promise<ClaimOwnershipTestContext> => {
+        const accounts = await ethers.getSigners();
+        const deployParams = { owner: accounts[0] };
+
+        const universalProfileInit = await new UniversalProfileInit__factory(
+          accounts[0]
+        ).deploy();
+
+        const universalProfileProxy = await deployProxy(
+          universalProfileInit.address,
+          accounts[0]
+        );
+
+        const universalProfile = universalProfileInit.attach(
+          universalProfileProxy
+        );
+
+        return { accounts, contract: universalProfile, deployParams };
+      };
 
     describe("when deploying the contract as proxy", () => {
       let context: LSP3TestContext;
@@ -180,6 +203,18 @@ describe("UniversalProfile", () => {
 
         let lsp1Context = await buildLSP1TestContext();
         return lsp1Context;
+      });
+
+      shouldBehaveLikeClaimOwnership(async () => {
+        let claimOwnershipContext = await buildClaimOwnershipTestContext();
+
+        await initializeProxy({
+          accounts: claimOwnershipContext.accounts,
+          universalProfile: claimOwnershipContext.contract,
+          deployParams: claimOwnershipContext.deployParams,
+        });
+
+        return claimOwnershipContext;
       });
     });
   });

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -1,6 +1,7 @@
 import { ethers } from "hardhat";
 import {
   ILSP1UniversalReceiver,
+  LSP0ERC725Account,
   UniversalProfileInit__factory,
   UniversalProfile__factory,
   UniversalReceiverTester__factory,
@@ -61,7 +62,9 @@ describe("UniversalProfile", () => {
           accounts[0]
         ).deploy(deployParams.owner.address);
 
-        return { accounts, contract, deployParams };
+        const onlyOwnerRevertString = "Ownable: caller is not the owner";
+
+        return { accounts, contract, deployParams, onlyOwnerRevertString };
       };
 
     describe("when deploying the contract", () => {
@@ -157,7 +160,14 @@ describe("UniversalProfile", () => {
           universalProfileProxy
         );
 
-        return { accounts, contract: universalProfile, deployParams };
+        const onlyOwnerRevertString = "Ownable: caller is not the owner";
+
+        return {
+          accounts,
+          contract: universalProfile,
+          deployParams,
+          onlyOwnerRevertString,
+        };
       };
 
     describe("when deploying the contract as proxy", () => {
@@ -210,7 +220,7 @@ describe("UniversalProfile", () => {
 
         await initializeProxy({
           accounts: claimOwnershipContext.accounts,
-          universalProfile: claimOwnershipContext.contract,
+          universalProfile: claimOwnershipContext.contract as LSP0ERC725Account,
           deployParams: claimOwnershipContext.deployParams,
         });
 


### PR DESCRIPTION
# What does this PR introduce?

## Features

- [x] add support for `claimOwnership(...)`in LSP9 Vault.

## Refactor

- [x] **BREAKING CHANGE:** edit LSP9 interface ID `0x5e38b596` -> `0xf3456c26` to include `IClaimOwnership`.
- move hooks `_notifyVaultSender(address)` and `_notifyVaultReceiver(addresss)` from `transferOwnership(address)` -> `claimOwnership()` function = **only notify + run these hooks when ownership has been fully transferred and claimed.**

## Tests

- add claimOwnership test for Proxy version of Universal Profile
- [x] add ClaimOwnership behaviour tests into LSP9 test suite