### PR TITLE
refactor: use ERC725Y overloaded selectors from @erc725 npm package

### DIFF
--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -6,7 +6,7 @@ import {UniversalProfile} from "../UniversalProfile.sol";
 import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
-import {setDataSingleSelector} from "../LSP6KeyManager/LSP6Constants.sol";
+import {SETDATA_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
 
 contract Executor {
     uint256 internal constant _OPERATION_CALL = 0;
@@ -30,7 +30,7 @@ contract Executor {
         bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         bytes memory value = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, key, value);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -39,7 +39,7 @@ contract Executor {
         bytes32 key = keccak256(abi.encodePacked("Some Key"));
         bytes memory value = abi.encodePacked("Some value");
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, key, value);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -48,7 +48,7 @@ contract Executor {
         public
         returns (bytes memory)
     {
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, _key, _value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, _key, _value);
 
         return _keyManager.execute(erc725Payload);
     }
@@ -88,7 +88,7 @@ contract Executor {
         bytes32 key = 0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1;
         bytes memory value = "Some value";
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, key, value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -104,7 +104,7 @@ contract Executor {
         bytes32 key = keccak256(abi.encodePacked("Some Key"));
         bytes memory value = abi.encodePacked("Some value");
 
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, key, value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, key, value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,
@@ -120,7 +120,7 @@ contract Executor {
         public
         returns (bool)
     {
-        bytes memory erc725Payload = abi.encodeWithSelector(setDataSingleSelector, _key, _value);
+        bytes memory erc725Payload = abi.encodeWithSelector(SETDATA_SELECTOR, _key, _value);
 
         bytes memory keyManagerPayload = abi.encodeWithSelector(
             _keyManager.execute.selector,

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -57,9 +57,3 @@ bytes32 constant _PERMISSION_SUPER_TRANSFERVALUE = 0x000000000000000000000000000
 bytes32 constant _PERMISSION_SUPER_CALL         = 0x0000000000000000000000000000000000000000000000000000000000001000;
 bytes32 constant _PERMISSION_SUPER_STATICCALL   = 0x0000000000000000000000000000000000000000000000000000000000002000;
 bytes32 constant _PERMISSION_SUPER_DELEGATECALL = 0x0000000000000000000000000000000000000000000000000000000000004000;
-
-
-/// @dev see IERC725Y interface
-///      https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/interfaces/IERC725Y.sol
-bytes4 constant setDataSingleSelector = bytes4(keccak256("setData(bytes32,bytes)"));
-bytes4 constant setDataMultipleSelector = bytes4(keccak256("setData(bytes32[],bytes[])"));

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -26,11 +26,15 @@ import {InvalidABIEncodedArray} from "../LSP2ERC725YJSONSchema/LSP2Errors.sol";
 
 // constants
 import {
+    // ERC725X
     OPERATION_CALL,
     OPERATION_CREATE,
     OPERATION_CREATE2,
     OPERATION_STATICCALL,
-    OPERATION_DELEGATECALL
+    OPERATION_DELEGATECALL,
+    // ERC725Y
+    SETDATA_SELECTOR,
+    SETDATA_ARRAY_SELECTOR
 } from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _INTERFACEID_ERC1271,
@@ -180,7 +184,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         if (permissions == bytes32(0)) revert NoPermissionsSet(from);
 
-        if (erc725Function == setDataSingleSelector) {
+        if (erc725Function == SETDATA_SELECTOR) {
             (bytes32 inputKey, bytes memory inputValue) = abi.decode(payload[4:], (bytes32, bytes));
 
             if (
@@ -195,7 +199,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
                 _verifyCanSetData(from, permissions, wrappedInputKey);
             }
-        } else if (erc725Function == setDataMultipleSelector) {
+        } else if (erc725Function == SETDATA_ARRAY_SELECTOR) {
             (bytes32[] memory inputKeys, bytes[] memory inputValues) = abi.decode(
                 payload[4:],
                 (bytes32[], bytes[])

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -9,6 +9,7 @@ import {ILSP6KeyManager} from "./ILSP6KeyManager.sol";
 import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
+import {SETDATA_ARRAY_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
 import "../LSP6KeyManager/LSP6Constants.sol";
 
 library LSP6Utils {
@@ -101,7 +102,7 @@ library LSP6Utils {
         bytes32[] memory keys,
         bytes[] memory values
     ) internal returns (bytes memory result) {
-        bytes memory payload = abi.encodeWithSelector(hex"14a6e293", keys, values);
+        bytes memory payload = abi.encodeWithSelector(SETDATA_ARRAY_SELECTOR, keys, values);
         result = ILSP6KeyManager(keyManagerAddress).execute(payload);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

Version `3.1.1` of `@erc725/smart-contracts` introduce the `bytes4` function selectors of the overloaded functions `setData(bytes32,bytes)` or `setData(bytes32[],bytes[])`.

https://github.com/ERC725Alliance/ERC725/releases/tag/v3.1.1

Use the selectors from this npm package to improve readability.
