### PR TITLE
refactor!: edit LSP2 keys according to new spec

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -51,15 +51,15 @@ const OPERATION_TYPES = {
 
 const SupportedStandards = {
 	LSP3UniversalProfile: {
-		key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6',
+		key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
 		value: '0xabe425d6',
 	},
 	LSP4DigitalAsset: {
-		key: '0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624',
+		key: '0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c',
 		value: '0xa4d96624',
 	},
 	LSP9Vault: {
-		key: '0xeafec4d89fa9619884b6b891356264550000000000000000000000007c0334a1',
+		key: '0xeafec4d89fa9619884b600007c0334a14085fefa8b51ae5a40895018882bdb90',
 		value: '0x7c0334a1',
 	},
 };

--- a/constants.js
+++ b/constants.js
@@ -235,11 +235,11 @@ const EventSignatures = {
 		 * event UniversalReceiver(
 		 *    address indexed from,
 		 *    bytes32 indexed typeId,
-		 *    bytes32 indexed returnedValue,
+		 *    bytes indexed returnedValue,
 		 *    bytes receivedData
 		 * );
 		 *
-		 * signature = keccak256('UniversalReceiver(address,bytes32,bytes32,bytes)')
+		 * signature = keccak256('UniversalReceiver(address,bytes32,bytes,bytes)')
 		 */
 		UniversalReceiver: '0x8187df79ab47ad16102e7bc8760349a115b3ba9869b8cedd78996f930ac9cac3',
 	},

--- a/constants.js
+++ b/constants.js
@@ -212,14 +212,11 @@ const EventSignatures = {
 	},
 	ERC725Y: {
 		/**
-		 * event DataChanged(
-		 *      bytes32 indexed key,
-		 *      bytes value
-		 * );
+		 * event DataChanged(bytes32 indexed key);
 		 *
-		 * signature = keccak256('DataChanged(bytes32,bytes)')
+		 * signature = keccak256('DataChanged(bytes32)')
 		 */
-		DataChanged: '0xece574603820d07bc9b91f2a932baadf4628aabcb8afba49776529c14a6104b2',
+		DataChanged: '0xcdf4e344c0d23d4cdd0474039d176c55b19d531070dbe17856bfb993a5b5720b',
 	},
 	// ERC725Account
 	LSP0: {

--- a/constants.js
+++ b/constants.js
@@ -90,7 +90,7 @@ const ERC725YKeys = {
 	},
 	LSP5: {
 		// LSP5ReceivedAssetsMap:<address>
-		LSP5ReceivedAssetsMap: '0x812c4334633eb81600000000',
+		LSP5ReceivedAssetsMap: '0x812c4334633eb816c80d0000',
 		// keccak256('LSP5ReceivedAssets[]')
 		'LSP5ReceivedAssets[]':
 			'0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
@@ -100,19 +100,19 @@ const ERC725YKeys = {
 		'AddressPermissions[]':
 			'0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
 		// AddressPermissions:Permissions:<address>
-		'AddressPermissions:Permissions': '0x4b80742d0000000082ac0000',
+		'AddressPermissions:Permissions': '0x4b80742de2bf82acb3630000',
 		// AddressPermissions:AllowedAddresses:<address>
-		'AddressPermissions:AllowedAddresses': '0x4b80742d00000000c6dd0000',
+		'AddressPermissions:AllowedAddresses': '0x4b80742de2bfc6dd6b3c0000',
 		// AddressPermissions:AllowedFunctions:<address>
-		'AddressPermissions:AllowedFunctions': '0x4b80742d000000008efe0000',
+		'AddressPermissions:AllowedFunctions': '0x4b80742de2bf8efea1e80000',
 		// AddressPermissions:AllowedStandards:<address>
-		'AddressPermissions:AllowedStandards': '0x4b80742d000000003efa0000',
+		'AddressPermissions:AllowedStandards': '0x4b80742de2bf3efa94a30000',
 		// AddressPermissions:AllowedERC725YKeys:<address>
-		'AddressPermissions:AllowedERC725YKeys': '0x4b80742d0000000090b80000',
+		'AddressPermissions:AllowedERC725YKeys': '0x4b80742de2bf90b8b4850000',
 	},
 	LSP10: {
 		// keccak256('LSP10VaultsMap')
-		LSP10VaultsMap: '0x192448c3c0f88c7f00000000',
+		LSP10VaultsMap: '0x192448c3c0f88c7f238c0000',
 		// keccak256('LSP10Vaults[]')
 		'LSP10Vaults[]': '0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06',
 	},

--- a/constants.js
+++ b/constants.js
@@ -77,10 +77,6 @@ const ERC725YKeys = {
 	LSP3: {
 		// keccak256('LSP3Profile')
 		LSP3Profile: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
-		// LSP3IssuedAssetsMap:<address>
-		LSP3IssuedAssetsMap: '0x83f5e77bfb14241600000000',
-		// keccak256('LSP3IssuedAssets[]')
-		'LSP3IssuedAssets[]': '0x3a47ab5bd3a594c3a8995f8fa58d0876c96819ca4516bd76100c92462f2f9dc0',
 	},
 	LSP4: {
 		// keccak256('LSP4TokenName')
@@ -120,6 +116,12 @@ const ERC725YKeys = {
 		// keccak256('LSP10Vaults[]')
 		'LSP10Vaults[]': '0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06',
 	},
+	LSP12: {
+		// LSP12IssuedAssetsMap:<address>
+		LSP12IssuedAssetsMap: '0x74ac2555c10b9349e78f0000',
+		// keccak256('LSP12IssuedAssets[]')
+		'LSP12IssuedAssets[]': '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+	},
 };
 
 const BasicUPSetup_Schema = [
@@ -138,8 +140,8 @@ const BasicUPSetup_Schema = [
 		valueType: 'address',
 	},
 	{
-		name: 'LSP3IssuedAssets[]',
-		key: ERC725YKeys.LSP3['LSP3IssuedAssets[]'],
+		name: 'LSP12IssuedAssets[]',
+		key: ERC725YKeys.LSP12['LSP12IssuedAssets[]'],
 		keyType: 'Array',
 		valueContent: 'Number',
 		valueType: 'uint256',

--- a/contracts/LSP10ReceivedVaults/LSP10Constants.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Constants.sol
@@ -6,5 +6,5 @@ pragma solidity ^0.8.0;
 // keccak256('LSP10Vaults[]')
 bytes32 constant _LSP10_VAULTS_ARRAY_KEY = 0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06;
 
-// bytes8(keccak256('LSP10VaultsMap')) + bytes4(0)
-bytes12 constant _LSP10_VAULTS_MAP_KEY_PREFIX = 0x192448c3c0f88c7f00000000;
+// bytes10(keccak256('LSP10VaultsMap')) + bytes2(0)
+bytes12 constant _LSP10_VAULTS_MAP_KEY_PREFIX = 0x192448c3c0f88c7f238c0000;

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -34,16 +34,13 @@ abstract contract TokenAndVaultHandling {
         if (!ERC165CheckerCustom.supportsERC165Interface(keyManager, _INTERFACEID_LSP6)) return "";
 
         address accountAddress = address(LSP6KeyManager(keyManager).target());
-        
+
         // check if the caller is the same account controlled by the keyManager
         if (msg.sender != accountAddress) return "";
         (bool senderHook, bytes32 arrayKey, bytes12 mapPrefix, bytes4 interfaceID) = LSP1Utils
             .getTransferDetails(typeId);
 
-        bytes32 mapKey = LSP2Utils.generateBytes20MappingWithGroupingKey(
-            mapPrefix,
-            bytes20(sender)
-        );
+        bytes32 mapKey = LSP2Utils.generateMappingKey(mapPrefix, bytes20(sender));
         bytes memory mapValue = IERC725Y(msg.sender).getData(mapKey);
 
         if (!senderHook) {

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -32,10 +32,7 @@ abstract contract TokenHandling {
         (bool senderHook, bytes32 arrayKey, bytes12 mapPrefix, bytes4 interfaceID) = LSP1Utils
             .getTransferDetails(typeId);
 
-        bytes32 mapKey = LSP2Utils.generateBytes20MappingWithGroupingKey(
-            mapPrefix,
-            bytes20(sender)
-        );
+        bytes32 mapKey = LSP2Utils.generateMappingKey(mapPrefix, bytes20(sender));
         bytes memory mapValue = IERC725Y(msg.sender).getData(mapKey);
 
         if (!senderHook) {

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -90,7 +90,7 @@ library LSP2Utils {
         return generateBytes32Key(generatedKey);
     }
 
-    function generateBytes20MappingWithGroupingKey(
+    function generateMappingWithGroupingKey(
         string memory _firstWord,
         string memory _secondWord,
         address _address
@@ -108,7 +108,7 @@ library LSP2Utils {
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateBytes20MappingWithGroupingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+    function generateMappingWithGroupingKey(bytes12 _keyPrefix, bytes20 _bytes20)
         internal
         pure
         returns (bytes32)

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -61,24 +61,33 @@ library LSP2Utils {
         bytes32 lastWordHash = keccak256(bytes(_lastWord));
 
         bytes memory temporaryBytes = abi.encodePacked(
-            bytes16(firstWordHash),
-            bytes12(0),
-            bytes4(lastWordHash)
+            bytes10(firstWordHash),
+            bytes2(0),
+            bytes20(lastWordHash)
         );
 
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateBytes20MappingKey(string memory _firstWord, address _address)
+    function generateMappingKey(string memory _firstWord, address _address)
         internal
         pure
         returns (bytes32)
     {
         bytes32 firstWordHash = keccak256(bytes(_firstWord));
 
-        bytes memory temporaryBytes = abi.encodePacked(bytes8(firstWordHash), bytes4(0), _address);
+        bytes memory temporaryBytes = abi.encodePacked(bytes10(firstWordHash), bytes2(0), _address);
 
         return generateBytes32Key(temporaryBytes);
+    }
+
+    function generateMappingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes memory generatedKey = bytes.concat(_keyPrefix, _bytes20);
+        return generateBytes32Key(generatedKey);
     }
 
     function generateBytes20MappingWithGroupingKey(
@@ -90,9 +99,8 @@ library LSP2Utils {
         bytes32 secondWordHash = keccak256(bytes(_secondWord));
 
         bytes memory temporaryBytes = abi.encodePacked(
-            bytes4(firstWordHash),
-            bytes4(0),
-            bytes2(secondWordHash),
+            bytes6(firstWordHash),
+            bytes4(secondWordHash),
             bytes2(0),
             _address
         );

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.0;
 
 // --- ERC725Y entries
 
-// bytes16(keccak256('SupportedStandard')) + bytes12(0) + bytes4(keccak256('LSP4DigitalAsset'))
-bytes32 constant _LSP4_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b6b89135626455000000000000000000000000a4d96624;
+// bytes10(keccak256('SupportedStandard')) + bytes2(0) + bytes20(keccak256('LSP4DigitalAsset'))
+bytes32 constant _LSP4_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c;
 
 // bytes4(keccak256('LSP4DigitalAsset'))
 bytes constant _LSP4_SUPPORTED_STANDARDS_VALUE = hex"a4d96624";

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
@@ -18,8 +18,8 @@ bytes32 constant _LSP4_TOKEN_SYMBOL_KEY = 0x2f0a68ab07768e01943a599e73362a0e17a6
 // keccak256('LSP4Creators[]')
 bytes32 constant _LSP4_CREATORS_ARRAY_KEY = 0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7;
 
-// bytes8(keccak256('LSP4CreatorsMap')) + bytes4(0)
-bytes12 constant _LSP4_CREATORS_MAP_KEY_PREFIX = 0x6de85eaf5d982b4e00000000;
+// bytes10(keccak256('LSP4CreatorsMap')) + bytes2(0)
+bytes12 constant _LSP4_CREATORS_MAP_KEY_PREFIX = 0x6de85eaf5d982b4e5da00000;
 
 // keccak256('LSP4Metadata')
 bytes32 constant _LSP4_METADATA_KEY = 0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e;

--- a/contracts/LSP5ReceivedAssets/LSP5Constants.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Constants.sol
@@ -6,5 +6,5 @@ pragma solidity ^0.8.0;
 // keccak256('LSP5ReceivedAssets[]')
 bytes32 constant _LSP5_RECEIVED_ASSETS_ARRAY_KEY = 0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b;
 
-// bytes8(keccak256('LSP5ReceivedAssetsMap')) + bytes4(0)
-bytes12 constant _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX = 0x812c4334633eb81600000000;
+// bytes10(keccak256('LSP5ReceivedAssetsMap')) + bytes2(0)
+bytes12 constant _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX = 0x812c4334633eb816c80d0000;

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -95,10 +95,7 @@ library LSP5Utils {
 
             bytes memory lastKeyValue = _account.getData(lastKey);
 
-            bytes32 mapOfLastkey = LSP2Utils.generateBytes20MappingWithGroupingKey(
-                mapPrefix,
-                bytes20(lastKeyValue)
-            );
+            bytes32 mapOfLastkey = LSP2Utils.generateMappingKey(mapPrefix, bytes20(lastKeyValue));
 
             bytes memory mapValueOfLastkey = _account.getData(mapOfLastkey);
 

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -155,12 +155,4 @@ library LSP5Utils {
         bytes memory val = BytesLib.slice(mapValue, 4, 8);
         return BytesLib.toUint64(val, 0);
     }
-
-    function extractTokenAmount(bytes32 typeId, bytes memory data) internal pure returns (uint256) {
-        if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
-            return uint256(bytes32(BytesLib.slice(data, 40, 32)));
-        } else {
-            return 1;
-        }
-    }
 }

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -17,22 +17,22 @@ bytes32 constant _LSP6KEY_ADDRESSPERMISSIONS_ARRAY = 0xdf30dba06db6a30e65354d9a6
 bytes16 constant _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX = 0xdf30dba06db6a30e65354d9a64c60986;
 
 // AddressPermissions:...
-bytes8 constant _LSP6KEY_ADDRESSPERMISSIONS_PREFIX = 0x4b80742d00000000;
+bytes6 constant _LSP6KEY_ADDRESSPERMISSIONS_PREFIX = 0x4b80742de2bf;
 
-// bytes4(keccak256('AddressPermissions')) + bytes4(0) + bytes2(keccak256('Permissions')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX = 0x4b80742d0000000082ac0000; // AddressPermissions:Permissions:<address> --> bytes32
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('Permissions')) + bytes2(0)
+bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX = 0x4b80742de2bf82acb3630000; // AddressPermissions:Permissions:<address> --> bytes32
 
-// bytes4(keccak256('AddressPermissions')) + bytes4(0) + bytes2(keccak256('AllowedAddresses')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX = 0x4b80742d00000000c6dd0000; // AddressPermissions:AllowedAddresses:<address> --> address[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedAddresses')) + bytes2(0)
+bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX = 0x4b80742de2bfc6dd6b3c0000; // AddressPermissions:AllowedAddresses:<address> --> address[]
 
-// bytes4(keccak256('AddressPermissions')) + bytes4(0) + bytes2(keccak256('AllowedFunctions')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742d000000008efe0000; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedFunctions')) + bytes2(0)
+bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742de2bf8efea1e80000; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
 
-// bytes4(keccak256('AddressPermissions')) + bytes4(0) + bytes2(keccak256('AllowedStandards')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742d000000003efa0000; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedStandards')) + bytes2(0)
+bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742de2bf3efa94a30000; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
 
-// bytes4(keccak256('AddressPermissions')) + bytes4(0) + bytes2(keccak256('AllowedERC725YKeys')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742d0000000090b80000; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes32[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedERC725YKeys')) + bytes2(0)
+bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b4850000; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes32[]
 
 // DEFAULT PERMISSIONS VALUES
 bytes32 constant _PERMISSION_CHANGEOWNER        = 0x0000000000000000000000000000000000000000000000000000000000000001;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -217,7 +217,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             if (
                 // CHECK for permission keys
-                bytes8(key) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
+                bytes6(key) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
                 bytes16(key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
             ) {
                 _verifyCanSetPermissions(key, inputValues[ii], _from, _permissions);

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -20,7 +20,7 @@ library LSP6Utils {
         returns (bytes32)
     {
         bytes memory permissions = _account.getData(
-            LSP2Utils.generateBytes20MappingWithGroupingKey(
+            LSP2Utils.generateMappingWithGroupingKey(
                 _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
                 bytes20(_address)
             )
@@ -36,7 +36,7 @@ library LSP6Utils {
     {
         return
             _account.getData(
-                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX,
                     bytes20(_address)
                 )
@@ -50,7 +50,7 @@ library LSP6Utils {
     {
         return
             _account.getData(
-                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX,
                     bytes20(_address)
                 )
@@ -64,7 +64,7 @@ library LSP6Utils {
     {
         return
             _account.getData(
-                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX,
                     bytes20(_address)
                 )
@@ -78,7 +78,7 @@ library LSP6Utils {
     {
         return
             _account.getData(
-                LSP2Utils.generateBytes20MappingWithGroupingKey(
+                LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX,
                     bytes20(_address)
                 )

--- a/contracts/LSP9Vault/LSP9Constants.sol
+++ b/contracts/LSP9Vault/LSP9Constants.sol
@@ -6,8 +6,8 @@ bytes4 constant _INTERFACEID_LSP9 = 0x8c1d44f6;
 
 // --- ERC725Y Keys
 
-// bytes16(keccak256('SupportedStandard')) + bytes12(0) + bytes4(keccak256('LSP9Vault'))
-bytes32 constant _LSP9_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b6b891356264550000000000000000000000007c0334a1;
+// bytes10(keccak256('SupportedStandard')) + bytes2(0) + bytes20(keccak256('LSP9Vault'))
+bytes32 constant _LSP9_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b600007c0334a14085fefa8b51ae5a40895018882bdb90;
 
 // bytes4(keccak256('LSP9Vault'))
 bytes constant _LSP9_SUPPORTED_STANDARDS_VALUE = hex"7c0334a1";

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -16,7 +16,7 @@ contract UniversalProfile is LSP0ERC725Account {
      */
     constructor(address _newOwner) LSP0ERC725Account(_newOwner) {
         // set key SupportedStandards:LSP3UniversalProfile
-        bytes32 key = 0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6;
+        bytes32 key = 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38;
         bytes memory value = hex"abe425d6";
         _setData(key, value);
     }

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -15,7 +15,7 @@ abstract contract UniversalProfileInitAbstract is LSP0ERC725AccountInitAbstract 
         LSP0ERC725AccountInitAbstract._initialize(_newOwner);
 
         // set key SupportedStandards:LSP3UniversalProfile
-        bytes32 key = 0xeafec4d89fa9619884b6b89135626455000000000000000000000000abe425d6;
+        bytes32 key = 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38;
         bytes memory value = hex"abe425d6";
         _setData(key, value);
     }

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -158,10 +158,10 @@ export const shouldBehaveLikePermissionSetData = (
           );
         });
 
-        it("(should pass): adding 10 LSP3IssuedAssets", async () => {
-          let lsp3IssuedAssets = getRandomAddresses(10);
+        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+          let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = { "LSP3IssuedAssets[]": lsp3IssuedAssets };
+          const data = { "LSP12IssuedAssets[]": lsp12IssuedAssets };
 
           const encodedData = encodeData(data, BasicUPSetup_Schema);
           const flattenedEncodedData = flattenEncodedData(encodedData);
@@ -186,14 +186,14 @@ export const shouldBehaveLikePermissionSetData = (
           expect(fetchedResult).toEqual(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP3IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
+        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
               hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
-            "LSP3IssuedAssets[]": [
+            "LSP12IssuedAssets[]": [
               "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
               "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
             ],
@@ -254,10 +254,10 @@ export const shouldBehaveLikePermissionSetData = (
           );
         });
 
-        it("(should pass): adding 10 LSP3IssuedAssets", async () => {
-          let lsp3IssuedAssets = getRandomAddresses(10);
+        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+          let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = { "LSP3IssuedAssets[]": lsp3IssuedAssets };
+          const data = { "LSP12IssuedAssets[]": lsp12IssuedAssets };
 
           const encodedData = encodeData(data, BasicUPSetup_Schema);
           const flattenedEncodedData = flattenEncodedData(encodedData);
@@ -282,14 +282,14 @@ export const shouldBehaveLikePermissionSetData = (
           expect(fetchedResult).toEqual(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP3IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
+        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
               hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
-            "LSP3IssuedAssets[]": [
+            "LSP12IssuedAssets[]": [
               "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
               "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
             ],
@@ -345,10 +345,10 @@ export const shouldBehaveLikePermissionSetData = (
           );
         });
 
-        it("(should fail): adding 10 LSP3IssuedAssets", async () => {
-          let lsp3IssuedAssets = getRandomAddresses(10);
+        it("(should fail): adding 10 LSP12IssuedAssets", async () => {
+          let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = { "LSP3IssuedAssets[]": lsp3IssuedAssets };
+          const data = { "LSP12IssuedAssets[]": lsp12IssuedAssets };
 
           const encodedData = encodeData(data, BasicUPSetup_Schema);
           const flattenedEncodedData = flattenEncodedData(encodedData);
@@ -373,14 +373,14 @@ export const shouldBehaveLikePermissionSetData = (
           );
         });
 
-        it("(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP3IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
+        it("(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
               hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
-            "LSP3IssuedAssets[]": [
+            "LSP12IssuedAssets[]": [
               "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
               "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
             ],

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -84,28 +84,28 @@ export const shouldBehaveLikeLSP3 = (
   });
 
   describe("when interacting with the ERC725Y storage", () => {
-    let lsp3IssuedAssetsKeys = [
-      ERC725YKeys.LSP3["LSP3IssuedAssets[]"].substring(0, 34) +
+    let lsp12IssuedAssetsKeys = [
+      ERC725YKeys.LSP12["LSP12IssuedAssets[]"].substring(0, 34) +
         "00000000000000000000000000000000",
-      ERC725YKeys.LSP3["LSP3IssuedAssets[]"].substring(0, 34) +
+      ERC725YKeys.LSP12["LSP12IssuedAssets[]"].substring(0, 34) +
         "00000000000000000000000000000001",
     ];
-    let lsp3IssuedAssetsValues = [
+    let lsp12IssuedAssetsValues = [
       "0xd94353d9b005b3c0a9da169b768a31c57844e490",
       "0xdaea594e385fc724449e3118b2db7e86dfba1826",
     ];
 
-    it("should set the 3 x keys for a basic UP setup => `LSP3Profile`, `LSP3IssuedAssets[]` and `LSP1UniversalReceiverDelegate`", async () => {
+    it("should set the 3 x keys for a basic UP setup => `LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`", async () => {
       let keys = [
         ERC725YKeys.LSP3.LSP3Profile,
-        ERC725YKeys.LSP3["LSP3IssuedAssets[]"],
-        ...lsp3IssuedAssetsKeys,
+        ERC725YKeys.LSP12["LSP12IssuedAssets[]"],
+        ...lsp12IssuedAssetsKeys,
         ERC725YKeys.LSP0.LSP1UniversalReceiverDelegate,
       ];
       let values = [
         "0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178",
         "0x0000000000000000000000000000000000000000000000000000000000000002",
-        ...lsp3IssuedAssetsValues,
+        ...lsp12IssuedAssetsValues,
         "0x1183790f29be3cdfd0a102862fea1a4a30b3adab",
       ];
 
@@ -118,35 +118,35 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).toEqual(values);
     });
 
-    it("should add +10 more LSP3IssuedAssets[]", async () => {
+    it("should add +10 more LSP12IssuedAssets[]", async () => {
       let newIssuedAssets = getRandomAddresses(10);
 
       const expectedKeysLength =
-        lsp3IssuedAssetsKeys.length + newIssuedAssets.length;
+        lsp12IssuedAssetsKeys.length + newIssuedAssets.length;
       const expectedValuesLength =
-        lsp3IssuedAssetsValues.length + newIssuedAssets.length;
+        lsp12IssuedAssetsValues.length + newIssuedAssets.length;
 
       for (let ii = 0; ii < newIssuedAssets.length; ii++) {
-        let hexIndex = ethers.utils.hexlify(lsp3IssuedAssetsKeys.length);
+        let hexIndex = ethers.utils.hexlify(lsp12IssuedAssetsKeys.length);
 
-        lsp3IssuedAssetsKeys.push(
-          ERC725YKeys.LSP3["LSP3IssuedAssets[]"].substring(0, 34) +
+        lsp12IssuedAssetsKeys.push(
+          ERC725YKeys.LSP12["LSP12IssuedAssets[]"].substring(0, 34) +
             ethers.utils.hexZeroPad(hexIndex, 16).substring(2)
         );
 
-        lsp3IssuedAssetsValues.push(newIssuedAssets[ii]);
+        lsp12IssuedAssetsValues.push(newIssuedAssets[ii]);
       }
-      expect(lsp3IssuedAssetsKeys.length).toEqual(expectedKeysLength);
-      expect(lsp3IssuedAssetsValues.length).toEqual(expectedValuesLength);
+      expect(lsp12IssuedAssetsKeys.length).toEqual(expectedKeysLength);
+      expect(lsp12IssuedAssetsValues.length).toEqual(expectedValuesLength);
 
       let keys = [
-        ...lsp3IssuedAssetsKeys,
-        ERC725YKeys.LSP3["LSP3IssuedAssets[]"], // update array length
+        ...lsp12IssuedAssetsKeys,
+        ERC725YKeys.LSP12["LSP12IssuedAssets[]"], // update array length
       ];
 
       let values = [
-        ...lsp3IssuedAssetsValues,
-        ethers.utils.hexZeroPad(lsp3IssuedAssetsValues.length, 32),
+        ...lsp12IssuedAssetsValues,
+        ethers.utils.hexZeroPad(lsp12IssuedAssetsValues.length, 32),
       ];
 
       await context.universalProfile["setData(bytes32[],bytes[])"](
@@ -159,26 +159,26 @@ export const shouldBehaveLikeLSP3 = (
     });
 
     for (let ii = 1; ii <= 8; ii++) {
-      it("should add +1 LSP3IssuedAssets", async () => {
-        let hexIndex = ethers.utils.hexlify(lsp3IssuedAssetsKeys.length + 1);
+      it("should add +1 LSP12IssuedAssets", async () => {
+        let hexIndex = ethers.utils.hexlify(lsp12IssuedAssetsKeys.length + 1);
 
-        lsp3IssuedAssetsKeys.push(
-          ERC725YKeys.LSP3["LSP3IssuedAssets[]"].substring(0, 34) +
+        lsp12IssuedAssetsKeys.push(
+          ERC725YKeys.LSP12["LSP12IssuedAssets[]"].substring(0, 34) +
             ethers.utils.hexZeroPad(hexIndex, 16).substring(2)
         );
 
-        lsp3IssuedAssetsValues.push(
+        lsp12IssuedAssetsValues.push(
           ethers.Wallet.createRandom().address.toLowerCase()
         );
 
         let keys = [
-          ...lsp3IssuedAssetsKeys,
-          ERC725YKeys.LSP3["LSP3IssuedAssets[]"], // update array length
+          ...lsp12IssuedAssetsKeys,
+          ERC725YKeys.LSP12["LSP12IssuedAssets[]"], // update array length
         ];
 
         let values = [
-          ...lsp3IssuedAssetsValues,
-          ethers.utils.hexZeroPad(lsp3IssuedAssetsValues.length, 32),
+          ...lsp12IssuedAssetsValues,
+          ethers.utils.hexZeroPad(lsp12IssuedAssetsValues.length, 32),
         ];
 
         await context.universalProfile["setData(bytes32[],bytes[])"](


### PR DESCRIPTION
## What does this PR introduce?
- Edit all keys and functions to match the new spec of the [LSP2-ERC725YJSONSchema Standard](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md) after the change in this [commit](https://github.com/lukso-network/LIPs/commit/2d2c727956ad1fe0bcbb496e6719a626925b116b).

### Changes

- Smart Contract Including:
     - `KeyManagerCore.sol` to handle the permission key after changing from `bytes8` to `bytes6`


- Key Changes Including:
     - Change in `.sol` const files
     - Change in `.js` const files
     - Change in `LSP2Utils` library

- Test Changes Include:
     - UniversalProfile Tests (Related to LSP12IssuedAssets)
     - LSP6KeyManager Tests (Related to LSP12IssuedAssets)

- Change Naming of function to match KeyType in `LSP5Utils` lib