### PR TITLE
refactor: use OZ-upgradeable contracts to avoid conflicts in Init contracts

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // modules
 import {LSP0ERC725AccountCore} from "./LSP0ERC725AccountCore.sol";
-import {Initializable} from "@erc725/smart-contracts/contracts/custom/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -10,8 +10,7 @@ import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // modules
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
 // errors
@@ -28,9 +27,7 @@ import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Con
  *
  * This contract implement the core logic of the functions for the {ILSP7DigitalAsset} interface.
  */
-abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
-    using Address for address;
-
+abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     // --- Storage
 
     bool internal _isNFT;
@@ -74,14 +71,14 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
      * @inheritdoc ILSP7DigitalAsset
      */
     function authorizeOperator(address operator, uint256 amount) public virtual override {
-        _updateOperator(_msgSender(), operator, amount);
+        _updateOperator(msg.sender, operator, amount);
     }
 
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
     function revokeOperator(address operator) public virtual override {
-        _updateOperator(_msgSender(), operator, 0);
+        _updateOperator(msg.sender, operator, 0);
     }
 
     /**
@@ -113,7 +110,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) public virtual override {
-        address operator = _msgSender();
+        address operator = msg.sender;
         if (operator != from) {
             uint256 operatorAmount = _operatorAuthorizedAmount[from][operator];
             if (amount > operatorAmount) {
@@ -203,7 +200,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
             revert LSP7CannotSendWithAddressZero();
         }
 
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         _beforeTokenTransfer(address(0), to, amount);
 
@@ -240,7 +237,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
             revert LSP7AmountExceedsBalance(balance, from, amount);
         }
 
-        address operator = _msgSender();
+        address operator = msg.sender;
         if (operator != from) {
             uint256 authorizedAmount = _operatorAuthorizedAmount[from][operator];
             if (amount > authorizedAmount) {
@@ -287,7 +284,7 @@ abstract contract LSP7DigitalAssetCore is Context, ILSP7DigitalAsset {
             revert LSP7AmountExceedsBalance(balance, from, amount);
         }
 
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         _beforeTokenTransfer(from, to, amount);
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
@@ -47,7 +47,7 @@ abstract contract LSP7CompatibleERC20Core is
      * Using force=true so that EOA and any contract may receive the tokens.
      */
     function transfer(address to, uint256 amount) public virtual override returns (bool) {
-        transfer(_msgSender(), to, amount, true, "");
+        transfer(msg.sender, to, amount, true, "");
         return true;
     }
 
@@ -72,7 +72,7 @@ abstract contract LSP7CompatibleERC20Core is
     {
         super.authorizeOperator(operator, amount);
 
-        emit Approval(_msgSender(), operator, amount);
+        emit Approval(msg.sender, operator, amount);
     }
 
     // --- Internals

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -10,8 +10,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // modules
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
 
 // errors
@@ -26,10 +25,9 @@ import {_TYPEID_LSP8_TOKENSSENDER, _TYPEID_LSP8_TOKENSRECIPIENT} from "./LSP8Con
  * @author Matthew Stevens
  * @dev Core Implementation of a LSP8 compliant contract.
  */
-abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8IdentifiableDigitalAsset {
+abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAsset {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
-    using Address for address;
 
     // --- Storage
 
@@ -89,7 +87,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
      */
     function authorizeOperator(address operator, bytes32 tokenId) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
-        address caller = _msgSender();
+        address caller = msg.sender;
 
         if (tokenOwner != caller) {
             revert LSP8NotTokenOwner(tokenOwner, tokenId, caller);
@@ -114,7 +112,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
      */
     function revokeOperator(address operator, bytes32 tokenId) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
-        address caller = _msgSender();
+        address caller = msg.sender;
 
         if (tokenOwner != caller) {
             revert LSP8NotTokenOwner(tokenOwner, tokenId, caller);
@@ -185,7 +183,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
         bool force,
         bytes memory data
     ) public virtual override {
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         if (!_isOperatorOrOwner(operator, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, operator);
@@ -284,7 +282,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
             revert LSP8TokenIdAlreadyMinted(tokenId);
         }
 
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         _beforeTokenTransfer(address(0), to, tokenId);
 
@@ -307,7 +305,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
      */
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         _beforeTokenTransfer(tokenOwner, address(0), tokenId);
 
@@ -347,7 +345,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
             revert LSP8CannotSendToAddressZero();
         }
 
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         _beforeTokenTransfer(from, to, tokenId);
 

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -6,7 +6,7 @@ import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.so
 
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
-import {Initializable} from "@erc725/smart-contracts/contracts/custom/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {LSP9VaultCore, ClaimOwnership} from "./LSP9VaultCore.sol";
 
 // constants

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@erc725/smart-contracts": "^3.1.2",
         "@openzeppelin/contracts": "^4.7.1",
+        "@openzeppelin/contracts-upgradeable": "^4.7.1",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
@@ -3153,6 +3154,11 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.1.tgz",
       "integrity": "sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw=="
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz",
+      "integrity": "sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg=="
     },
     "node_modules/@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",
@@ -33863,6 +33869,11 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.1.tgz",
       "integrity": "sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw=="
+    },
+    "@openzeppelin/contracts-upgradeable": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.1.tgz",
+      "integrity": "sha512-5EFiZld3DYFd8aTL8eeMnhnaWh1/oXLXFNuFMrgF3b1DNPshF3LCyO7VR6lc+gac2URJ0BlVcZoCfkk/3MoEfg=="
     },
     "@primitivefi/hardhat-dodoc": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@erc725/smart-contracts": "^3.1.2",
     "@openzeppelin/contracts": "^4.7.1",
+    "@openzeppelin/contracts-upgradeable": "^4.7.1",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
@@ -99,18 +99,6 @@ describe("LSP7", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("should have locked (= initialized) the implementation contract", async () => {
-        const accounts = await ethers.getSigners();
-
-        const lsp7TesterInit = await new LSP7InitTester__factory(
-          accounts[0]
-        ).deploy();
-
-        const isInitialized = await lsp7TesterInit.callStatic.initialized();
-
-        expect(isInitialized).toBeTruthy();
-      });
-
       it("prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
@@ -106,20 +106,6 @@ describe("LSP7CompatibleERC20", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("should have locked (= initialized) the implementation contract", async () => {
-        const accounts = await ethers.getSigners();
-
-        const lsp7CompatibilityForERC20TesterInit =
-          await new LSP7CompatibleERC20InitTester__factory(
-            accounts[0]
-          ).deploy();
-
-        const isInitialized =
-          await lsp7CompatibilityForERC20TesterInit.callStatic.initialized();
-
-        expect(isInitialized).toBeTruthy();
-      });
-
       it("prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 

--- a/tests/LSP7DigitalAsset/extensions/LSP7Mintable.test.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7Mintable.test.ts
@@ -96,18 +96,6 @@ describe("LSP7Mintable", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("should have locked (= initialized) the implementation contract", async () => {
-        const accounts = await ethers.getSigners();
-
-        const lsp7MintableInit = await new LSP7MintableInit__factory(
-          accounts[0]
-        ).deploy();
-
-        const isInitialized = await lsp7MintableInit.callStatic.initialized();
-
-        expect(isInitialized).toBeTruthy();
-      });
-
       it("prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -134,18 +134,6 @@ describe("LSP9Vault", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("should have locked (= initialized) the implementation contract", async () => {
-        const accounts = await ethers.getSigners();
-
-        const lsp9VaultInit = await new LSP9VaultInit__factory(
-          accounts[0]
-        ).deploy();
-
-        const isInitialized = await lsp9VaultInit.callStatic.initialized();
-
-        expect(isInitialized).toBeTruthy();
-      });
-
       it("prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -198,18 +198,6 @@ describe("UniversalProfile", () => {
       };
 
     describe("when deploying the base implementation contract", () => {
-      it("should have locked (= initialized) the implementation contract", async () => {
-        const accounts = await ethers.getSigners();
-
-        const universalProfileInit = await new UniversalProfileInit__factory(
-          accounts[0]
-        ).deploy();
-
-        const isInitialized =
-          await universalProfileInit.callStatic.initialized();
-
-        expect(isInitialized).toBeTruthy();
-      });
       it("prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 


### PR DESCRIPTION
## What does this PR introduce?
- [x] remove custom Initializable contract
- [x] replace custom Initializable contract with OZ-upgradeable Initializable contract
- [x] remove tests related to custom Initializable contract
- [x] remove contracts that may conflict with OZ-upgradeable contracts (Context, Address, etc..) 
Closes #233

Will need also to release erc725 smart contract after this change: https://github.com/ERC725Alliance/ERC725/pull/150