### PR TITLE
refactor: flip `index` and `interfaceId` in LSP5 & LSP10

### DIFF
--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -39,7 +39,7 @@ library LSP5Utils {
             keys[1] = LSP2Utils.generateArrayKeyAtIndex(_arrayKey, 0);
 
             values[0] = UtilsLib.uint256ToBytes(1);
-            values[2] = bytes.concat(bytes8(0), _appendix);
+            values[2] = bytes.concat(_appendix, bytes8(0));
         } else if (rawArrayLength.length == 32) {
             uint256 arrayLength = abi.decode(rawArrayLength, (uint256));
             uint256 newArrayLength = arrayLength + 1;
@@ -47,7 +47,7 @@ library LSP5Utils {
             keys[1] = LSP2Utils.generateArrayKeyAtIndex(_arrayKey, newArrayLength - 1);
 
             values[0] = UtilsLib.uint256ToBytes(newArrayLength);
-            values[2] = bytes.concat(bytes8(uint64(arrayLength)), _appendix);
+            values[2] = bytes.concat(_appendix, bytes8(uint64(arrayLength)));
         }
     }
 
@@ -102,7 +102,7 @@ library LSP5Utils {
 
             bytes memory mapValueOfLastkey = _account.getData(mapOfLastkey);
 
-            bytes memory appendix = BytesLib.slice(mapValueOfLastkey, 8, 4);
+            bytes memory appendix = BytesLib.slice(mapValueOfLastkey, 0, 4);
 
             keys[2] = arrayKeyToRemove;
             values[2] = lastKeyValue;
@@ -111,7 +111,7 @@ library LSP5Utils {
             values[3] = "";
 
             keys[4] = mapOfLastkey;
-            values[4] = bytes.concat(bytes8(index), appendix);
+            values[4] = bytes.concat(appendix, bytes8(index));
         }
     }
 
@@ -155,7 +155,7 @@ library LSP5Utils {
         returns (uint64)
     {
         bytes memory mapValue = _account.getData(_mapKey);
-        bytes memory val = BytesLib.slice(mapValue, 0, 8);
+        bytes memory val = BytesLib.slice(mapValue, 4, 8);
         return BytesLib.toUint64(val, 0);
     }
 

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -171,8 +171,8 @@ export function callPayload(from: any, to: string, abi: string) {
 export async function getLSP5MapAndArrayKeysValue(account, token) {
   let mapKey = ERC725YKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substr(2);
   const mapValue = await account["getData(bytes32)"](mapKey);
-  const indexInHex = mapValue.substr(0, 18);
-  const interfaceId = "0x" + mapValue.substr(18);
+  const indexInHex = "0x" + mapValue.substr(10, 16);
+  const interfaceId =  mapValue.substr(0,10);
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
   const rawIndexInArray = ethers.utils.hexZeroPad(
     ethers.utils.hexValue(indexInNumber),
@@ -199,8 +199,8 @@ export async function getLSP5MapAndArrayKeysValue(account, token) {
 export async function getLSP10MapAndArrayKeysValue(account, lsp9Vault) {
   let mapKey = ERC725YKeys.LSP10.LSP10VaultsMap + lsp9Vault.address.substr(2);
   const mapValue = await account["getData(bytes32)"](mapKey);
-  const indexInHex = mapValue.substr(0, 18);
-  const interfaceId = "0x" + mapValue.substr(18);
+  const indexInHex = "0x" + mapValue.substr(10, 16);
+  const interfaceId = mapValue.substr(0,10);
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
   const rawIndexInArray = ethers.utils.hexZeroPad(
     ethers.utils.hexValue(indexInNumber),


### PR DESCRIPTION
## What does this PR introduce?
- Changing the arranging of the data set for `LSP5-ReceivedAssetsMap` and `LSP10-VaultsMap` according to the specs. 
[LSP5-ReceivedAssetsMap](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-5-ReceivedAssets.md#lsp5receivedassetsmap)
[LSP10-VaultsMap](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-10-ReceivedVaults.md#lsp10vaultsmap)