### PR TITLE
test: simplify testing events using Hardhat Chai matchers

### DIFF
--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -172,9 +172,7 @@ export const shouldBehaveLikeClaimOwnership = (
       it("should have emitted a OwnershipTransferred event", async () => {
         const owner = await context.contract.owner();
 
-        let tx = await context.contract.connect(newOwner).claimOwnership();
-
-        await expect(tx)
+        await expect(await context.contract.connect(newOwner).claimOwnership())
           .to.emit(context.contract, "OwnershipTransferred")
           .withArgs(
             owner, // previous owner

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -243,29 +243,17 @@ export const shouldBehaveLikeClaimOwnership = (
           const recipient = context.accounts[3];
           const amount = ethers.utils.parseEther("3");
 
-          const recipientBalanceBefore = await provider.getBalance(
-            recipient.address
+          await expect(() =>
+            context.contract
+              .connect(newOwner)
+              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x")
+          ).to.changeEtherBalances(
+            [context.contract.address, recipient.address],
+            [
+              `-${amount}`, // account balance should have gone down
+              amount, // recipient balance should have gone up
+            ]
           );
-          const accountBalanceBefore = await provider.getBalance(
-            context.contract.address
-          );
-
-          await context.contract
-            .connect(newOwner)
-            .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x");
-
-          const recipientBalanceAfter = await provider.getBalance(
-            recipient.address
-          );
-          const accountBalanceAfter = await provider.getBalance(
-            context.contract.address
-          );
-
-          // recipient balance should have gone up
-          expect(recipientBalanceAfter).to.be.gt(recipientBalanceBefore);
-
-          // account balance should have gone down
-          expect(accountBalanceAfter).to.be.lt(accountBalanceBefore);
         });
       });
     });

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -78,8 +78,9 @@ export const shouldBehaveLikeClaimOwnership = (
           "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
         const value = "0xabcd";
 
-        // prettier-ignore
-        await context.contract.connect(context.deployParams.owner)["setData(bytes32,bytes)"](key, value);
+        await context.contract
+          .connect(context.deployParams.owner)
+          ["setData(bytes32,bytes)"](key, value);
 
         const result = await context.contract["getData(bytes32)"](key);
         expect(result).to.equal(value);
@@ -232,8 +233,9 @@ export const shouldBehaveLikeClaimOwnership = (
             "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
           const value = "0xabcd";
 
-          // prettier-ignore
-          await context.contract.connect(newOwner)["setData(bytes32,bytes)"](key, value);
+          await context.contract
+            .connect(newOwner)
+            ["setData(bytes32,bytes)"](key, value);
 
           const result = await context.contract["getData(bytes32)"](key);
           expect(result).to.equal(value);

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -36,13 +36,13 @@ export const shouldBehaveLikeLSP1 = (
         const caller = context.accounts[2];
         const data = "0xaabbccdd";
 
-        let tx = await context.lsp1Implementation
-          .connect(caller)
-          .universalReceiver(LSP1_HOOK_PLACEHOLDER, data, {
-            value: valueSent,
-          });
-
-        await expect(tx)
+        await expect(
+          context.lsp1Implementation
+            .connect(caller)
+            .universalReceiver(LSP1_HOOK_PLACEHOLDER, data, {
+              value: valueSent,
+            })
+        )
           .to.emit(context.lsp1Implementation, "UniversalReceiver")
           .withArgs(
             // from
@@ -62,12 +62,12 @@ export const shouldBehaveLikeLSP1 = (
     describe("from a Contract", () => {
       describe("via a contract call - `contract.universalReceiver(...)`", () => {
         it("should emit an UniversalReceiver(...) event", async () => {
-          let tx = await context.lsp1Checker.checkImplementation(
-            context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER
-          );
-
-          await expect(tx)
+          await expect(
+            context.lsp1Checker.checkImplementation(
+              context.lsp1Implementation.address,
+              LSP1_HOOK_PLACEHOLDER
+            )
+          )
             .to.emit(context.lsp1Implementation, "UniversalReceiver")
             .withArgs(
               // from
@@ -86,12 +86,12 @@ export const shouldBehaveLikeLSP1 = (
 
       describe("via a low-level call - `address(contract).call(...)`", () => {
         it("should emit an UniversalReceiver(...) event", async () => {
-          let tx = await context.lsp1Checker.checkImplementationLowLevelCall(
-            context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER
-          );
-
-          await expect(tx)
+          await expect(
+            context.lsp1Checker.checkImplementationLowLevelCall(
+              context.lsp1Implementation.address,
+              LSP1_HOOK_PLACEHOLDER
+            )
+          )
             .to.emit(context.lsp1Implementation, "UniversalReceiver")
             .withArgs(
               // from
@@ -169,13 +169,13 @@ export const shouldBehaveLikeLSP1 = (
 
       describe("via a contract call - `contract.universalReceiver(...)`", () => {
         it("should emit an UniversalReceiver(...) event", async () => {
-          let tx = await context.lsp1Checker.checkImplementation(
-            context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER,
-            { value: valueSent }
-          );
-
-          await expect(tx)
+          await expect(
+            context.lsp1Checker.checkImplementation(
+              context.lsp1Implementation.address,
+              LSP1_HOOK_PLACEHOLDER,
+              { value: valueSent }
+            )
+          )
             .to.emit(context.lsp1Implementation, "UniversalReceiver")
             .withArgs(
               // from
@@ -194,13 +194,13 @@ export const shouldBehaveLikeLSP1 = (
 
       describe("via a low-level call - `address(contract).call(...)`", () => {
         it("should emit an UniversalReceiver(...) event", async () => {
-          let tx = await context.lsp1Checker.checkImplementationLowLevelCall(
-            context.lsp1Implementation.address,
-            LSP1_HOOK_PLACEHOLDER,
-            { value: valueSent }
-          );
-
-          await expect(tx)
+          await expect(
+            context.lsp1Checker.checkImplementationLowLevelCall(
+              context.lsp1Implementation.address,
+              LSP1_HOOK_PLACEHOLDER,
+              { value: valueSent }
+            )
+          )
             .to.emit(context.lsp1Implementation, "UniversalReceiver")
             .withArgs(
               // from

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -33,40 +33,29 @@ export const shouldBehaveLikeLSP1 = (
 
     describe("from an EOA", () => {
       it("should emit a UniversalReceiver(...) event with correct topics", async () => {
-        let caller = context.accounts[2];
+        const caller = context.accounts[2];
+        const data = "0xaabbccdd";
 
         let tx = await context.lsp1Implementation
           .connect(caller)
-          .universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x", {
+          .universalReceiver(LSP1_HOOK_PLACEHOLDER, data, {
             value: valueSent,
           });
 
-        let receipt = await tx.wait();
-
-        // event should come from the lsp1Implementation
-        expect(receipt.logs[0].address).to.equal(
-          context.lsp1Implementation.address
-        );
-
-        // should be the Universal Receiver event (= event signature)
-        expect(receipt.logs[0].topics[0]).to.equal(
-          EventSignatures.LSP1["UniversalReceiver"]
-        );
-
-        // from
-        expect(receipt.logs[0].topics[1]).to.equal(
-          ethers.utils.hexZeroPad(caller.address.toLowerCase(), 32)
-        );
-
-        // typeId
-        expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-        // value + receivedData (any parameter not index)
-        const dataField = abiCoder.encode(
-          ["uint256", "bytes"],
-          [valueSent, "0x"]
-        );
-        expect(receipt.logs[0].data).to.equal(dataField);
+        await expect(tx)
+          .to.emit(context.lsp1Implementation, "UniversalReceiver")
+          .withArgs(
+            // from
+            caller.address,
+            // value
+            valueSent,
+            // typeId
+            LSP1_HOOK_PLACEHOLDER,
+            // returnedValue
+            "0x",
+            // receivedData
+            data
+          );
       });
     });
 
@@ -78,32 +67,20 @@ export const shouldBehaveLikeLSP1 = (
             LSP1_HOOK_PLACEHOLDER
           );
 
-          let receipt = await tx.wait();
-
-          // event should come from account
-          expect(receipt.logs[0].address).to.equal(
-            context.lsp1Implementation.address
-          );
-          // should be the Universal Receiver event (= event signature)
-          expect(receipt.logs[0].topics[0]).to.equal(
-            EventSignatures.LSP1["UniversalReceiver"]
-          );
-          // from
-          expect(receipt.logs[0].topics[1]).to.equal(
-            ethers.utils.hexZeroPad(
-              context.lsp1Checker.address.toLowerCase(),
-              32
-            )
-          );
-          // typeId
-          expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-          // value + receivedData (any parameter not index)
-          const dataField = abiCoder.encode(
-            ["uint256", "bytes"],
-            [valueSent, "0x"]
-          );
-          expect(receipt.logs[0].data).to.equal(dataField);
+          await expect(tx)
+            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .withArgs(
+              // from
+              context.lsp1Checker.address,
+              // value
+              valueSent,
+              // typeId
+              LSP1_HOOK_PLACEHOLDER,
+              // returnedValue
+              "0x",
+              // receivedData
+              "0x"
+            );
         });
       });
 
@@ -114,32 +91,20 @@ export const shouldBehaveLikeLSP1 = (
             LSP1_HOOK_PLACEHOLDER
           );
 
-          let receipt = await tx.wait();
-
-          // event should come from account
-          expect(receipt.logs[0].address).to.equal(
-            context.lsp1Implementation.address
-          );
-          // should be the Universal Receiver event (= event signature)
-          expect(receipt.logs[0].topics[0]).to.equal(
-            EventSignatures.LSP1["UniversalReceiver"]
-          );
-          // from
-          expect(receipt.logs[0].topics[1]).to.equal(
-            ethers.utils.hexZeroPad(
-              context.lsp1Checker.address.toLowerCase(),
-              32
-            )
-          );
-          // typeId
-          expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-          // value + receivedData (any parameter not index)
-          const dataField = abiCoder.encode(
-            ["uint256", "bytes"],
-            [valueSent, "0x"]
-          );
-          expect(receipt.logs[0].data).to.equal(dataField);
+          await expect(tx)
+            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .withArgs(
+              // from
+              context.lsp1Checker.address,
+              // value
+              valueSent,
+              // typeId
+              LSP1_HOOK_PLACEHOLDER,
+              // returnedValue
+              "0x",
+              // receivedData
+              "0x"
+            );
         });
       });
 
@@ -210,32 +175,20 @@ export const shouldBehaveLikeLSP1 = (
             { value: valueSent }
           );
 
-          let receipt = await tx.wait();
-
-          // event should come from account
-          expect(receipt.logs[0].address).to.equal(
-            context.lsp1Implementation.address
-          );
-          // should be the Universal Receiver event (= event signature)
-          expect(receipt.logs[0].topics[0]).to.equal(
-            EventSignatures.LSP1["UniversalReceiver"]
-          );
-          // from
-          expect(receipt.logs[0].topics[1]).to.equal(
-            ethers.utils.hexZeroPad(
-              context.lsp1Checker.address.toLowerCase(),
-              32
-            )
-          );
-          // typeId
-          expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-          // value + receivedData (any parameter not index)
-          const dataField = abiCoder.encode(
-            ["uint256", "bytes"],
-            [valueSent.toHexString(), "0x"]
-          );
-          expect(receipt.logs[0].data).to.equal(dataField);
+          await expect(tx)
+            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .withArgs(
+              // from
+              context.lsp1Checker.address,
+              // value
+              valueSent,
+              // typeId
+              LSP1_HOOK_PLACEHOLDER,
+              // returnedValue
+              "0x",
+              // receivedData
+              "0x"
+            );
         });
       });
 
@@ -247,32 +200,20 @@ export const shouldBehaveLikeLSP1 = (
             { value: valueSent }
           );
 
-          let receipt = await tx.wait();
-
-          // event should come from account
-          expect(receipt.logs[0].address).to.equal(
-            context.lsp1Implementation.address
-          );
-          // should be the Universal Receiver event (= event signature)
-          expect(receipt.logs[0].topics[0]).to.equal(
-            EventSignatures.LSP1["UniversalReceiver"]
-          );
-          // from
-          expect(receipt.logs[0].topics[1]).to.equal(
-            ethers.utils.hexZeroPad(
-              context.lsp1Checker.address.toLowerCase(),
-              32
-            )
-          );
-          // typeId
-          expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-          // value + receivedData (any parameter not index)
-          const dataField = abiCoder.encode(
-            ["uint256", "bytes"],
-            [valueSent.toHexString(), "0x"]
-          );
-          expect(receipt.logs[0].data).to.equal(dataField);
+          await expect(tx)
+            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .withArgs(
+              // from
+              context.lsp1Checker.address,
+              // value
+              valueSent,
+              // typeId
+              LSP1_HOOK_PLACEHOLDER,
+              // returnedValue
+              "0x",
+              // receivedData
+              "0x"
+            );
         });
       });
     });

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -207,12 +207,12 @@ export const shouldBehaveLikeLSP3 = (
       const sender = context.accounts[0];
       const amount = ethers.utils.parseEther("5");
 
-      let tx = await sender.sendTransaction({
-        to: context.universalProfile.address,
-        value: amount,
-      });
-
-      await expect(tx)
+      await expect(
+        sender.sendTransaction({
+          to: context.universalProfile.address,
+          value: amount,
+        })
+      )
         .to.emit(context.universalProfile, "ValueReceived")
         .withArgs(sender.address, amount);
     });
@@ -221,13 +221,13 @@ export const shouldBehaveLikeLSP3 = (
       const sender = context.accounts[0];
       const amount = ethers.utils.parseEther("5");
 
-      let tx = await context.accounts[0].sendTransaction({
-        to: context.universalProfile.address,
-        value: amount,
-        data: "0xaabbccdd",
-      });
-
-      await expect(tx)
+      await expect(
+        sender.sendTransaction({
+          to: context.universalProfile.address,
+          value: amount,
+          data: "0xaabbccdd",
+        })
+      )
         .to.emit(context.universalProfile, "ValueReceived")
         .withArgs(sender.address, amount);
     });

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -204,30 +204,32 @@ export const shouldBehaveLikeLSP3 = (
 
   describe("when sending native tokens to the contract", () => {
     it("should emit the right ValueReceived event", async () => {
-      let tx = await context.accounts[0].sendTransaction({
+      const sender = context.accounts[0];
+      const amount = ethers.utils.parseEther("5");
+
+      let tx = await sender.sendTransaction({
         to: context.universalProfile.address,
-        value: ethers.utils.parseEther("5"),
+        value: amount,
       });
 
-      let receipt = await tx.wait();
-
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.LSP0.ValueReceived
-      );
+      await expect(tx)
+        .to.emit(context.universalProfile, "ValueReceived")
+        .withArgs(sender.address, amount);
     });
 
     it("should allow to send a random payload as well, and emit the ValueReceived event", async () => {
+      const sender = context.accounts[0];
+      const amount = ethers.utils.parseEther("5");
+
       let tx = await context.accounts[0].sendTransaction({
         to: context.universalProfile.address,
-        value: ethers.utils.parseEther("5"),
+        value: amount,
         data: "0xaabbccdd",
       });
 
-      let receipt = await tx.wait();
-
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.LSP0.ValueReceived
-      );
+      await expect(tx)
+        .to.emit(context.universalProfile, "ValueReceived")
+        .withArgs(sender.address, amount);
     });
   });
 
@@ -239,10 +241,8 @@ export const shouldBehaveLikeLSP3 = (
         data: "0xaabbccdd",
       });
 
-      let receipt = await tx.wait();
-
       // check that no event was emitted
-      expect(receipt.logs.length).to.equal(0);
+      await expect(tx).to.not.emit(context.universalProfile, "ValueReceived");
     });
   });
 };

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -90,7 +90,7 @@ describe("UniversalProfile", () => {
           const balance = await provider.getBalance(
             context.universalProfile.address
           );
-          expect(balance.toNumber()).to.equal(testCase.initialFunding || 0);
+          expect(balance).to.equal(testCase.initialFunding || 0);
         });
       });
     });
@@ -231,7 +231,7 @@ describe("UniversalProfile", () => {
             const balance = await provider.getBalance(
               context.universalProfile.address
             );
-            expect(balance.toNumber()).to.equal(testCase.initialFunding || 0);
+            expect(balance).to.equal(testCase.initialFunding || 0);
           });
 
           shouldInitializeLikeLSP3(async () => {


### PR DESCRIPTION
# What does this PR introduce?

Hardhat comes with very convenient Chai matchers for testing events. These can be used to test more easily events and their parameters (instead of using the old method of going through the logs and searching each topics).

This PR refactor the tests that check for proper event emissions for the following events:

- `ValueReceived`
- `UniversalReceiver`
- `OwnershipTransferred`