### PR TITLE
refactor: replace >0 by !=0

### DIFF
--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -90,7 +90,7 @@ contract UniversalFactory {
         bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
         contractCreated = Create2.deploy(msg.value, generatedSalt, byteCode);
 
-        if (initializeCallData.length > 0) {
+        if (initializeCallData.length != 0) {
             // solhint-disable avoid-low-level-calls
             (bool success, bytes memory returnData) = contractCreated.call(initializeCallData);
             Address.verifyCallResult(
@@ -121,7 +121,7 @@ contract UniversalFactory {
         bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
         proxy = Clones.cloneDeterministic(baseContract, generatedSalt);
 
-        if (initializeCallData.length > 0) {
+        if (initializeCallData.length != 0) {
             // solhint-disable avoid-low-level-calls
             (bool success, bytes memory returnData) = proxy.call{value: msg.value}(
                 initializeCallData
@@ -134,7 +134,7 @@ contract UniversalFactory {
         } else {
             // @todo check if this part make sense
             // Return value sent
-            if (msg.value > 0) {
+            if (msg.value != 0) {
                 // solhint-disable avoid-low-level-calls
                 (bool success, bytes memory returnData) = payable(msg.sender).call{
                     value: msg.value
@@ -154,7 +154,7 @@ contract UniversalFactory {
         pure
         returns (bytes32)
     {
-        bool initializable = initializeCallData.length > 0;
+        bool initializable = initializeCallData.length != 0;
         if (initializable) {
             return keccak256(abi.encodePacked(initializable, initializeCallData, salt));
         } else {

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -54,7 +54,7 @@ abstract contract LSP0ERC725AccountCore is
      * @dev Emits an event when receiving native tokens
      */
     fallback() external payable virtual {
-        if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
     }
 
     //    TODO to be discussed

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -271,15 +271,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     ) internal view {
         // prettier-ignore
         if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX) {
-            
+
             // key = AddressPermissions:Permissions:<address>
             _verifyCanSetBytes32Permissions(key, from, permissions);
-        
+
         } else if (key == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY) {
 
             // key = AddressPermissions[]
             _verifyCanSetPermissionsArray(key, value, from, permissions);
-        
+
         } else if (bytes16(key) == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX) {
 
             // key = AddressPermissions[index]
@@ -477,7 +477,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         bool hasSuperTransferValue = permissions.hasPermission(_PERMISSION_SUPER_TRANSFERVALUE);
 
-        if (value > 0) {
+        if (value != 0) {
             // prettier-ignore
             hasSuperTransferValue || _requirePermissions(from, permissions, _PERMISSION_TRANSFERVALUE);
         }
@@ -489,7 +489,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         if (hasSuperOperation && isCallDataPresent && value == 0) return;
 
         // Skip if caller has SUPER permission for value transfers
-        if (hasSuperTransferValue && !isCallDataPresent && value > 0) return;
+        if (hasSuperTransferValue && !isCallDataPresent && value != 0) return;
 
         // Skip if both SUPER permissions are present
         if (hasSuperOperation && hasSuperTransferValue) return;
@@ -498,7 +498,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         address to = address(bytes20(payload[48:68]));
         _verifyAllowedAddress(from, to);
 
-        if (to.code.length > 0) {
+        if (to.code.length != 0) {
             // CHECK for ALLOWED STANDARDS
             _verifyAllowedStandard(from, to);
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -68,7 +68,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      * @dev Emits an event when receiving native tokens
      */
     fallback() external payable virtual {
-        if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
     }
 
     // ERC165


### PR DESCRIPTION
# What does this PR introduce?

`!=0` is a cheaper operation than `>0` and safe to use on `uint` with solidity `ˆ0.8.0` 

#242 