### PR TITLE
refactor: use type casting instead of `BytesLib` library for `universalReceiver()` function

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -8,7 +8,6 @@ import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1Univ
 
 // libraries
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // modules
@@ -146,7 +145,8 @@ abstract contract LSP0ERC725AccountCore is
         bytes memory data = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
         if (data.length >= 20) {
-            address universalReceiverDelegate = BytesLib.toAddress(data, 0);
+            address universalReceiverDelegate = address(bytes20(data));
+
             if (
                 ERC165Checker.supportsERC165Interface(
                     universalReceiverDelegate,

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -7,7 +7,6 @@ import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalRec
 import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // libraries
-import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // modules
@@ -157,7 +156,8 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         bytes memory data = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
         if (data.length >= 20) {
-            address universalReceiverDelegate = BytesLib.toAddress(data, 0);
+            address universalReceiverDelegate = address(bytes20(data));
+
             if (
                 ERC165Checker.supportsERC165Interface(
                     universalReceiverDelegate,


### PR DESCRIPTION
# What does this PR introduce?

## Current Behaviour

`LSP0ERC725AccountCore` and `LSP9VaultCore` contracts uses `BytesLib` library to convert the raw bytes of `LSP1UniversalReceiverDelegate` data key (fetched from the ERC725Y key-value store) in the `universalReceiver(...)` function.

## New Behaviour

Remove the `BytesLib` library in this function and use explicit type casting.with `address(bytes20(...))`.

This:
- reduces the LSP0 and LSP9 contract bytecode by 114 bytes (= slightly cheaper deployment cost)
- save 84 gas when calling the `universalReceiver(...)` function.