### PR TITLE
chore: update of OpenZeppelin package and the custom ERC165Checker

### DIFF
--- a/contracts/Custom/ERC165Checker.sol
+++ b/contracts/Custom/ERC165Checker.sol
@@ -125,6 +125,6 @@ library ERC165Checker {
         );
         (bool success, bytes memory result) = account.staticcall{gas: 30000}(encodedParams);
         if (result.length < 32) return false;
-        return success && abi.decode(result, (bool));
+        return success && abi.decode(result, (uint256)) > 0;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^3.1.2",
-        "@openzeppelin/contracts": "^4.6.0",
+        "@openzeppelin/contracts": "^4.7.1",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
@@ -3150,9 +3150,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.6.0.tgz",
-      "integrity": "sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg=="
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.1.tgz",
+      "integrity": "sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw=="
     },
     "node_modules/@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",
@@ -33860,9 +33860,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.6.0.tgz",
-      "integrity": "sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg=="
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.1.tgz",
+      "integrity": "sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw=="
     },
     "@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
     "@erc725/smart-contracts": "^3.1.2",
-    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts": "^4.7.1",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# What does this PR introduce? 

- [x] update of OpenZeppelin package from `^4.6.0` to `^4.7.1`

- [x] update of our custom ERC165Checker according to https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3552/files