### PR TITLE
fix: underflow error for AllowedERC725YKey + allow to set the zero key `0x00000000...00000000` via the Key Manager

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -618,7 +618,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         // CHECK each bytes of the key, starting from the end (right to left)
         // skip each empty bytes `0x00` to find the first non-empty byte
-        while (key[index] == 0x00) index--;
+        while (key[index] == 0x00 && index != 0) index--;
 
         return 32 - (index + 1);
     }

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -1643,4 +1643,88 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       });
     });
   });
+
+  describe("bytes32(0) (= zero key) as an allowed ERC725Y data key", () => {
+    let controllerCanSetSomeKeys: SignerWithAddress;
+
+    const customKey1 = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("CustomKey1")
+    );
+    const customKey2 = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("CustomKey2")
+    );
+
+    const zeroKey =
+      "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    beforeAll(async () => {
+      context = await buildContext();
+
+      controllerCanSetSomeKeys = context.accounts[1];
+
+      const permissionKeys = [
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          context.owner.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          controllerCanSetSomeKeys.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+          controllerCanSetSomeKeys.address.substring(2),
+      ];
+
+      const permissionValues = [
+        ALL_PERMISSIONS,
+        PERMISSIONS.SETDATA,
+        abiCoder.encode(["bytes32[]"], [[customKey1, customKey2, zeroKey]]),
+      ];
+
+      await setupKeyManager(context, permissionKeys, permissionValues);
+    });
+
+    [
+      { allowedDataKey: customKey1 },
+      { allowedDataKey: customKey2 },
+      { allowedDataKey: zeroKey },
+    ].forEach((testCase) => {
+      it(`should pass when setting an allowed data key: ${testCase.allowedDataKey}`, async () => {
+        const key = testCase.allowedDataKey;
+        const value = ethers.utils.hexlify(
+          ethers.utils.toUtf8Bytes("some value for " + key)
+        );
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+        await context.keyManager
+          .connect(controllerCanSetSomeKeys)
+          .execute(setDataPayload);
+
+        const result = await context.universalProfile["getData(bytes32)"](key);
+        expect(result).toEqual(value);
+      });
+    });
+
+    it("should fail when setting a non-allowed data key", async () => {
+      const key = ERC725YKeys.LSP3["LSP3Profile"];
+      const value = ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes("some value for " + key)
+      );
+
+      const setDataPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "setData(bytes32,bytes)",
+          [key, value]
+        );
+
+      await expect(
+        context.keyManager
+          .connect(controllerCanSetSomeKeys)
+          .execute(setDataPayload)
+      ).toBeRevertedWith(
+        NotAllowedERC725YKeyError(controllerCanSetSomeKeys.address, key)
+      );
+    });
+  });
 };


### PR DESCRIPTION
# What does this PR introduce?

The `AllowedERC725YKey` feature in the LSP6 Key Manager currently does not allowed to set `0x0000000000000000000000000000000000000000000000000000000000000000` (= `bytes32(0)` or 32 x `00` bytes) as an allowed ERC725YKey.

If a controller address has this data key in its list of allowed ERC725Y data key, the check against the allowed data key leads to **integer underflow when counting the number of zero trailing bytes** 🚫 in the allowed data key _(see screenshot below)._

![unknown](https://user-images.githubusercontent.com/31145285/177990039-968e9ab3-093d-4f44-889c-dfc093366305.png)

As a result, this can lead the controller to be stuck and prevent the controller address from setting data on the account linked to this KeyManager.

This PR fixes this bug, while also allowing to whitelist any allowed ERC725Y data key by setting the **zero-key** `0x00000000...00000000` in the list of allowed ERC725Y data keys.