### PR TITLE
fix!: lock LSP9 base contracts on deployment + improve variable names

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -143,10 +143,10 @@ abstract contract LSP0ERC725AccountCore is
         override
         returns (bytes memory returnValue)
     {
-        bytes memory storedValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
+        bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
-        if (storedValue.length >= 20) {
-            address universalReceiverDelegate = address(bytes20(storedValue));
+        if (lsp1DelegateValue.length >= 20) {
+            address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
             if (
                 ERC165Checker.supportsERC165Interface(

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -21,14 +21,14 @@ import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDA
 contract LSP9Vault is LSP9VaultCore {
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
-     * @param _newOwner the owner of the contract
+     * @param newOwner the owner of the contract
      */
-    constructor(address _newOwner) {
-        OwnableUnset._setOwner(_newOwner);
+    constructor(address newOwner) {
+        OwnableUnset._setOwner(newOwner);
 
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
-        _notifyVaultReceiver(_newOwner);
+        _notifyVaultReceiver(newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -158,7 +158,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
         if (lsp1DelegateValue.length >= 20) {
-            address universalReceiverDelegate = address(bytes20(data));
+            address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
             if (
                 ERC165Checker.supportsERC165Interface(

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -116,8 +116,8 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 _key, bytes memory _value) public virtual override onlyAllowed {
-        _setData(_key, _value);
+    function setData(bytes32 dataKey, bytes memory dataValue) public virtual override onlyAllowed {
+        _setData(dataKey, dataValue);
     }
 
     /**
@@ -128,15 +128,15 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory _keys, bytes[] memory _values)
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
         public
         virtual
         override
         onlyAllowed
     {
-        require(_keys.length == _values.length, "Keys length not equal to values length");
-        for (uint256 i = 0; i < _keys.length; i++) {
-            _setData(_keys[i], _values[i]);
+        require(dataKeys.length == dataValues.length, "Keys length not equal to values length");
+        for (uint256 i = 0; i < dataKeys.length; i++) {
+            _setData(dataKeys[i], dataValues[i]);
         }
     }
 
@@ -145,19 +145,19 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * @dev Forwards the call to the UniversalReceiverDelegate if set.
-     * @param _typeId The type of call received.
-     * @param _data The data received.
+     * @param typeId The type of call received.
+     * @param data The data received.
      */
-    function universalReceiver(bytes32 _typeId, bytes calldata _data)
+    function universalReceiver(bytes32 typeId, bytes calldata data)
         external
         payable
         virtual
         override
         returns (bytes memory returnValue)
     {
-        bytes memory data = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
+        bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
-        if (data.length >= 20) {
+        if (lsp1DelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(data));
 
             if (
@@ -167,10 +167,10 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
                 )
             ) {
                 returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
-                    .universalReceiverDelegate(msg.sender, msg.value, _typeId, _data);
+                    .universalReceiverDelegate(msg.sender, msg.value, typeId, data);
             }
         }
-        emit UniversalReceiver(msg.sender, msg.value, _typeId, returnValue, _data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, returnValue, data);
     }
 
     // internal functions
@@ -178,18 +178,18 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     /**
      * @dev Calls the universalReceiver function of the sender if supports LSP1 InterfaceId
      */
-    function _notifyVaultSender(address _sender) internal virtual {
-        if (ERC165Checker.supportsERC165Interface(_sender, _INTERFACEID_LSP1)) {
-            ILSP1UniversalReceiver(_sender).universalReceiver(_TYPEID_LSP9_VAULTSENDER, "");
+    function _notifyVaultSender(address sender) internal virtual {
+        if (ERC165Checker.supportsERC165Interface(sender, _INTERFACEID_LSP1)) {
+            ILSP1UniversalReceiver(sender).universalReceiver(_TYPEID_LSP9_VAULTSENDER, "");
         }
     }
 
     /**
      * @dev Calls the universalReceiver function of the recipient if supports LSP1 InterfaceId
      */
-    function _notifyVaultReceiver(address _receiver) internal virtual {
-        if (ERC165Checker.supportsERC165Interface(_receiver, _INTERFACEID_LSP1)) {
-            ILSP1UniversalReceiver(_receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
+    function _notifyVaultReceiver(address receiver) internal virtual {
+        if (ERC165Checker.supportsERC165Interface(receiver, _INTERFACEID_LSP1)) {
+            ILSP1UniversalReceiver(receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
         }
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -12,9 +12,9 @@ import {LSP9VaultInitAbstract} from "./LSP9VaultInitAbstract.sol";
 contract LSP9VaultInit is LSP9VaultInitAbstract {
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
-     * @param _newOwner the owner of the contract
+     * @param newOwner the owner of the contract
      */
-    function initialize(address _newOwner) public virtual initializer {
-        LSP9VaultInitAbstract._initialize(_newOwner);
+    function initialize(address newOwner) public virtual initializer {
+        LSP9VaultInitAbstract._initialize(newOwner);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -11,6 +11,11 @@ import {LSP9VaultInitAbstract} from "./LSP9VaultInitAbstract.sol";
  */
 contract LSP9VaultInit is LSP9VaultInitAbstract {
     /**
+     * @dev lock the base (= implementation) contract on deployment
+     */
+    constructor() initializer {} // solhint-disable no-empty-blocks
+
+    /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param newOwner the owner of the contract
      */

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -19,12 +19,12 @@ import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDA
  * @dev Could be owned by a UniversalProfile and able to register received asset with UniversalReceiverDelegateVault
  */
 abstract contract LSP9VaultInitAbstract is Initializable, LSP9VaultCore {
-    function _initialize(address _newOwner) internal virtual onlyInitializing {
-        OwnableUnset._setOwner(_newOwner);
+    function _initialize(address newOwner) internal virtual onlyInitializing {
+        OwnableUnset._setOwner(newOwner);
 
         // set key SupportedStandards:LSP9Vault
         _setData(_LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE);
 
-        _notifyVaultReceiver(_newOwner);
+        _notifyVaultReceiver(newOwner);
     }
 }

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -133,6 +133,34 @@ describe("LSP9Vault", () => {
       );
     };
 
+    describe("when deploying the base implementation contract", () => {
+      it("should have locked (= initialized) the implementation contract", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp9VaultInit = await new LSP9VaultInit__factory(
+          accounts[0]
+        ).deploy();
+
+        const isInitialized = await lsp9VaultInit.callStatic.initialized();
+
+        expect(isInitialized).toBeTruthy();
+      });
+
+      it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp9VaultInit = await new LSP9VaultInit__factory(
+          accounts[0]
+        ).deploy();
+
+        const randomCaller = accounts[1];
+
+        await expect(
+          lsp9VaultInit.initialize(randomCaller.address)
+        ).toBeRevertedWith("Initializable: contract is already initialized");
+      });
+    });
+
     describe("when deploying the contract as proxy", () => {
       let context: LSP9TestContext;
 


### PR DESCRIPTION
# What does this PR introduce?

## Fix 🐛  

- [x] ⛔ add a constructor with initializer to `LSP9VaultInit` base contract to lock implementation contract immediately on deployment.

## Styles 🎨 

- [x] fix variable names from underscore to mixedCase.