### PR TITLE
build: edit artifacts wildcard pattern for included files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "files": [
     "contracts/**/*.sol",
     "!contracts/Helpers/**/*.sol",
-    "artifacts/**/*.json",
+    "artifacts/*.json",
     "constants.js",
     "README.md",
     "CONTRIBUTING.md",


### PR DESCRIPTION
The `package.json` file mentions the following matching pattern for artifacts to include in the npm package:

`artifacts/**/*.json`

This pattern is out of date, as the command `hardhat prepare-package` will generate all the artifacts as a `.json` list under the `artifacts/` folder, without including any subfolders.