### PR TITLE
fix: assets inheritance + lock `LSP8MintableInit` base contract on deployment

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -3,14 +3,17 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP7DigitalAssetInit} from "../LSP7DigitalAssetInit.sol";
+import {LSP7DigitalAssetInitAbstract} from "../LSP7DigitalAssetInitAbstract.sol";
 import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 import {LSP7CappedSupplyCore} from "./LSP7CappedSupplyCore.sol";
 
 /**
  * @dev LSP7 extension, adds token supply cap.
  */
-abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInit, LSP7CappedSupplyCore {
+abstract contract LSP7CappedSupplyInitAbstract is
+    LSP7DigitalAssetInitAbstract,
+    LSP7CappedSupplyCore
+{
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {
             revert LSP7CappedSupplyRequired();

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -10,6 +10,11 @@ import {LSP7MintableInitAbstract} from "./LSP7MintableInitAbstract.sol";
  */
 contract LSP7MintableInit is LSP7MintableInitAbstract {
     /**
+     * @dev initialize (= lock) base contract on deployment
+     */
+    constructor() initializer {}
+
+    /**
      * @notice Sets the token-Metadata and register LSP7InterfaceId
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
@@ -21,7 +26,7 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
         string memory symbol_,
         address newOwner_,
         bool isNFT_
-    ) public virtual override initializer {
+    ) public virtual initializer {
         LSP7MintableInitAbstract._initialize(name_, symbol_, newOwner_, isNFT_);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -10,7 +10,7 @@ import {LSP7MintableCore} from "./LSP7MintableCore.sol";
 /**
  * @dev LSP7 extension, mintable.
  */
-abstract contract LSP7MintableInitAbstract is LSP7DigitalAssetInit, LSP7MintableCore {
+abstract contract LSP7MintableInitAbstract is LSP7DigitalAssetInitAbstract, LSP7MintableCore {
     function _initialize(
         string memory name_,
         string memory symbol_,

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -4,14 +4,14 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
-import {LSP8IdentifiableDigitalAssetInit} from "../LSP8IdentifiableDigitalAssetInit.sol";
+import {LSP8IdentifiableDigitalAssetInitAbstract} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
 
 /**
  * @dev LSP8 extension, adds token supply cap.
  */
 abstract contract LSP8CappedSupplyInitAbstract is
-    LSP8IdentifiableDigitalAssetInit,
+    LSP8IdentifiableDigitalAssetInitAbstract,
     LSP8CappedSupplyCore
 {
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
@@ -10,6 +10,11 @@ import {LSP8MintableInitAbstract} from "./LSP8MintableInitAbstract.sol";
  */
 contract LSP8MintableInit is LSP8MintableInitAbstract {
     /**
+     * @dev initialize (= lock) base contract on deployment
+     */
+    constructor() initializer {}
+
+    /**
      * @notice Sets the token-Metadata and register LSP8InterfaceId
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token

--- a/deploy/011_deploy_base_lsp8_mintable.ts
+++ b/deploy/011_deploy_base_lsp8_mintable.ts
@@ -17,12 +17,6 @@ const deployBaseLSP8Mintable: DeployFunction = async ({
 
   const LSP8MintableInit = await ethers.getContractFactory("LSP8MintableInit");
   const lsp8MintableInit = await LSP8MintableInit.attach(deployResult.address);
-
-  await lsp8MintableInit.initialize(
-    "LSP8 Mintable Init",
-    "LSP8MI",
-    ethers.constants.AddressZero
-  );
 };
 
 export default deployBaseLSP8Mintable;


### PR DESCRIPTION
# What does this PR introduce?

## Fix

- [x] inheritance of `LSP7CappedSupplyInitAbstract` and `LSP8MintableInitAbstract`, to inherit from the Abstract version of `LSP7DigitalAssetInitAbstract`
- [x] lock `LSP8MintableInit` (base contract) on deployment.

## Chore

- [x] remove call to `initialize(...)` in deployment script for `LSP8MintableInit`.