### PR TITLE
refactor: :recycle: prevent reinitializing via inheritance on base contracts

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -11,9 +11,11 @@ import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725AccountInitAbstract.sol
  */
 contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
     /**
-     * @dev initialize the base (= implementation) contract
+     * @dev @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {} // solhint-disable no-empty-blocks
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the owner of the contract

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -10,6 +10,13 @@ import {LSP6KeyManagerInitAbstract} from "./LSP6KeyManagerInitAbstract.sol";
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
 contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
+    
+    /**
+     * @dev initialize (= lock) base implementation contract on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
     /**
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
      * @param target_ The address of the ER725Account to control

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -14,7 +14,13 @@ import {LSP7DigitalAssetInitAbstract} from "./LSP7DigitalAssetInitAbstract.sol";
  * For a generic mechanism, see {LSP7Mintable}.
  */
 contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
-    constructor() initializer {} // solhint-disable no-empty-blocks
+
+    /**
+     * @dev initialize (= lock) base implementation contract on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the token-Metadata

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Init.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Init.sol
@@ -7,9 +7,11 @@ import {LSP7CompatibleERC20InitAbstract} from "./LSP7CompatibleERC20InitAbstract
 
 contract LSP7CompatibleERC20Init is LSP7CompatibleERC20InitAbstract {
     /**
-     * @dev initialize the base (= implementation) contract
+     * @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {}
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the name, the symbol and the owner of the token

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -10,9 +10,11 @@ import {LSP7MintableInitAbstract} from "./LSP7MintableInitAbstract.sol";
  */
 contract LSP7MintableInit is LSP7MintableInitAbstract {
     /**
-     * @dev initialize (= lock) base contract on deployment
+     * @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {}
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the token-Metadata and register LSP7InterfaceId

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
@@ -10,6 +10,14 @@ import {LSP8IdentifiableDigitalAssetInitAbstract} from "./LSP8IdentifiableDigita
  * @dev Proxy Implementation of a LSP8 compliant contract.
  */
 contract LSP8IdentifiableDigitalAssetInit is LSP8IdentifiableDigitalAssetInitAbstract {
+    
+    /**
+     * @dev initialize (= lock) base implementation contract on deployment
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
     /**
      * @notice Sets the token-Metadata
      * @param name_ The name of the token

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
@@ -10,9 +10,11 @@ import {LSP8MintableInitAbstract} from "./LSP8MintableInitAbstract.sol";
  */
 contract LSP8MintableInit is LSP8MintableInitAbstract {
     /**
-     * @dev initialize (= lock) base contract on deployment
+     * @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {}
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the token-Metadata and register LSP8InterfaceId

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -11,9 +11,11 @@ import {LSP9VaultInitAbstract} from "./LSP9VaultInitAbstract.sol";
  */
 contract LSP9VaultInit is LSP9VaultInitAbstract {
     /**
-     * @dev lock the base (= implementation) contract on deployment
+     * @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {} // solhint-disable no-empty-blocks
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key

--- a/contracts/UniversalProfileInit.sol
+++ b/contracts/UniversalProfileInit.sol
@@ -11,9 +11,11 @@ import {UniversalProfileInitAbstract} from "./UniversalProfileInitAbstract.sol";
  */
 contract UniversalProfileInit is UniversalProfileInitAbstract {
     /**
-     * @dev initialize the base (= implementation) contract
+     * @dev initialize (= lock) base implementation contract on deployment
      */
-    constructor() initializer {} // solhint-disable no-empty-blocks
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP3UniversalProfile key


### PR DESCRIPTION
# What does this PR introduce?

Use the `_disableInitializers()` method inside of the base contract (= `Init` versions), so to prevent reinitializing any of the base contract via inheritance.