### PR TITLE
fix: use safer code for LSP6 - Key Manager contracts and improve styles

### DIFF
--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -53,7 +53,7 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         return _addressPermission.hasPermission(_permissions);
     }
 
-    function countZeroBytes(bytes32 _key) public pure returns (uint256 zeroBytesCount_) {
-        return super._countZeroBytes(_key);
+    function countTrailingZeroBytes(bytes32 _key) public pure returns (uint256 zeroBytesCount_) {
+        return super._countTrailingZeroBytes(_key);
     }
 }

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -16,19 +16,19 @@ library LSP2Utils {
 
     /* solhint-disable no-inline-assembly */
 
-    function generateBytes32Key(bytes memory _rawKey) internal pure returns (bytes32 key) {
+    function generateBytes32Key(bytes memory rawKey) internal pure returns (bytes32 key) {
         // solhint-disable-next-line
         assembly {
-            key := mload(add(_rawKey, 32))
+            key := mload(add(rawKey, 32))
         }
     }
 
-    function generateSingletonKey(string memory _keyName) internal pure returns (bytes32) {
-        return keccak256(bytes(_keyName));
+    function generateSingletonKey(string memory keyName) internal pure returns (bytes32) {
+        return keccak256(bytes(keyName));
     }
 
-    function generateArrayKey(string memory _keyName) internal pure returns (bytes32) {
-        bytes memory keyName = bytes(_keyName);
+    function generateArrayKey(string memory keyName) internal pure returns (bytes32) {
+        bytes memory keyName = bytes(keyName);
 
         // prettier-ignore
         require(
@@ -40,25 +40,25 @@ library LSP2Utils {
         return keccak256(keyName);
     }
 
-    function generateArrayElementKeyAtIndex(bytes32 _arrayKey, uint256 _index)
+    function generateArrayElementKeyAtIndex(bytes32 arrayKey, uint256 index)
         internal
         pure
         returns (bytes32)
     {
         bytes memory elementInArray = UtilsLib.concatTwoBytes16(
-            bytes16(_arrayKey),
-            bytes16(uint128(_index))
+            bytes16(arrayKey),
+            bytes16(uint128(index))
         );
         return generateBytes32Key(elementInArray);
     }
 
-    function generateMappingKey(string memory _firstWord, string memory _lastWord)
+    function generateMappingKey(string memory firstWord, string memory lastWord)
         internal
         pure
         returns (bytes32)
     {
-        bytes32 firstWordHash = keccak256(bytes(_firstWord));
-        bytes32 lastWordHash = keccak256(bytes(_lastWord));
+        bytes32 firstWordHash = keccak256(bytes(firstWord));
+        bytes32 lastWordHash = keccak256(bytes(lastWord));
 
         bytes memory temporaryBytes = abi.encodePacked(
             bytes10(firstWordHash),
@@ -69,34 +69,34 @@ library LSP2Utils {
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateMappingKey(string memory _firstWord, address _address)
+    function generateMappingKey(string memory firstWord, address _address)
         internal
         pure
         returns (bytes32)
     {
-        bytes32 firstWordHash = keccak256(bytes(_firstWord));
+        bytes32 firstWordHash = keccak256(bytes(firstWord));
 
         bytes memory temporaryBytes = abi.encodePacked(bytes10(firstWordHash), bytes2(0), _address);
 
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateMappingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+    function generateMappingKey(bytes12 keyPrefix, bytes20 bytes20Value)
         internal
         pure
         returns (bytes32)
     {
-        bytes memory generatedKey = bytes.concat(_keyPrefix, _bytes20);
+        bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
         return generateBytes32Key(generatedKey);
     }
 
     function generateMappingWithGroupingKey(
-        string memory _firstWord,
-        string memory _secondWord,
+        string memory firstWord,
+        string memory secondWord,
         address _address
     ) internal pure returns (bytes32) {
-        bytes32 firstWordHash = keccak256(bytes(_firstWord));
-        bytes32 secondWordHash = keccak256(bytes(_secondWord));
+        bytes32 firstWordHash = keccak256(bytes(firstWord));
+        bytes32 secondWordHash = keccak256(bytes(secondWord));
 
         bytes memory temporaryBytes = abi.encodePacked(
             bytes6(firstWordHash),
@@ -108,50 +108,50 @@ library LSP2Utils {
         return generateBytes32Key(temporaryBytes);
     }
 
-    function generateMappingWithGroupingKey(bytes12 _keyPrefix, bytes20 _bytes20)
+    function generateMappingWithGroupingKey(bytes12 keyPrefix, bytes20 bytes20Value)
         internal
         pure
         returns (bytes32)
     {
-        bytes memory generatedKey = bytes.concat(_keyPrefix, _bytes20);
+        bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
         return generateBytes32Key(generatedKey);
     }
 
     function generateJSONURLValue(
-        string memory _hashFunction,
-        string memory _json,
-        string memory _url
-    ) internal pure returns (bytes memory key_) {
-        bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
-        bytes32 jsonDigest = keccak256(bytes(_json));
+        string memory hashFunction,
+        string memory json,
+        string memory url
+    ) internal pure returns (bytes memory key) {
+        bytes32 hashFunctionDigest = keccak256(bytes(hashFunction));
+        bytes32 jsonDigest = keccak256(bytes(json));
 
-        key_ = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, _url);
+        key = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, url);
     }
 
     function generateASSETURLValue(
-        string memory _hashFunction,
-        string memory _assetBytes,
-        string memory _url
-    ) internal pure returns (bytes memory key_) {
-        bytes32 hashFunctionDigest = keccak256(bytes(_hashFunction));
-        bytes32 jsonDigest = keccak256(bytes(_assetBytes));
+        string memory hashFunction,
+        string memory assetBytes,
+        string memory url
+    ) internal pure returns (bytes memory key) {
+        bytes32 hashFunctionDigest = keccak256(bytes(hashFunction));
+        bytes32 jsonDigest = keccak256(bytes(assetBytes));
 
-        key_ = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, _url);
+        key = abi.encodePacked(bytes4(hashFunctionDigest), jsonDigest, url);
     }
 
-    function isEncodedArray(bytes memory _data) internal pure returns (bool) {
-        uint256 nbOfBytes = _data.length;
+    function isEncodedArray(bytes memory data) internal pure returns (bool) {
+        uint256 nbOfBytes = data.length;
 
         // 1) there must be at least 32 bytes to store the offset
         if (nbOfBytes < 32) return false;
 
         // 2) there must be at least the same number of bytes specified by
         // the offset value (otherwise, the offset points to nowhere)
-        uint256 offset = uint256(bytes32(_data));
+        uint256 offset = uint256(bytes32(data));
         if (nbOfBytes < offset) return false;
 
         // 3) there must be at least 32 x length bytes after offset
-        uint256 arrayLength = _data.toUint256(offset);
+        uint256 arrayLength = data.toUint256(offset);
 
         //   32 bytes word (= offset)
         // + 32 bytes word (= array length)
@@ -161,11 +161,11 @@ library LSP2Utils {
         return true;
     }
 
-    function isEncodedArrayOfAddresses(bytes memory _data) internal pure returns (bool) {
-        if (!isEncodedArray(_data)) return false;
+    function isEncodedArrayOfAddresses(bytes memory data) internal pure returns (bool) {
+        if (!isEncodedArray(data)) return false;
 
-        uint256 offset = uint256(bytes32(_data));
-        uint256 arrayLength = _data.toUint256(offset);
+        uint256 offset = uint256(bytes32(data));
+        uint256 arrayLength = data.toUint256(offset);
 
         uint256 pointer = offset + 32;
 
@@ -183,15 +183,15 @@ library LSP2Utils {
         return true;
     }
 
-    function isBytes4EncodedArray(bytes memory _data) internal pure returns (bool) {
-        if (!isEncodedArray(_data)) return false;
+    function isBytes4EncodedArray(bytes memory data) internal pure returns (bool) {
+        if (!isEncodedArray(data)) return false;
 
-        uint256 offset = uint256(bytes32(_data));
-        uint256 arrayLength = _data.toUint256(offset);
+        uint256 offset = uint256(bytes32(data));
+        uint256 arrayLength = data.toUint256(offset);
         uint256 pointer = offset + 32;
 
         for (uint256 ii = 0; ii < arrayLength; ii++) {
-            bytes32 key = _data.toBytes32(pointer);
+            bytes32 key = data.toBytes32(pointer);
 
             // check that the trailing bytes are zero bytes "00"
             if (uint224(uint256(key)) != 0) return false;

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -28,16 +28,16 @@ library LSP2Utils {
     }
 
     function generateArrayKey(string memory keyName) internal pure returns (bytes32) {
-        bytes memory keyName = bytes(keyName);
+        bytes memory dataKey = bytes(keyName);
 
         // prettier-ignore
         require(
-            keyName[keyName.length - 2] == 0x5b && // "[" in utf8 encoded
-                keyName[keyName.length - 1] == 0x5d, // "]" in utf8
+            dataKey[dataKey.length - 2] == 0x5b && // "[" in utf8 encoded
+                dataKey[dataKey.length - 1] == 0x5d, // "]" in utf8
             "Missing empty square brackets \"[]\" at the end of the key name"
         );
 
-        return keccak256(keyName);
+        return keccak256(dataKey);
     }
 
     function generateArrayElementKeyAtIndex(bytes32 arrayKey, uint256 index)
@@ -170,7 +170,7 @@ library LSP2Utils {
         uint256 pointer = offset + 32;
 
         for (uint256 ii = 0; ii < arrayLength; ii++) {
-            bytes32 key = _data.toBytes32(pointer);
+            bytes32 key = data.toBytes32(pointer);
 
             // check that the leading bytes are zero bytes "00"
             // NB: address type is padded on the left (unlike bytes20 type that is padded on the right)

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -16,13 +16,6 @@ library LSP2Utils {
 
     /* solhint-disable no-inline-assembly */
 
-    function generateBytes32Key(bytes memory rawKey) internal pure returns (bytes32 key) {
-        // solhint-disable-next-line
-        assembly {
-            key := mload(add(rawKey, 32))
-        }
-    }
-
     function generateSingletonKey(string memory keyName) internal pure returns (bytes32) {
         return keccak256(bytes(keyName));
     }
@@ -49,7 +42,7 @@ library LSP2Utils {
             bytes16(arrayKey),
             bytes16(uint128(index))
         );
-        return generateBytes32Key(elementInArray);
+        return bytes32(elementInArray);
     }
 
     function generateMappingKey(string memory firstWord, string memory lastWord)
@@ -60,25 +53,25 @@ library LSP2Utils {
         bytes32 firstWordHash = keccak256(bytes(firstWord));
         bytes32 lastWordHash = keccak256(bytes(lastWord));
 
-        bytes memory temporaryBytes = abi.encodePacked(
+        bytes memory temporaryBytes = bytes.concat(
             bytes10(firstWordHash),
             bytes2(0),
             bytes20(lastWordHash)
         );
 
-        return generateBytes32Key(temporaryBytes);
+        return bytes32(temporaryBytes);
     }
 
-    function generateMappingKey(string memory firstWord, address _address)
+    function generateMappingKey(string memory firstWord, address addr)
         internal
         pure
         returns (bytes32)
     {
         bytes32 firstWordHash = keccak256(bytes(firstWord));
 
-        bytes memory temporaryBytes = abi.encodePacked(bytes10(firstWordHash), bytes2(0), _address);
+        bytes memory temporaryBytes = bytes.concat(bytes10(firstWordHash), bytes2(0), bytes20(addr));
 
-        return generateBytes32Key(temporaryBytes);
+        return bytes32(temporaryBytes);
     }
 
     function generateMappingKey(bytes12 keyPrefix, bytes20 bytes20Value)
@@ -87,25 +80,25 @@ library LSP2Utils {
         returns (bytes32)
     {
         bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
-        return generateBytes32Key(generatedKey);
+        return bytes32(generatedKey);
     }
 
     function generateMappingWithGroupingKey(
         string memory firstWord,
         string memory secondWord,
-        address _address
+        address addr
     ) internal pure returns (bytes32) {
         bytes32 firstWordHash = keccak256(bytes(firstWord));
         bytes32 secondWordHash = keccak256(bytes(secondWord));
 
-        bytes memory temporaryBytes = abi.encodePacked(
+        bytes memory temporaryBytes = bytes.concat(
             bytes6(firstWordHash),
             bytes4(secondWordHash),
             bytes2(0),
-            _address
+            bytes20(addr)
         );
 
-        return generateBytes32Key(temporaryBytes);
+        return bytes32(temporaryBytes);
     }
 
     function generateMappingWithGroupingKey(bytes12 keyPrefix, bytes20 bytes20Value)
@@ -114,7 +107,7 @@ library LSP2Utils {
         returns (bytes32)
     {
         bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
-        return generateBytes32Key(generatedKey);
+        return bytes32(generatedKey);
     }
 
     function generateJSONURLValue(

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -11,7 +11,7 @@ interface ILSP6KeyManager is
     IERC1271
     /* is ERC165 */
 {
-    event Executed(uint256 indexed _value, bytes4 _selector);
+    event Executed(uint256 indexed value, bytes4 selector);
 
     /**
      * @notice returns the address of the account linked to this KeyManager
@@ -25,31 +25,31 @@ interface ILSP6KeyManager is
     function target() external view returns (address);
 
     /**
-     * @notice get latest nonce for `_from` for channel ID: `_channel`
+     * @notice get latest nonce for `from` for channel ID: `channelId`
      * @dev use channel ID = 0 for sequential nonces, any other number for out-of-order execution (= execution in parallel)
-     * @param _address caller address
-     * @param _channel channel id
+     * @param from caller address
+     * @param channelId channel id
      */
-    function getNonce(address _address, uint256 _channel) external view returns (uint256);
+    function getNonce(address from, uint256 channelId) external view returns (uint256);
 
     /**
      * @notice execute the following payload on the ERC725Account: `_calldata`
      * @dev the ERC725Account will return some data on successful call, or revert on failure
-     * @param _calldata the payload to execute. Obtained in web3 via encodeABI()
-     * @return result_ the data being returned by the ERC725 Account
+     * @param payload the payload to execute. Obtained in web3 via encodeABI()
+     * @return the data being returned by the ERC725 Account
      */
-    function execute(bytes calldata _calldata) external payable returns (bytes memory);
+    function execute(bytes calldata payload) external payable returns (bytes memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor
-     * @param _signature bytes32 ethereum signature
-     * @param _nonce the address' nonce (in a specific `_channel`), obtained via `getNonce(...)`. Used to prevent replay attack
-     * @param _calldata obtained via encodeABI() in web3
-     * @return result_ the data being returned by the ERC725 Account
+     * @param signature bytes32 ethereum signature
+     * @param nonce the address' nonce (in a specific `_channel`), obtained via `getNonce(...)`. Used to prevent replay attack
+     * @param payload obtained via encodeABI() in web3
+     * @return the data being returned by the ERC725 Account
      */
     function executeRelayCall(
-        bytes memory _signature,
-        uint256 _nonce,
-        bytes calldata _calldata
+        bytes memory signature,
+        uint256 nonce,
+        bytes calldata payload
     ) external payable returns (bytes memory);
 }

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -35,3 +35,9 @@ error NotAllowedFunction(address from, bytes4 disallowedFunction);
  * @param disallowedKey a bytes32 key that `from` is not authorised to set on the ERC725Y storage
  */
 error NotAllowedERC725YKey(address from, bytes32 disallowedKey);
+
+/**
+ * @dev the address provided as a target linked to this KeyManager is invalid
+ *      e.g. address(0)
+ */
+error InvalidLSP6Target();

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -13,10 +13,10 @@ import {InvalidLSP6Target} from "./LSP6Errors.sol";
 contract LSP6KeyManager is LSP6KeyManagerCore {
     /**
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
-     * @param _account The address of the ER725Account to control
+     * @param target_ The address of the ER725Account to control
      */
-    constructor(address _account) {
-        if (_account == address(0)) revert InvalidLSP6Target();
-        target = _account;
+    constructor(address target_) {
+        if (target_ == address(0)) revert InvalidLSP6Target();
+        target = target_;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.6;
 
 // modules
 import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
+import {InvalidLSP6Target} from "./LSP6Errors.sol";
 
 /**
  * @title Implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
@@ -15,6 +16,7 @@ contract LSP6KeyManager is LSP6KeyManagerCore {
      * @param _account The address of the ER725Account to control
      */
     constructor(address _account) {
+        if (_account == address(0)) revert InvalidLSP6Target();
         target = _account;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -49,7 +49,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     using ERC165Checker for address;
 
     address public override target;
-    mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
+    mapping(address => mapping(uint256 => uint256)) internal nonceStore;
 
     /**
      * @dev See {IERC165-supportsInterface}.
@@ -65,7 +65,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @inheritdoc ILSP6KeyManager
      */
     function getNonce(address from, uint256 channelId) external view override returns (uint256) {
-        uint128 nonceId = uint128(_nonceStore[from][channelId]);
+        uint128 nonceId = uint128(nonceStore[from][channelId]);
         return (uint256(channelId) << 128) | nonceId;
     }
 
@@ -126,7 +126,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         require(_isValidNonce(signer, nonce), "executeRelayCall: Invalid nonce");
 
         // increase nonce after successful verification
-        _nonceStore[signer][nonce >> 128]++;
+        nonceStore[signer][nonce >> 128]++;
 
         _verifyPermissions(signer, payload);
 
@@ -154,8 +154,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     function _isValidNonce(address from, uint256 idx) internal view returns (bool) {
         // idx % (1 << 128) = nonce
         // (idx >> 128) = channel
-        // equivalent to: return (nonce == _nonceStore[_from][channel]
-        return (idx % (1 << 128)) == (_nonceStore[from][idx >> 128]);
+        // equivalent to: return (nonce == nonceStore[_from][channel]
+        return (idx % (1 << 128)) == (nonceStore[from][idx >> 128]);
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -49,7 +49,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     using ERC165Checker for address;
 
     address public override target;
-    mapping(address => mapping(uint256 => uint256)) internal nonceStore;
+    mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
 
     /**
      * @dev See {IERC165-supportsInterface}.
@@ -65,7 +65,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @inheritdoc ILSP6KeyManager
      */
     function getNonce(address from, uint256 channelId) external view override returns (uint256) {
-        uint128 nonceId = uint128(nonceStore[from][channelId]);
+        uint128 nonceId = uint128(_nonceStore[from][channelId]);
         return (uint256(channelId) << 128) | nonceId;
     }
 
@@ -126,7 +126,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         require(_isValidNonce(signer, nonce), "executeRelayCall: Invalid nonce");
 
         // increase nonce after successful verification
-        nonceStore[signer][nonce >> 128]++;
+        _nonceStore[signer][nonce >> 128]++;
 
         _verifyPermissions(signer, payload);
 
@@ -154,8 +154,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     function _isValidNonce(address from, uint256 idx) internal view returns (bool) {
         // idx % (1 << 128) = nonce
         // (idx >> 128) = channel
-        // equivalent to: return (nonce == nonceStore[_from][channel]
-        return (idx % (1 << 128)) == (nonceStore[from][idx >> 128]);
+        // equivalent to: return (nonce == _nonceStore[_from][channel]
+        return (idx % (1 << 128)) == (_nonceStore[from][idx >> 128]);
     }
 
     /**
@@ -413,12 +413,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                 // and compare only the relevant parts of each ERC725Y keys
                 //
                 // for an allowed key = 0xcafecafecafecafecafecafecafecafe00000000000000000000000000000000
-                //               
+                //
                 //                        |------compare this part-------|------discard this part--------|
                 //                        v                              v                               v
                 //               mask = 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
                 //        & input key = 0xcafecafecafecafecafecafecafecafe00000000000000000000000011223344
-                //                        
+                //
                 mask = bytes32(type(uint256).max) << (8 * zeroBytesCount);
 
                 if (allowedERC725YKeys[ii] == (inputKeys[jj] & mask)) {

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -186,10 +186,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             } else {
 
-                bytes32[] memory inputKeys = new bytes32[](1);
-                inputKeys[0] = inputKey;
+                bytes32[] memory wrappedInputKey = new bytes32[](1);
+                wrappedInputKey[0] = inputKey;
 
-                _verifyCanSetData(from, permissions, inputKeys);
+                _verifyCanSetData(from, permissions, wrappedInputKey);
             }
 
         } else if (erc725Function == setDataMultipleSelector) {

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -64,7 +64,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address from, uint256 channelId) public view override returns (uint256) {
+    function getNonce(address from, uint256 channelId) external view override returns (uint256) {
         uint128 nonceId = uint128(_nonceStore[from][channelId]);
         return (uint256(channelId) << 128) | nonceId;
     }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -64,21 +64,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address _from, uint256 _channel) public view override returns (uint256) {
-        uint128 nonceId = uint128(_nonceStore[_from][_channel]);
-        return (uint256(_channel) << 128) | nonceId;
+    function getNonce(address from, uint256 channelId) public view override returns (uint256) {
+        uint128 nonceId = uint128(_nonceStore[from][channelId]);
+        return (uint256(channelId) << 128) | nonceId;
     }
 
     /**
      * @inheritdoc IERC1271
      */
-    function isValidSignature(bytes32 _hash, bytes memory _signature)
+    function isValidSignature(bytes32 dataHash, bytes memory signature)
         public
         view
         override
         returns (bytes4 magicValue)
     {
-        address recoveredAddress = _hash.recover(_signature);
+        address recoveredAddress = dataHash.recover(signature);
 
         return (
             ERC725Y(target).getPermissionsFor(recoveredAddress).hasPermission(_PERMISSION_SIGN)
@@ -90,19 +90,19 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function execute(bytes calldata _calldata) external payable override returns (bytes memory) {
-        _verifyPermissions(msg.sender, _calldata);
+    function execute(bytes calldata payload) external payable override returns (bytes memory) {
+        _verifyPermissions(msg.sender, payload);
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory result) = target.call{value: msg.value, gas: gasleft()}(
-            _calldata
+            payload
         );
 
         if (!success) {
             ErrorHandlerLib.revertWithParsedError(result);
         }
 
-        emit Executed(msg.value, bytes4(_calldata));
+        emit Executed(msg.value, bytes4(payload));
         return result.length != 0 ? abi.decode(result, (bytes)) : result;
     }
 
@@ -110,36 +110,36 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @inheritdoc ILSP6KeyManager
      */
     function executeRelayCall(
-        bytes memory _signature,
-        uint256 _nonce,
-        bytes calldata _calldata
+        bytes memory signature,
+        uint256 nonce,
+        bytes calldata payload
     ) external payable override returns (bytes memory) {
         bytes memory blob = abi.encodePacked(
             block.chainid,
             address(this), // needs to be signed for this keyManager
-            _nonce,
-            _calldata
+            nonce,
+            payload
         );
 
-        address signer = keccak256(blob).toEthSignedMessageHash().recover(_signature);
+        address signer = keccak256(blob).toEthSignedMessageHash().recover(signature);
 
-        require(_isValidNonce(signer, _nonce), "executeRelayCall: Invalid nonce");
+        require(_isValidNonce(signer, nonce), "executeRelayCall: Invalid nonce");
 
         // increase nonce after successful verification
-        _nonceStore[signer][_nonce >> 128]++;
+        _nonceStore[signer][nonce >> 128]++;
 
-        _verifyPermissions(signer, _calldata);
+        _verifyPermissions(signer, payload);
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory result) = target.call{value: msg.value, gas: gasleft()}(
-            _calldata
+            payload
         );
 
         if (!success) {
             ErrorHandlerLib.revertWithParsedError(result);
         }
 
-        emit Executed(msg.value, bytes4(_calldata));
+        emit Executed(msg.value, bytes4(payload));
         return result.length != 0 ? abi.decode(result, (bytes)) : result;
     }
 
@@ -148,33 +148,33 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @dev "idx" is a 256bits (unsigned) integer, where:
      *          - the 128 leftmost bits = channelId
      *      and - the 128 rightmost bits = nonce within the channel
-     * @param _from caller address
-     * @param _idx (channel id + nonce within the channel)
+     * @param from caller address
+     * @param idx (channel id + nonce within the channel)
      */
-    function _isValidNonce(address _from, uint256 _idx) internal view returns (bool) {
+    function _isValidNonce(address from, uint256 idx) internal view returns (bool) {
         // idx % (1 << 128) = nonce
         // (idx >> 128) = channel
         // equivalent to: return (nonce == _nonceStore[_from][channel]
-        return (_idx % (1 << 128)) == (_nonceStore[_from][_idx >> 128]);
+        return (idx % (1 << 128)) == (_nonceStore[from][idx >> 128]);
     }
 
     /**
      * @dev verify the permissions of the _from address that want to interact with the `target`
-     * @param _from the address making the request
-     * @param _calldata the payload that will be run on `target`
+     * @param from the address making the request
+     * @param payload the payload that will be run on `target`
      */
-    function _verifyPermissions(address _from, bytes calldata _calldata) internal view {
-        bytes4 erc725Function = bytes4(_calldata[:4]);
+    function _verifyPermissions(address from, bytes calldata payload) internal view {
+        bytes4 erc725Function = bytes4(payload[:4]);
 
         // get the permissions of the caller
-        bytes32 permissions = ERC725Y(target).getPermissionsFor(_from);
+        bytes32 permissions = ERC725Y(target).getPermissionsFor(from);
 
-        if (permissions == bytes32(0)) revert NoPermissionsSet(_from);
+        if (permissions == bytes32(0)) revert NoPermissionsSet(from);
 
         // prettier-ignore
         if (erc725Function == setDataSingleSelector) {
 
-            (bytes32 inputKey, bytes memory inputValue) = abi.decode(_calldata[4:], (bytes32, bytes));
+            (bytes32 inputKey, bytes memory inputValue) = abi.decode(payload[4:], (bytes32, bytes));
 
             if (
                 // CHECK for permission keys
@@ -182,19 +182,19 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                 bytes16(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
             ) {
 
-                _verifyCanSetPermissions(inputKey, inputValue, _from, permissions);
+                _verifyCanSetPermissions(inputKey, inputValue, from, permissions);
 
             } else {
 
                 bytes32[] memory inputKeys = new bytes32[](1);
                 inputKeys[0] = inputKey;
 
-                _verifyCanSetData(_from, permissions, inputKeys);
+                _verifyCanSetData(from, permissions, inputKeys);
             }
 
         } else if (erc725Function == setDataMultipleSelector) {
 
-            (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(_calldata[4:], (bytes32[], bytes[]));
+            (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(payload[4:], (bytes32[], bytes[]));
 
             bool isSettingERC725YKeys = false;
             
@@ -208,7 +208,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                     bytes6(key) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
                     bytes16(key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
                 ) {
-                    _verifyCanSetPermissions(key, value, _from, permissions);
+                    _verifyCanSetPermissions(key, value, from, permissions);
 
                     // "nullify" permission keys
                     // to not check them against allowed ERC725Y keys
@@ -221,19 +221,19 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
 
             if (isSettingERC725YKeys) {
-                _verifyCanSetData(_from, permissions, inputKeys);
+                _verifyCanSetData(from, permissions, inputKeys);
             }
 
         } else if (erc725Function == IERC725X.execute.selector) {
             
-            _verifyCanExecute(_from, permissions, _calldata);
+            _verifyCanExecute(from, permissions, payload);
 
         } else if (
             erc725Function == OwnableUnset.transferOwnership.selector ||
             erc725Function == IClaimOwnership.claimOwnership.selector
         ) {
 
-            _requirePermissions(_from, permissions, _PERMISSION_CHANGEOWNER);
+            _requirePermissions(from, permissions, _PERMISSION_CHANGEOWNER);
     
         } else {
             revert("_verifyPermissions: invalid ERC725 selector");
@@ -243,107 +243,107 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @dev verify if `_from` has the required permissions to set some keys
      * on the linked ERC725Account
-     * @param _from the address who want to set the keys
-     * @param _permissions the permissions
-     * @param _inputKeys the data keys being set
+     * @param from the address who want to set the keys
+     * @param permissions the permissions
+     * @param inputKeys the data keys being set
      * containing a list of keys-value pairs
      */
     function _verifyCanSetData(
-        address _from,
-        bytes32 _permissions,
-        bytes32[] memory _inputKeys
+        address from,
+        bytes32 permissions,
+        bytes32[] memory inputKeys
     ) internal view {
         // Skip if caller has SUPER permissions
-        if (_permissions.hasPermission(_PERMISSION_SUPER_SETDATA)) return;
+        if (permissions.hasPermission(_PERMISSION_SUPER_SETDATA)) return;
 
-        _requirePermissions(_from, _permissions, _PERMISSION_SETDATA);
+        _requirePermissions(from, permissions, _PERMISSION_SETDATA);
 
-        _verifyAllowedERC725YKeys(_from, _inputKeys);
+        _verifyAllowedERC725YKeys(from, inputKeys);
     }
 
     function _verifyCanSetPermissions(
-        bytes32 _key,
-        bytes memory _value,
-        address _from,
-        bytes32 _permissions
+        bytes32 key,
+        bytes memory value,
+        address from,
+        bytes32 permissions
     ) internal view {
         // prettier-ignore
-        if (bytes12(_key) == _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX) {
+        if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX) {
             
             // key = AddressPermissions:Permissions:<address>
-            _verifyCanSetBytes32Permissions(_key, _from, _permissions);
+            _verifyCanSetBytes32Permissions(key, from, permissions);
         
-        } else if (_key == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY) {
+        } else if (key == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY) {
 
             // key = AddressPermissions[]
-            _verifyCanSetPermissionsArray(_key, _value, _from, _permissions);
+            _verifyCanSetPermissionsArray(key, value, from, permissions);
         
-        } else if (bytes16(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX) {
+        } else if (bytes16(key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX) {
 
             // key = AddressPermissions[index]
-            _requirePermissions(_from, _permissions, _PERMISSION_CHANGEPERMISSIONS);
+            _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
 
-        } else if (bytes12(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX) {
+        } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX) {
 
             // AddressPermissions:AllowedAddresses:<address>
             require(
-                LSP2Utils.isEncodedArrayOfAddresses(_value),
+                LSP2Utils.isEncodedArrayOfAddresses(value),
                 "LSP6KeyManager: invalid ABI encoded array of addresses"
             );
 
-            bytes memory storedAllowedAddresses = ERC725Y(target).getData(_key);
+            bytes memory storedAllowedAddresses = ERC725Y(target).getData(key);
 
             if (storedAllowedAddresses.length == 0) {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_ADDPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
 
             } else {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_CHANGEPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
 
             }
 
         } else if (
-            bytes12(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX ||
-            bytes12(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX
+            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX ||
+            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX
         ) {
 
             // AddressPermissions:AllowedFunctions:<address>
             // AddressPermissions:AllowedStandards:<address>
             require(
-                LSP2Utils.isBytes4EncodedArray(_value),
+                LSP2Utils.isBytes4EncodedArray(value),
                 "LSP6KeyManager: invalid ABI encoded array of bytes4"
             );
 
-            bytes memory storedAllowedBytes4 = ERC725Y(target).getData(_key);
+            bytes memory storedAllowedBytes4 = ERC725Y(target).getData(key);
 
             if (storedAllowedBytes4.length == 0) {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_ADDPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
 
             } else {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_CHANGEPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
 
             }
 
-        } else if (bytes12(_key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX) {
+        } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX) {
 
             // AddressPermissions:AllowedERC725YKeys:<address>
             require(
-                LSP2Utils.isEncodedArray(_value),
+                LSP2Utils.isEncodedArray(value),
                 "LSP6KeyManager: invalid ABI encoded array of bytes32"
             );
 
-            bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(_key);
+            bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(key);
 
             if (storedAllowedERC725YKeys.length == 0) {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_ADDPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
 
             } else {
 
-                _requirePermissions(_from, _permissions, _PERMISSION_CHANGEPERMISSIONS);
+                _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
 
             }
 
@@ -351,40 +351,40 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     function _verifyCanSetBytes32Permissions(
-        bytes32 _key,
-        address _from,
-        bytes32 _callerPermissions
+        bytes32 key,
+        address from,
+        bytes32 callerPermissions
     ) internal view {
-        if (bytes32(ERC725Y(target).getData(_key)) == bytes32(0)) {
+        if (bytes32(ERC725Y(target).getData(key)) == bytes32(0)) {
             // if there is nothing stored under this data key,
             // we are trying to ADD permissions for a NEW address
-            _requirePermissions(_from, _callerPermissions, _PERMISSION_ADDPERMISSIONS);
+            _requirePermissions(from, callerPermissions, _PERMISSION_ADDPERMISSIONS);
         } else {
             // if there are already some permissions stored under this data key,
             // we are trying to CHANGE the permissions of an address
             // (that has already some EXISTING permissions set)
-            _requirePermissions(_from, _callerPermissions, _PERMISSION_CHANGEPERMISSIONS);
+            _requirePermissions(from, callerPermissions, _PERMISSION_CHANGEPERMISSIONS);
         }
     }
 
     function _verifyCanSetPermissionsArray(
-        bytes32 _key,
-        bytes memory _value,
-        address _from,
-        bytes32 _permissions
+        bytes32 key,
+        bytes memory value,
+        address from,
+        bytes32 permissions
     ) internal view {
-        uint256 arrayLength = uint256(bytes32(ERC725Y(target).getData(_key)));
-        uint256 newLength = uint256(bytes32(_value));
+        uint256 arrayLength = uint256(bytes32(ERC725Y(target).getData(key)));
+        uint256 newLength = uint256(bytes32(value));
 
         if (newLength > arrayLength) {
-            _requirePermissions(_from, _permissions, _PERMISSION_ADDPERMISSIONS);
+            _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
         } else {
-            _requirePermissions(_from, _permissions, _PERMISSION_CHANGEPERMISSIONS);
+            _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
         }
     }
 
-    function _verifyAllowedERC725YKeys(address _from, bytes32[] memory _inputKeys) internal view {
-        bytes memory allowedERC725YKeysEncoded = ERC725Y(target).getAllowedERC725YKeysFor(_from);
+    function _verifyAllowedERC725YKeys(address from, bytes32[] memory inputKeys) internal view {
+        bytes memory allowedERC725YKeysEncoded = ERC725Y(target).getAllowedERC725YKeysFor(from);
 
         // whitelist any ERC725Y key
         if (
@@ -402,12 +402,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         // loop through each allowed ERC725Y key retrieved from storage
         for (uint256 ii = 0; ii < allowedERC725YKeys.length; ii++) {
             // required to know which part of the input key to compare against the allowed key
-            zeroBytesCount = _countZeroBytes(allowedERC725YKeys[ii]);
+            zeroBytesCount = _countTrailingZeroBytes(allowedERC725YKeys[ii]);
 
             // loop through each keys given as input
-            for (uint256 jj = 0; jj < _inputKeys.length; jj++) {
+            for (uint256 jj = 0; jj < inputKeys.length; jj++) {
                 // skip permissions keys that have been previously "nulled"
-                if (_inputKeys[jj] == bytes32(0)) continue;
+                if (inputKeys[jj] == bytes32(0)) continue;
 
                 // solhint-disable no-inline-assembly
                 assembly {
@@ -432,32 +432,32 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                     mask := shl(mul(8, zeroBytesCount), 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
                 }
 
-                if (allowedERC725YKeys[ii] == (_inputKeys[jj] & mask)) {
+                if (allowedERC725YKeys[ii] == (inputKeys[jj] & mask)) {
                     // if the input key matches the allowed key
                     // make it null to mark it as allowed
-                    _inputKeys[jj] = bytes32(0);
+                    inputKeys[jj] = bytes32(0);
                 }
             }
         }
 
-        for (uint256 ii = 0; ii < _inputKeys.length; ii++) {
-            if (_inputKeys[ii] != bytes32(0)) revert NotAllowedERC725YKey(_from, _inputKeys[ii]);
+        for (uint256 ii = 0; ii < inputKeys.length; ii++) {
+            if (inputKeys[ii] != bytes32(0)) revert NotAllowedERC725YKey(from, inputKeys[ii]);
         }
     }
 
     /**
-     * @dev verify if `_from` has the required permissions to make an external call
+     * @dev verify if `from` has the required permissions to make an external call
      * via the linked ERC725Account
-     * @param _from the address who want to run the execute function on the ERC725Account
-     * @param _permissions the permissions of the caller
-     * @param _calldata the ABI encoded payload `target.execute(...)`
+     * @param from the address who want to run the execute function on the ERC725Account
+     * @param permissions the permissions of the caller
+     * @param payload the ABI encoded payload `target.execute(...)`
      */
     function _verifyCanExecute(
-        address _from,
-        bytes32 _permissions,
-        bytes calldata _calldata
+        address from,
+        bytes32 permissions,
+        bytes calldata payload
     ) internal view {
-        uint256 operationType = uint256(bytes32(_calldata[4:36]));
+        uint256 operationType = uint256(bytes32(payload[4:36]));
         require(operationType < 5, "LSP6KeyManager: invalid operation type");
 
         // TODO: if re-enable delegatecall, add check to ensure owner() + initialized() are not overriden after delegatecall
@@ -466,27 +466,27 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
         );
 
-        uint256 value = uint256(bytes32(_calldata[68:100]));
+        uint256 value = uint256(bytes32(payload[68:100]));
 
         // prettier-ignore
         bool isContractCreation = operationType == OPERATION_CREATE || operationType == OPERATION_CREATE2;
-        bool isCallDataPresent = _calldata.length > 164;
+        bool isCallDataPresent = payload.length > 164;
 
         // SUPER operation only applies to contract call, not contract creation
         bool hasSuperOperation = isContractCreation
             ? false
-            : _permissions.hasPermission(_extractSuperPermissionFromOperation(operationType));
+            : permissions.hasPermission(_extractSuperPermissionFromOperation(operationType));
 
         if (isCallDataPresent) {
             // prettier-ignore
-            hasSuperOperation || _requirePermissions(_from, _permissions, _extractPermissionFromOperation(operationType));
+            hasSuperOperation || _requirePermissions(from, permissions, _extractPermissionFromOperation(operationType));
         }
 
-        bool hasSuperTransferValue = _permissions.hasPermission(_PERMISSION_SUPER_TRANSFERVALUE);
+        bool hasSuperTransferValue = permissions.hasPermission(_PERMISSION_SUPER_TRANSFERVALUE);
 
         if (value > 0) {
             // prettier-ignore
-            hasSuperTransferValue || _requirePermissions(_from, _permissions, _PERMISSION_TRANSFERVALUE);
+            hasSuperTransferValue || _requirePermissions(from, permissions, _PERMISSION_TRANSFERVALUE);
         }
 
         // Skip on contract creation (CREATE or CREATE2)
@@ -502,54 +502,54 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         if (hasSuperOperation && hasSuperTransferValue) return;
 
         // CHECK for ALLOWED ADDRESSES
-        address to = address(bytes20(_calldata[48:68]));
-        _verifyAllowedAddress(_from, to);
+        address to = address(bytes20(payload[48:68]));
+        _verifyAllowedAddress(from, to);
 
         if (to.code.length > 0) {
             // CHECK for ALLOWED STANDARDS
-            _verifyAllowedStandard(_from, to);
+            _verifyAllowedStandard(from, to);
 
             // CHECK for ALLOWED FUNCTIONS
             // extract bytes4 function selector from payload passed to ERC725X.execute(...)
-            if (_calldata.length >= 168) _verifyAllowedFunction(_from, bytes4(_calldata[164:168]));
+            if (payload.length >= 168) _verifyAllowedFunction(from, bytes4(payload[164:168]));
         }
     }
 
     /**
      * @dev extract the required permission + a descriptive string, based on the `_operationType`
      * being run via ERC725Account.execute(...)
-     * @param _operationType 0 = CALL, 1 = CREATE, 2 = CREATE2, etc... See ERC725X docs for more infos.
-     * @return permissionsRequired_ (bytes32) the permission associated with the `_operationType`
+     * @param operationType 0 = CALL, 1 = CREATE, 2 = CREATE2, etc... See ERC725X docs for more infos.
+     * @return permissionsRequired (bytes32) the permission associated with the `_operationType`
      */
-    function _extractPermissionFromOperation(uint256 _operationType)
+    function _extractPermissionFromOperation(uint256 operationType)
         internal
         pure
-        returns (bytes32 permissionsRequired_)
+        returns (bytes32 permissionsRequired)
     {
-        if (_operationType == OPERATION_CALL) return _PERMISSION_CALL;
-        else if (_operationType == OPERATION_CREATE) return _PERMISSION_DEPLOY;
-        else if (_operationType == OPERATION_CREATE2) return _PERMISSION_DEPLOY;
-        else if (_operationType == OPERATION_STATICCALL) return _PERMISSION_STATICCALL;
-        else if (_operationType == OPERATION_DELEGATECALL) return _PERMISSION_DELEGATECALL;
+        if (operationType == OPERATION_CALL) return _PERMISSION_CALL;
+        else if (operationType == OPERATION_CREATE) return _PERMISSION_DEPLOY;
+        else if (operationType == OPERATION_CREATE2) return _PERMISSION_DEPLOY;
+        else if (operationType == OPERATION_STATICCALL) return _PERMISSION_STATICCALL;
+        else if (operationType == OPERATION_DELEGATECALL) return _PERMISSION_DELEGATECALL;
     }
 
-    function _extractSuperPermissionFromOperation(uint256 _operationType)
+    function _extractSuperPermissionFromOperation(uint256 operationType)
         internal
         pure
-        returns (bytes32 superPermission_)
+        returns (bytes32 superPermission)
     {
-        if (_operationType == OPERATION_CALL) return _PERMISSION_SUPER_CALL;
-        else if (_operationType == OPERATION_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
-        else if (_operationType == OPERATION_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
+        if (operationType == OPERATION_CALL) return _PERMISSION_SUPER_CALL;
+        else if (operationType == OPERATION_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
+        else if (operationType == OPERATION_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
     }
 
     /**
-     * @dev verify if `_from` is authorised to interact with address `_to` via the linked ERC725Account
-     * @param _from the caller address
-     * @param _to the address to interact with
+     * @dev verify if `from` is authorised to interact with address `to` via the linked ERC725Account
+     * @param from the caller address
+     * @param to the address to interact with
      */
-    function _verifyAllowedAddress(address _from, address _to) internal view {
-        bytes memory allowedAddresses = ERC725Y(target).getAllowedAddressesFor(_from);
+    function _verifyAllowedAddress(address from, address to) internal view {
+        bytes memory allowedAddresses = ERC725Y(target).getAllowedAddressesFor(from);
 
         // whitelist any address
         if (
@@ -562,19 +562,19 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         address[] memory allowedAddressesList = abi.decode(allowedAddresses, (address[]));
 
         for (uint256 ii = 0; ii < allowedAddressesList.length; ii++) {
-            if (_to == allowedAddressesList[ii]) return;
+            if (to == allowedAddressesList[ii]) return;
         }
-        revert NotAllowedAddress(_from, _to);
+        revert NotAllowedAddress(from, to);
     }
 
     /**
-     * @dev if `_from` is restricted to interact with contracts that implement a specific interface,
-     * verify that `_to` implements one of these interface.
-     * @param _from the caller address
-     * @param _to the address of the contract to interact with
+     * @dev if `from` is restricted to interact with contracts that implement a specific interface,
+     * verify that `to` implements one of these interface.
+     * @param from the caller address
+     * @param to the address of the contract to interact with
      */
-    function _verifyAllowedStandard(address _from, address _to) internal view {
-        bytes memory allowedStandards = ERC725Y(target).getAllowedStandardsFor(_from);
+    function _verifyAllowedStandard(address from, address to) internal view {
+        bytes memory allowedStandards = ERC725Y(target).getAllowedStandardsFor(from);
 
         // whitelist any standard interface (ERC165)
         if (
@@ -587,20 +587,20 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes4[] memory allowedStandardsList = abi.decode(allowedStandards, (bytes4[]));
 
         for (uint256 ii = 0; ii < allowedStandardsList.length; ii++) {
-            if (_to.supportsERC165Interface(allowedStandardsList[ii])) return;
+            if (to.supportsERC165Interface(allowedStandardsList[ii])) return;
         }
         revert("Not Allowed Standards");
     }
 
     /**
-     * @dev verify if `_from` is authorised to use the linked ERC725Account
-     * to run a specific function `_functionSelector` at a target contract
-     * @param _from the caller address
-     * @param _functionSelector the bytes4 function selector of the function to run
+     * @dev verify if `from` is authorised to use the linked ERC725Account
+     * to run a specific function `functionSelector` at a target contract
+     * @param from the caller address
+     * @param functionSelector the bytes4 function selector of the function to run
      * at the target contract
      */
-    function _verifyAllowedFunction(address _from, bytes4 _functionSelector) internal view {
-        bytes memory allowedFunctions = ERC725Y(target).getAllowedFunctionsFor(_from);
+    function _verifyAllowedFunction(address from, bytes4 functionSelector) internal view {
+        bytes memory allowedFunctions = ERC725Y(target).getAllowedFunctionsFor(from);
 
         // whitelist any function
         if (
@@ -613,47 +613,47 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes4[] memory allowedFunctionsList = abi.decode(allowedFunctions, (bytes4[]));
 
         for (uint256 ii = 0; ii < allowedFunctionsList.length; ii++) {
-            if (_functionSelector == allowedFunctionsList[ii]) return;
+            if (functionSelector == allowedFunctionsList[ii]) return;
         }
-        revert NotAllowedFunction(_from, _functionSelector);
+        revert NotAllowedFunction(from, functionSelector);
     }
 
-    function _countZeroBytes(bytes32 _key) internal pure returns (uint256) {
+    function _countTrailingZeroBytes(bytes32 key) internal pure returns (uint256) {
         uint256 index = 31;
 
         // CHECK each bytes of the key, starting from the end (right to left)
-        // skip the empty bytes `0x00` to find the first non-empty bytes
-        while (_key[index] == 0x00) index--;
+        // skip each empty bytes `0x00` to find the first non-empty byte
+        while (key[index] == 0x00) index--;
 
         return 32 - (index + 1);
     }
 
     function _requirePermissions(
-        address _from,
-        bytes32 _addressPermissions,
-        bytes32 _permissionRequired
+        address from,
+        bytes32 addressPermissions,
+        bytes32 permissionRequired
     ) internal pure returns (bool) {
-        if (!_addressPermissions.hasPermission(_permissionRequired)) {
-            string memory permissionErrorString = _getPermissionErrorString(_permissionRequired);
-            revert NotAuthorised(_from, permissionErrorString);
+        if (!addressPermissions.hasPermission(permissionRequired)) {
+            string memory permissionErrorString = _getPermissionErrorString(permissionRequired);
+            revert NotAuthorised(from, permissionErrorString);
         }
     }
 
-    function _getPermissionErrorString(bytes32 _permission)
+    function _getPermissionErrorString(bytes32 permission)
         internal
         pure
         returns (string memory errorMessage)
     {
-        if (_permission == _PERMISSION_CHANGEOWNER) return "TRANSFEROWNERSHIP";
-        if (_permission == _PERMISSION_CHANGEPERMISSIONS) return "CHANGEPERMISSIONS";
-        if (_permission == _PERMISSION_ADDPERMISSIONS) return "ADDPERMISSIONS";
-        if (_permission == _PERMISSION_SETDATA) return "SETDATA";
-        if (_permission == _PERMISSION_CALL) return "CALL";
-        if (_permission == _PERMISSION_STATICCALL) return "STATICCALL";
-        if (_permission == _PERMISSION_DELEGATECALL) return "DELEGATECALL";
+        if (permission == _PERMISSION_CHANGEOWNER) return "TRANSFEROWNERSHIP";
+        if (permission == _PERMISSION_CHANGEPERMISSIONS) return "CHANGEPERMISSIONS";
+        if (permission == _PERMISSION_ADDPERMISSIONS) return "ADDPERMISSIONS";
+        if (permission == _PERMISSION_SETDATA) return "SETDATA";
+        if (permission == _PERMISSION_CALL) return "CALL";
+        if (permission == _PERMISSION_STATICCALL) return "STATICCALL";
+        if (permission == _PERMISSION_DELEGATECALL) return "DELEGATECALL";
         // TODO: add support to display CREATE or CREATE2 in the revert error
-        if (_permission == _PERMISSION_DEPLOY) return "DEPLOY";
-        if (_permission == _PERMISSION_TRANSFERVALUE) return "TRANSFERVALUE";
-        if (_permission == _PERMISSION_SIGN) return "SIGN";
+        if (permission == _PERMISSION_DEPLOY) return "DEPLOY";
+        if (permission == _PERMISSION_TRANSFERVALUE) return "TRANSFERVALUE";
+        if (permission == _PERMISSION_SIGN) return "SIGN";
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -14,7 +14,7 @@ contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
      * @param _account The address of the ER725Account to control
      */
-    function initialize(address _account) public virtual initializer {
+    function initialize(address _account) external virtual initializer {
         LSP6KeyManagerInitAbstract._initialize(_account);
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -12,9 +12,9 @@ import {LSP6KeyManagerInitAbstract} from "./LSP6KeyManagerInitAbstract.sol";
 contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
     /**
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
-     * @param _account The address of the ER725Account to control
+     * @param target_ The address of the ER725Account to control
      */
-    function initialize(address _account) external virtual initializer {
-        LSP6KeyManagerInitAbstract._initialize(_account);
+    function initialize(address target_) external virtual initializer {
+        LSP6KeyManagerInitAbstract._initialize(target_);
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -13,8 +13,8 @@ import {InvalidLSP6Target} from "./LSP6Errors.sol";
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
 abstract contract LSP6KeyManagerInitAbstract is Initializable, LSP6KeyManagerCore {
-    function _initialize(address _account) internal virtual onlyInitializing {
-        if (_account == address(0)) revert InvalidLSP6Target();
-        target = _account;
+    function _initialize(address target_) internal virtual onlyInitializing {
+        if (target_ == address(0)) revert InvalidLSP6Target();
+        target = target_;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.6;
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
+import {InvalidLSP6Target} from "./LSP6Errors.sol";
 
 /**
  * @title Proxy implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
@@ -13,6 +14,7 @@ import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
  */
 abstract contract LSP6KeyManagerInitAbstract is Initializable, LSP6KeyManagerCore {
     function _initialize(address _account) internal virtual onlyInitializing {
+        if (_account == address(0)) revert InvalidLSP6Target();
         target = _account;
     }
 }

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -82,11 +82,11 @@ library LSP6Utils {
     }
 
     /**
-     * @dev compare the permissions `_addressPermissions` of an address
-     *      to check if they includes the permissions `_permissionToCheck`
-     * @param _addressPermission the permissions of an address stored on an ERC725 account
-     * @param _permissionToCheck the permissions to check
-     * @return true if `_addressPermissions` includes `_permissionToCheck`, false otherwise
+     * @dev compare the permissions `addressPermissions` of an address
+     *      to check if they includes the permissions `permissionToCheck`
+     * @param addressPermission the permissions of an address stored on an ERC725 account
+     * @param permissionToCheck the permissions to check
+     * @return true if `addressPermissions` includes `permissionToCheck`, false otherwise
      */
     function hasPermission(bytes32 addressPermission, bytes32 permissionToCheck)
         internal

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -14,69 +14,69 @@ import "../LSP6KeyManager/LSP6Constants.sol";
 library LSP6Utils {
     using LSP2Utils for bytes12;
 
-    function getPermissionsFor(IERC725Y account, address _address) internal view returns (bytes32) {
-        bytes memory permissions = account.getData(
+    function getPermissionsFor(IERC725Y target, address caller) internal view returns (bytes32) {
+        bytes memory permissions = target.getData(
             LSP2Utils.generateMappingWithGroupingKey(
                 _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
-                bytes20(_address)
+                bytes20(caller)
             )
         );
 
         return bytes32(permissions);
     }
 
-    function getAllowedAddressesFor(IERC725Y _account, address _address)
+    function getAllowedAddressesFor(IERC725Y target, address caller)
         internal
         view
         returns (bytes memory)
     {
         return
-            _account.getData(
+            target.getData(
                 LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX,
-                    bytes20(_address)
+                    bytes20(caller)
                 )
             );
     }
 
-    function getAllowedFunctionsFor(IERC725Y _account, address _address)
+    function getAllowedFunctionsFor(IERC725Y target, address caller)
         internal
         view
         returns (bytes memory)
     {
         return
-            _account.getData(
+            target.getData(
                 LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX,
-                    bytes20(_address)
+                    bytes20(caller)
                 )
             );
     }
 
-    function getAllowedStandardsFor(IERC725Y _account, address _address)
+    function getAllowedStandardsFor(IERC725Y target, address caller)
         internal
         view
         returns (bytes memory)
     {
         return
-            _account.getData(
+            target.getData(
                 LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX,
-                    bytes20(_address)
+                    bytes20(caller)
                 )
             );
     }
 
-    function getAllowedERC725YKeysFor(IERC725Y _account, address _address)
+    function getAllowedERC725YKeysFor(IERC725Y target, address caller)
         internal
         view
         returns (bytes memory)
     {
         return
-            _account.getData(
+            target.getData(
                 LSP2Utils.generateMappingWithGroupingKey(
                     _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX,
-                    bytes20(_address)
+                    bytes20(caller)
                 )
             );
     }

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -14,12 +14,8 @@ import "../LSP6KeyManager/LSP6Constants.sol";
 library LSP6Utils {
     using LSP2Utils for bytes12;
 
-    function getPermissionsFor(IERC725Y _account, address _address)
-        internal
-        view
-        returns (bytes32)
-    {
-        bytes memory permissions = _account.getData(
+    function getPermissionsFor(IERC725Y account, address _address) internal view returns (bytes32) {
+        bytes memory permissions = account.getData(
             LSP2Utils.generateMappingWithGroupingKey(
                 _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
                 bytes20(_address)
@@ -92,12 +88,12 @@ library LSP6Utils {
      * @param _permissionToCheck the permissions to check
      * @return true if `_addressPermissions` includes `_permissionToCheck`, false otherwise
      */
-    function hasPermission(bytes32 _addressPermission, bytes32 _permissionToCheck)
+    function hasPermission(bytes32 addressPermission, bytes32 permissionToCheck)
         internal
         pure
         returns (bool)
     {
-        return (_addressPermission & _permissionToCheck) == _permissionToCheck;
+        return (addressPermission & permissionToCheck) == permissionToCheck;
     }
 
     function setDataViaKeyManager(

--- a/contracts/Utils/UtilsLib.sol
+++ b/contracts/Utils/UtilsLib.sol
@@ -16,11 +16,7 @@ library UtilsLib {
         pure
         returns (bytes memory result)
     {
-        result = new bytes(32);
-        assembly {
-            mstore(add(result, 32), b1)
-            mstore(add(result, 48), b2)
-        }
+        result = bytes.concat(b1, b2);
     }
 
     /**
@@ -31,10 +27,7 @@ library UtilsLib {
         pure
         returns (bytes memory bytes_)
     {
-        bytes_ = new bytes(32);
-        assembly {
-            mstore(add(bytes_, 32), num)
-        }
+        bytes_ = bytes.concat(bytes32(num));
     }
 
     /**
@@ -45,15 +38,6 @@ library UtilsLib {
         pure
         returns (bytes memory bytes_)
     {
-        assembly {
-            let m := mload(0x40)
-            addr := and(addr, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
-            mstore(
-                add(m, 20),
-                xor(0x140000000000000000000000000000000000000000, addr)
-            )
-            mstore(0x40, add(m, 52))
-            bytes_ := m
-        }
+        bytes_ = bytes.concat(bytes20(addr));
     }
 }

--- a/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
@@ -116,9 +116,10 @@ export const testAllowedERC725YKeysInternals = (
       it(
         "Singleton: should return 0 for `LSP3Profile` -> " + SINGLETON_KEY,
         async () => {
-          let result = await context.keyManagerInternalTester.countZeroBytes(
-            SINGLETON_KEY
-          );
+          let result =
+            await context.keyManagerInternalTester.countTrailingZeroBytes(
+              SINGLETON_KEY
+            );
 
           expect(result.toNumber()).toEqual(0);
         }
@@ -127,9 +128,10 @@ export const testAllowedERC725YKeysInternals = (
       it(
         "Array: should return 16 for `LSP4Creators[]` -> " + ARRAY_KEY,
         async () => {
-          let result = await context.keyManagerInternalTester.countZeroBytes(
-            ARRAY_KEY
-          );
+          let result =
+            await context.keyManagerInternalTester.countTrailingZeroBytes(
+              ARRAY_KEY
+            );
 
           expect(result.toNumber()).toEqual(16);
         }
@@ -139,9 +141,10 @@ export const testAllowedERC725YKeysInternals = (
         "Mapping: should return 16 for `SupportedStandards:...` -> " +
           MAPPING_KEY,
         async () => {
-          let result = await context.keyManagerInternalTester.countZeroBytes(
-            MAPPING_KEY
-          );
+          let result =
+            await context.keyManagerInternalTester.countTrailingZeroBytes(
+              MAPPING_KEY
+            );
 
           expect(result.toNumber()).toEqual(16);
         }
@@ -151,9 +154,10 @@ export const testAllowedERC725YKeysInternals = (
         "Bytes20Mapping: should return 16 for `LSP5ReceivedAssetsMap:...` -> " +
           BYTES20_MAPPING_KEY,
         async () => {
-          let result = await context.keyManagerInternalTester.countZeroBytes(
-            BYTES20_MAPPING_KEY
-          );
+          let result =
+            await context.keyManagerInternalTester.countTrailingZeroBytes(
+              BYTES20_MAPPING_KEY
+            );
 
           expect(result.toNumber()).toEqual(24);
         }


### PR DESCRIPTION
# What does this PR introduce?

After analyzing the LSP6 contracts with slither (static analysis tool)

## Refactor

- [x] change function visibility of functions `initialize(...)` and `getNonce(....)` (in LSP6) from `public` -> `external`.
- [x] remove assembly blocks in `LSP2Utils` and `UtilsLib` contracts to fix slither informational error about usage of inline assembly (increase gas cost of +664 for LSP7 Token Transfer, TBD in future if reintroduce or not).

## Bug fixes

- [x] add check during deployment to ensure Key Manager does not get linked to: `address(0)`
- [x] refactor assembly block to compare mask against dynamic keys, so to remove Slither error about **"invalid shift**
- [x] rename variable to fix slither uninitialized storage error](https://github.com/lukso-network/lsp-smart-contracts/pull/203/commits/2563f61bc1cfbfe046421f341329360d39a1018e)

## Style

- [x] remove underscore in most parameters names and use mixedCase for the contracts: `LSP6KeyManagerCore`, `LSP2Utils` and `LSP6Utils`