### PR TITLE
FIX: Update Openzeppelin to enable ECDSA signature malleabbility

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
     "@erc725/smart-contracts": "^3.1.2",
-    "@openzeppelin/contracts": "^4.7.1",
-    "@openzeppelin/contracts-upgradeable": "^4.7.1",
+    "@openzeppelin/contracts": "^4.7.3",
+    "@openzeppelin/contracts-upgradeable": "^4.7.3",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**What does this PR introduce?**
A security vulnerability was discovered in the affected version of `@openzeppelin/contracts` and  `@openzeppelin/contracts-upgradeable` `>= 4.1.0 ` with Patched versions released on `< 4.7.3`.

As described the Impact includes:

The functions `ECDSA.recover` and `ECDSA.tryRecover` are vulnerable to a kind of signature malleability due to accepting `EIP-2098` compact signatures in addition to the traditional 65-byte signature format. This is only an issue for the functions that take a single `bytes` argument and not the functions that take `r, v, s` or ` r, vs` as separate arguments.

The potentially affected contracts are those that implement signature reuse or replay protection by marking the signature itself as used rather than the signed message or a nonce included in it. A user may take a signature that has already been submitted, submit it again in a different form, and bypass this protection.

The following contract implements might be subject to this vulnerability:

- LSP0ERC725AccountCore `and`
- LSP6KeyManagerCore

The above is extracted from [ECDSA signature malleability](https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories/GHSA-4h98-2769-gh6h) with more details.