### PR TITLE
build: upgrade `@erc725/smart-contracts` package

### DIFF
--- a/contracts/Helpers/ERC165Interfaces.sol
+++ b/contracts/Helpers/ERC165Interfaces.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 // ERC interfaces
 import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -16,8 +16,6 @@ contract LSP0ERC725Account is LSP0ERC725AccountCore {
      * @param _newOwner the owner of the contract
      */
     constructor(address _newOwner) {
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
+        OwnableUnset._setOwner(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 /**
  * @title Implementation of ERC725Account

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -14,7 +14,7 @@ import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {ClaimOwnership} from "../Utils/ClaimOwnership.sol";
 
 // constants

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -13,8 +13,6 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
  */
 abstract contract LSP0ERC725AccountInitAbstract is Initializable, LSP0ERC725AccountCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
+        OwnableUnset._setOwner(_newOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 // modules
 import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 /**
  * @title Inheritable Proxy Implementation of ERC725Account

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@erc725/smart-contracts/contracts/custom/Initializable.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 /**

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {ERC725YInitAbstract, ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
 
 // constants

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -7,7 +7,7 @@ import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.so
 import {ILSP6KeyManager} from "./ILSP6KeyManager.sol";
 
 // modules
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {IClaimOwnership} from "../Utils/IClaimOwnership.sol";
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -6,7 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
 import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -6,7 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP7DigitalAssetInit} from "../LSP7DigitalAssetInit.sol";
 import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -6,7 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP4DigitalAssetMetadata} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol";
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -6,7 +6,6 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -3,7 +3,6 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP8IdentifiableDigitalAssetInit} from "../LSP8IdentifiableDigitalAssetInit.sol";
 import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -25,9 +25,8 @@ contract LSP9Vault is LSP9VaultCore {
      * @param _newOwner the owner of the contract
      */
     constructor(address _newOwner) {
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
+        OwnableUnset._setOwner(_newOwner);
+
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 // modules
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {ERC725} from "@erc725/smart-contracts/contracts/ERC725.sol";
 import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -13,7 +13,7 @@ import {ERC165CheckerCustom} from "../Utils/ERC165CheckerCustom.sol";
 // modules
 import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {ClaimOwnership} from "../Utils/ClaimOwnership.sol";
 
 // constants

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -21,9 +21,8 @@ import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Utils/IClaimOwnership.sol";
  */
 abstract contract LSP9VaultInitAbstract is Initializable, LSP9VaultCore {
     function _initialize(address _newOwner) internal virtual onlyInitializing {
-        if (_newOwner != owner()) {
-            OwnableUnset.initOwner(_newOwner);
-        }
+        OwnableUnset._setOwner(_newOwner);
+
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 // modules
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -6,7 +6,7 @@ import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.so
 
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@erc725/smart-contracts/contracts/custom/Initializable.sol";
 import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants

--- a/contracts/Utils/ClaimOwnership.sol
+++ b/contracts/Utils/ClaimOwnership.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 import {IClaimOwnership} from "./IClaimOwnership.sol";
 
 // modules
-import {OwnableUnset} from "@erc725/smart-contracts/contracts/utils/OwnableUnset.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     address public override pendingOwner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^3.0.2",
-        "@openzeppelin/contracts": "^4.3.1",
+        "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
@@ -3150,9 +3150,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
-      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.6.0.tgz",
+      "integrity": "sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg=="
     },
     "node_modules/@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",
@@ -33860,9 +33860,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.4.1.tgz",
-      "integrity": "sha512-o+pHCf/yMLSlV5MkDQEzEQL402i6SoRnktru+0rdSxVEFZcTzzGhZCAtZjUFyKGazMSv1TilzMg+RbED1N8XHQ=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.6.0.tgz",
+      "integrity": "sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg=="
     },
     "@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^3.0.2",
+        "@erc725/smart-contracts": "^3.0.3",
         "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
       },
@@ -710,11 +710,11 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.2.tgz",
-      "integrity": "sha512-wjsxnzOx/l+BppXJ+Y/l+uRHNKYzk+eg+MCnA6sPe6BXMYn9538hzzdgPHCUfAyui4IpJ+dO+eDQRf6a4pnXTQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.3.tgz",
+      "integrity": "sha512-rXZRBLaPC3UAg7X46HbDOYuibPnsb8l8IC6lq1w7WIDEzEUKhh9wukkBzQsX4ka5EpvfRFn4BaHr+PLuHVfQkA==",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.3.1",
+        "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
       }
     },
@@ -32108,11 +32108,11 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.2.tgz",
-      "integrity": "sha512-wjsxnzOx/l+BppXJ+Y/l+uRHNKYzk+eg+MCnA6sPe6BXMYn9538hzzdgPHCUfAyui4IpJ+dO+eDQRf6a4pnXTQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.3.tgz",
+      "integrity": "sha512-rXZRBLaPC3UAg7X46HbDOYuibPnsb8l8IC6lq1w7WIDEzEUKhh9wukkBzQsX4ka5EpvfRFn4BaHr+PLuHVfQkA==",
       "requires": {
-        "@openzeppelin/contracts": "^4.3.1",
+        "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
     "@erc725/smart-contracts": "^3.0.2",
-    "@openzeppelin/contracts": "^4.3.1",
+    "@openzeppelin/contracts": "^4.6.0",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^3.0.2",
+    "@erc725/smart-contracts": "^3.0.3",
     "@openzeppelin/contracts": "^4.6.0",
     "solidity-bytes-utils": "0.8.0"
   },


### PR DESCRIPTION
## What does this PR introduce?
- Upgrading  `@erc725/smart-contracts` package with the necessary changes:
     - Changing `OwnableUnset` path to custom folder 
     - Use `_setOwner` function instead of `initOwner`
     - Introduce custom `Initializable` contract in LSP0 & LSP9
- Remove unnecessary import statements.