### PR TITLE
refactor: change `external` visibility to `public`

### DIFF
--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -14,7 +14,7 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     address public override pendingOwner;
 
-    function claimOwnership() external virtual override {
+    function claimOwnership() public virtual override {
         _claimOwnership();
     }
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -137,7 +137,7 @@ abstract contract LSP0ERC725AccountCore is
      * @param data The data received.
      */
     function universalReceiver(bytes32 typeId, bytes calldata data)
-        external
+        public
         payable
         virtual
         override

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -64,7 +64,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address from, uint256 channelId) external view override returns (uint256) {
+    function getNonce(address from, uint256 channelId) public view override returns (uint256) {
         uint128 nonceId = uint128(_nonceStore[from][channelId]);
         return (uint256(channelId) << 128) | nonceId;
     }
@@ -90,7 +90,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function execute(bytes calldata payload) external payable override returns (bytes memory) {
+    function execute(bytes calldata payload) public payable override returns (bytes memory) {
         _verifyPermissions(msg.sender, payload);
 
         // solhint-disable avoid-low-level-calls
@@ -113,7 +113,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes memory signature,
         uint256 nonce,
         bytes calldata payload
-    ) external payable override returns (bytes memory) {
+    ) public payable override returns (bytes memory) {
         bytes memory blob = abi.encodePacked(
             block.chainid,
             address(this), // needs to be signed for this keyManager

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -14,7 +14,7 @@ contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
      * @param target_ The address of the ER725Account to control
      */
-    function initialize(address target_) external virtual initializer {
+    function initialize(address target_) public virtual initializer {
         LSP6KeyManagerInitAbstract._initialize(target_);
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -135,7 +135,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         uint256[] memory amount,
         bool force,
         bytes[] memory data
-    ) external virtual override {
+    ) public virtual override {
         if (
             from.length != to.length || from.length != amount.length || from.length != data.length
         ) {

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibilityForERC20Core.sol
@@ -23,7 +23,7 @@ abstract contract LSP7CompatibilityForERC20Core is
     /**
      * @inheritdoc ILSP7CompatibilityForERC20
      */
-    function approve(address operator, uint256 amount) external virtual override returns (bool) {
+    function approve(address operator, uint256 amount) public virtual override returns (bool) {
         authorizeOperator(operator, amount);
         return true;
     }
@@ -32,7 +32,7 @@ abstract contract LSP7CompatibilityForERC20Core is
      * @inheritdoc ILSP7CompatibilityForERC20
      */
     function allowance(address tokenOwner, address operator)
-        external
+        public
         view
         virtual
         override
@@ -46,7 +46,7 @@ abstract contract LSP7CompatibilityForERC20Core is
      * @dev Compatible with ERC20 transfer.
      * Using force=true so that EOA and any contract may receive the tokens.
      */
-    function transfer(address to, uint256 amount) external virtual override returns (bool) {
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
         transfer(_msgSender(), to, amount, true, "");
         return true;
     }
@@ -60,7 +60,7 @@ abstract contract LSP7CompatibilityForERC20Core is
         address from,
         address to,
         uint256 amount
-    ) external virtual override(ILSP7CompatibilityForERC20) returns (bool) {
+    ) public virtual override(ILSP7CompatibilityForERC20) returns (bool) {
         transfer(from, to, amount, true, "");
         return true;
     }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -204,7 +204,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
         bytes32[] memory tokenId,
         bool force,
         bytes[] memory data
-    ) external virtual override {
+    ) public virtual override {
         if (
             from.length != to.length || from.length != tokenId.length || from.length != data.length
         ) {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibilityForERC721Core.sol
@@ -46,14 +46,14 @@ abstract contract LSP8CompatibilityForERC721Core is
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function ownerOf(uint256 tokenId) external view virtual override returns (address) {
+    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         return tokenOwnerOf(bytes32(tokenId));
     }
 
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function approve(address operator, uint256 tokenId) external virtual override {
+    function approve(address operator, uint256 tokenId) public virtual override {
         authorizeOperator(operator, bytes32(tokenId));
 
         emit Approval(tokenOwnerOf(bytes32(tokenId)), operator, tokenId);
@@ -62,7 +62,7 @@ abstract contract LSP8CompatibilityForERC721Core is
     /**
      * @inheritdoc ILSP8CompatibilityForERC721
      */
-    function getApproved(uint256 tokenId) external view virtual override returns (address) {
+    function getApproved(uint256 tokenId) public view virtual override returns (address) {
         bytes32 tokenIdAsBytes32 = bytes32(tokenId);
         _existsOrError(tokenIdAsBytes32);
 
@@ -108,7 +108,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         address from,
         address to,
         uint256 tokenId
-    ) external virtual override {
+    ) public virtual override {
         return transfer(from, to, bytes32(tokenId), true, "");
     }
 
@@ -121,7 +121,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         address from,
         address to,
         uint256 tokenId
-    ) external virtual override {
+    ) public virtual override {
         return transfer(from, to, bytes32(tokenId), false, "");
     }
 
@@ -134,7 +134,7 @@ abstract contract LSP8CompatibilityForERC721Core is
         address to,
         uint256 tokenId,
         bytes memory data
-    ) external virtual override {
+    ) public virtual override {
         return transfer(from, to, bytes32(tokenId), false, data);
     }
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -97,7 +97,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     /**
      * @dev Transfer the ownership and notify the vault sender and vault receiver
      */
-    function claimOwnership() external virtual override {
+    function claimOwnership() public virtual override {
         address previousOwner = owner();
 
         _claimOwnership();
@@ -149,7 +149,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      * @param data The data received.
      */
     function universalReceiver(bytes32 typeId, bytes calldata data)
-        external
+        public
         payable
         virtual
         override


### PR DESCRIPTION
## What does this PR introduce ?
- Allowing for more flexibility with inheriting the lsp-smart-contracts, visibility changed from `external` to `public` in some functions.