### PR TITLE
fix: add `setApprovalForAll(...)` in `LSP8CompatibleERC721`

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -226,7 +226,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is Context, ILSP8Identifiable
     }
 
     function _clearOperators(address tokenOwner, bytes32 tokenId) internal virtual {
-        // TODO: here is a good exmaple of why having multiple operators will be expensive.. we
+        // TODO: here is a good example of why having multiple operators will be expensive.. we
         // need to clear them on token transfer
         //
         // NOTE: this may cause a tx to fail if there is too many operators to clear, in which case

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
@@ -28,6 +28,12 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
 
     /**
+     * @dev This emits when an operator is enabled or disabled for an owner.
+     * The operator can manage all NFTs of the owner.
+     */
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    /**
      * @dev Compatible with ERC721 transferFrom.
      * @param from The sending address
      * @param to The receiving address
@@ -78,6 +84,14 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @param tokenId The tokenId to approve
      */
     function approve(address operator, uint256 tokenId) external;
+
+    /**
+     * @notice Enable or disable approval for a third party ("operator") to manage all of `msg.sender`'s assets
+     * @dev Emits the ApprovalForAll event. The contract MUST allow multiple operators per owner.
+     * @param _operator Address to add to the set of authorized operators
+     * @param _approved True if the operator is approved, false to revoke approval
+     */
+    function setApprovalForAll(address _operator, bool _approved) external;
 
     /**
      * @dev Compatible with ERC721 getApproved.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
@@ -80,7 +80,7 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
 
     /**
      * @dev Compatible with ERC721 approve.
-     * @param operator The address to approve for `amount`
+     * @param operator The address to approve for `tokenId`
      * @param tokenId The tokenId to approve
      */
     function approve(address operator, uint256 tokenId) external;

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -159,7 +159,7 @@ abstract contract LSP8CompatibleERC721Core is
         emit Approval(
             tokenOwnerOf(tokenId),
             operator,
-            abi.decode(abi.encodePacked(tokenId), (uint256))
+            uint256(tokenId)
         );
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -69,7 +69,7 @@ abstract contract LSP8CompatibleERC721Core is
     }
 
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        _setApprovalForAll(msg.sender, operator, approved);
+        _setApprovalForAll(_msgSender(), operator, approved);
     }
 
     /**
@@ -172,13 +172,13 @@ abstract contract LSP8CompatibleERC721Core is
     ) internal virtual override {
         address operator = _msgSender();
 
-        if (!isApprovedForAll(from, operator) && !_isOperatorOrOwner(operator, bytes32(tokenId))) {
-            revert LSP8NotTokenOperator(bytes32(tokenId), operator);
+        if (!isApprovedForAll(from, operator) && !_isOperatorOrOwner(operator, tokenId)) {
+            revert LSP8NotTokenOperator(tokenId, operator);
         }
 
         super._transfer(from, to, tokenId, force, data);
 
-        emit Transfer(from, to, abi.decode(abi.encodePacked(tokenId), (uint256)));
+        emit Transfer(from, to, uint256(tokenId));
     }
 
     function _mint(
@@ -189,7 +189,7 @@ abstract contract LSP8CompatibleERC721Core is
     ) internal virtual override {
         super._mint(to, tokenId, force, data);
 
-        emit Transfer(address(0), to, abi.decode(abi.encodePacked(tokenId), (uint256)));
+        emit Transfer(address(0), to, uint256(tokenId));
     }
 
     function _burn(bytes32 tokenId, bytes memory data) internal virtual override {
@@ -197,7 +197,7 @@ abstract contract LSP8CompatibleERC721Core is
 
         super._burn(tokenId, data);
 
-        emit Transfer(tokenOwner, address(0), abi.decode(abi.encodePacked(tokenId), (uint256)));
+        emit Transfer(tokenOwner, address(0), uint256(tokenId));
     }
 
     /**
@@ -210,7 +210,7 @@ abstract contract LSP8CompatibleERC721Core is
         address operator,
         bool approved
     ) internal virtual {
-        require(tokensOwner != operator, "LSP8: approve to caller");
+        require(tokensOwner != operator, "LSP8CompatibleERC721: approve to caller");
         _operatorApprovals[tokensOwner][operator] = approved;
         emit ApprovalForAll(tokensOwner, operator, approved);
     }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -14,6 +14,9 @@ import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {LSP4Compatibility} from "../../LSP4DigitalAssetMetadata/LSP4Compatibility.sol";
 import {LSP8IdentifiableDigitalAssetCore} from "../LSP8IdentifiableDigitalAssetCore.sol";
 
+// errors
+import "../LSP8Errors.sol";
+
 // constants
 import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.sol";
 
@@ -115,7 +118,7 @@ abstract contract LSP8CompatibleERC721Core is
         address to,
         uint256 tokenId
     ) public virtual override {
-        return transfer(from, to, bytes32(tokenId), true, "");
+        return _transfer(from, to, bytes32(tokenId), true, "");
     }
 
     /**
@@ -128,7 +131,7 @@ abstract contract LSP8CompatibleERC721Core is
         address to,
         uint256 tokenId
     ) public virtual override {
-        return transfer(from, to, bytes32(tokenId), false, "");
+        return _transfer(from, to, bytes32(tokenId), false, "");
     }
 
     /*
@@ -141,7 +144,7 @@ abstract contract LSP8CompatibleERC721Core is
         uint256 tokenId,
         bytes memory data
     ) public virtual override {
-        return transfer(from, to, bytes32(tokenId), false, data);
+        return _transfer(from, to, bytes32(tokenId), false, data);
     }
 
     // --- Overrides
@@ -167,6 +170,12 @@ abstract contract LSP8CompatibleERC721Core is
         bool force,
         bytes memory data
     ) internal virtual override {
+        address operator = _msgSender();
+
+        if (!isApprovedForAll(from, operator) && !_isOperatorOrOwner(operator, bytes32(tokenId))) {
+            revert LSP8NotTokenOperator(bytes32(tokenId), operator);
+        }
+
         super._transfer(from, to, tokenId, force, data);
 
         emit Transfer(from, to, abi.decode(abi.encodePacked(tokenId), (uint256)));

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
@@ -264,17 +264,6 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         await context.lsp8CompatibleERC721
           .connect(context.accounts.owner)
           .mint(txParams.to, txParams.tokenId, txParams.data);
-
-        // @todo
-        // add 3 x individual operators per tokenId to test if the operators array is cleared
-        // once the tokenId has been transferred by operator that is approvedForAll
-        // const operatorsPerTokenIds = getRandomAddresses(3);
-
-        // operatorsPerTokenIds.map(async (operator) => {
-        //   await context.lsp8CompatibleERC721
-        //     .connect(context.accounts.owner)
-        //     .approve(operator, tokenId);
-        // });
       });
 
       await context.lsp8CompatibleERC721
@@ -351,7 +340,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             const sender = context.accounts.owner.address;
             const recipient = context.accounts.tokenReceiver.address;
 
-            const tx = await context.lsp8CompatibleERC721
+            await context.lsp8CompatibleERC721
               .connect(context.accounts.operator)
               .transferFrom(sender, recipient, testCase.tokenId);
 
@@ -378,22 +367,42 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             );
           });
 
-          // @todo
-          //   it("should have cleared operators array", async () => {
-          //     const sender = context.accounts.owner.address;
-          //     const recipient = context.accounts.tokenReceiver.address;
+          it("should have cleared operators array", async () => {
+            // add 3 x individual operators per tokenId to test if the operators array is cleared
+            // once the tokenId has been transferred by operator that is approvedForAll
+            // const operatorsPerTokenIds = getRandomAddresses(1);
+            const operatorsPerTokenIdsBefore = [
+              "0xcafecafecafecafecafecafecafecafecafecafe",
+              "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+              "0xf00df00df00df00df00df00df00df00df00df00d",
+            ];
 
-          //     const tx = await context.lsp8CompatibleERC721
-          //       .connect(context.accounts.operator)
-          //       .transferFrom(sender, recipient, testCase.tokenId);
+            await context.lsp8CompatibleERC721
+              .connect(context.accounts.owner)
+              .approve(operatorsPerTokenIdsBefore[0], testCase.tokenId);
 
-          //     const operatorsForTokenIdAfter =
-          //       await context.lsp8CompatibleERC721.getOperatorsOf(
-          //         testCase.tokenId
-          //       );
+            await context.lsp8CompatibleERC721
+              .connect(context.accounts.owner)
+              .approve(operatorsPerTokenIdsBefore[1], testCase.tokenId);
 
-          //     expect(operatorsForTokenIdAfter).toStrictEqual([]);
-          //   });
+            await context.lsp8CompatibleERC721
+              .connect(context.accounts.owner)
+              .approve(operatorsPerTokenIdsBefore[2], testCase.tokenId);
+
+            const sender = context.accounts.owner.address;
+            const recipient = context.accounts.tokenReceiver.address;
+
+            await context.lsp8CompatibleERC721
+              .connect(context.accounts.operator)
+              .transferFrom(sender, recipient, testCase.tokenId);
+
+            const operatorsForTokenIdAfter =
+              await context.lsp8CompatibleERC721.getOperatorsOf(
+                testCase.tokenId
+              );
+
+            expect(operatorsForTokenIdAfter).toStrictEqual([]);
+          });
         });
       });
     });

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -1,3 +1,4 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers } from "hardhat";
 
 export const abiCoder = ethers.utils.defaultAbiCoder;
@@ -36,12 +37,12 @@ export const TOKEN_ID = {
   EIGHT: "0x367f9d97f8dd1bece61f8b74c5db7616958147682674fd32de73490bd6347f60",
 };
 
-export function getRandomAddresses(count) {
-  let addresses = [];
+export function getRandomAddresses(count: Number): string[] {
+  let addresses: string[] = [];
   for (let ii = 0; ii < count; ii++) {
     // addresses stored under ERC725Y storage have always lowercases character.
     // therefore, disable the checksum by converting to lowercase to avoid failing tests
-    let randomAddress = new ethers.Wallet.createRandom().address.toLowerCase();
+    let randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
     addresses.push(randomAddress);
   }
 


### PR DESCRIPTION
# What does this PR introduce?

The backward compatible version of LSP8 with ERC721 is missing a function `setApprovalForAll(...)` that is part of the ERC721 interface.

This PR introduces this function in `LSP8CompatibleERC721` alongside a mapping `_operatorsApprovals` storing the operators address that are approved for all tokenIds owned by a `tokenOwner`.

> **NB:** gas cost of `transferFrom(...)` with `LSP8CompatibleERC721` is around 188k gas.