### PR TITLE
docs: edit comments title for LSP7/LSP8 interface

### DIFF
--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -7,7 +7,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
- * @title interface of the LSP7 - Digital Asset to represent a fungible token.
+ * @title interface of the LSP7 - Digital Asset standard.
  */
 interface ILSP7DigitalAsset is IERC165, IERC725Y {
     // --- Events

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -7,7 +7,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
- * @dev Required interface of a LSP8 compliant contract.
+ * @title interface of the LSP7 - Digital Asset to represent a fungible token.
  */
 interface ILSP7DigitalAsset is IERC165, IERC725Y {
     // --- Events

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -7,7 +7,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
- * @title interface of the LSP8 - Identifiable Digital Asset to represent a non-fungible token.
+ * @title interface of the LSP8 - Identifiable Digital Asset standard.
  */
 interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
     // --- Events

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -7,7 +7,7 @@ import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
 
 /**
- * @dev Required interface of a LSP8 compliant contract.
+ * @title interface of the LSP8 - Identifiable Digital Asset to represent a non-fungible token.
  */
 interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
     // --- Events

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -19,7 +19,6 @@ import "./LSP8Errors.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
-// import {} from "../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "./LSP8Constants.sol";
 
 /**


### PR DESCRIPTION
Fixed an issue in Natspec docs of LSP7/LSP8 + improved `@title` tag