### PR TITLE
perf: save 2,140 gas on deployment of LSP4

### DIFF
--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -34,6 +34,6 @@ abstract contract LSP4DigitalAssetMetadata is ERC725Y {
     function _setData(bytes32 key, bytes memory value) internal virtual override {
         require(key != _LSP4_TOKEN_NAME_KEY, "LSP4: cannot edit Token Name after deployment");
         require(key != _LSP4_TOKEN_SYMBOL_KEY, "LSP4: cannot edit Token Symbol after deployment");
-        super._setData(key, value);
+        _setData(key, value);
     }
 }

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -30,6 +30,6 @@ abstract contract LSP4DigitalAssetMetadataInitAbstract is ERC725YInitAbstract {
     function _setData(bytes32 key, bytes memory value) internal virtual override {
         require(key != _LSP4_TOKEN_NAME_KEY, "LSP4: cannot edit Token Name after deployment");
         require(key != _LSP4_TOKEN_SYMBOL_KEY, "LSP4: cannot edit Token Symbol after deployment");
-        super._setData(key, value);
+        _setData(key, value);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

remove reference to parent contract in overloaded `_setData(...)` function in LSP4 (function overloaded to check that not overriding data keys `TOKEN_NAME` and `TOKEN_SYMBOL`