### PR TITLE
feat: add path for `setData(bytes32,bytes)` in `LSP6KeyManager`

### DIFF
--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -6,7 +6,7 @@ import {UniversalProfile} from "../UniversalProfile.sol";
 import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
-import {setDataMultipleSelector} from "../LSP6KeyManager/LSP6Constants.sol";
+import {setDataSingleSelector} from "../LSP6KeyManager/LSP6Constants.sol";
 
 contract Executor {
     uint256 internal constant _OPERATION_CALL = 0;
@@ -28,26 +28,20 @@ contract Executor {
     // -----------
 
     function setHardcodedKey() public returns (bytes memory) {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
-
         // prettier-ignore
-        keys[0] = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
-        values[0] = "Some value";
+        bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
+        bytes memory value = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
 
         return _keyManager.execute(erc725Payload);
     }
 
     function setComputedKey() public returns (bytes memory) {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
+        bytes32 key = keccak256(abi.encodePacked("Some Key"));
+        bytes memory value = abi.encodePacked("Some value");
 
-        keys[0] = keccak256(abi.encodePacked("Some Key"));
-        values[0] = abi.encodePacked("Some value");
-
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -56,13 +50,7 @@ contract Executor {
         public
         returns (bytes memory)
     {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
-
-        keys[0] = _key;
-        values[0] = _value;
-
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, _key, _value);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -99,14 +87,11 @@ contract Executor {
     // ----------------------
 
     function setHardcodedKeyRawCall() public returns (bool) {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
-
         // prettier-ignore
-        keys[0] = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
-        values[0] = "Some value";
+        bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
+        bytes memory value = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -119,13 +104,10 @@ contract Executor {
     }
 
     function setComputedKeyRawCall() public returns (bool) {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
+        bytes32 key = keccak256(abi.encodePacked("Some Key"));
+        bytes memory value = abi.encodePacked("Some value");
 
-        keys[0] = keccak256(abi.encodePacked("Some Key"));
-        values[0] = abi.encodePacked("Some value");
-
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -141,13 +123,7 @@ contract Executor {
         public
         returns (bool)
     {
-        bytes32[] memory keys = new bytes32[](1);
-        bytes[] memory values = new bytes[](1);
-
-        keys[0] = _key;
-        values[0] = _value;
-
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataMultipleSelector, keys, values);
+        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, _key, _value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.0;
 // --- ERC165 interface ids
 bytes4 constant _INTERFACEID_LSP6 = 0xc403d48f;
 
-// 0x4b80742d00000000c6dd000054dD2f5A45C8e7C83248a5a9F3c67b001F6AcC05
-
 // --- ERC725Y Keys
 
 // PERMISSIONS KEYS
@@ -60,11 +58,8 @@ bytes32 constant _PERMISSION_SUPER_CALL         = 0x0000000000000000000000000000
 bytes32 constant _PERMISSION_SUPER_STATICCALL   = 0x0000000000000000000000000000000000000000000000000000000000002000;
 bytes32 constant _PERMISSION_SUPER_DELEGATECALL = 0x0000000000000000000000000000000000000000000000000000000000004000;
 
-// TODO: test if gas cost difference when storing as:
-// - bytes4 0x14a6e293
-// - keccak256("setData(bytes32[],bytes[])")
 
-// - keccak256("setData(bytes32,bytes)")
-bytes4 constant setDataSingleSelector = 0x7f23690c;
-// - keccak256("setData(bytes32[],bytes[])")
-bytes4 constant setDataMultipleSelector = 0x14a6e293;
+/// @dev see IERC725Y interface
+///      https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/interfaces/IERC725Y.sol
+bytes4 constant setDataSingleSelector = bytes4(keccak256("setData(bytes32,bytes)"));
+bytes4 constant setDataMultipleSelector = bytes4(keccak256("setData(bytes32[],bytes[])"));

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -63,4 +63,8 @@ bytes32 constant _PERMISSION_SUPER_DELEGATECALL = 0x0000000000000000000000000000
 // TODO: test if gas cost difference when storing as:
 // - bytes4 0x14a6e293
 // - keccak256("setData(bytes32[],bytes[])")
+
+// - keccak256("setData(bytes32,bytes)")
+bytes4 constant setDataSingle = 0x7f23690c;
+// - keccak256("setData(bytes32[],bytes[])")
 bytes4 constant setDataMultipleSelector = 0x14a6e293;

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -65,6 +65,6 @@ bytes32 constant _PERMISSION_SUPER_DELEGATECALL = 0x0000000000000000000000000000
 // - keccak256("setData(bytes32[],bytes[])")
 
 // - keccak256("setData(bytes32,bytes)")
-bytes4 constant setDataSingle = 0x7f23690c;
+bytes4 constant setDataSingleSelector = 0x7f23690c;
 // - keccak256("setData(bytes32[],bytes[])")
 bytes4 constant setDataMultipleSelector = 0x14a6e293;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -182,9 +182,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             bytes6(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
             bytes16(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
         ) {
+
             _verifyCanSetPermissions(inputKey, inputValue, _from, permissions);
+
         } else {
-            _verifyCanSetData(_from, permissions, inputKey);
+
+            bytes32[] memory inputKeys = new bytes32[](1);
+            inputKeys[0] = inputKey;
+
+            _verifyCanSetData(_from, permissions, inputKeys);
         }
 
         } else if (erc725Function == setDataMultipleSelector) {
@@ -213,7 +219,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                     isSettingERC725YKeys = true;
                 }
 
-                if (isSettingERC725YKeys) _verifyCanSetData(_from, permissions, key);            
+            }
+
+            if (isSettingERC725YKeys) {
+                _verifyCanSetData(_from, permissions, inputKeys);
             }
 
         } else if (erc725Function == IERC725X.execute.selector) {
@@ -237,20 +246,20 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * on the linked ERC725Account
      * @param _from the address who want to set the keys
      * @param _permissions the permissions
-     * @param _key the data key
+     * @param _inputKeys the data keys being set
      * containing a list of keys-value pairs
      */
     function _verifyCanSetData(
         address _from,
         bytes32 _permissions,
-        bytes32 _key
+        bytes32[] memory _inputKeys
     ) internal view {
         // Skip if caller has SUPER permissions
         if (_permissions.hasPermission(_PERMISSION_SUPER_SETDATA)) return;
 
         _requirePermissions(_from, _permissions, _PERMISSION_SETDATA);
 
-        // _verifyAllowedERC725YKeys(_from, inputKeys);
+        _verifyAllowedERC725YKeys(_from, _inputKeys);
     }
 
     function _verifyCanSetPermissions(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.6;
 // interfaces
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 import {ILSP6KeyManager} from "./ILSP6KeyManager.sol";
 
 // modules
@@ -172,9 +173,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         if (permissions == bytes32(0)) revert NoPermissionsSet(_from);
 
         // prettier-ignore
-        if (erc725Function == setDataMultipleSelector) {
+        if (erc725Function == setDataSingle) {
+
+            (bytes32 inputKey, bytes memory inputValue) = abi.decode(_calldata[4:], (bytes32, bytes));
+            _verifyCanSetData(_from, permissions, inputKey, inputValue);
+
+        } else if (erc725Function == setDataMultipleSelector) {
+
+            (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(_calldata[4:], (bytes32[], bytes[]));
             
-            _verifyCanSetData(_from, permissions, _calldata);
+            // loop through each ERC725Y data keys
+            for (uint256 ii = 0; ii < inputKeys.length; ii++) {
+                bytes32 key = inputKeys[ii];
+                bytes memory value = inputValues[ii];
+                _verifyCanSetData(_from, permissions, key, value);
+            }  
 
         } else if (erc725Function == IERC725X.execute.selector) {
             
@@ -196,39 +209,32 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @dev verify if `_from` has the required permissions to set some keys
      * on the linked ERC725Account
      * @param _from the address who want to set the keys
-     * @param _calldata the ABI encoded payload `target.setData(keys, values)`
+     * @param _permissions the permissions
+     * @param _key the data key
+     * @param _value the data value
      * containing a list of keys-value pairs
      */
     function _verifyCanSetData(
         address _from,
         bytes32 _permissions,
-        bytes calldata _calldata
+        bytes32 _key,
+        bytes memory _value
     ) internal view {
-        (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(
-            _calldata[4:],
-            (bytes32[], bytes[])
-        );
-
         bool isSettingERC725YKeys = false;
 
-        // loop through each ERC725Y data keys
-        for (uint256 ii = 0; ii < inputKeys.length; ii++) {
-            bytes32 key = inputKeys[ii];
+        if (
+            // CHECK for permission keys
+            bytes6(_key) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
+            bytes16(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
+        ) {
+            _verifyCanSetPermissions(_key, _value, _from, _permissions);
 
-            if (
-                // CHECK for permission keys
-                bytes6(key) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
-                bytes16(key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
-            ) {
-                _verifyCanSetPermissions(key, inputValues[ii], _from, _permissions);
-
-                // "nullify" permission keys
-                // to not check them against allowed ERC725Y keys
-                inputKeys[ii] = bytes32(0);
-            } else {
-                // if the key is any other bytes32 key
-                isSettingERC725YKeys = true;
-            }
+            // "nullify" permission keys
+            // to not check them against allowed ERC725Y keys
+            // inputKeys[ii] = bytes32(0);
+        } else {
+            // if the key is any other bytes32 key
+            isSettingERC725YKeys = true;
         }
 
         if (isSettingERC725YKeys) {
@@ -237,7 +243,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             _requirePermissions(_from, _permissions, _PERMISSION_SETDATA);
 
-            _verifyAllowedERC725YKeys(_from, inputKeys);
+            // _verifyAllowedERC725YKeys(_from, inputKeys);
         }
     }
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.6;
 // interfaces
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
-import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 import {ILSP6KeyManager} from "./ILSP6KeyManager.sol";
 
 // modules

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -177,21 +177,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             (bytes32 inputKey, bytes memory inputValue) = abi.decode(_calldata[4:], (bytes32, bytes));
 
-        if (
-            // CHECK for permission keys
-            bytes6(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
-            bytes16(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
-        ) {
+            if (
+                // CHECK for permission keys
+                bytes6(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
+                bytes16(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
+            ) {
 
-            _verifyCanSetPermissions(inputKey, inputValue, _from, permissions);
+                _verifyCanSetPermissions(inputKey, inputValue, _from, permissions);
 
-        } else {
+            } else {
 
-            bytes32[] memory inputKeys = new bytes32[](1);
-            inputKeys[0] = inputKey;
+                bytes32[] memory inputKeys = new bytes32[](1);
+                inputKeys[0] = inputKey;
 
-            _verifyCanSetData(_from, permissions, inputKeys);
-        }
+                _verifyCanSetData(_from, permissions, inputKeys);
+            }
 
         } else if (erc725Function == setDataMultipleSelector) {
 

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -121,8 +121,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
           await context.keyManager
             .connect(controllerCanSetOneKey)
@@ -144,8 +144,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
 
           await expect(
@@ -274,8 +274,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
           await context.keyManager
             .connect(controllerCanSetManyKeys)
@@ -295,8 +295,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
           await context.keyManager
             .connect(controllerCanSetManyKeys)
@@ -316,8 +316,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
           await context.keyManager
             .connect(controllerCanSetManyKeys)
@@ -339,8 +339,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [newValue]]
+              "setData(bytes32,bytes)",
+              [key, newValue]
             );
 
           await expect(
@@ -983,8 +983,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [value]]
+              "setData(bytes32,bytes)",
+              [key, value]
             );
           await context.keyManager
             .connect(context.owner)
@@ -1081,8 +1081,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[mappingKey], [mappingValue]]
+              "setData(bytes32,bytes)",
+              [mappingKey, mappingValue]
             );
 
           await context.keyManager
@@ -1103,8 +1103,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[mappingKey], [mappingValue]]
+              "setData(bytes32,bytes)",
+              [mappingKey, mappingValue]
             );
 
           await context.keyManager
@@ -1125,8 +1125,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[mappingKey], [mappingValue]]
+              "setData(bytes32,bytes)",
+              [mappingKey, mappingValue]
             );
           await context.keyManager
             .connect(controllerCanSetMappingKeys)
@@ -1146,8 +1146,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[mappingKey], [mappingValue]]
+              "setData(bytes32,bytes)",
+              [mappingKey, mappingValue]
             );
 
           await context.keyManager
@@ -1168,8 +1168,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[notAllowedMappingKey], [notAllowedMappingValue]]
+              "setData(bytes32,bytes)",
+              [notAllowedMappingKey, notAllowedMappingValue]
             );
 
           await expect(
@@ -1357,9 +1357,10 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[randomMappingKey], [randomMappingValue]]
+              "setData(bytes32,bytes)",
+              [randomMappingKey, randomMappingValue]
             );
+
           await context.keyManager
             .connect(context.owner)
             .execute(setDataPayload);
@@ -1462,8 +1463,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [value]]
+              "setData(bytes32,bytes)",
+              [key, value]
             );
 
           await context.keyManager
@@ -1484,8 +1485,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [value]]
+              "setData(bytes32,bytes)",
+              [key, value]
             );
 
           await context.keyManager
@@ -1506,8 +1507,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [value]]
+              "setData(bytes32,bytes)",
+              [key, value]
             );
 
           await context.keyManager
