### PR TITLE
refactor: simplify inheritance in LSP0 & LSP9

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -2,51 +2,22 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP0ERC725AccountCore, ClaimOwnership} from "./LSP0ERC725AccountCore.sol";
-import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
+import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
-
-// constants
-import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
-import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Implementation of ERC725Account
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
-contract LSP0ERC725Account is ERC725, LSP0ERC725AccountCore {
+contract LSP0ERC725Account is LSP0ERC725AccountCore {
     /**
      * @notice Sets the owner of the contract
      * @param _newOwner the owner of the contract
      */
-    constructor(address _newOwner) ERC725(_newOwner) {} // solhint-disable no-empty-blocks
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725, LSP0ERC725AccountCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_ERC1271 ||
-            interfaceId == _INTERFACEID_LSP0 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    function transferOwnership(address _newOwner)
-        public
-        virtual
-        override(LSP0ERC725AccountCore, OwnableUnset)
-        onlyOwner
-    {
-        ClaimOwnership._transferOwnership(_newOwner);
+    constructor(address _newOwner) {
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -35,14 +35,14 @@ abstract contract LSP0ERC725AccountCore is
     ILSP1UniversalReceiver
 {
     /**
-     * @notice Emitted when a native token is received
+     * @notice Emitted when receiving native tokens
      * @param sender The address of the sender
      * @param value The amount of value sent
      */
     event ValueReceived(address indexed sender, uint256 indexed value);
 
     /**
-     * @dev Emits an event when a native token is received
+     * @dev Emits an event when receiving native tokens
      */
     receive() external payable {
         emit ValueReceived(_msgSender(), msg.value);

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -34,8 +34,16 @@ abstract contract LSP0ERC725AccountCore is
     IERC1271,
     ILSP1UniversalReceiver
 {
+    /**
+     * @notice Emitted when a native token is received
+     * @param sender The address of the sender
+     * @param value The amount of value sent
+     */
     event ValueReceived(address indexed sender, uint256 indexed value);
 
+    /**
+     * @dev Emits an event when a native token is received
+     */
     receive() external payable {
         emit ValueReceived(_msgSender(), msg.value);
     }
@@ -54,6 +62,42 @@ abstract contract LSP0ERC725AccountCore is
     //            default { return (0, returndatasize()) }
     //        }
     //    }
+
+    // ERC165
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_ERC1271 ||
+            interfaceId == _INTERFACEID_LSP0 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
+            super.supportsInterface(interfaceId);
+    }
+
+    // ERC173 - Modified ClaimOwnership
+
+    /**
+     * @dev Sets the pending owner
+     */
+    function transferOwnership(address _newOwner)
+        public
+        virtual
+        override(ClaimOwnership, OwnableUnset)
+        onlyOwner
+    {
+        ClaimOwnership._transferOwnership(_newOwner);
+    }
+
+    // ERC1271
 
     /**
      * @notice Checks if an owner signed `_data`.
@@ -85,6 +129,8 @@ abstract contract LSP0ERC725AccountCore is
         }
     }
 
+    // LSP1
+
     /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * @dev Forwards the call to the UniversalReceiverDelegate if set.
@@ -112,32 +158,5 @@ abstract contract LSP0ERC725AccountCore is
             }
         }
         emit UniversalReceiver(_msgSender(), _typeId, returnValue, _data);
-    }
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_ERC1271 ||
-            interfaceId == _INTERFACEID_LSP0 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    function transferOwnership(address _newOwner)
-        public
-        virtual
-        override(ClaimOwnership, OwnableUnset)
-        onlyOwner
-    {
-        ClaimOwnership._transferOwnership(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -2,49 +2,19 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP0ERC725AccountCore, ClaimOwnership} from "./LSP0ERC725AccountCore.sol";
-import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
+import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
-
-// constants
-import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271} from "./LSP0Constants.sol";
-import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725Account
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
  * @dev Bundles ERC725X and ERC725Y, ERC1271 and LSP1UniversalReceiver and allows receiving native tokens
  */
-abstract contract LSP0ERC725AccountInitAbstract is ERC725InitAbstract, LSP0ERC725AccountCore {
-    function _initialize(address _newOwner) internal virtual override onlyInitializing {
-        ERC725InitAbstract._initialize(_newOwner);
-    }
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725InitAbstract, LSP0ERC725AccountCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_ERC1271 ||
-            interfaceId == _INTERFACEID_LSP0 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    function transferOwnership(address _newOwner)
-        public
-        virtual
-        override(LSP0ERC725AccountCore, OwnableUnset)
-        onlyOwner
-    {
-        ClaimOwnership._transferOwnership(_newOwner);
+abstract contract LSP0ERC725AccountInitAbstract is Initializable, LSP0ERC725AccountCore {
+    function _initialize(address _newOwner) internal virtual onlyInitializing {
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
     }
 }

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -19,82 +19,18 @@ import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-contract LSP9Vault is ERC725, LSP9VaultCore {
+contract LSP9Vault is LSP9VaultCore {
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param _newOwner the owner of the contract
      */
-    constructor(address _newOwner) ERC725(_newOwner) {
+    constructor(address _newOwner) {
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
         _notifyVaultReceiver(_newOwner);
-    }
-
-    /**
-     * @inheritdoc IERC725Y
-     * @dev Sets data as bytes in the vault storage for a single key.
-     * SHOULD only be callable by the owner of the contract set via ERC173
-     * and the UniversalReceiverDelegate
-     *
-     * Emits a {DataChanged} event.
-     */
-    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
-        _setData(_key, _value);
-    }
-
-    /**
-     * @inheritdoc IERC725Y
-     * @dev Sets array of data at multiple given `key`
-     * SHOULD only be callable by the owner of the contract set via ERC173
-     * and the UniversalReceiverDelegate
-     *
-     * Emits a {DataChanged} event.
-     */
-    function setData(bytes32[] memory _keys, bytes[] memory _values)
-        public
-        virtual
-        override
-        onlyAllowed
-    {
-        require(_keys.length == _values.length, "Keys length not equal to values length");
-        for (uint256 i = 0; i < _keys.length; i++) {
-            _setData(_keys[i], _values[i]);
-        }
-    }
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725, LSP9VaultCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_LSP9 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    /**
-     * @inheritdoc OwnableUnset
-     */
-    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        ClaimOwnership._transferOwnership(newOwner);
-    }
-
-    /**
-     * @dev Transfer the ownership and notify the vault sender and vault receiver
-     */
-    function claimOwnership() public virtual override {
-        address previousOwner = owner();
-        super.claimOwnership();
-
-        _notifyVaultSender(previousOwner);
-        _notifyVaultReceiver(msg.sender);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 // interfaces
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
@@ -63,6 +64,84 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         emit ValueReceived(_msgSender(), msg.value);
     }
 
+    // ERC165
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore)
+        returns (bool)
+    {
+        return
+            interfaceId == _INTERFACEID_LSP9 ||
+            interfaceId == _INTERFACEID_LSP1 ||
+            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
+            super.supportsInterface(interfaceId);
+    }
+
+    // ERC173 - Modified ClaimOwnership
+
+    /**
+     * @dev Sets the pending owner
+     */
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(ClaimOwnership, OwnableUnset)
+        onlyOwner
+    {
+        ClaimOwnership._transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Transfer the ownership and notify the vault sender and vault receiver
+     */
+    function claimOwnership() public virtual override {
+        address previousOwner = owner();
+        super.claimOwnership();
+
+        _notifyVaultSender(previousOwner);
+        _notifyVaultReceiver(msg.sender);
+    }
+
+    // ERC725
+
+    /**
+     * @inheritdoc IERC725Y
+     * @dev Sets data as bytes in the vault storage for a single key.
+     * SHOULD only be callable by the owner of the contract set via ERC173
+     * and the UniversalReceiverDelegate
+     *
+     * Emits a {DataChanged} event.
+     */
+    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
+        _setData(_key, _value);
+    }
+
+    /**
+     * @inheritdoc IERC725Y
+     * @dev Sets array of data at multiple given `key`
+     * SHOULD only be callable by the owner of the contract set via ERC173
+     * and the UniversalReceiverDelegate
+     *
+     * Emits a {DataChanged} event.
+     */
+    function setData(bytes32[] memory _keys, bytes[] memory _values)
+        public
+        virtual
+        override
+        onlyAllowed
+    {
+        require(_keys.length == _values.length, "Keys length not equal to values length");
+        for (uint256 i = 0; i < _keys.length; i++) {
+            _setData(_keys[i], _values[i]);
+        }
+    }
+
     // LSP1
 
     /**
@@ -112,31 +191,5 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         if (ERC165CheckerCustom.supportsERC165Interface(_receiver, _INTERFACEID_LSP1)) {
             ILSP1UniversalReceiver(_receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
         }
-    }
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_LSP9 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(ClaimOwnership, OwnableUnset)
-        onlyOwner
-    {
-        ClaimOwnership._transferOwnership(newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -28,7 +28,7 @@ import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER
  */
 contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1UniversalReceiver {
     /**
-     * @notice Emitted when a native token is received
+     * @notice Emitted when receiving native tokens
      * @param sender The address of the sender
      * @param value The amount of value sent
      */
@@ -58,7 +58,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     // public functions
 
     /**
-     * @dev Emits an event when a native token is received
+     * @dev Emits an event when receiving native tokens
      */
     receive() external payable {
         emit ValueReceived(_msgSender(), msg.value);

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -6,7 +6,7 @@ import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.so
 
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
-import {ERC725InitAbstract} from "@erc725/smart-contracts/contracts/ERC725InitAbstract.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants
@@ -19,80 +19,14 @@ import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
  * @author Fabian Vogelsteller, Yamen Merhi, Jean Cavallera
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
-abstract contract LSP9VaultInitAbstract is ERC725InitAbstract, LSP9VaultCore {
-    function _initialize(address _newOwner) internal virtual override onlyInitializing {
-        ERC725InitAbstract._initialize(_newOwner);
-
+abstract contract LSP9VaultInitAbstract is Initializable, LSP9VaultCore {
+    function _initialize(address _newOwner) internal virtual onlyInitializing {
+        if (_newOwner != owner()) {
+            OwnableUnset.initOwner(_newOwner);
+        }
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
         _notifyVaultReceiver(_newOwner);
-    }
-
-    /**
-     * @inheritdoc IERC725Y
-     * @dev Sets data as bytes in the vault storage for a single key.
-     * SHOULD only be callable by the owner of the contract set via ERC173
-     * and the UniversalReceiverDelegate
-     *
-     * Emits a {DataChanged} event.
-     */
-    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
-        _setData(_key, _value);
-    }
-
-    /**
-     * @inheritdoc IERC725Y
-     * @dev Sets array of data at multiple given `key`
-     * SHOULD only be callable by the owner of the contract set via ERC173
-     * and the UniversalReceiverDelegate
-     *
-     * Emits a {DataChanged} event.
-     */
-    function setData(bytes32[] memory _keys, bytes[] memory _values)
-        public
-        virtual
-        override
-        onlyAllowed
-    {
-        require(_keys.length == _values.length, "Keys length not equal to values length");
-        for (uint256 i = 0; i < _keys.length; i++) {
-            _setData(_keys[i], _values[i]);
-        }
-    }
-
-    /**
-     * @dev See {IERC165-supportsInterface}.
-     */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725InitAbstract, LSP9VaultCore)
-        returns (bool)
-    {
-        return
-            interfaceId == _INTERFACEID_LSP9 ||
-            interfaceId == _INTERFACEID_LSP1 ||
-            interfaceId == _INTERFACEID_CLAIM_OWNERSHIP ||
-            super.supportsInterface(interfaceId);
-    }
-
-    /**
-     * @inheritdoc OwnableUnset
-     */
-    function transferOwnership(address newOwner) public virtual override(LSP9VaultCore, OwnableUnset) onlyOwner {
-        ClaimOwnership._transferOwnership(newOwner);
-    }
-
-    /**
-     * @dev Transfer the ownership and notify the vault sender and vault receiver
-     */
-    function claimOwnership() public virtual override {
-        address previousOwner = owner();
-        super.claimOwnership();
-
-        _notifyVaultSender(previousOwner);
-        _notifyVaultReceiver(msg.sender);
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- Simplifying inheritance of LSP0 and LSP9 by removing the inheritance of ERC725 and setting the owner manually in the constructor/initializer.
- Style functions in ERC order with adding few nastpec comments.