### PR TITLE
fix!: lock LSP7 base contracts on deployment + improve heading comments

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -16,6 +16,10 @@ import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
  * @title LSP7DigitalAsset contract
  * @author Matthew Stevens
  * @dev Implementation of a LSP7 compliant contract.
+ *
+ * This implementation is agnostic to the way tokens are created.
+ * A supply mechanism has to be added in a derived contract using {_mint}
+ * For a generic mechanism, see {LSP7Mintable}.
  */
 contract LSP7DigitalAsset is LSP4DigitalAssetMetadata, LSP7DigitalAssetCore {
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -25,6 +25,8 @@ import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Con
  * @title LSP7DigitalAsset contract
  * @author Matthew Stevens
  * @dev Core Implementation of a LSP7 compliant contract.
+ *
+ * This contract implement the core logic of the functions for the {ILSP7DigitalAsset} interface.
  */
 abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
     using Address for address;

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -8,6 +8,10 @@ import {LSP7DigitalAssetInitAbstract} from "./LSP7DigitalAssetInitAbstract.sol";
  * @title LSP7DigitalAsset contract
  * @author Matthew Stevens
  * @dev Proxy Implementation of a LSP7 compliant contract.
+ *
+ * This implementation is agnostic to the way tokens are created.
+ * A supply mechanism has to be added in a derived contract using {_mint}
+ * For a generic mechanism, see {LSP7Mintable}.
  */
 contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -14,6 +14,8 @@ import {LSP7DigitalAssetInitAbstract} from "./LSP7DigitalAssetInitAbstract.sol";
  * For a generic mechanism, see {LSP7Mintable}.
  */
 contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
+    constructor() initializer {} // solhint-disable no-empty-blocks
+
     /**
      * @notice Sets the token-Metadata
      * @param name_ The name of the token

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -9,6 +9,8 @@ import {LSP7MintableInitAbstract} from "./LSP7MintableInitAbstract.sol";
  * @dev LSP7 extension, mintable.
  */
 contract LSP7MintableInit is LSP7MintableInitAbstract {
+    constructor() initializer {} // solhint-disable no-empty-blocks
+
     /**
      * @notice Sets the token-Metadata and register LSP7InterfaceId
      * @param name_ The name of the token


### PR DESCRIPTION
# What does this PR introduce?

## Fix

- [x] ⛔ 🔒  lock base contract immediately on deployment by applying a `constructor` with an `initializer` into it. This was applied to the following contracts: `LSP7DigitalAssetInit` and `LSP7MintableInit`.

## Style

- [x] improve heading comments for `LSP7DigitalAsset` and `LSP7DigitalAssetInit` to specify that a supply mechanism must be created in the implementation contract deriving from it.


