### PR TITLE
chore: remove functions of Context contract

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -69,7 +69,7 @@ abstract contract LSP8CompatibleERC721Core is
     }
 
     function setApprovalForAll(address operator, bool approved) public virtual override {
-        _setApprovalForAll(_msgSender(), operator, approved);
+        _setApprovalForAll(msg.sender, operator, approved);
     }
 
     /**
@@ -156,11 +156,7 @@ abstract contract LSP8CompatibleERC721Core is
     {
         super.authorizeOperator(operator, tokenId);
 
-        emit Approval(
-            tokenOwnerOf(tokenId),
-            operator,
-            uint256(tokenId)
-        );
+        emit Approval(tokenOwnerOf(tokenId), operator, uint256(tokenId));
     }
 
     function _transfer(
@@ -170,7 +166,7 @@ abstract contract LSP8CompatibleERC721Core is
         bool force,
         bytes memory data
     ) internal virtual override {
-        address operator = _msgSender();
+        address operator = msg.sender;
 
         if (!isApprovedForAll(from, operator) && !_isOperatorOrOwner(operator, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, operator);


### PR DESCRIPTION
## What does this PR introduce?
- https://github.com/lukso-network/lsp-smart-contracts/pull/238 removed the Context contract but another following PR, made a fix on a contract that included some functions of Context Contract.

This PR will remove the functions related to Context contract so the contracts can compile successfully.