### PR TITLE
fix: remove `dataValue` param from DataChanged event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^3.0.3",
+        "@erc725/smart-contracts": "^3.1.0",
         "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
       },
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.3.tgz",
-      "integrity": "sha512-rXZRBLaPC3UAg7X46HbDOYuibPnsb8l8IC6lq1w7WIDEzEUKhh9wukkBzQsX4ka5EpvfRFn4BaHr+PLuHVfQkA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.1.0.tgz",
+      "integrity": "sha512-yze4C/GuCbHE8rxcKZ4aGJcHvsNUdL8ktDWPbxxY+/wWdtn5kzdEs7HlGWo8YJkzvngMCDfxyZp5doIIH020CA==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"
@@ -32108,9 +32108,9 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.0.3.tgz",
-      "integrity": "sha512-rXZRBLaPC3UAg7X46HbDOYuibPnsb8l8IC6lq1w7WIDEzEUKhh9wukkBzQsX4ka5EpvfRFn4BaHr+PLuHVfQkA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.1.0.tgz",
+      "integrity": "sha512-yze4C/GuCbHE8rxcKZ4aGJcHvsNUdL8ktDWPbxxY+/wWdtn5kzdEs7HlGWo8YJkzvngMCDfxyZp5doIIH020CA==",
       "requires": {
         "@openzeppelin/contracts": "^4.6.0",
         "solidity-bytes-utils": "0.8.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^3.0.3",
+    "@erc725/smart-contracts": "^3.1.0",
     "@openzeppelin/contracts": "^4.6.0",
     "solidity-bytes-utils": "0.8.0"
   },

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -1182,8 +1182,7 @@ export const shouldInitializeLikeLSP7 = (
         context.lsp7,
         "DataChanged",
         [
-          SupportedStandards.LSP4DigitalAsset.key,
-          SupportedStandards.LSP4DigitalAsset.value,
+          SupportedStandards.LSP4DigitalAsset.key
         ]
       );
       expect(
@@ -1199,7 +1198,7 @@ export const shouldInitializeLikeLSP7 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp7,
         "DataChanged",
-        [nameKey, expectedNameValue]
+        [nameKey]
       );
       expect(await context.lsp7["getData(bytes32)"](nameKey)).toEqual(
         expectedNameValue
@@ -1212,7 +1211,7 @@ export const shouldInitializeLikeLSP7 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp7,
         "DataChanged",
-        [symbolKey, expectedSymbolValue]
+        [symbolKey]
       );
       expect(await context.lsp7["getData(bytes32)"](symbolKey)).toEqual(
         expectedSymbolValue

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.behaviour.ts
@@ -545,8 +545,7 @@ export const shouldInitializeLikeLSP7CompatibilityForERC20 = (
         context.lsp7CompatibilityForERC20,
         "DataChanged",
         [
-          SupportedStandards.LSP4DigitalAsset.key,
-          SupportedStandards.LSP4DigitalAsset.value,
+          SupportedStandards.LSP4DigitalAsset.key
         ]
       );
       expect(
@@ -563,7 +562,7 @@ export const shouldInitializeLikeLSP7CompatibilityForERC20 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp7CompatibilityForERC20,
         "DataChanged",
-        [nameKey, expectedNameValue]
+        [nameKey]
       );
       expect(
         await context.lsp7CompatibilityForERC20["getData(bytes32)"](nameKey)
@@ -577,7 +576,7 @@ export const shouldInitializeLikeLSP7CompatibilityForERC20 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp7CompatibilityForERC20,
         "DataChanged",
-        [symbolKey, expectedSymbolValue]
+        [symbolKey]
       );
       expect(
         await context.lsp7CompatibilityForERC20["getData(bytes32)"](symbolKey)

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -1360,8 +1360,7 @@ export const shouldInitializeLikeLSP8 = (
         context.lsp8,
         "DataChanged",
         [
-          SupportedStandards.LSP4DigitalAsset.key,
-          SupportedStandards.LSP4DigitalAsset.value,
+          SupportedStandards.LSP4DigitalAsset.key
         ]
       );
       expect(
@@ -1377,7 +1376,7 @@ export const shouldInitializeLikeLSP8 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp8,
         "DataChanged",
-        [nameKey, expectedNameValue]
+        [nameKey]
       );
       expect(await context.lsp8["getData(bytes32)"](nameKey)).toEqual(
         expectedNameValue
@@ -1390,7 +1389,7 @@ export const shouldInitializeLikeLSP8 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp8,
         "DataChanged",
-        [symbolKey, expectedSymbolValue]
+        [symbolKey]
       );
       expect(await context.lsp8["getData(bytes32)"](symbolKey)).toEqual(
         expectedSymbolValue

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721.behaviour.ts
@@ -786,8 +786,7 @@ export const shouldInitializeLikeLSP8CompatibilityForERC721 = (
         context.lsp8CompatibilityForERC721,
         "DataChanged",
         [
-          SupportedStandards.LSP4DigitalAsset.key,
-          SupportedStandards.LSP4DigitalAsset.value,
+          SupportedStandards.LSP4DigitalAsset.key
         ]
       );
       expect(
@@ -804,7 +803,7 @@ export const shouldInitializeLikeLSP8CompatibilityForERC721 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp8CompatibilityForERC721,
         "DataChanged",
-        [nameKey, expectedNameValue]
+        [nameKey]
       );
       expect(
         await context.lsp8CompatibilityForERC721["getData(bytes32)"](nameKey)
@@ -818,7 +817,7 @@ export const shouldInitializeLikeLSP8CompatibilityForERC721 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp8CompatibilityForERC721,
         "DataChanged",
-        [symbolKey, expectedSymbolValue]
+        [symbolKey]
       );
       expect(
         await context.lsp8CompatibilityForERC721["getData(bytes32)"](symbolKey)

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -285,7 +285,7 @@ export const shouldInitializeLikeLSP9 = (
       await expect(context.initializeTransaction).toHaveEmittedWith(
         context.lsp9Vault,
         "DataChanged",
-        [SupportedStandards.LSP9Vault.key, SupportedStandards.LSP9Vault.value]
+        [SupportedStandards.LSP9Vault.key]
       );
       expect(
         await context.lsp9Vault["getData(bytes32)"](


### PR DESCRIPTION
## What does this PR introduce?
- [x] Removing the `dataValue` param from DataChanged event in tests.
- [x] Upgrade erc725-smart-contracts to use latest version.