### PR TITLE
refactor!: disable operation type DELEGATECALL in KeyManager

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -25,6 +25,14 @@ import {LSP6Utils} from "./LSP6Utils.sol";
 import "./LSP6Errors.sol";
 
 // constants
+// prettier-ignore
+import {
+    OPERATION_CALL,
+    OPERATION_CREATE,
+    OPERATION_CREATE2,
+    OPERATION_STATICCALL,
+    OPERATION_DELEGATECALL
+} from "@erc725/smart-contracts/contracts/constants.sol";
 import {_INTERFACEID_ERC1271, _ERC1271_MAGICVALUE, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
 import "./LSP6Constants.sol";
 
@@ -433,7 +441,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         uint256 value = uint256(bytes32(_calldata[68:100]));
 
-        bool isContractCreation = operationType == 1 || operationType == 2;
+        // prettier-ignore
+        bool isContractCreation = operationType == OPERATION_CREATE || operationType == OPERATION_CREATE2;
         bool isCallDataPresent = _calldata.length > 164;
 
         // SUPER operation only applies to contract call, not contract creation
@@ -490,11 +499,11 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         pure
         returns (bytes32 permissionsRequired_)
     {
-        if (_operationType == 0) return _PERMISSION_CALL;
-        else if (_operationType == 1) return _PERMISSION_DEPLOY;
-        else if (_operationType == 2) return _PERMISSION_DEPLOY;
-        else if (_operationType == 3) return _PERMISSION_STATICCALL;
-        else if (_operationType == 4) return _PERMISSION_DELEGATECALL;
+        if (_operationType == OPERATION_CALL) return _PERMISSION_CALL;
+        else if (_operationType == OPERATION_CREATE) return _PERMISSION_DEPLOY;
+        else if (_operationType == OPERATION_CREATE2) return _PERMISSION_DEPLOY;
+        else if (_operationType == OPERATION_STATICCALL) return _PERMISSION_STATICCALL;
+        else if (_operationType == OPERATION_DELEGATECALL) return _PERMISSION_DELEGATECALL;
     }
 
     function _extractSuperPermissionFromOperation(uint256 _operationType)
@@ -502,9 +511,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         pure
         returns (bytes32 superPermission_)
     {
-        if (_operationType == 0) return _PERMISSION_SUPER_CALL;
-        else if (_operationType == 3) return _PERMISSION_SUPER_STATICCALL;
-        else if (_operationType == 4) return _PERMISSION_SUPER_DELEGATECALL;
+        if (_operationType == OPERATION_CALL) return _PERMISSION_SUPER_CALL;
+        else if (_operationType == OPERATION_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
+        else if (_operationType == OPERATION_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -439,6 +439,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         uint256 operationType = uint256(bytes32(_calldata[4:36]));
         require(operationType < 5, "LSP6KeyManager: invalid operation type");
 
+        // TODO: if re-enable delegatecall, add check to ensure owner() + initialized() are not overriden after delegatecall
+        require(
+            operationType != OPERATION_DELEGATECALL,
+            "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
+        );
+
         uint256 value = uint256(bytes32(_calldata[68:100]));
 
         // prettier-ignore

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -238,9 +238,9 @@ export const shouldBehaveLikePermissionDelegateCall = (
         ];
       });
 
-      describe("it should bypass allowed addresses check", () => {
+      describe("it should revert since DELEGATECALL is disallowed", () => {
         for (let ii = 0; ii < 5; ii++) {
-          it(`should allow delegate call to contract nb ${ii}`, async () => {
+          it(`delegate call to contract nb ${ii}`, async () => {
             const key =
               "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
             const value = "0xbbbbbbbbbbbbbbbb";
@@ -265,19 +265,24 @@ export const shouldBehaveLikePermissionDelegateCall = (
                 delegateCallPayload,
               ]);
 
-            await context.keyManager.connect(caller).execute(executePayload);
+            await expect(
+              context.keyManager.connect(caller).execute(executePayload)
+            ).toBeRevertedWith(
+              "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
+            );
 
+            // storage should remain unchanged and not set
             const newStorage = await context.universalProfile[
               "getData(bytes32)"
             ](key);
-            expect(newStorage).toEqual(value);
+            expect(newStorage).toEqual("0x");
           });
         }
       });
     });
 
     describe("when calling an allowed contract", () => {
-      it("should allow to interact with the 1st allowed contract", async () => {
+      it("should revert with DELEGATECALL disallowed when trying to interact with the 1st allowed contract", async () => {
         const key =
           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         const value = "0xbbbbbbbbbbbbbbbb";
@@ -301,14 +306,18 @@ export const shouldBehaveLikePermissionDelegateCall = (
             delegateCallPayload,
           ]);
 
-        await context.keyManager.connect(caller).execute(executePayload);
+        await expect(
+          context.keyManager.connect(caller).execute(executePayload)
+        ).toBeRevertedWith(
+          "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
+        );
 
         // prettier-ignore
         const newStorage = await context.universalProfile["getData(bytes32)"](key);
-        expect(newStorage).toEqual(value);
+        expect(newStorage).toEqual("0x");
       });
 
-      it("should allow to interact with the 2nd allowed contract", async () => {
+      it("should revert with DELEGATECALL disallowed when trying to interact with the 2nd allowed contract", async () => {
         const key =
           "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         const value = "0xbbbbbbbbbbbbbbbb";
@@ -332,11 +341,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
             delegateCallPayload,
           ]);
 
-        await context.keyManager.connect(caller).execute(executePayload);
+        await expect(
+          context.keyManager.connect(caller).execute(executePayload)
+        ).toBeRevertedWith(
+          "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
+        );
 
         // prettier-ignore
         const newStorage = await context.universalProfile["getData(bytes32)"](key);
-        expect(newStorage).toEqual(value);
+        expect(newStorage).toEqual("0x");
       });
     });
   });

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -59,8 +59,8 @@ export const shouldBehaveLikePermissionDelegateCall = (
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when trying to make a DELEGATECALL via UP", () => {
-    it("should pass when the caller has ALL PERMISSIONS", async () => {
+  describe("when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed", () => {
+    it("should revert even if caller has ALL PERMISSIONS", async () => {
       const key =
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
       const value = "0xbbbbbbbbbbbbbbbb";
@@ -88,17 +88,14 @@ export const shouldBehaveLikePermissionDelegateCall = (
           delegateCallPayload,
         ]);
 
-      await context.keyManager.connect(context.owner).execute(executePayload);
-
-      // verify that the setData ran in the context of the calling UP
-      // and that it updated its ERC725Y storage
-      const newStorage = await context.universalProfile["getData(bytes32)"](
-        key
+      await expect(
+        context.keyManager.connect(context.owner).execute(executePayload)
+      ).toBeRevertedWith(
+        "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
       );
-      expect(newStorage).toEqual(value);
     });
 
-    it("should pass if caller has permission DELEGATECALL", async () => {
+    it("should revert even if caller has permission DELEGATECALL", async () => {
       const key =
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
       const value = "0xbbbbbbbbbbbbbbbb";
@@ -126,19 +123,16 @@ export const shouldBehaveLikePermissionDelegateCall = (
           delegateCallPayload,
         ]);
 
-      await context.keyManager
-        .connect(addressCanDelegateCall)
-        .execute(executePayload);
-
-      // verify that the setData ran in the context of the calling UP
-      // and that it updated its ERC725Y storage
-      const newStorage = await context.universalProfile["getData(bytes32)"](
-        key
+      await expect(
+        context.keyManager
+          .connect(addressCanDelegateCall)
+          .execute(executePayload)
+      ).toBeRevertedWith(
+        "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
       );
-      expect(newStorage).toEqual(value);
     });
 
-    it("should fail when caller does not have permission DELEGATECALL", async () => {
+    it("should revert with operation disallowed, even if caller does not have permission DELEGATECALL", async () => {
       const key =
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
       const value = "0xbbbbbbbbbbbbbbbb";
@@ -171,7 +165,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
           .connect(addressCannotDelegateCall)
           .execute(executePayload)
       ).toBeRevertedWith(
-        NotAuthorisedError(addressCannotDelegateCall.address, "DELEGATECALL")
+        "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
       );
     });
   });


### PR DESCRIPTION
# What does this PR introduce?

⚠️ As discussed and agreed, we want to disallow DELEGATECALL for any ERC725 account linked to this KeyManager for safety reasons, as **delegatecall is a dangerous operation** that can introduce side effects on the linked account's storage.

## Refactor

- [x] revert when trying to run `ERC725X.execute(...)` with operation type == 4
- use `OPERATION_TYPE` constants imported from `@erc725/smart-contracts` package.