### PR TITLE
fix: enable to clear array for allowed data key permissions

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -285,11 +285,17 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX) {
 
-            // AddressPermissions:AllowedAddresses:<address>
-            require(
-                LSP2Utils.isEncodedArrayOfAddresses(value),
-                "LSP6KeyManager: invalid ABI encoded array of addresses"
-            );
+            bool isClearingArray = value.length == 0;
+
+            if (!isClearingArray) {
+                // AddressPermissions:AllowedAddresses:<address>
+                require(
+                    LSP2Utils.isEncodedArrayOfAddresses(value),
+                    "LSP6KeyManager: invalid ABI encoded array of addresses"
+                );
+            }
+
+            
 
             bytes memory storedAllowedAddresses = ERC725Y(target).getData(key);
 
@@ -304,16 +310,20 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
 
         } else if (
-            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX ||
-            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX
+            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX ||
+            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX
         ) {
+            bool isClearingArray = value.length == 0;
 
-            // AddressPermissions:AllowedFunctions:<address>
-            // AddressPermissions:AllowedStandards:<address>
-            require(
-                LSP2Utils.isBytes4EncodedArray(value),
-                "LSP6KeyManager: invalid ABI encoded array of bytes4"
-            );
+            if (!isClearingArray) {
+                // AddressPermissions:AllowedFunctions:<address>
+                // AddressPermissions:AllowedStandards:<address>
+                require(
+                    LSP2Utils.isBytes4EncodedArray(value),
+                    "LSP6KeyManager: invalid ABI encoded array of bytes4"
+                );
+            }
+
 
             bytes memory storedAllowedBytes4 = ERC725Y(target).getData(key);
 
@@ -329,11 +339,16 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX) {
 
-            // AddressPermissions:AllowedERC725YKeys:<address>
-            require(
-                LSP2Utils.isEncodedArray(value),
-                "LSP6KeyManager: invalid ABI encoded array of bytes32"
-            );
+            bool isClearingArray = value.length == 0;
+
+            if (!isClearingArray) {
+                // AddressPermissions:AllowedERC725YKeys:<address>
+                require(
+                    LSP2Utils.isEncodedArray(value),
+                    "LSP6KeyManager: invalid ABI encoded array of bytes32"
+                );
+            }
+
 
             bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(key);
 

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2004,175 +2004,175 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           );
         });
       });
+    });
 
-      describe("when caller has CHANGEPERMISSIONS", () => {
-        describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YKeys:...", () => {
-          it("should pass when adding an extra allowed ERC725Y data key", async () => {
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              beneficiary.address.substring(2);
+    describe("when caller has CHANGEPERMISSIONS", () => {
+      describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YKeys:...", () => {
+        it("should pass when adding an extra allowed ERC725Y data key", async () => {
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            beneficiary.address.substring(2);
 
-            let value = abiCoder.encode(
-              ["bytes32[]"],
+          let value = abiCoder.encode(
+            ["bytes32[]"],
+            [
               [
-                [
-                  ERC725YKeys.LSP3["LSP3Profile"],
-                  // prettier-ignore
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
-                  // prettier-ignore
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
-                ],
-              ]
-            );
+                ERC725YKeys.LSP3["LSP3Profile"],
+                // prettier-ignore
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+                // prettier-ignore
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
+              ],
+            ]
+          );
 
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
 
-            await context.keyManager
-              .connect(canOnlyChangePermissions)
-              .execute(payload);
+          await context.keyManager
+            .connect(canOnlyChangePermissions)
+            .execute(payload);
 
-            // prettier-ignore
-            const result = await context.universalProfile["getData(bytes32)"](key);
-            expect(result).toEqual(value);
-          });
-
-          it("should pass when removing an allowed ERC725Y data key", async () => {
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              beneficiary.address.substring(2);
-
-            let value = abiCoder.encode(
-              ["bytes32[]"],
-              [[ERC725YKeys.LSP3["LSP3Profile"]]]
-            );
-
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
-
-            await context.keyManager
-              .connect(canOnlyChangePermissions)
-              .execute(payload);
-
-            // prettier-ignore
-            const result = await context.universalProfile["getData(bytes32)"](key);
-            expect(result).toEqual(value);
-          });
-
-          it("should pass when trying to clear the array completely", async () => {
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              beneficiary.address.substring(2);
-
-            let value = "0x";
-
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
-
-            await context.keyManager
-              .connect(canOnlyChangePermissions)
-              .execute(payload);
-
-            // prettier-ignore
-            const result = await context.universalProfile["getData(bytes32)"](key);
-            expect(result).toEqual(value);
-          });
-
-          it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              beneficiary.address.substring(2);
-
-            let value = "0xbadbadbadbad";
-
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
-
-            await expect(
-              context.keyManager
-                .connect(canOnlyChangePermissions)
-                .execute(payload)
-            ).toBeRevertedWith(
-              "LSP6KeyManager: invalid ABI encoded array of bytes32"
-            );
-          });
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
+          expect(result).toEqual(value);
         });
 
-        describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YKeys:...", () => {
-          it("should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)", async () => {
-            let newController = new ethers.Wallet.createRandom();
+        it("should pass when removing an allowed ERC725Y data key", async () => {
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            beneficiary.address.substring(2);
 
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              newController.address.substr(2);
+          let value = abiCoder.encode(
+            ["bytes32[]"],
+            [[ERC725YKeys.LSP3["LSP3Profile"]]]
+          );
 
-            let value = abiCoder.encode(
-              ["bytes32[]"],
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+          await context.keyManager
+            .connect(canOnlyChangePermissions)
+            .execute(payload);
+
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
+          expect(result).toEqual(value);
+        });
+
+        it("should pass when trying to clear the array completely", async () => {
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            beneficiary.address.substring(2);
+
+          let value = "0x";
+
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+          await context.keyManager
+            .connect(canOnlyChangePermissions)
+            .execute(payload);
+
+          // prettier-ignore
+          const result = await context.universalProfile["getData(bytes32)"](key);
+          expect(result).toEqual(value);
+        });
+
+        it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            beneficiary.address.substring(2);
+
+          let value = "0xbadbadbadbad";
+
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+          await expect(
+            context.keyManager
+              .connect(canOnlyChangePermissions)
+              .execute(payload)
+          ).toBeRevertedWith(
+            "LSP6KeyManager: invalid ABI encoded array of bytes32"
+          );
+        });
+      });
+
+      describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YKeys:...", () => {
+        it("should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)", async () => {
+          let newController = new ethers.Wallet.createRandom();
+
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            newController.address.substr(2);
+
+          let value = abiCoder.encode(
+            ["bytes32[]"],
+            [
               [
-                [
-                  ethers.utils.keccak256(
-                    ethers.utils.toUtf8Bytes("My Custom Key 1")
-                  ),
-                  ethers.utils.keccak256(
-                    ethers.utils.toUtf8Bytes("My Custom Key 2")
-                  ),
-                ],
-              ]
-            );
+                ethers.utils.keccak256(
+                  ethers.utils.toUtf8Bytes("My Custom Key 1")
+                ),
+                ethers.utils.keccak256(
+                  ethers.utils.toUtf8Bytes("My Custom Key 2")
+                ),
+              ],
+            ]
+          );
 
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
 
