### PR TITLE
docs: Add documentation for feature DEPLOYMENT.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,7 +1,8 @@
 
 # Deployment
 
-You can find a deployment utility with hardhat to easily deploy the smart contracts locally or on our L14 test network.
+You can find a deployment utility with hardhat to easily deploy the smart contracts locally or on our L14 test network,
+if you don't have some LYX test token visit [LUKSO l14 Fauset](http://faucet.l14.lukso.network/), for fauset.
 
 All the deployment scripts for `base` contracts initialize the contract after deployment to the zero address for security.
 
@@ -21,12 +22,6 @@ All the deployment scripts for `base` contracts initialize the contract after de
 ```
 
 &nbsp;
-
-Skip the next two steps (2 & 3) if you already have some LYX test token.
-
-2. Visit [LUKSO l14 Fauset](http://faucet.l14.lukso.network/), for fauset.
-
-3. In other to verify you recieved some fauset [L14 Public Testnet Config](https://docs.lukso.tech/networks/l14-testnet) 
 
 4. run the command using one of the available `--tags`
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,6 +22,8 @@ All the deployment scripts for `base` contracts initialize the contract after de
 
 &nbsp;
 
+Skip the next two steps (2 & 3) if you already have some LYX test token.
+
 2. Visit [LUKSO l14 Fauset](http://faucet.l14.lukso.network/), for fauset.
 
 3. In other to verify you recieved some fauset [L14 Public Testnet Config](https://docs.lukso.tech/networks/l14-testnet) 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -23,7 +23,7 @@ All the deployment scripts for `base` contracts initialize the contract after de
 
 &nbsp;
 
-4. run the command using one of the available `--tags`
+2. run the command using one of the available `--tags`
 
 ```
 npx hardhat deploy --network luksoL14 --tags <options> --reset

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -22,7 +22,11 @@ All the deployment scripts for `base` contracts initialize the contract after de
 
 &nbsp;
 
-2. run the command using one of the available `--tags`
+2. Visit [LUKSO l14 Fauset](http://faucet.l14.lukso.network/), for fauset.
+
+3. In other to verify you recieved some fauset [L14 Public Testnet Config](https://docs.lukso.tech/networks/l14-testnet) 
+
+4. run the command using one of the available `--tags`
 
 ```
 npx hardhat deploy --network luksoL14 --tags <options> --reset

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 # Deployment
 
 You can find a deployment utility with hardhat to easily deploy the smart contracts locally or on our L14 test network,
-if you don't have some LYX test token visit [LUKSO l14 Fauset](http://faucet.l14.lukso.network/), for fauset.
+if you don't have some LYX test token visit [LUKSO l14 Faucet](http://faucet.l14.lukso.network/), for faucet.
 
 All the deployment scripts for `base` contracts initialize the contract after deployment to the zero address for security.
 


### PR DESCRIPTION
Improve the Deployment doc, the current documentation guide on deployment doesn't specify how to get fauset and deploy successfully:
![image](https://user-images.githubusercontent.com/40717516/171515583-cd4f4bd5-2190-4267-b1c8-c8b49f9f1150.png)
