### PR TITLE
fix: edit old `Executed` event signatures in `constants.js`

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -190,18 +190,18 @@ const PERMISSIONS = {
 
 const LSP1_TYPE_IDS = {
 	// keccak256('LSP7TokensSender')
-	LSP7_TOKENSENDER: "0x40b8bec57d7b5ff0dbd9e9acd0a47dfeb0101e1a203766f5ccab00445fbf39e9",
+	LSP7_TOKENSENDER: '0x40b8bec57d7b5ff0dbd9e9acd0a47dfeb0101e1a203766f5ccab00445fbf39e9',
 	// keccak256('LSP7TokensRecipient')
-	LSP7_TOKENRECIPIENT: "0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f",
+	LSP7_TOKENRECIPIENT: '0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f',
 	// keccak256('LSP8TokensSender')
-	LSP8_TOKENSENDER: "0x3724c94f0815e936299cca424da4140752198e0beb7931a6e0925d11bc97544c",
+	LSP8_TOKENSENDER: '0x3724c94f0815e936299cca424da4140752198e0beb7931a6e0925d11bc97544c',
 	// keccak256('LSP8TokensRecipient')
-	LSP8_TOKENRECIPIENT: "0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01",
+	LSP8_TOKENRECIPIENT: '0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01',
 	// keccak256("LSP9VaultSender")
-	LSP9_VAULTSENDER: "0x3ca9f769340018257ac15b3a00e502e8fb730d66086f774210f84d0205af31e7",
+	LSP9_VAULTSENDER: '0x3ca9f769340018257ac15b3a00e502e8fb730d66086f774210f84d0205af31e7',
 	// keccak256("LSP9VaultRecipient")
-	LSP9_VAULTRECIPIENT: "0x09aaf55960715d8d86b57af40be36b0bfd469c9a3643445d8c65d39e27b4c56f"
-}
+	LSP9_VAULTRECIPIENT: '0x09aaf55960715d8d86b57af40be36b0bfd469c9a3643445d8c65d39e27b4c56f',
+};
 
 // ----------
 
@@ -348,12 +348,12 @@ const EventSignatures = {
 		 *      uint256 indexed _operation,
 		 *      address indexed _to,
 		 *      uint256 indexed _value,
-		 *      bytes _data
+		 *      bytes4 _data
 		 * );
 		 *
-		 * signature = keccak256('Executed(uint256,address,uint256,bytes)')
+		 * signature = keccak256('Executed(uint256,address,uint256,bytes4)')
 		 */
-		Executed: '0x1f920dbda597d7bf95035464170fa58d0a4b57f13a1c315ace6793b9f63688b8',
+		Executed: '0x4810874456b8e6487bd861375cf6abd8e1c8bb5858c8ce36a86a04dabfac199e',
 	},
 	ERC725Y: {
 		/**
@@ -393,12 +393,12 @@ const EventSignatures = {
 		/**
 		 * event Executed(
 		 *     uint256 indexed _value,
-		 *     bytes _data
+		 *     bytes4 _data
 		 * );
 		 *
-		 * signature = keccak256('Executed(uint256,bytes)')
+		 * signature = keccak256('Executed(uint256,bytes4)')
 		 */
-		Executed: '0x2e733a17851169f232b3859260eb3ad2a086afd54e999eb4ea9afb7791702e41',
+		Executed: '0x6b9340454526f665e369d7ac17353d0b73774a4a80f746b959ece8130e0f1d72',
 	},
 	LSP7: {
 		/**


### PR DESCRIPTION
# What does this PR introduce?

The file `constants.js` contains the old event signatures of `Executed` from ERC725X and LSP6 (that contain the old `bytes` parameter instead of `bytes4`).

Update these value based on the new implementations.