### PR TITLE
feat: create `LSP3Constants.sol`

### DIFF
--- a/contracts/LSP3UniversalProfile/LSP3Constants.sol
+++ b/contracts/LSP3UniversalProfile/LSP3Constants.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// bytes10(keccak256('SupportedStandard')) + bytes2(0) + bytes20(keccak256('LSP4DigitalAsset'))
+bytes32 constant _LSP3_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38;
+
+// bytes4(keccak256('LSP4DigitalAsset'))
+bytes constant _LSP3_SUPPORTED_STANDARDS_VALUE = hex"abe425d6";
+
+// bytes32(keccak256("LSP3Profile"))
+bytes32 constant _LSP3_PROFILE_KEY = 0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5;

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.0;
 // modules
 import {LSP0ERC725Account} from "./LSP0ERC725Account/LSP0ERC725Account.sol";
 
+// constants
+// prettier-ignore
+import {
+    _LSP3_SUPPORTED_STANDARDS_KEY, 
+    _LSP3_SUPPORTED_STANDARDS_VALUE
+} from "./LSP3UniversalProfile/LSP3Constants.sol";
+
 /**
  * @title implementation of a LUKSO's Universal Profile based on LSP3
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -16,8 +23,6 @@ contract UniversalProfile is LSP0ERC725Account {
      */
     constructor(address _newOwner) LSP0ERC725Account(_newOwner) {
         // set key SupportedStandards:LSP3UniversalProfile
-        bytes32 key = 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38;
-        bytes memory value = hex"abe425d6";
-        _setData(key, value);
+        _setData(_LSP3_SUPPORTED_STANDARDS_KEY, _LSP3_SUPPORTED_STANDARDS_VALUE);
     }
 }

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -5,6 +5,13 @@ pragma solidity ^0.8.0;
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol";
 
+// constants
+// prettier-ignore
+import {
+    _LSP3_SUPPORTED_STANDARDS_KEY, 
+    _LSP3_SUPPORTED_STANDARDS_VALUE
+} from "./LSP3UniversalProfile/LSP3Constants.sol";
+
 /**
  * @title Inheritable Proxy implementation of a LUKSO's Universal Profile based on LSP3
  * @author Fabian Vogelsteller <fabian@lukso.network>
@@ -15,8 +22,6 @@ abstract contract UniversalProfileInitAbstract is LSP0ERC725AccountInitAbstract 
         LSP0ERC725AccountInitAbstract._initialize(_newOwner);
 
         // set key SupportedStandards:LSP3UniversalProfile
-        bytes32 key = 0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38;
-        bytes memory value = hex"abe425d6";
-        _setData(key, value);
+        _setData(_LSP3_SUPPORTED_STANDARDS_KEY, _LSP3_SUPPORTED_STANDARDS_VALUE);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

## Feat

- create a new file `LSP3Constants.sol` that include all the data keys defined in LSP3 - Universal Profile Metadata Standard.

This file can then be used by contracts importing the library to use the two constant values defined in this file.

## Refactor

- [x] use internal `_setData(...)` function in the constructor / initializer of the `UniversalProfile` / `UniversalProfileInit` contract (= save 55 gas on deployment).