### PR TITLE
build: include constants for length + index access for LSP2 Array data key types

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ You can find more infos on how to deploy the contracts via hardhat in the [DEPLO
 
 ### Available Constants
 
-You can access interface IDs and other constants, using the `constants.js` file from the [lsp-smart-contracts package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts).
-You can find all accessible constants in the [`constants.js` file](https://github.com/lukso-network/lsp-smart-contracts/blob/main/constants.js).
+You can access interface IDs and other constants, using the [`constants.js` file](https://github.com/lukso-network/lsp-smart-contracts/blob/main/constants.js) file from the [lsp-smart-contracts package](https://www.npmjs.com/package/@lukso/lsp-smart-contracts).
 
 
 ```js
@@ -92,4 +91,13 @@ const {
     ALL_PERMISSIONS,
     EventSignatures,
 } = require("@lukso/lsp-smart-contracts/constants.js");
+```
+
+It also includes constant values [Array data keys](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#Array) to retrieve both the array length and for index access.
+
+```js
+'LSP5ReceivedAssets[]': {
+    length: '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+    index: '0x6460ee3c0aac563ccbf76d6e1d07bada',
+},
 ```

--- a/constants.js
+++ b/constants.js
@@ -86,19 +86,28 @@ const ERC725YKeys = {
 		// keccak256('LSP4Metadata')
 		LSP4Metadata: '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
 		// keccak256('"LSP4Creators[]')
-		'LSP4Creators[]': '0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7',
+		'LSP4Creators[]': {
+			// use this key to get the number of elements in the array
+			length: '0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7',
+			// use this key + bytes16(index) to access an index in the array
+			index: '0x114bd03b3a46d48759680d81ebb2b414',
+		},
 	},
 	LSP5: {
 		// LSP5ReceivedAssetsMap:<address>
 		LSP5ReceivedAssetsMap: '0x812c4334633eb816c80d0000',
 		// keccak256('LSP5ReceivedAssets[]')
-		'LSP5ReceivedAssets[]':
-			'0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+		'LSP5ReceivedAssets[]': {
+			length: '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+			index: '0x6460ee3c0aac563ccbf76d6e1d07bada',
+		},
 	},
 	LSP6: {
 		// keccak256('AddressPermissions[]')
-		'AddressPermissions[]':
-			'0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+		'AddressPermissions[]': {
+			length: '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+			index: '0xdf30dba06db6a30e65354d9a64c60986',
+		},
 		// AddressPermissions:Permissions:<address>
 		'AddressPermissions:Permissions': '0x4b80742de2bf82acb3630000',
 		// AddressPermissions:AllowedAddresses:<address>
@@ -114,13 +123,19 @@ const ERC725YKeys = {
 		// keccak256('LSP10VaultsMap')
 		LSP10VaultsMap: '0x192448c3c0f88c7f238c0000',
 		// keccak256('LSP10Vaults[]')
-		'LSP10Vaults[]': '0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06',
+		'LSP10Vaults[]': {
+			length: '0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06',
+			index: '0x55482936e01da86729a45d2b87a6b1d3',
+		},
 	},
 	LSP12: {
 		// LSP12IssuedAssetsMap:<address>
 		LSP12IssuedAssetsMap: '0x74ac2555c10b9349e78f0000',
 		// keccak256('LSP12IssuedAssets[]')
-		'LSP12IssuedAssets[]': '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+		'LSP12IssuedAssets[]': {
+			length: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+			index: '0x7c8c3416d6cda87cd42c71ea1843df28',
+		},
 	},
 };
 


### PR DESCRIPTION
# What does this PR introduce?

## What is the current behaviour?

Currently, tools like lsp-factory.js need to use the `String.slice()` syntax with LSP constants to build LSP data keys for array index access.

For instance (taken from the [_lsp-factory.js_ source code](https://github.com/lukso-network/tools-lsp-factory/blob/8ea2eb36ead007c0282034f971868e0c90339d3b/src/lib/classes/lsp7-digtal-asset.spec.ts#L284-L289)):

```js
const [creator1, creator2] = await digitalAsset.getData([
        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
          ethers.utils.hexZeroPad(ethers.utils.hexlify([0]), 16).substring(2),
        LSP4_KEYS.LSP4_CREATORS_ARRAY.slice(0, 34) +
          ethers.utils.hexZeroPad(ethers.utils.hexlify([1]), 16).substring(2),
      ]);
```

This make it difficult for interface and tools looking to use LSP2 Array data keys.

## What is the new behaviour?

In the `constants.js` file, for each LSP data keys of type [Array](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-2-ERC725YJSONSchema.md#Array), include the constant value for both **length** and **index** access, so that these values can be used directly, without the need to use `.slice()`.

Example from the updated `constants.js`

```js
'LSP5ReceivedAssets[]': {
    length: '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
    index: '0x6460ee3c0aac563ccbf76d6e1d07bada',
},
```