-            await expect(
-              context.keyManager
-                .connect(canOnlyChangePermissions)
-                .execute(payload)
-            ).toBeRevertedWith(
-              NotAuthorisedError(
-                canOnlyChangePermissions.address,
-                "ADDPERMISSIONS"
-              )
-            );
-          });
+          await expect(
+            context.keyManager
+              .connect(canOnlyChangePermissions)
+              .execute(payload)
+          ).toBeRevertedWith(
+            NotAuthorisedError(
+              canOnlyChangePermissions.address,
+              "ADDPERMISSIONS"
+            )
+          );
+        });
 
-          it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
-            let newController = new ethers.Wallet.createRandom();
+        it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
+          let newController = new ethers.Wallet.createRandom();
 
-            let key =
-              ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-              newController.address.substr(2);
+          let key =
+            ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            newController.address.substr(2);
 
-            let value = "0xbadbadbadbad";
+          let value = "0xbadbadbadbad";
 
-            let payload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, value]
-            );
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
 
-            await expect(
-              context.keyManager
-                .connect(canOnlyChangePermissions)
-                .execute(payload)
-            ).toBeRevertedWith(
-              "LSP6KeyManager: invalid ABI encoded array of bytes32"
-            );
-          });
+          await expect(
+            context.keyManager
+              .connect(canOnlyChangePermissions)
+              .execute(payload)
+          ).toBeRevertedWith(
+            "LSP6KeyManager: invalid ABI encoded array of bytes32"
+          );
         });
       });
     });
   });
 
-  describe.skip("setting mixed keys (SETDATA, CHANGE & ADD Permissions", () => {
+  describe("setting mixed keys (SETDATA, CHANGE & ADD Permissions", () => {
     let canSetDataAndAddPermissions: SignerWithAddress,
       canSetDataAndChangePermissions: SignerWithAddress,
       canSetDataOnly: SignerWithAddress;

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -1925,9 +1925,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await expect(
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
-          ).toBeRevertedWith(
-            "LSP6KeyManager: invalid ABI encoded array of bytes32"
-          );
+          ).toBeRevertedWith(InvalidABIEncodedArrayError(value, "bytes32"));
         });
       });
 
@@ -2081,9 +2079,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canOnlyChangePermissions)
               .execute(payload)
-          ).toBeRevertedWith(
-            "LSP6KeyManager: invalid ABI encoded array of bytes32"
-          );
+          ).toBeRevertedWith(InvalidABIEncodedArrayError(value, "bytes32"));
         });
       });
 
@@ -2144,9 +2140,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canOnlyChangePermissions)
               .execute(payload)
-          ).toBeRevertedWith(
-            "LSP6KeyManager: invalid ABI encoded array of bytes32"
-          );
+          ).toBeRevertedWith(InvalidABIEncodedArrayError(value, "bytes32"));
         });
       });
     });


### PR DESCRIPTION
# What does this PR introduce?

as reported by @dzbo , it is not possible to clear the array of allowed addresses, functions, standards or ERC725Y data keys (= reset from a list/abi-encoded array back to `0x`).

## Fix 🐛 

- [x] refactor `LSP6KeyManagerCore` to check if the value is a valid abi-encoded array only if the value is not `0x`.

## Tests 🧪 

- [x] add additional tests for this scenario for ADD _vs_ CHANGE permissions.
