### PR TITLE
feat: update universalReceiver to latest spec

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -234,14 +234,15 @@ const EventSignatures = {
 		/**
 		 * event UniversalReceiver(
 		 *    address indexed from,
+		 * 	  uint256 value,
 		 *    bytes32 indexed typeId,
 		 *    bytes indexed returnedValue,
 		 *    bytes receivedData
 		 * );
 		 *
-		 * signature = keccak256('UniversalReceiver(address,bytes32,bytes,bytes)')
+		 * signature = keccak256('UniversalReceiver(address,uint256,bytes32,bytes,bytes)')
 		 */
-		UniversalReceiver: '0x8187df79ab47ad16102e7bc8760349a115b3ba9869b8cedd78996f930ac9cac3',
+		UniversalReceiver: '0x9c3ba68eb5742b8e3961aea0afc7371a71bf433c8a67a831803b64c064a178c2',
 	},
 	LSP6: {
 		/**

--- a/constants.js
+++ b/constants.js
@@ -19,7 +19,7 @@ const INTERFACE_IDS = {
 	ERC725Y: '0x714df77c',
 	LSP0ERC725Account: '0x9a3bfe88',
 	LSP1UniversalReceiver: '0x6bb56a14',
-	LSP1UniversalReceiverDelegate: '0xc2d7bcc1',
+	LSP1UniversalReceiverDelegate: '0xa245bbda',
 	LSP6KeyManager: '0xc403d48f',
 	LSP7DigitalAsset: '0xe33f65c3',
 	LSP8IdentifiableDigitalAsset: '0x49399145',

--- a/contracts/Helpers/Tokens/TokenReceiverWithLSP1.sol
+++ b/contracts/Helpers/Tokens/TokenReceiverWithLSP1.sol
@@ -20,6 +20,7 @@ contract TokenReceiverWithLSP1 is ERC165Storage, ILSP1UniversalReceiver {
 
     function universalReceiver(bytes32 typeId, bytes memory data)
         external
+        payable
         override
         returns (bytes memory returnValue)
     {

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -18,6 +18,7 @@ contract UniversalReceiverDelegateRevert is ILSP1UniversalReceiverDelegate, ERC1
     /* solhint-disable no-unused-vars */
     function universalReceiverDelegate(
         address sender,
+        uint256 value,
         bytes32 typeId,
         bytes memory data
     ) external pure override returns (bytes memory) {

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
@@ -7,16 +7,17 @@ import {ILSP1UniversalReceiver} from "../../LSP1UniversalReceiver/ILSP1Universal
 contract UniversalReceiverTester {
     function callImplementationAndReturn(address target, bytes32 typeId)
         external
+        payable
         returns (bytes memory)
     {
         return ILSP1UniversalReceiver(target).universalReceiver(typeId, "");
     }
 
-    function checkImplementation(address _target, bytes32 _typeId) external {
+    function checkImplementation(address _target, bytes32 _typeId) external payable {
         ILSP1UniversalReceiver(_target).universalReceiver(_typeId, "");
     }
 
-    function checkImplementationLowLevelCall(address _target, bytes32 _typeId) external {
+    function checkImplementationLowLevelCall(address _target, bytes32 _typeId) external payable {
         // solhint-disable avoid-low-level-calls
         (bool success, ) = _target.call(
             abi.encodeWithSelector(ILSP1UniversalReceiver.universalReceiver.selector, _typeId, "")

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
@@ -14,15 +14,17 @@ contract UniversalReceiverTester {
     }
 
     function checkImplementation(address _target, bytes32 _typeId) external payable {
-        ILSP1UniversalReceiver(_target).universalReceiver(_typeId, "");
+        ILSP1UniversalReceiver(_target).universalReceiver{ value: msg.value }(_typeId, "");
     }
 
     function checkImplementationLowLevelCall(address _target, bytes32 _typeId) external payable {
         // solhint-disable avoid-low-level-calls
-        (bool success, ) = _target.call(
+        (bool success, ) = _target.call{ value: msg.value }(
             abi.encodeWithSelector(ILSP1UniversalReceiver.universalReceiver.selector, _typeId, "")
         );
 
         require(success, "low-level call to `universalReceiver(...)` function failed");
     }
+
+    receive() external payable {}
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -138,6 +138,7 @@ abstract contract LSP0ERC725AccountCore is
      */
     function universalReceiver(bytes32 _typeId, bytes calldata _data)
         external
+        payable
         virtual
         override
         returns (bytes memory returnValue)

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -155,9 +155,9 @@ abstract contract LSP0ERC725AccountCore is
                 )
             ) {
                 returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
-                    .universalReceiverDelegate(msg.sender, _typeId, _data);
+                    .universalReceiverDelegate(msg.sender, msg.value, _typeId, _data);
             }
         }
-        emit UniversalReceiver(msg.sender, _typeId, returnValue, _data);
+        emit UniversalReceiver(msg.sender, msg.value, _typeId, returnValue, _data);
     }
 }

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
@@ -9,12 +9,14 @@ interface ILSP1UniversalReceiver {
     /**
      * @notice Emitted when the universalReceiver function is succesfully executed
      * @param from The address calling the universalReceiver function
+     * @param value The amount sent to the universalReceiver function
      * @param typeId The hash of a specific standard or a hook
      * @param returnedValue The return value of universalReceiver function
      * @param receivedData The arbitrary data passed to universalReceiver function
      */
     event UniversalReceiver(
         address indexed from,
+        uint256 value,
         bytes32 indexed typeId,
         bytes indexed returnedValue,
         bytes receivedData

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
@@ -33,5 +33,6 @@ interface ILSP1UniversalReceiver {
      */
     function universalReceiver(bytes32 typeId, bytes calldata data)
         external
+        payable
         returns (bytes memory);
 }

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol
@@ -9,13 +9,15 @@ pragma solidity ^0.8.0;
 interface ILSP1UniversalReceiverDelegate {
     /**
      * @dev Get called by the universalReceiver function, can be customized to have a specific logic
-     * @param sender The address calling the universalReceiver function
+     * @param caller The address calling the universalReceiver function
+     * @param value The amount sent to the universalReceiver function
      * @param typeId The hash of a specific standard or a hook
      * @param data The arbitrary data received with the call
      * @return result Any useful data could be returned
      */
     function universalReceiverDelegate(
-        address sender,
+        address caller,
+        uint256 value,
         bytes32 typeId,
         bytes memory data
     ) external returns (bytes memory result);

--- a/contracts/LSP1UniversalReceiver/LSP1Constants.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Constants.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
 bytes4 constant _INTERFACEID_LSP1 = 0x6bb56a14;
-bytes4 constant _INTERFACEID_LSP1_DELEGATE = 0xc2d7bcc1;
+bytes4 constant _INTERFACEID_LSP1_DELEGATE = 0xa245bbda;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -36,6 +36,7 @@ contract LSP1UniversalReceiverDelegateUP is
      */
     function universalReceiverDelegate(
         address sender,
+        uint256 value,
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual override returns (bytes memory result) {

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -32,6 +32,7 @@ contract LSP1UniversalReceiverDelegateVault is
      */
     function universalReceiverDelegate(
         address sender,
+        uint256 value,
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual override returns (bytes memory result) {

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -166,10 +166,10 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
                 )
             ) {
                 returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
-                    .universalReceiverDelegate(msg.sender, _typeId, _data);
+                    .universalReceiverDelegate(msg.sender, msg.value, _typeId, _data);
             }
         }
-        emit UniversalReceiver(msg.sender, _typeId, returnValue, _data);
+        emit UniversalReceiver(msg.sender, msg.value, _typeId, returnValue, _data);
     }
 
     // internal functions

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -149,6 +149,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      */
     function universalReceiver(bytes32 _typeId, bytes calldata _data)
         external
+        payable
         virtual
         override
         returns (bytes memory returnValue)

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -40,6 +40,7 @@ contract UniversalReceiverAddressStore is
 
     function universalReceiverDelegate(
         address sender,
+        uint256 value,
         bytes32 typeId,
         bytes memory
     ) external override onlyAccount returns (bytes memory) {

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -18,7 +18,7 @@ contract UniversalReceiverAddressStore is
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    bytes4 internal constant _INTERFACE_ID_LSP1DELEGATE = 0xc2d7bcc1;
+    bytes4 internal constant _INTERFACE_ID_LSP1DELEGATE = 0xa245bbda;
 
     bytes32 internal constant _TOKENS_RECIPIENT_INTERFACE_HASH =
         0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b; // keccak256("ERC777TokensRecipient")

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -152,7 +152,7 @@ export const shouldBehaveLikeLSP1 = (
   });
 
   describe("when calling the `universalReceiver(...)` function while sending native tokens", () => {
-    const valueSent = ethers.utils.parseEther("5");
+    const valueSent = ethers.utils.parseEther("3");
 
     describe("from an EOA", () => {
       it("should emit a UniversalReceiver(...) event with correct topics", async () => {
@@ -195,9 +195,9 @@ export const shouldBehaveLikeLSP1 = (
 
     describe("from a Contract", () => {
       beforeEach(async () => {
-        context.accounts[0].sendTransaction({
+        await context.accounts[0].sendTransaction({
           to: context.lsp1Checker.address,
-          value: ethers.utils.parseEther("20"),
+          value: ethers.utils.parseEther("5"),
         });
       });
 
@@ -205,7 +205,8 @@ export const shouldBehaveLikeLSP1 = (
         it("should emit an UniversalReceiver(...) event", async () => {
           let tx = await context.lsp1Checker.checkImplementation(
             context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER
+            LSP1_HOOK_PLACEHOLDER,
+            { value: valueSent }
           );
 
           let receipt = await tx.wait();
@@ -241,7 +242,8 @@ export const shouldBehaveLikeLSP1 = (
         it("should emit an UniversalReceiver(...) event", async () => {
           let tx = await context.lsp1Checker.checkImplementationLowLevelCall(
             context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER
+            LSP1_HOOK_PLACEHOLDER,
+            { value: valueSent }
           );
 
           let receipt = await tx.wait();


### PR DESCRIPTION
## What does this PR introduce?
- Mark `universalReceiver(..)` function as payable
- Add `value` param to `universalReceiverDelegate(..)` function
- Add `value` param to UniversalReceiver event
- Update LSP1Delegate InterfaceID 