### PR TITLE
ci: use Node.js version 16.15.0

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -22,10 +22,10 @@ jobs:
         uses: EndBug/version-check@v1
         id: check
 
-      - name: Use Node.js '16.x'
+      - name: Use Node.js '16.15.0'
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "16.15.0"
           cache: "npm"
 
       - run: npm ci

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v2
 
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-      - name: Use Node.js v16
+      - name: Use Node.js '16.15.0'
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "16.15.0"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/mythx-analysis.yml
+++ b/.github/workflows/mythx-analysis.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node.js v16
+      - name: Setup Node.js '16.15.0'
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "16.15.0"
           cache: "npm"
 
       - name: Set up Python 3.8

--- a/.github/workflows/publish-npm-artifact.yml
+++ b/.github/workflows/publish-npm-artifact.yml
@@ -3,7 +3,7 @@ name: Publish NPM artifacts
 
 on:
   repository_dispatch:
-      types: [trigger-release]
+    types: [trigger-release]
 
 jobs:
   npm-build-artifacts:
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js v16
+      - name: Use Node.js '16.15.0'
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "16.15.0"
           registry-url: "https://registry.npmjs.org"
           scope: "@lukso"
           cache: "npm"


### PR DESCRIPTION
# What does this PR introduce?

Recently, the CI on the repository failed at the step of installing the dependencies with `npm ci`. After investigation, this seems to be due to different versions of Node.js being used in different workflows.

(click on step named "Use Node.js '16.x' to see details)
- Node.js version node v16.15.0 (npm v8.5.5) -> OK ✅  (_e.g._ https://github.com/lukso-network/lsp-smart-contracts/runs/6780284640?check_suite_focus=true)
- Node.js version v16.15.1 (npm v8.11.0) -> fail ❌ (e.g. https://github.com/lukso-network/lsp-smart-contracts/runs/6824463119?check_suite_focus=true)

Maybe this is due to the fact that version 16.15.1 upgraded to npm 8.11?

## Current behaviour

Installing the dependencies with version 16.15.0 succeed ✅ 

```bash
nvm install 16.15.0
nvm use 16.15.0
npm ci
```
output
```bash
added 2978 packages, and audited 2982 packages in 3m

172 packages are looking for funding
  run `npm fund` for details

56 vulnerabilities (4 low, 11 moderate, 38 high, 3 critical)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

Installing the dependencies with version 16.15.1 fails ❌  

```bash
nvm install 16.15.1
nvm use 16.15.1
npm ci
```

```bash
npm ERR! code EUSAGE
npm ERR! 
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm ERR! 
npm ERR! Missing: ethereum-waffle@3.4.4 from lock file
npm ERR! Invalid: lock file's hardhat@2.6.2 does not satisfy hardhat@2.9.9
npm ERR! Missing: acorn@8.7.1 from lock file
npm ERR! Missing: @ethereum-waffle/chai@3.4.4 from lock file
npm ERR! Missing: @ethereum-waffle/compiler@3.4.4 from lock file
npm ERR! Missing: @ethereum-waffle/mock-contract@3.4.4 from lock file
npm ERR! Invalid: lock file's @ethereum-waffle/provider@3.4.0 does not satisfy @ethereum-waffle/provider@3.4.4
// ...
```

## New Behaviour

Enforce the CI to use versions 16.15.0 to ensure installation of dependencies succeed.