### PR TITLE
style: edit prettier config for Solidity contracts + run prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -14,7 +14,8 @@
       "files": "*.sol",
       "options": {
         "tabWidth": 4,
-        "printWidth": 100
+        "printWidth": 100,
+        "compiler": "0.8.7"
       }
     }
   ]

--- a/contracts/Factories/Create2Factory.sol
+++ b/contracts/Factories/Create2Factory.sol
@@ -43,11 +43,7 @@ contract Create2Factory {
      * - `bytecode` must not be empty.
      * - `salt` must have not been used for `bytecode` already.
      */
-    function deploy(bytes32 salt, bytes memory bytecode)
-        public
-        payable
-        returns (address)
-    {
+    function deploy(bytes32 salt, bytes memory bytecode) public payable returns (address) {
         address addr;
         uint256 amount = msg.value;
 
@@ -67,11 +63,7 @@ contract Create2Factory {
      * @dev Returns the address where a contract will be stored if deployed via {deploy}. Any change in the
      * `bytecodeHash` or `salt` will result in a new destination address.
      */
-    function computeAddress(bytes32 salt, bytes32 bytecodeHash)
-        public
-        view
-        returns (address)
-    {
+    function computeAddress(bytes32 salt, bytes32 bytecodeHash) public view returns (address) {
         return computeAddress(salt, bytecodeHash, address(this));
     }
 
@@ -84,9 +76,7 @@ contract Create2Factory {
         bytes32 bytecodeHash,
         address deployer
     ) public pure returns (address) {
-        bytes32 _data = keccak256(
-            abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHash)
-        );
+        bytes32 _data = keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHash));
         return address(uint160(uint256(_data)));
     }
 }

--- a/contracts/Helpers/ERC165Interfaces.sol
+++ b/contracts/Helpers/ERC165Interfaces.sol
@@ -16,15 +16,22 @@ import {IERC223} from "./Tokens/IERC223.sol";
 
 // LSPs interfaces
 import {ILSP1UniversalReceiver as ILSP1} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import {ILSP1UniversalReceiverDelegate as ILSP1Delegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate as ILSP1Delegate
+} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 import {ILSP6KeyManager as ILSP6} from "../LSP6KeyManager/ILSP6KeyManager.sol";
 import {ILSP7DigitalAsset as ILSP7} from "../LSP7DigitalAsset/ILSP7DigitalAsset.sol";
-import {ILSP8IdentifiableDigitalAsset as ILSP8} from "../LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol";
+import {
+    ILSP8IdentifiableDigitalAsset as ILSP8
+} from "../LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol";
 import {IClaimOwnership, _INTERFACEID_CLAIM_OWNERSHIP} from "../Custom/IClaimOwnership.sol";
 
 // constants
 import {_INTERFACEID_LSP0} from "../LSP0ERC725Account/LSP0Constants.sol";
-import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {
+    _INTERFACEID_LSP1,
+    _INTERFACEID_LSP1_DELEGATE
+} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP6} from "../LSP6KeyManager/LSP6Constants.sol";
 import {_INTERFACEID_LSP7} from "../LSP7DigitalAsset/LSP7Constants.sol";
 import {_INTERFACEID_LSP8} from "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";

