### PR TITLE
chore(release): prepare rc-0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,110 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.6.1](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.5.0...v0.6.1) (2022-06-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* edit LSP2 keys according to new spec (#177)
+* disable delegatecall
+* remove DELEGATECALL from ALL_PERMISSIONS
+* change name of interface IDs to match with docs
+* edit LSP0 + LSP9 interface IDs in constant.ts
+* add owner and transferOwnership in LSP0 / LSP9 interface ID
+* edit LSP9 interface ID
+* edit LSP0 interface ID
+* add ClaimOwnership in LSP9 Vault (#164)
+* prevent editing token name and symbols on LSP4
+* change LSP0 interface ID by adding ClaimOwnership interface ID
+* set owner permission in fixture to setup KeyManager
+* change LSP6 interface ID
+* rename function account() -> target() in LSP1
+* rename function account() -> target() in LSP6
+* **lsp6:** add `account()` function as part of the LSP6 interface (#131)
+
+### Features
+
+* add ClaimOwnership in LSP9 Vault ([#164](https://github.com/lukso-network/lsp-smart-contracts/issues/164)) ([edb9e1d](https://github.com/lukso-network/lsp-smart-contracts/commit/edb9e1dbf5829925c25e35cb2e35ad471e677f8b))
+* add claimOwnership(...) path in KeyManager ([dde4221](https://github.com/lukso-network/lsp-smart-contracts/commit/dde4221cb6cd88af55d23a942cc2a32936919d01))
+* add constant Solidity file for LSP3 ([ea20351](https://github.com/lukso-network/lsp-smart-contracts/commit/ea203519375beabf5d6993829939c769cf2d7be8))
+* add interface + abstract contract OwnableClaim ([4416e81](https://github.com/lukso-network/lsp-smart-contracts/commit/4416e818e0a95db2fb883051ce2365035fcccd2c))
+* add interface ID check for ClaimOwnership ([dd2b219](https://github.com/lukso-network/lsp-smart-contracts/commit/dd2b219a547a9ba2deb4af3b60b55cc5d6e5fbdf))
+* add LSP5 and LSP10 Constants files ([dd3d1a8](https://github.com/lukso-network/lsp-smart-contracts/commit/dd3d1a8bb8b9c867c121aa3b1301adeb71029fd0))
+* add LSP5Utils lib ([e8e5c2a](https://github.com/lukso-network/lsp-smart-contracts/commit/e8e5c2a0a7af567427100bd178fe6268c28b5ce6))
+* add SUPER permissions in constants.ts ([d363124](https://github.com/lukso-network/lsp-smart-contracts/commit/d363124b3fe02e645b5900f5277fac8196cbab21))
+* add SUPER permissions in permissions constants ([ae3a2e5](https://github.com/lukso-network/lsp-smart-contracts/commit/ae3a2e523e07af5ee5f030160b27bd46f6e46988))
+* add support for SUPER OPERATION (CALL, STATICCALL, ...) to skip allowed checks ([90b94a2](https://github.com/lukso-network/lsp-smart-contracts/commit/90b94a27edcdef9d821cbbbf83a3cae3ef1e8949))
+* allow delegatecall via KeyManager ([c73ecf1](https://github.com/lukso-network/lsp-smart-contracts/commit/c73ecf18ab9b72089c5c4f0fcb3bcf5294376a9e))
+* extend jest matcher `toBeRevertedWith` as it does not work as expected with custom errors ([3a925ee](https://github.com/lukso-network/lsp-smart-contracts/commit/3a925ee7f17cb0a4e5ff75b6666684aa5bd43dd0))
+* introduce `ErroHandlerLib` in execution in LSP6 ([724d411](https://github.com/lukso-network/lsp-smart-contracts/commit/724d41112d9f092936904b03deaaca52fe6bc502))
+* **lsp6:** add `account()` function as part of the LSP6 interface ([#131](https://github.com/lukso-network/lsp-smart-contracts/issues/131)) ([db7b297](https://github.com/lukso-network/lsp-smart-contracts/commit/db7b297b8af86cd2dc04b3d870f204d0e6545b4e))
+* LSP7 and LSP8 use solidity custom errors ([b353655](https://github.com/lukso-network/lsp-smart-contracts/commit/b3536556eed552e1acc172d98a297b923c939eb0))
+* UniversalFactory ([#139](https://github.com/lukso-network/lsp-smart-contracts/issues/139)) ([3164d9a](https://github.com/lukso-network/lsp-smart-contracts/commit/3164d9a704da3c5d99c47a7b46a19741f8e696d8))
+* update universalReceiver to latest spec ([#193](https://github.com/lukso-network/lsp-smart-contracts/issues/193)) ([5b2bc60](https://github.com/lukso-network/lsp-smart-contracts/commit/5b2bc601acbf467b132fc38093fdad9a54fdef1c))
+* use custom errors for LSP7/8 CappedSupply contracts ([07ac935](https://github.com/lukso-network/lsp-smart-contracts/commit/07ac935bf336562358930f07d9f86b710cd59d73))
+* use custom version of `ERC165Checker` ([#132](https://github.com/lukso-network/lsp-smart-contracts/issues/132)) ([0e7bbec](https://github.com/lukso-network/lsp-smart-contracts/commit/0e7bbec34a75de9a9ba31db6146e162a800d3406))
+
+
+### Bug Fixes
+
+* :bug: incorrect revert error for NotAuthorised(_from, "STATICCALL") ([a2e52ed](https://github.com/lukso-network/lsp-smart-contracts/commit/a2e52ed328c6b6799ded9a1396cde11765e7d784))
+* `isValidSignature` function check ([#120](https://github.com/lukso-network/lsp-smart-contracts/issues/120)) ([2f2762d](https://github.com/lukso-network/lsp-smart-contracts/commit/2f2762da71095009949b1a045730d2ed3c8416b7))
+* add chainId to the signed message in LSP6 ([2fdfb59](https://github.com/lukso-network/lsp-smart-contracts/commit/2fdfb59b9a379bc83191a4bec6a0f315b5f5a5e0))
+* add permissions check when setting keys for `AddressPermissions[]` and `AddressPermissions[index]` ([#125](https://github.com/lukso-network/lsp-smart-contracts/issues/125)) ([18a143c](https://github.com/lukso-network/lsp-smart-contracts/commit/18a143c95086598a887b3df4cc907c18241b39c1))
+* add sender code length check in UniversalReceiverDelegate ([12180a4](https://github.com/lukso-network/lsp-smart-contracts/commit/12180a4612c8e5e1e9303a6efad616f03b61bec8))
+* admin caller with `ALL_PERMISSIONS` can call any functions part of the Universal Profile's ABI ([#128](https://github.com/lukso-network/lsp-smart-contracts/issues/128)) ([ec384d3](https://github.com/lukso-network/lsp-smart-contracts/commit/ec384d3e7869334ec63e4a0c805282b90bd9794a))
+* apply checks-effects-interactions pattern ([77e2c43](https://github.com/lukso-network/lsp-smart-contracts/commit/77e2c43790cdac24bddf1540e09d83446017391f))
+* apply checks-effects-interactions pattern ([#121](https://github.com/lukso-network/lsp-smart-contracts/issues/121)) ([6e0e5b2](https://github.com/lukso-network/lsp-smart-contracts/commit/6e0e5b2a6002cd6cb7af98de8de221d6837181dd))
+* boolean check ([a7be1bd](https://github.com/lukso-network/lsp-smart-contracts/commit/a7be1bd5afd919f5de66a06b3c62784fbeef443f))
+* comments ([69f0e8a](https://github.com/lukso-network/lsp-smart-contracts/commit/69f0e8af001f7625545b8c8aa1782b47ef461663))
+* disable solhint with `no-unused-vars` in LSP1-URD ([ae6dcff](https://github.com/lukso-network/lsp-smart-contracts/commit/ae6dcffdd6404753ed2d81a400b19d9244479874))
+* ERC1271 in export ([db80c69](https://github.com/lukso-network/lsp-smart-contracts/commit/db80c694ae2a3a06ff86b1d68728199ebac9288a))
+* failing test ([1edef46](https://github.com/lukso-network/lsp-smart-contracts/commit/1edef460f5139ac343c6d61d2c3f43fb8137482d))
+* fix OwnableUnset folder location in import statements ([c6702a0](https://github.com/lukso-network/lsp-smart-contracts/commit/c6702a09279e001d32e1cf63f661511cde1e85bc))
+* flip `index` and `interfaceID` in LSP5 & LSP10 ([a926fa7](https://github.com/lukso-network/lsp-smart-contracts/commit/a926fa74590e1256aaaff59667eaad3f5d6ce645))
+* inherit LSP0 contracts from most base to most derive ([bac9f5d](https://github.com/lukso-network/lsp-smart-contracts/commit/bac9f5dbe261de81242a6783ab0119e07557951f))
+* inherit LSP1 contracts from most base to most derive ([1911886](https://github.com/lukso-network/lsp-smart-contracts/commit/1911886d03dbc42683369559aac064319b0ead3e))
+* inherit LSP6 contracts from most base to most derive ([22762e0](https://github.com/lukso-network/lsp-smart-contracts/commit/22762e0874361f4c7bb863b3b4d2209716e2ae30))
+* inherit LSP7 contracts from most base to most derive ([de29a58](https://github.com/lukso-network/lsp-smart-contracts/commit/de29a58fa0a7ed4db83151008a7f82b21777cc27))
+* inherit LSP8 contracts from most base to most derive ([5f05302](https://github.com/lukso-network/lsp-smart-contracts/commit/5f053025f2c1bfb5ce858c0d4bf0d289a5542259))
+* inherit LSP9 contracts from most base to most derive ([b34a049](https://github.com/lukso-network/lsp-smart-contracts/commit/b34a049edf43cfe9f90159082a725c346224a04b))
+* **lsp6:** fix bugs for `AllowedERC725YKeys` when input is multiple keys that include allowed + not allowed keys ([#134](https://github.com/lukso-network/lsp-smart-contracts/issues/134)) ([8f95a79](https://github.com/lukso-network/lsp-smart-contracts/commit/8f95a7959df4047c2421b4fdb34a523fa2f62ae5))
+* move AddressRegistry contract under Legacy/ folder ([3cf8102](https://github.com/lukso-network/lsp-smart-contracts/commit/3cf8102fe5137ba2111c4e2e8ed1fd7eada4c432))
+* override `supportsInterface` in LSP0 ([6415e5f](https://github.com/lukso-network/lsp-smart-contracts/commit/6415e5f25bf2b64d2a30ae08c27ff514211f6f0f))
+* override `supportsInterface` in LSP7 ([3840e6b](https://github.com/lukso-network/lsp-smart-contracts/commit/3840e6ba0983b88530ebef6872a441fb7d07e266))
+* override `supportsInterface` in LSP8 ([57385b5](https://github.com/lukso-network/lsp-smart-contracts/commit/57385b5eb50cb7c53e2e3acee537ce56748fae4e))
+* override `supportsInterface` in LSP9 ([707ba59](https://github.com/lukso-network/lsp-smart-contracts/commit/707ba5983138d90ddf6c9f17489c21fcf7cf5574))
+* prevent editing token name and symbols on LSP4 ([d69b01f](https://github.com/lukso-network/lsp-smart-contracts/commit/d69b01f3aa83014ce90ab6b2c402fa8101e6b252))
+* re-order `executeRelayCall(..)` params and remove `_signedFor` ([7ce3f96](https://github.com/lukso-network/lsp-smart-contracts/commit/7ce3f9632aa0efc45f310cd27ba74a0f5da8120c))
+* reference to Allowed Standards Map key ([e8993e6](https://github.com/lukso-network/lsp-smart-contracts/commit/e8993e6b7bbcbe26d9284f2e4c47305843ebc68b))
+* replace `initOwner` with `_setOwner` function ([5183765](https://github.com/lukso-network/lsp-smart-contracts/commit/5183765f53b1c7432ae7f6dc7bec4cbb276dd86d))
+* resolve merge conflicts in LSP6Core ([2519ee1](https://github.com/lukso-network/lsp-smart-contracts/commit/2519ee1d0ce70911d98afd21c43a475a32cb6218))
+* send the `msg.value` instead of 0 in `executeRelayCall(.)` ([d64855c](https://github.com/lukso-network/lsp-smart-contracts/commit/d64855cb0f22ea199390fb9ced17017dcb8e535c))
+* **tests:** delegatecall tests to a function that does not use onlyOwner ([5a33d4b](https://github.com/lukso-network/lsp-smart-contracts/commit/5a33d4bf0a89a86dd0386c80cedeea3c063dcb8d))
+* update interfaceID for LSP6 ([499ee6a](https://github.com/lukso-network/lsp-smart-contracts/commit/499ee6a73eef210e022c81a0590df8666502c815))
+* use internal `_getData` instead `getDataSingle` ([c7f7bc2](https://github.com/lukso-network/lsp-smart-contracts/commit/c7f7bc27081ced33f2af7228d6345d8131bb00ef))
+* validate values for abi-encoded arrays in KeyManager ([#152](https://github.com/lukso-network/lsp-smart-contracts/issues/152)) ([200ff28](https://github.com/lukso-network/lsp-smart-contracts/commit/200ff2857c8e48a45c7761cf8a490fe094eaf8da))
+
+
+### build
+
+* change name of interface IDs to match with docs ([19e9e54](https://github.com/lukso-network/lsp-smart-contracts/commit/19e9e54a22f0e7f40961b1a0616cac73fd7a56d2))
+
+
+* add owner and transferOwnership in LSP0 / LSP9 interface ID ([d4079a8](https://github.com/lukso-network/lsp-smart-contracts/commit/d4079a87757066585187c0bda949a00c6accc4ee))
+* change LSP0 interface ID by adding ClaimOwnership interface ID ([37173ba](https://github.com/lukso-network/lsp-smart-contracts/commit/37173ba81b27647da9bd7b5000fb10e7932b89b1))
+* change LSP6 interface ID ([8362ecd](https://github.com/lukso-network/lsp-smart-contracts/commit/8362ecd8218c0fe76d5b5f53c528b62be43da7d7))
+* disable delegatecall ([7a66e4f](https://github.com/lukso-network/lsp-smart-contracts/commit/7a66e4f0f1d30163f8f6f3bacb8dabbdd2be0ac0))
+* edit LSP0 + LSP9 interface IDs in constant.ts ([bb8133f](https://github.com/lukso-network/lsp-smart-contracts/commit/bb8133f0684799fa3fcb8feb79fbdb0821039990))
+* edit LSP0 interface ID ([03ae8f4](https://github.com/lukso-network/lsp-smart-contracts/commit/03ae8f447c0c0bf506dafd445c35ef57995dc9f5))
+* edit LSP2 keys according to new spec ([#177](https://github.com/lukso-network/lsp-smart-contracts/issues/177)) ([494c354](https://github.com/lukso-network/lsp-smart-contracts/commit/494c354c9a4813b8ed8e3b09934f669f4a47bd56))
+* edit LSP9 interface ID ([44dbfda](https://github.com/lukso-network/lsp-smart-contracts/commit/44dbfdad4faff6ed91556295c9806a291215450a))
+* remove DELEGATECALL from ALL_PERMISSIONS ([a3bf44c](https://github.com/lukso-network/lsp-smart-contracts/commit/a3bf44c19fd7ca907ba07bdc3f17938c8de7bbda))
+* rename function account() -> target() in LSP1 ([035a0e5](https://github.com/lukso-network/lsp-smart-contracts/commit/035a0e52e63f2412285b43666e5b1d02e49a3d2b))
+* rename function account() -> target() in LSP6 ([1e4949c](https://github.com/lukso-network/lsp-smart-contracts/commit/1e4949cb6e281d5411b70762f0e7b347a9620050))
+* set owner permission in fixture to setup KeyManager ([6999787](https://github.com/lukso-network/lsp-smart-contracts/commit/6999787df38cde2e3dff4b1e307de06df28f5d5a))
+
 ## [0.6.0](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.5.0...v0.6.0) (2022-06-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,116 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.6.1](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.5.0...v0.6.1) (2022-06-10)
+## [0.6.1](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.6.0...v0.6.1) (2022-06-10)
 
+### BREAKING CHANGES
 
-### ⚠ BREAKING CHANGES
-
-* edit LSP2 keys according to new spec (#177)
-* disable delegatecall
-* remove DELEGATECALL from ALL_PERMISSIONS
-* change name of interface IDs to match with docs
-* edit LSP0 + LSP9 interface IDs in constant.ts
-* add owner and transferOwnership in LSP0 / LSP9 interface ID
-* edit LSP9 interface ID
-* edit LSP0 interface ID
-* add ClaimOwnership in LSP9 Vault (#164)
-* prevent editing token name and symbols on LSP4
-* change LSP0 interface ID by adding ClaimOwnership interface ID
-* set owner permission in fixture to setup KeyManager
-* change LSP6 interface ID
-* rename function account() -> target() in LSP1
-* rename function account() -> target() in LSP6
-* **lsp6:** add `account()` function as part of the LSP6 interface (#131)
+* the LSP2 array data keys defined in `constants.js` are now splitted in two: `.length` and `.index` ([#192](https://github.com/lukso-network/lsp-smart-contracts/pull/192))
 
 ### Features
 
-* add ClaimOwnership in LSP9 Vault ([#164](https://github.com/lukso-network/lsp-smart-contracts/issues/164)) ([edb9e1d](https://github.com/lukso-network/lsp-smart-contracts/commit/edb9e1dbf5829925c25e35cb2e35ad471e677f8b))
-* add claimOwnership(...) path in KeyManager ([dde4221](https://github.com/lukso-network/lsp-smart-contracts/commit/dde4221cb6cd88af55d23a942cc2a32936919d01))
-* add constant Solidity file for LSP3 ([ea20351](https://github.com/lukso-network/lsp-smart-contracts/commit/ea203519375beabf5d6993829939c769cf2d7be8))
-* add interface + abstract contract OwnableClaim ([4416e81](https://github.com/lukso-network/lsp-smart-contracts/commit/4416e818e0a95db2fb883051ce2365035fcccd2c))
-* add interface ID check for ClaimOwnership ([dd2b219](https://github.com/lukso-network/lsp-smart-contracts/commit/dd2b219a547a9ba2deb4af3b60b55cc5d6e5fbdf))
-* add LSP5 and LSP10 Constants files ([dd3d1a8](https://github.com/lukso-network/lsp-smart-contracts/commit/dd3d1a8bb8b9c867c121aa3b1301adeb71029fd0))
-* add LSP5Utils lib ([e8e5c2a](https://github.com/lukso-network/lsp-smart-contracts/commit/e8e5c2a0a7af567427100bd178fe6268c28b5ce6))
-* add SUPER permissions in constants.ts ([d363124](https://github.com/lukso-network/lsp-smart-contracts/commit/d363124b3fe02e645b5900f5277fac8196cbab21))
-* add SUPER permissions in permissions constants ([ae3a2e5](https://github.com/lukso-network/lsp-smart-contracts/commit/ae3a2e523e07af5ee5f030160b27bd46f6e46988))
-* add support for SUPER OPERATION (CALL, STATICCALL, ...) to skip allowed checks ([90b94a2](https://github.com/lukso-network/lsp-smart-contracts/commit/90b94a27edcdef9d821cbbbf83a3cae3ef1e8949))
-* allow delegatecall via KeyManager ([c73ecf1](https://github.com/lukso-network/lsp-smart-contracts/commit/c73ecf18ab9b72089c5c4f0fcb3bcf5294376a9e))
-* extend jest matcher `toBeRevertedWith` as it does not work as expected with custom errors ([3a925ee](https://github.com/lukso-network/lsp-smart-contracts/commit/3a925ee7f17cb0a4e5ff75b6666684aa5bd43dd0))
-* introduce `ErroHandlerLib` in execution in LSP6 ([724d411](https://github.com/lukso-network/lsp-smart-contracts/commit/724d41112d9f092936904b03deaaca52fe6bc502))
-* **lsp6:** add `account()` function as part of the LSP6 interface ([#131](https://github.com/lukso-network/lsp-smart-contracts/issues/131)) ([db7b297](https://github.com/lukso-network/lsp-smart-contracts/commit/db7b297b8af86cd2dc04b3d870f204d0e6545b4e))
-* LSP7 and LSP8 use solidity custom errors ([b353655](https://github.com/lukso-network/lsp-smart-contracts/commit/b3536556eed552e1acc172d98a297b923c939eb0))
-* UniversalFactory ([#139](https://github.com/lukso-network/lsp-smart-contracts/issues/139)) ([3164d9a](https://github.com/lukso-network/lsp-smart-contracts/commit/3164d9a704da3c5d99c47a7b46a19741f8e696d8))
+* update `receive()` function to `fallback() payable`, to allow sending random bytes payload to the fallback function. ([#194](https://github.com/lukso-network/lsp-smart-contracts/pull/194))
+
 * update universalReceiver to latest spec ([#193](https://github.com/lukso-network/lsp-smart-contracts/issues/193)) ([5b2bc60](https://github.com/lukso-network/lsp-smart-contracts/commit/5b2bc601acbf467b132fc38093fdad9a54fdef1c))
-* use custom errors for LSP7/8 CappedSupply contracts ([07ac935](https://github.com/lukso-network/lsp-smart-contracts/commit/07ac935bf336562358930f07d9f86b710cd59d73))
-* use custom version of `ERC165Checker` ([#132](https://github.com/lukso-network/lsp-smart-contracts/issues/132)) ([0e7bbec](https://github.com/lukso-network/lsp-smart-contracts/commit/0e7bbec34a75de9a9ba31db6146e162a800d3406))
 
+* add error signatures in `constants.js`([#191](https://github.com/lukso-network/lsp-smart-contracts/pull/191))
+* add LSP1 Type IDs in `constants.js` ([#196](https://github.com/lukso-network/lsp-smart-contracts/pull/196))
 
-### Bug Fixes
-
-* :bug: incorrect revert error for NotAuthorised(_from, "STATICCALL") ([a2e52ed](https://github.com/lukso-network/lsp-smart-contracts/commit/a2e52ed328c6b6799ded9a1396cde11765e7d784))
-* `isValidSignature` function check ([#120](https://github.com/lukso-network/lsp-smart-contracts/issues/120)) ([2f2762d](https://github.com/lukso-network/lsp-smart-contracts/commit/2f2762da71095009949b1a045730d2ed3c8416b7))
-* add chainId to the signed message in LSP6 ([2fdfb59](https://github.com/lukso-network/lsp-smart-contracts/commit/2fdfb59b9a379bc83191a4bec6a0f315b5f5a5e0))
-* add permissions check when setting keys for `AddressPermissions[]` and `AddressPermissions[index]` ([#125](https://github.com/lukso-network/lsp-smart-contracts/issues/125)) ([18a143c](https://github.com/lukso-network/lsp-smart-contracts/commit/18a143c95086598a887b3df4cc907c18241b39c1))
-* add sender code length check in UniversalReceiverDelegate ([12180a4](https://github.com/lukso-network/lsp-smart-contracts/commit/12180a4612c8e5e1e9303a6efad616f03b61bec8))
-* admin caller with `ALL_PERMISSIONS` can call any functions part of the Universal Profile's ABI ([#128](https://github.com/lukso-network/lsp-smart-contracts/issues/128)) ([ec384d3](https://github.com/lukso-network/lsp-smart-contracts/commit/ec384d3e7869334ec63e4a0c805282b90bd9794a))
-* apply checks-effects-interactions pattern ([77e2c43](https://github.com/lukso-network/lsp-smart-contracts/commit/77e2c43790cdac24bddf1540e09d83446017391f))
-* apply checks-effects-interactions pattern ([#121](https://github.com/lukso-network/lsp-smart-contracts/issues/121)) ([6e0e5b2](https://github.com/lukso-network/lsp-smart-contracts/commit/6e0e5b2a6002cd6cb7af98de8de221d6837181dd))
-* boolean check ([a7be1bd](https://github.com/lukso-network/lsp-smart-contracts/commit/a7be1bd5afd919f5de66a06b3c62784fbeef443f))
-* comments ([69f0e8a](https://github.com/lukso-network/lsp-smart-contracts/commit/69f0e8af001f7625545b8c8aa1782b47ef461663))
-* disable solhint with `no-unused-vars` in LSP1-URD ([ae6dcff](https://github.com/lukso-network/lsp-smart-contracts/commit/ae6dcffdd6404753ed2d81a400b19d9244479874))
-* ERC1271 in export ([db80c69](https://github.com/lukso-network/lsp-smart-contracts/commit/db80c694ae2a3a06ff86b1d68728199ebac9288a))
-* failing test ([1edef46](https://github.com/lukso-network/lsp-smart-contracts/commit/1edef460f5139ac343c6d61d2c3f43fb8137482d))
-* fix OwnableUnset folder location in import statements ([c6702a0](https://github.com/lukso-network/lsp-smart-contracts/commit/c6702a09279e001d32e1cf63f661511cde1e85bc))
-* flip `index` and `interfaceID` in LSP5 & LSP10 ([a926fa7](https://github.com/lukso-network/lsp-smart-contracts/commit/a926fa74590e1256aaaff59667eaad3f5d6ce645))
-* inherit LSP0 contracts from most base to most derive ([bac9f5d](https://github.com/lukso-network/lsp-smart-contracts/commit/bac9f5dbe261de81242a6783ab0119e07557951f))
-* inherit LSP1 contracts from most base to most derive ([1911886](https://github.com/lukso-network/lsp-smart-contracts/commit/1911886d03dbc42683369559aac064319b0ead3e))
-* inherit LSP6 contracts from most base to most derive ([22762e0](https://github.com/lukso-network/lsp-smart-contracts/commit/22762e0874361f4c7bb863b3b4d2209716e2ae30))
-* inherit LSP7 contracts from most base to most derive ([de29a58](https://github.com/lukso-network/lsp-smart-contracts/commit/de29a58fa0a7ed4db83151008a7f82b21777cc27))
-* inherit LSP8 contracts from most base to most derive ([5f05302](https://github.com/lukso-network/lsp-smart-contracts/commit/5f053025f2c1bfb5ce858c0d4bf0d289a5542259))
-* inherit LSP9 contracts from most base to most derive ([b34a049](https://github.com/lukso-network/lsp-smart-contracts/commit/b34a049edf43cfe9f90159082a725c346224a04b))
-* **lsp6:** fix bugs for `AllowedERC725YKeys` when input is multiple keys that include allowed + not allowed keys ([#134](https://github.com/lukso-network/lsp-smart-contracts/issues/134)) ([8f95a79](https://github.com/lukso-network/lsp-smart-contracts/commit/8f95a7959df4047c2421b4fdb34a523fa2f62ae5))
-* move AddressRegistry contract under Legacy/ folder ([3cf8102](https://github.com/lukso-network/lsp-smart-contracts/commit/3cf8102fe5137ba2111c4e2e8ed1fd7eada4c432))
-* override `supportsInterface` in LSP0 ([6415e5f](https://github.com/lukso-network/lsp-smart-contracts/commit/6415e5f25bf2b64d2a30ae08c27ff514211f6f0f))
-* override `supportsInterface` in LSP7 ([3840e6b](https://github.com/lukso-network/lsp-smart-contracts/commit/3840e6ba0983b88530ebef6872a441fb7d07e266))
-* override `supportsInterface` in LSP8 ([57385b5](https://github.com/lukso-network/lsp-smart-contracts/commit/57385b5eb50cb7c53e2e3acee537ce56748fae4e))
-* override `supportsInterface` in LSP9 ([707ba59](https://github.com/lukso-network/lsp-smart-contracts/commit/707ba5983138d90ddf6c9f17489c21fcf7cf5574))
-* prevent editing token name and symbols on LSP4 ([d69b01f](https://github.com/lukso-network/lsp-smart-contracts/commit/d69b01f3aa83014ce90ab6b2c402fa8101e6b252))
-* re-order `executeRelayCall(..)` params and remove `_signedFor` ([7ce3f96](https://github.com/lukso-network/lsp-smart-contracts/commit/7ce3f9632aa0efc45f310cd27ba74a0f5da8120c))
-* reference to Allowed Standards Map key ([e8993e6](https://github.com/lukso-network/lsp-smart-contracts/commit/e8993e6b7bbcbe26d9284f2e4c47305843ebc68b))
-* replace `initOwner` with `_setOwner` function ([5183765](https://github.com/lukso-network/lsp-smart-contracts/commit/5183765f53b1c7432ae7f6dc7bec4cbb276dd86d))
-* resolve merge conflicts in LSP6Core ([2519ee1](https://github.com/lukso-network/lsp-smart-contracts/commit/2519ee1d0ce70911d98afd21c43a475a32cb6218))
-* send the `msg.value` instead of 0 in `executeRelayCall(.)` ([d64855c](https://github.com/lukso-network/lsp-smart-contracts/commit/d64855cb0f22ea199390fb9ced17017dcb8e535c))
-* **tests:** delegatecall tests to a function that does not use onlyOwner ([5a33d4b](https://github.com/lukso-network/lsp-smart-contracts/commit/5a33d4bf0a89a86dd0386c80cedeea3c063dcb8d))
-* update interfaceID for LSP6 ([499ee6a](https://github.com/lukso-network/lsp-smart-contracts/commit/499ee6a73eef210e022c81a0590df8666502c815))
-* use internal `_getData` instead `getDataSingle` ([c7f7bc2](https://github.com/lukso-network/lsp-smart-contracts/commit/c7f7bc27081ced33f2af7228d6345d8131bb00ef))
-* validate values for abi-encoded arrays in KeyManager ([#152](https://github.com/lukso-network/lsp-smart-contracts/issues/152)) ([200ff28](https://github.com/lukso-network/lsp-smart-contracts/commit/200ff2857c8e48a45c7761cf8a490fe094eaf8da))
-
-
-### build
-
-* change name of interface IDs to match with docs ([19e9e54](https://github.com/lukso-network/lsp-smart-contracts/commit/19e9e54a22f0e7f40961b1a0616cac73fd7a56d2))
-
-
-* add owner and transferOwnership in LSP0 / LSP9 interface ID ([d4079a8](https://github.com/lukso-network/lsp-smart-contracts/commit/d4079a87757066585187c0bda949a00c6accc4ee))
-* change LSP0 interface ID by adding ClaimOwnership interface ID ([37173ba](https://github.com/lukso-network/lsp-smart-contracts/commit/37173ba81b27647da9bd7b5000fb10e7932b89b1))
-* change LSP6 interface ID ([8362ecd](https://github.com/lukso-network/lsp-smart-contracts/commit/8362ecd8218c0fe76d5b5f53c528b62be43da7d7))
-* disable delegatecall ([7a66e4f](https://github.com/lukso-network/lsp-smart-contracts/commit/7a66e4f0f1d30163f8f6f3bacb8dabbdd2be0ac0))
-* edit LSP0 + LSP9 interface IDs in constant.ts ([bb8133f](https://github.com/lukso-network/lsp-smart-contracts/commit/bb8133f0684799fa3fcb8feb79fbdb0821039990))
-* edit LSP0 interface ID ([03ae8f4](https://github.com/lukso-network/lsp-smart-contracts/commit/03ae8f447c0c0bf506dafd445c35ef57995dc9f5))
-* edit LSP2 keys according to new spec ([#177](https://github.com/lukso-network/lsp-smart-contracts/issues/177)) ([494c354](https://github.com/lukso-network/lsp-smart-contracts/commit/494c354c9a4813b8ed8e3b09934f669f4a47bd56))
-* edit LSP9 interface ID ([44dbfda](https://github.com/lukso-network/lsp-smart-contracts/commit/44dbfdad4faff6ed91556295c9806a291215450a))
-* remove DELEGATECALL from ALL_PERMISSIONS ([a3bf44c](https://github.com/lukso-network/lsp-smart-contracts/commit/a3bf44c19fd7ca907ba07bdc3f17938c8de7bbda))
-* rename function account() -> target() in LSP1 ([035a0e5](https://github.com/lukso-network/lsp-smart-contracts/commit/035a0e52e63f2412285b43666e5b1d02e49a3d2b))
-* rename function account() -> target() in LSP6 ([1e4949c](https://github.com/lukso-network/lsp-smart-contracts/commit/1e4949cb6e281d5411b70762f0e7b347a9620050))
-* set owner permission in fixture to setup KeyManager ([6999787](https://github.com/lukso-network/lsp-smart-contracts/commit/6999787df38cde2e3dff4b1e307de06df28f5d5a))
 
 ## [0.6.0](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.5.0...v0.6.0) (2022-06-03)
 
 
 ### ⚠ BREAKING CHANGES
 
-* edit LSP2 keys according to new spec (#177)
 * disable delegatecall
 * remove DELEGATECALL from ALL_PERMISSIONS
 * change name of interface IDs to match with docs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukso/lsp-smart-contracts",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The reference implementation for universal profiles smart contracts",
   "directories": {
     "test": "test"


### PR DESCRIPTION
# What does this PR introduce?

- [x] bump `package.json` version from `0.6.0` -> `0.6.1`
- [x] added release to `CHANGELOG.md`