### PR TITLE
chore: add `virtual` keyword to the fallback function

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -43,7 +43,7 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      */
-    fallback() external payable {
+    fallback() external payable virtual {
         if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
     }
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -57,7 +57,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     /**
      * @dev Emits an event when receiving native tokens
      */
-    fallback() external payable {
+    fallback() external payable virtual {
         if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
     }
 


### PR DESCRIPTION
## What does this PR introduce?
- Adding virtual keyword to the fallback function in LSP0/LSP9