### PR TITLE
chore: add hardhat-etherscan dependency to verify contracts on L14

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -12,7 +12,7 @@ All the deployment scripts for `base` contracts initialize the contract after de
 
 ```ts
     // public L14 test network
-    L14: {
+    luksoL14: {
       live: true,
       url: "https://rpc.l14.lukso.network",
       chainId: 22,
@@ -25,7 +25,7 @@ All the deployment scripts for `base` contracts initialize the contract after de
 2. run the command using one of the available `--tags`
 
 ```
-npx hardhat deploy --network L14 --tags <options> --reset
+npx hardhat deploy --network luksoL14 --tags <options> --reset
 ```
 
 Available `--tags <options>` are:
@@ -52,12 +52,12 @@ Available `--tags <options>` are:
 
 ```
 // Deploy the 3 contracts
-npx hardhat deploy --network L14 --tags standard --reset
+npx hardhat deploy --network luksoL14 --tags standard --reset
 
 
 // Deploy the 3 contracts as base contracts (to be used behind proxies)
-npx hardhat deploy --network L14 --tags base --reset
+npx hardhat deploy --network luksoL14 --tags base --reset
 
 // Deploy a specific contract
-npx hardhat deploy --network L14 --tags UniversalProfile --reset
+npx hardhat deploy --network luksoL14 --tags UniversalProfile --reset
 ```

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,6 +2,7 @@ import { HardhatUserConfig } from "hardhat/config";
 
 import "@nomiclabs/hardhat-waffle";
 import "@nomiclabs/hardhat-web3";
+import "@nomiclabs/hardhat-etherscan";
 
 import "@typechain/hardhat";
 import "hardhat-packager";
@@ -22,7 +23,7 @@ const config: HardhatUserConfig = {
       saveDeployments: false,
     },
     // public L14 test network
-    L14: {
+    luksoL14: {
       live: true,
       url: "https://rpc.l14.lukso.network",
       chainId: 22,
@@ -37,6 +38,21 @@ const config: HardhatUserConfig = {
   },
   namedAccounts: {
     owner: 0,
+  },
+  etherscan: {
+    // no API is required to verify contracts
+    // via the Blockscout instance of the L14 network
+    apiKey: "no-api-key-needed",
+    customChains: [
+      {
+        network: "luksoL14",
+        chainId: 22,
+        urls: {
+          apiURL: "https://blockscout.com/lukso/l14/api",
+          browserURL: "https://blockscout.com/lukso/l14",
+        },
+      },
+    ],
   },
   solidity: {
     version: "0.8.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@erc725/erc725.js": "0.8.0",
         "@ethereum-waffle/jest": "^3.3.0",
         "@nomiclabs/hardhat-ethers": "^2.0.2",
+        "@nomiclabs/hardhat-etherscan": "^3.1.0-rc.0",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@nomiclabs/hardhat-web3": "^2.0.0",
         "@primitivefi/hardhat-dodoc": "^0.1.1",
@@ -3057,6 +3058,70 @@
         "hardhat": "^2.0.0"
       }
     },
+    "node_modules/@nomiclabs/hardhat-etherscan": {
+      "version": "3.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.0-rc.0.tgz",
+      "integrity": "sha512-l4yA4PJvmjvm4EsN1OXHmI89tKs6Tk/Jks/f4QwafmQIVTqT1FutPUrwOrG9FbGus2BWDB+AxlxIh8UkTAfimQ==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "semver": "^6.3.0",
+        "undici": "^4.14.1"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@nomiclabs/hardhat-waffle": {
       "version": "2.0.1",
       "integrity": "sha512-2YR2V5zTiztSH9n8BYWgtv3Q+EL0N5Ltm1PAr5z20uAY4SkkfylJ98CIqt18XFvxTD5x4K2wKBzddjV9ViDAZQ==",
@@ -5244,6 +5309,19 @@
     "node_modules/caseless": {
       "version": "0.12.0",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "node_modules/cbor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "dev": true,
+      "dependencies": {
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -26253,6 +26331,15 @@
       "version": "1.1.75",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
+    "node_modules/nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
@@ -29998,6 +30085,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
+      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
@@ -33697,6 +33793,55 @@
       "dev": true,
       "requires": {}
     },
+    "@nomiclabs/hardhat-etherscan": {
+      "version": "3.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.0-rc.0.tgz",
+      "integrity": "sha512-l4yA4PJvmjvm4EsN1OXHmI89tKs6Tk/Jks/f4QwafmQIVTqT1FutPUrwOrG9FbGus2BWDB+AxlxIh8UkTAfimQ==",
+      "dev": true,
+      "requires": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^5.0.2",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "semver": "^6.3.0",
+        "undici": "^4.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@nomiclabs/hardhat-waffle": {
       "version": "2.0.1",
       "integrity": "sha512-2YR2V5zTiztSH9n8BYWgtv3Q+EL0N5Ltm1PAr5z20uAY4SkkfylJ98CIqt18XFvxTD5x4K2wKBzddjV9ViDAZQ==",
@@ -35468,6 +35613,16 @@
     "caseless": {
       "version": "0.12.0",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "cbor": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
+      "integrity": "sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.1",
+        "nofilter": "^1.0.4"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -51701,6 +51856,12 @@
       "version": "1.1.75",
       "integrity": "sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw=="
     },
+    "nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
@@ -54512,6 +54673,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
+      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@erc725/erc725.js": "0.8.0",
     "@ethereum-waffle/jest": "^3.3.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-etherscan": "^3.1.0-rc.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@primitivefi/hardhat-dodoc": "^0.1.1",


### PR DESCRIPTION
# What does this PR introduce?

## Background

[An issue (#2661) was raised on Hardhat repository](https://github.com/NomicFoundation/hardhat/pull/2661) to add LUKSO L14 chain.

The objective was to add the L14 chain configs in `@nomiclabs/hardhat-etherscan`to be able to verify easily contracts deployed on L14. See docs of the plugin for more infos: https://github.com/NomicFoundation/hardhat/tree/master/packages/hardhat-etherscan

[This issue was solved in the following PR in hardhat](https://github.com/NomicFoundation/hardhat/pull/2597), and it is now possible to add custom chain to chain in the `@nomiclabs/hardhat-etherscan` plugin via the `hardhat.config.ts` file

## Build

- add release candidate version of `@nomiclabs/hardhat-etherscan@rc` in dev dependencies, so to enable verifying deployed contracts via CLI.
- add L14 chain configs in the `etherscan` object in `hardhat.config.ts`
- change reference `L14` -> `luksoL14` in DEPLOYMENT.md 