--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -11,7 +11,6 @@ import {setDataSingleSelector} from "../LSP6KeyManager/LSP6Constants.sol";
 contract Executor {
     uint256 internal constant _OPERATION_CALL = 0;
 
-    // prettier-ignore
     address internal constant _DUMMY_RECIPIENT = 0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe;
 
     LSP6KeyManager private _keyManager;
@@ -28,7 +27,6 @@ contract Executor {
     // -----------
 
     function setHardcodedKey() public returns (bytes memory) {
-        // prettier-ignore
         bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         bytes memory value = "Some value";
 
@@ -87,7 +85,6 @@ contract Executor {
     // ----------------------
 
     function setHardcodedKeyRawCall() public returns (bool) {
-        // prettier-ignore
         bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         bytes memory value = "Some value";
 

--- a/contracts/Helpers/Tokens/IERC223.sol
+++ b/contracts/Helpers/Tokens/IERC223.sol
@@ -26,10 +26,7 @@ abstract contract IERC223 {
      * @dev Transfers `value` tokens from `msg.sender` to `to` address
      * and returns `true` on success.
      */
-    function transfer(address to, uint256 value)
-        public
-        virtual
-        returns (bool success);
+    function transfer(address to, uint256 value) public virtual returns (bool success);
 
     /**
      * @dev Transfers `value` tokens from `msg.sender` to `to` address with `data` parameter

--- a/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
+++ b/contracts/Helpers/Tokens/LSP4CompatibilityTester.sol
@@ -7,7 +7,10 @@ import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 import {LSP4Compatibility} from "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
 
 // constants
-import {_LSP4_TOKEN_NAME_KEY, _LSP4_TOKEN_SYMBOL_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
+import {
+    _LSP4_TOKEN_NAME_KEY,
+    _LSP4_TOKEN_SYMBOL_KEY
+} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 
 contract LSP4CompatibilityTester is ERC725Y, LSP4Compatibility {
     constructor(

--- a/contracts/Helpers/Tokens/LSP7CappedSupplyInitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CappedSupplyInitTester.sol
@@ -3,8 +3,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP7DigitalAssetInitAbstract} from "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
-import {LSP7CappedSupplyInitAbstract} from "../../LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol";
+import {
+    LSP7DigitalAssetInitAbstract
+} from "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
+import {
+    LSP7CappedSupplyInitAbstract
+} from "../../LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol";
 
 contract LSP7CappedSupplyInitTester is LSP7CappedSupplyInitAbstract {
     function initialize(

--- a/contracts/Helpers/Tokens/LSP7CompatibleERC20InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7CompatibleERC20InitTester.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";
-import {LSP7CompatibleERC20Init} from "../../LSP7DigitalAsset/extensions/LSP7CompatibleERC20Init.sol";
+import {
+    LSP7CompatibleERC20Init
+} from "../../LSP7DigitalAsset/extensions/LSP7CompatibleERC20Init.sol";
 
 contract LSP7CompatibleERC20InitTester is LSP7CompatibleERC20Init {
     function mint(

--- a/contracts/Helpers/Tokens/LSP8CappedSupplyInitTester.sol
+++ b/contracts/Helpers/Tokens/LSP8CappedSupplyInitTester.sol
@@ -3,8 +3,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
-import {LSP8CappedSupplyInitAbstract} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8CappedSupplyInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol";
 
 contract LSP8CappedSupplyInitTester is LSP8CappedSupplyInitAbstract {
     function initialize(

--- a/contracts/Helpers/Tokens/LSP8CappedSupplyTester.sol
+++ b/contracts/Helpers/Tokens/LSP8CappedSupplyTester.sol
@@ -3,7 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
 import {LSP8CappedSupply} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol";
 
 contract LSP8CappedSupplyTester is LSP8CappedSupply {

--- a/contracts/Helpers/Tokens/LSP8CompatibleERC721Tester.sol
+++ b/contracts/Helpers/Tokens/LSP8CompatibleERC721Tester.sol
@@ -3,8 +3,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
-import {LSP8CompatibleERC721} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol";
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8CompatibleERC721
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol";
 
 // constants
 import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";

--- a/contracts/Helpers/Tokens/LSP8CompatibleERC721TesterInit.sol
+++ b/contracts/Helpers/Tokens/LSP8CompatibleERC721TesterInit.sol
@@ -3,8 +3,12 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
-import {LSP8CompatibleERC721InitAbstract} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8CompatibleERC721InitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol";
 
 // constants
 import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";

--- a/contracts/Helpers/Tokens/LSP8InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP8InitTester.sol
@@ -3,7 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 contract LSP8InitTester is LSP8IdentifiableDigitalAssetInitAbstract {
     function initialize(

--- a/contracts/Helpers/Tokens/LSP8Tester.sol
+++ b/contracts/Helpers/Tokens/LSP8Tester.sol
@@ -3,7 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
 
 contract LSP8Tester is LSP8IdentifiableDigitalAsset {
     /* solhint-disable no-empty-blocks */

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import {ILSP1UniversalReceiverDelegate} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // modules
 import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.0;
 
 // interfaces
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
-import {ILSP1UniversalReceiverDelegate} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // modules
 import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverTester.sol
@@ -14,12 +14,12 @@ contract UniversalReceiverTester {
     }
 
     function checkImplementation(address _target, bytes32 _typeId) external payable {
-        ILSP1UniversalReceiver(_target).universalReceiver{ value: msg.value }(_typeId, "");
+        ILSP1UniversalReceiver(_target).universalReceiver{value: msg.value}(_typeId, "");
     }
 
     function checkImplementationLowLevelCall(address _target, bytes32 _typeId) external payable {
         // solhint-disable avoid-low-level-calls
-        (bool success, ) = _target.call{ value: msg.value }(
+        (bool success, ) = _target.call{value: msg.value}(
             abi.encodeWithSelector(ILSP1UniversalReceiver.universalReceiver.selector, _typeId, "")
         );
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 // interfaces
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // libraries
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -17,8 +19,16 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
 import {ClaimOwnership} from "../Custom/ClaimOwnership.sol";
 
 // constants
-import {_INTERFACEID_LSP0, _INTERFACEID_ERC1271, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
-import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {
+    _INTERFACEID_LSP0,
+    _INTERFACEID_ERC1271,
+    _ERC1271_FAILVALUE
+} from "../LSP0ERC725Account/LSP0Constants.sol";
+import {
+    _INTERFACEID_LSP1,
+    _INTERFACEID_LSP1_DELEGATE,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
+} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Custom/IClaimOwnership.sol";
 
 /**
@@ -111,7 +121,6 @@ abstract contract LSP0ERC725AccountCore is
         override
         returns (bytes4 magicValue)
     {
-        // prettier-ignore
         address _owner = owner();
         // if OWNER is a contract
         if (_owner.code.length != 0) {

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -10,9 +10,18 @@ import {TokenAndVaultHandling} from "./Handling/TokenAndVaultHandling.sol";
 
 // constants
 import {_INTERFACEID_LSP1_DELEGATE} from "../LSP1Constants.sol";
-import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../../LSP7DigitalAsset/LSP7Constants.sol";
-import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
-import {_TYPEID_LSP9_VAULTSENDER, _TYPEID_LSP9_VAULTRECIPIENT} from "../../LSP9Vault/LSP9Constants.sol";
+import {
+    _TYPEID_LSP7_TOKENSSENDER,
+    _TYPEID_LSP7_TOKENSRECIPIENT
+} from "../../LSP7DigitalAsset/LSP7Constants.sol";
+import {
+    _TYPEID_LSP8_TOKENSSENDER,
+    _TYPEID_LSP8_TOKENSRECIPIENT
+} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+import {
+    _TYPEID_LSP9_VAULTSENDER,
+    _TYPEID_LSP9_VAULTRECIPIENT
+} from "../../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Core Implementation of contract writing the received Vaults and LSP7, LSP8 assets into your ERC725Account using

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -10,8 +10,14 @@ import {TokenHandling} from "./Handling/TokenHandling.sol";
 
 // constants
 import {_INTERFACEID_LSP1_DELEGATE} from "../LSP1Constants.sol";
-import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../../LSP7DigitalAsset/LSP7Constants.sol";
-import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+import {
+    _TYPEID_LSP7_TOKENSSENDER,
+    _TYPEID_LSP7_TOKENSRECIPIENT
+} from "../../LSP7DigitalAsset/LSP7Constants.sol";
+import {
+    _TYPEID_LSP8_TOKENSSENDER,
+    _TYPEID_LSP8_TOKENSRECIPIENT
+} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
 
 /**
  * @title Core Implementation of contract writing the received LSP7 and LSP8 assets into your Vault using

--- a/contracts/LSP1UniversalReceiver/LSP1Utils.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Utils.sol
@@ -2,11 +2,25 @@
 pragma solidity ^0.8.0;
 
 // constants
-import {_LSP5_RECEIVED_ASSETS_ARRAY_KEY, _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX} from "../LSP5ReceivedAssets/LSP5Constants.sol";
-import {_INTERFACEID_LSP7, _TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "../LSP7DigitalAsset/LSP7Constants.sol";
-import {_INTERFACEID_LSP8, _TYPEID_LSP8_TOKENSRECIPIENT, _TYPEID_LSP8_TOKENSSENDER} from "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+import {
+    _LSP5_RECEIVED_ASSETS_ARRAY_KEY,
+    _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX
+} from "../LSP5ReceivedAssets/LSP5Constants.sol";
+import {
+    _INTERFACEID_LSP7,
+    _TYPEID_LSP7_TOKENSSENDER,
+    _TYPEID_LSP7_TOKENSRECIPIENT
+} from "../LSP7DigitalAsset/LSP7Constants.sol";
+import {
+    _INTERFACEID_LSP8,
+    _TYPEID_LSP8_TOKENSRECIPIENT,
+    _TYPEID_LSP8_TOKENSSENDER
+} from "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
 import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT} from "../LSP9Vault/LSP9Constants.sol";
-import {_LSP10_VAULTS_ARRAY_KEY, _LSP10_VAULTS_MAP_KEY_PREFIX} from "../LSP10ReceivedVaults/LSP10Constants.sol";
+import {
+    _LSP10_VAULTS_ARRAY_KEY,
+    _LSP10_VAULTS_MAP_KEY_PREFIX
+} from "../LSP10ReceivedVaults/LSP10Constants.sol";
 
 library LSP1Utils {
     /**

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -26,7 +26,7 @@ library LSP2Utils {
         require(
             dataKey[dataKey.length - 2] == 0x5b && // "[" in utf8 encoded
                 dataKey[dataKey.length - 1] == 0x5d, // "]" in utf8
-            "Missing empty square brackets "[]" at the end of the key name'
+            "Missing empty square brackets '[]' at the end of the key name"
         );
 
         return keccak256(dataKey);

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -23,11 +23,10 @@ library LSP2Utils {
     function generateArrayKey(string memory keyName) internal pure returns (bytes32) {
         bytes memory dataKey = bytes(keyName);
 
-        // prettier-ignore
         require(
             dataKey[dataKey.length - 2] == 0x5b && // "[" in utf8 encoded
                 dataKey[dataKey.length - 1] == 0x5d, // "]" in utf8
-            "Missing empty square brackets \"[]\" at the end of the key name"
+            "Missing empty square brackets "[]" at the end of the key name'
         );
 
         return keccak256(dataKey);
@@ -69,7 +68,11 @@ library LSP2Utils {
     {
         bytes32 firstWordHash = keccak256(bytes(firstWord));
 
-        bytes memory temporaryBytes = bytes.concat(bytes10(firstWordHash), bytes2(0), bytes20(addr));
+        bytes memory temporaryBytes = bytes.concat(
+            bytes10(firstWordHash),
+            bytes2(0),
+            bytes20(addr)
+        );
 
         return bytes32(temporaryBytes);
     }

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -2,10 +2,8 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {
-    ERC725YInitAbstract,
-    ERC725YCore
-} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
+import {ERC725YInitAbstract} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 
 // constants
 import "./LSP4Constants.sol";

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -2,7 +2,10 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {ERC725YInitAbstract, ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
+import {
+    ERC725YInitAbstract,
+    ERC725YCore
+} from "@erc725/smart-contracts/contracts/ERC725YInitAbstract.sol";
 
 // constants
 import "./LSP4Constants.sol";

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -25,7 +25,6 @@ import "./LSP6Errors.sol";
 import {InvalidABIEncodedArray} from "../LSP2ERC725YJSONSchema/LSP2Errors.sol";
 
 // constants
-// prettier-ignore
 import {
     OPERATION_CALL,
     OPERATION_CREATE,
@@ -33,7 +32,11 @@ import {
     OPERATION_STATICCALL,
     OPERATION_DELEGATECALL
 } from "@erc725/smart-contracts/contracts/constants.sol";
-import {_INTERFACEID_ERC1271, _ERC1271_MAGICVALUE, _ERC1271_FAILVALUE} from "../LSP0ERC725Account/LSP0Constants.sol";
+import {
+    _INTERFACEID_ERC1271,
+    _ERC1271_MAGICVALUE,
+    _ERC1271_FAILVALUE
+} from "../LSP0ERC725Account/LSP0Constants.sol";
 import "./LSP6Constants.sol";
 
 /**
@@ -177,9 +180,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         if (permissions == bytes32(0)) revert NoPermissionsSet(from);
 
-        // prettier-ignore
         if (erc725Function == setDataSingleSelector) {
-
             (bytes32 inputKey, bytes memory inputValue) = abi.decode(payload[4:], (bytes32, bytes));
 
             if (
@@ -187,23 +188,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                 bytes6(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
                 bytes16(inputKey) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX
             ) {
-
                 _verifyCanSetPermissions(inputKey, inputValue, from, permissions);
-
             } else {
-
                 bytes32[] memory wrappedInputKey = new bytes32[](1);
                 wrappedInputKey[0] = inputKey;
 
                 _verifyCanSetData(from, permissions, wrappedInputKey);
             }
-
         } else if (erc725Function == setDataMultipleSelector) {
-
-            (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(payload[4:], (bytes32[], bytes[]));
+            (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(
+                payload[4:],
+                (bytes32[], bytes[])
+            );
 
             bool isSettingERC725YKeys = false;
-            
+
             // loop through each ERC725Y data keys
             for (uint256 ii = 0; ii < inputKeys.length; ii++) {
                 bytes32 key = inputKeys[ii];
@@ -223,24 +222,18 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
                     // if the key is any other bytes32 key
                     isSettingERC725YKeys = true;
                 }
-
             }
 
             if (isSettingERC725YKeys) {
                 _verifyCanSetData(from, permissions, inputKeys);
             }
-
         } else if (erc725Function == IERC725X.execute.selector) {
-            
             _verifyCanExecute(from, permissions, payload);
-
         } else if (
             erc725Function == OwnableUnset.transferOwnership.selector ||
             erc725Function == IClaimOwnership.claimOwnership.selector
         ) {
-
             _requirePermissions(from, permissions, _PERMISSION_CHANGEOWNER);
-    
         } else {
             revert InvalidERC725Function(erc725Function);
         }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -10,13 +10,13 @@ import {LSP6KeyManagerInitAbstract} from "./LSP6KeyManagerInitAbstract.sol";
  * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
  */
 contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
-    
     /**
      * @dev initialize (= lock) base implementation contract on deployment
      */
     constructor() {
         _disableInitializers();
     }
+
     /**
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
      * @param target_ The address of the ER725Account to control

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInit.sol
@@ -14,7 +14,6 @@ import {LSP7DigitalAssetInitAbstract} from "./LSP7DigitalAssetInitAbstract.sol";
  * For a generic mechanism, see {LSP7Mintable}.
  */
 contract LSP7DigitalAssetInit is LSP7DigitalAssetInitAbstract {
-
     /**
      * @dev initialize (= lock) base implementation contract on deployment
      */

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -6,7 +6,9 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
-import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
+import {
+    LSP4DigitalAssetMetadataInitAbstract
+} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 import {LSP7DigitalAssetCore} from "./LSP7DigitalAssetCore.sol";
 
 // constants

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -3,7 +3,11 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP7DigitalAssetInitAbstract, LSP4DigitalAssetMetadataInitAbstract, ERC725YCore} from "../LSP7DigitalAssetInitAbstract.sol";
+import {
+    LSP7DigitalAssetInitAbstract,
+    LSP4DigitalAssetMetadataInitAbstract,
+    ERC725YCore
+} from "../LSP7DigitalAssetInitAbstract.sol";
 import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
 import {LSP7CompatibleERC20Core} from "./LSP7CompatibleERC20Core.sol";
 

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP7CompatibleERC20MintableInitAbstract} from "./LSP7CompatibleERC20MintableInitAbstract.sol";
+import {
+    LSP7CompatibleERC20MintableInitAbstract
+} from "./LSP7CompatibleERC20MintableInitAbstract.sol";
 
 contract LSP7CompatibleERC20MintableInit is LSP7CompatibleERC20MintableInitAbstract {
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInit.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "./LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "./LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 /**
  * @title LSP8IdentifiableDigitalAsset contract
@@ -10,7 +12,6 @@ import {LSP8IdentifiableDigitalAssetInitAbstract} from "./LSP8IdentifiableDigita
  * @dev Proxy Implementation of a LSP8 compliant contract.
  */
 contract LSP8IdentifiableDigitalAssetInit is LSP8IdentifiableDigitalAssetInitAbstract {
-    
     /**
      * @dev initialize (= lock) base implementation contract on deployment
      */

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -7,7 +7,9 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "./LSP8IdentifiableDigitalAssetCore.sol";
-import {LSP4DigitalAssetMetadataInitAbstract} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
+import {
+    LSP4DigitalAssetMetadataInitAbstract
+} from "../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol";
 
 // constants
 import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 import {LSP8CappedSupplyCore} from "./LSP8CappedSupplyCore.sol";
 
 /**

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -9,7 +9,11 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 // modules
-import {LSP8IdentifiableDigitalAsset, LSP4DigitalAssetMetadata, ERC725YCore} from "../LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8IdentifiableDigitalAsset,
+    LSP4DigitalAssetMetadata,
+    ERC725YCore
+} from "../LSP8IdentifiableDigitalAsset.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP8CompatibleERC721Core} from "./LSP8CompatibleERC721Core.sol";
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -6,7 +6,11 @@ pragma solidity ^0.8.0;
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // modules
-import {LSP8IdentifiableDigitalAssetInitAbstract, LSP4DigitalAssetMetadataInitAbstract, ERC725YCore} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    LSP4DigitalAssetMetadataInitAbstract,
+    ERC725YCore
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 import {LSP8CompatibleERC721Core} from "./LSP8CompatibleERC721Core.sol";
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8CompatibleERC721MintableInitAbstract} from "./LSP8CompatibleERC721MintableInitAbstract.sol";
+import {
+    LSP8CompatibleERC721MintableInitAbstract
+} from "./LSP8CompatibleERC721MintableInitAbstract.sol";
 
 contract LSP8CompatibleERC721MintableInit is LSP8CompatibleERC721MintableInitAbstract {
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -3,7 +3,9 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 import {LSP8MintableCore} from "./LSP8MintableCore.sol";
 
 /**

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -11,7 +11,11 @@ import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
+import {
+    _INTERFACEID_LSP9,
+    _LSP9_SUPPORTED_STANDARDS_KEY,
+    _LSP9_SUPPORTED_STANDARDS_VALUE
+} from "../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -4,7 +4,9 @@ pragma solidity ^0.8.0;
 // interfaces
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // libraries
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
@@ -17,8 +19,16 @@ import {ClaimOwnership} from "../Custom/ClaimOwnership.sol";
 
 // constants
 import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Custom/IClaimOwnership.sol";
-import {_INTERFACEID_LSP1, _INTERFACEID_LSP1_DELEGATE, _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_INTERFACEID_LSP9, _TYPEID_LSP9_VAULTRECIPIENT, _TYPEID_LSP9_VAULTSENDER} from "./LSP9Constants.sol";
+import {
+    _INTERFACEID_LSP1,
+    _INTERFACEID_LSP1_DELEGATE,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
+} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {
+    _INTERFACEID_LSP9,
+    _TYPEID_LSP9_VAULTRECIPIENT,
+    _TYPEID_LSP9_VAULTSENDER
+} from "./LSP9Constants.sol";
 
 /**
  * @title Core Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -11,7 +11,11 @@ import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import {_INTERFACEID_LSP9, _LSP9_SUPPORTED_STANDARDS_KEY, _LSP9_SUPPORTED_STANDARDS_VALUE} from "../LSP9Vault/LSP9Constants.sol";
+import {
+    _INTERFACEID_LSP9,
+    _LSP9_SUPPORTED_STANDARDS_KEY,
+    _LSP9_SUPPORTED_STANDARDS_VALUE
+} from "../LSP9Vault/LSP9Constants.sol";
 
 /**
  * @title Inheritable Proxy Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import {ILSP1UniversalReceiverDelegate} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
 
 // libraries
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -5,9 +5,8 @@ pragma solidity ^0.8.0;
 import {LSP0ERC725Account} from "./LSP0ERC725Account/LSP0ERC725Account.sol";
 
 // constants
-// prettier-ignore
 import {
-    _LSP3_SUPPORTED_STANDARDS_KEY, 
+    _LSP3_SUPPORTED_STANDARDS_KEY,
     _LSP3_SUPPORTED_STANDARDS_VALUE
 } from "./LSP3UniversalProfile/LSP3Constants.sol";
 

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -5,9 +5,8 @@ pragma solidity ^0.8.0;
 import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol";
 
 // constants
-// prettier-ignore
 import {
-    _LSP3_SUPPORTED_STANDARDS_KEY, 
+    _LSP3_SUPPORTED_STANDARDS_KEY,
     _LSP3_SUPPORTED_STANDARDS_VALUE
 } from "./LSP3UniversalProfile/LSP3Constants.sol";
 

--- a/contracts/Utils/UtilsLib.sol
+++ b/contracts/Utils/UtilsLib.sol
@@ -11,33 +11,21 @@ library UtilsLib {
     /**
      * @dev concatenate two bytes16
      */
-    function concatTwoBytes16(bytes16 b1, bytes16 b2)
-        internal
-        pure
-        returns (bytes memory result)
-    {
+    function concatTwoBytes16(bytes16 b1, bytes16 b2) internal pure returns (bytes memory result) {
         result = bytes.concat(b1, b2);
     }
 
     /**
      * @dev cast uint256 to bytes
      */
-    function uint256ToBytes(uint256 num)
-        internal
-        pure
-        returns (bytes memory bytes_)
-    {
+    function uint256ToBytes(uint256 num) internal pure returns (bytes memory bytes_) {
         bytes_ = bytes.concat(bytes32(num));
     }
 
     /**
      * @dev cast address to bytes
      */
-    function addressToBytes(address addr)
-        internal
-        pure
-        returns (bytes memory bytes_)
-    {
+    function addressToBytes(address addr) internal pure returns (bytes memory bytes_) {
         bytes_ = bytes.concat(bytes20(addr));
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

Simply improving the header of the contracts by changing the prettier config for `.solc` files + running prettier against the new contracts.

This helps making the contract import headers a bit clearer and remove some `// prettier-disable` comments.