### PR TITLE
fix!: backward compatibility for `LSP7CompatibilityForERC20` for return statements + lock base contract on deployment

### DIFF
--- a/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibilityForERC20InitTester.sol
@@ -4,17 +4,9 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
-import {LSP7CompatibilityForERC20InitAbstract} from "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20InitAbstract.sol";
+import {LSP7CompatibilityForERC20Init} from "../../LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol";
 
-contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20InitAbstract {
-    function initialize(
-        string memory name,
-        string memory symbol,
-        address newOwner
-    ) public virtual initializer {
-        LSP7CompatibilityForERC20InitAbstract._initialize(name, symbol, newOwner);
-    }
-
+contract LSP7CompatibilityForERC20InitTester is LSP7CompatibilityForERC20Init {
     function mint(
         address to,
         uint256 amount,

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibilityForERC20.sol
@@ -32,7 +32,7 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
      * @param to The receiving address
      * @param amount The amount of tokens to transfer
      */
-    function transfer(address to, uint256 amount) external;
+    function transfer(address to, uint256 amount) external returns (bool);
 
     /*
      * @dev Compatible with ERC20 transferFrom
@@ -44,14 +44,14 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
         address from,
         address to,
         uint256 amount
-    ) external;
+    ) external returns (bool);
 
     /*
      * @dev Compatible with ERC20 approve
      * @param operator The address to approve for `amount`
      * @param amount The amount to approve
      */
-    function approve(address operator, uint256 amount) external;
+    function approve(address operator, uint256 amount) external returns (bool);
 
     /*
      * @dev Compatible with ERC20 allowance
@@ -59,5 +59,5 @@ interface ILSP7CompatibilityForERC20 is ILSP7DigitalAsset {
      * @param operator The address approved by the `tokenOwner`
      * @return The amount `operator` is approved by `tokenOwner`
      */
-    function allowance(address tokenOwner, address operator) external returns (uint256);
+    function allowance(address tokenOwner, address operator) external view returns (uint256);
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -18,11 +18,14 @@ abstract contract LSP7CompatibilityForERC20Core is
     LSP7DigitalAssetCore,
     ILSP7CompatibilityForERC20
 {
+    // --- Overrides
+
     /**
      * @inheritdoc ILSP7CompatibilityForERC20
      */
-    function approve(address operator, uint256 amount) external virtual override {
-        return authorizeOperator(operator, amount);
+    function approve(address operator, uint256 amount) external virtual override returns (bool) {
+        authorizeOperator(operator, amount);
+        return true;
     }
 
     /**
@@ -43,8 +46,9 @@ abstract contract LSP7CompatibilityForERC20Core is
      * @dev Compatible with ERC20 transfer.
      * Using force=true so that EOA and any contract may receive the tokens.
      */
-    function transfer(address to, uint256 amount) external virtual override {
-        return transfer(_msgSender(), to, amount, true, "");
+    function transfer(address to, uint256 amount) external virtual override returns (bool) {
+        transfer(_msgSender(), to, amount, true, "");
+        return true;
     }
 
     /**
@@ -56,11 +60,10 @@ abstract contract LSP7CompatibilityForERC20Core is
         address from,
         address to,
         uint256 amount
-    ) external virtual override {
-        return transfer(from, to, amount, true, "");
+    ) external virtual override(ILSP7CompatibilityForERC20) returns (bool) {
+        transfer(from, to, amount, true, "");
+        return true;
     }
-
-    // --- Overrides
 
     function authorizeOperator(address operator, uint256 amount)
         public
@@ -71,6 +74,8 @@ abstract contract LSP7CompatibilityForERC20Core is
 
         emit Approval(_msgSender(), operator, amount);
     }
+
+    // --- Internals
 
     function _transfer(
         address from,

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Init.sol
@@ -7,6 +7,11 @@ import {LSP7CompatibilityForERC20InitAbstract} from "./LSP7CompatibilityForERC20
 
 contract LSP7CompatibilityForERC20Init is LSP7CompatibilityForERC20InitAbstract {
     /**
+     * @dev initialize the base (= implementation) contract
+     */
+    constructor() initializer {}
+
+    /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.test.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20.test.ts
@@ -112,6 +112,39 @@ describe("LSP7CompatibilityForERC20", () => {
       );
     };
 
+    describe("when deploying the base implementation contract", () => {
+      it("should have locked (= initialized) the implementation contract", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp7CompatibilityForERC20TesterInit =
+          await new LSP7CompatibilityForERC20InitTester__factory(
+            accounts[0]
+          ).deploy();
+
+        const isInitialized =
+          await lsp7CompatibilityForERC20TesterInit.callStatic.initialized();
+
+        expect(isInitialized).toBeTruthy();
+      });
+
+      it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp7CompatibilityForERC20TesterInit =
+          await new LSP7CompatibilityForERC20InitTester__factory(
+            accounts[0]
+          ).deploy();
+
+        const randomCaller = accounts[1];
+
+        await expect(
+          lsp7CompatibilityForERC20TesterInit[
+            "initialize(string,string,address)"
+          ]("XXXXXXXXXXX", "XXX", randomCaller.address)
+        ).toBeRevertedWith("Initializable: contract is already initialized");
+      });
+    });
+
     describe("when deploying the contract as proxy", () => {
       let context: LSP7CompatibilityForERC20TestContext;
 


### PR DESCRIPTION
# What does this PR introduce?

In the `LSP7CompatibilityForERC20` implementation, the following functions do not behave completely in the same way as the functions defined in a standard `ERC20` interface:

[**standard** `ERC20` implementation from OpenZeppelin.](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/IERC20.sol)
```solidity
function approve(address spender, uint256 amount) external returns (bool);

function transfer(address to, uint256 amount) external returns (bool);

function transferFrom(
        address from,
        address to,
        uint256 amount
    ) external returns (bool);
```

Functions defined in `LSP7CompatibilityForERC20Core`

```solidity
function approve(address operator, uint256 amount) external virtual override {
    // ...
}

function transfer(address to, uint256 amount) external virtual override {
    // ...
}

function transferFrom(
    address from,
    address to,
    uint256 amount
) external virtual override {
    // ...
}
```

As shown above, these 3 functions in the LSP7 backward compatible version with ERC20 miss then return statement and do not return a `bool`.

This PR introduce this fix/enhancement to ensure the backward compatible version of LSP7 behaves in the same way by returning `true` when the functions `approve(...)`, `transfer(...)` or `transferFrom(...)` have executed successfully.

The LSP7 contracts that aim to be backwards compatible with ERC20 have do not behave completely like

## Enhancements

_see explanation above_

## 🐛 Bug fixes

- [x] ⛔ 🔒 lock base contract `LSP7CompatibilityForERC20Init` on deployment.

## 🧪  Tests

- [x] add tests to ensure base contract `LSP7CompatibilityForERC20Init` is locked on deployment