@@ -1528,8 +1529,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[key], [value]]
+              "setData(bytes32,bytes)",
+              [key, value]
             );
 
           await context.keyManager
@@ -1547,8 +1548,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
 
           let setDataPayload =
             context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32[],bytes[])",
-              [[notAllowedArrayKey], ["0x00"]]
+              "setData(bytes32,bytes)",
+              [notAllowedArrayKey, "0x00"]
             );
 
           await expect(
@@ -1575,9 +1576,12 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
               [keys, values]
             );
 
-          await context.keyManager
+          let tx = await context.keyManager
             .connect(controllerCanSetArrayKeys)
             .execute(setDataPayload);
+
+          let receipt = await tx.wait();
+          console.log("test gas cost: ", receipt.gasUsed.toNumber());
 
           let result = await context.universalProfile["getData(bytes32[])"](
             keys

--- a/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
@@ -143,8 +143,8 @@ export const shouldBehaveLikeAllowedStandards = (
 
         let setDataPayload =
           context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
         await context.keyManager.connect(context.owner).execute(setDataPayload);

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -101,7 +101,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
     describe("when setting one permission key", () => {
       describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD permissions", async () => {
+        it("should be allowed to ADD a permission", async () => {
           let newController = new ethers.Wallet.createRandom();
 
           let key =
@@ -109,8 +109,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             newController.address.substr(2);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [PERMISSIONS.SETDATA]]
+            "setData(bytes32,bytes)",
+            [key, PERMISSIONS.SETDATA]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -120,7 +120,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).toEqual(PERMISSIONS.SETDATA);
         });
 
-        it("should be allowed to CHANGE permissions", async () => {
+        it("should be allowed to CHANGE a permission", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressToEditPermissions.address.substring(2);
@@ -128,8 +128,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -144,8 +144,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(8, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -160,8 +160,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(4, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -171,7 +171,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).toEqual(value);
         });
 
-        it("should be allowed to edit AddressPermissions[4]", async () => {
+        it("should be allowed to edit key at index -> AddressPermissions[4]", async () => {
           let randomWallet = new ethers.Wallet.createRandom();
 
           let key =
@@ -181,8 +181,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = randomWallet.address;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -194,7 +194,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission ADDPERMISSIONS", () => {
-        it("should be allowed to add permissions", async () => {
+        it("should be allowed to add a permission", async () => {
           let newController = new ethers.Wallet.createRandom();
 
           let key =
@@ -204,8 +204,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager
@@ -217,7 +217,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).toEqual(value);
         });
 
-        it("should not be allowed to CHANGE permission", async () => {
+        it("should not be allowed to CHANGE a permission", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressToEditPermissions.address.substring(2);
@@ -225,8 +225,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -244,8 +244,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(8, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager
@@ -262,8 +262,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(4, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -276,7 +276,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should not be allowed to edit AddressPermissions[4]", async () => {
+        it("should not be allowed to edit key at index -> AddressPermissions[4]", async () => {
           let randomWallet = new ethers.Wallet.createRandom();
 
           let key =
@@ -286,8 +286,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = randomWallet.address;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -302,7 +302,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission CHANGEPERMISSION", () => {
-        it("should not be allowed to ADD permissions", async () => {
+        it("should not be allowed to ADD a permission", async () => {
           let newController = new ethers.Wallet.createRandom();
 
           let key =
@@ -312,8 +312,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -328,15 +328,15 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should not be allowed to set (= ADD) permissions for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -351,7 +351,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should be allowed to CHANGE permissions", async () => {
+        it("should be allowed to CHANGE a permission", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressToEditPermissions.address.substring(2);
@@ -359,8 +359,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager
@@ -377,8 +377,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(8, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -398,8 +398,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(4, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager
@@ -411,7 +411,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).toEqual(value);
         });
 
-        it("should be allowed to edit AddressPermissions[4]", async () => {
+        it("should be allowed to edit key at index -> AddressPermissions[4]", async () => {
           let randomWallet = new ethers.Wallet.createRandom();
 
           let key =
@@ -421,8 +421,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = randomWallet.address;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager
@@ -436,7 +436,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission SETDATA", () => {
-        it("should not be allowed to ADD permissions", async () => {
+        it("should not be allowed to ADD a permission", async () => {
           let newController = new ethers.Wallet.createRandom();
 
           let key =
@@ -446,8 +446,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -457,15 +457,15 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should not be allowed to set (= ADD) permissions for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -475,7 +475,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should not be allowed to CHANGE permission", async () => {
+        it("should not be allowed to CHANGE a permission", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
             addressToEditPermissions.address.substring(2);
@@ -483,8 +483,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = PERMISSIONS.SETDATA;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -499,8 +499,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(8, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -515,8 +515,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = ethers.utils.hexZeroPad(4, 32);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -526,7 +526,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
 
-        it("should not be allowed to edit AddressPermissions[4]", async () => {
+        it("should not be allowed to edit key at index -> AddressPermissions[4]", async () => {
           let randomWallet = new ethers.Wallet.createRandom();
 
           let key =
@@ -536,8 +536,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = randomWallet.address;
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -627,8 +627,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -654,8 +654,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -681,8 +681,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -708,8 +708,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -737,8 +737,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -761,8 +761,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -783,8 +783,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000cafecafecafecafecafecafecafecafecafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -815,8 +815,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -842,8 +842,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -871,8 +871,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -900,8 +900,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -929,8 +929,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -951,8 +951,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -973,8 +973,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000cafecafecafecafecafecafecafecafecafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1048,8 +1048,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1070,8 +1070,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1092,8 +1092,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1114,8 +1114,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1138,8 +1138,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1162,8 +1162,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1184,8 +1184,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000cafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1211,8 +1211,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1233,8 +1233,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1257,8 +1257,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1281,8 +1281,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1305,8 +1305,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1327,8 +1327,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1349,8 +1349,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000cafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1434,8 +1434,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1463,8 +1463,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1492,8 +1492,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1521,8 +1521,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1552,8 +1552,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1576,8 +1576,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1598,8 +1598,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000cafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1630,8 +1630,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -1659,8 +1659,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1683,8 +1683,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1707,8 +1707,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1731,8 +1731,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await context.keyManager
@@ -1753,8 +1753,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1775,8 +1775,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000cafecafecafe";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1872,8 +1872,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
         await context.keyManager
           .connect(canOnlyAddPermissions)
@@ -1895,8 +1895,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           let value = "0xbadbadbadbad";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -1931,8 +1931,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -146,8 +146,8 @@ export const shouldBehaveLikePermissionChangeOwner = (
           const value = "0xabcd";
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -365,8 +365,8 @@ export const shouldBehaveLikePermissionChangeOwner = (
         const value = "0xabcd";
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await expect(
@@ -396,8 +396,8 @@ export const shouldBehaveLikePermissionChangeOwner = (
         const value = "0xabcd";
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
         await newKeyManager.connect(context.owner).execute(payload);

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -72,8 +72,8 @@ export const shouldBehaveLikePermissionSetData = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(context.owner).execute(payload);
@@ -94,8 +94,8 @@ export const shouldBehaveLikePermissionSetData = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(canSetData).execute(payload);
@@ -116,8 +116,8 @@ export const shouldBehaveLikePermissionSetData = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await expect(
@@ -645,8 +645,8 @@ export const shouldBehaveLikePermissionSetData = (
 
       let finalSetDataPayload =
         bobContext.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[key], [value]]
+          "setData(bytes32,bytes)",
+          [key, value]
         );
 
       let bobKeyManagerPayload =
@@ -713,8 +713,8 @@ export const shouldBehaveLikePermissionSetData = (
 
         it(`should be allowed to set a disallowed key: ${key}`, async () => {
           const payload = context.universalProfile.interface.encodeFunctionData(
-            "setData(bytes32[],bytes[])",
-            [[key], [value]]
+            "setData(bytes32,bytes)",
+            [key, value]
           );
 
           await context.keyManager.connect(caller).execute(payload);
@@ -734,8 +734,8 @@ export const shouldBehaveLikePermissionSetData = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[allowedERC725YKeys[0]], [value]]
+          "setData(bytes32,bytes)",
+          [allowedERC725YKeys[0], value]
         );
 
         await context.keyManager.connect(caller).execute(payload);
@@ -752,8 +752,8 @@ export const shouldBehaveLikePermissionSetData = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[allowedERC725YKeys[1]], [value]]
+          "setData(bytes32,bytes)",
+          [allowedERC725YKeys[1], value]
         );
 
         await context.keyManager.connect(caller).execute(payload);
@@ -770,8 +770,8 @@ export const shouldBehaveLikePermissionSetData = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32[],bytes[])",
-          [[allowedERC725YKeys[2]], [value]]
+          "setData(bytes32,bytes)",
+          [allowedERC725YKeys[2], value]
         );
 
         await context.keyManager.connect(caller).execute(payload);


### PR DESCRIPTION
# What does this PR introduce?

https://github.com/ERC725Alliance/ERC725/pull/93 introduced a function overloading that allows setting a single data key.

## Current behaviour

The current implementation of the KeyManager does not recognise the `setData(bytes32,bytes)` selector. But only `setData(bytes32[],bytes[])` for an array of data keys.

This is problematic for protocols and interfaces, as it requires them to create arrays containing a single element for setting a single element.
This is more problematic, especially for protocols and smart contracts looking to set only one single data key, as it increases the gas cost by requiring to create of a memory array with one single entry.

## New Behaviour

- [x] add an extra path in the Key Manager that allows `setData(bytes32,bytes)` for setting a single data key in the linked ERC725 account.