### PR TITLE
fix: [QSP-6] fix incorrect index check for `_countTrailingZeroBytes(...)` in `LSP6KeyManagerCore.sol`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -612,13 +612,13 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     function _countTrailingZeroBytes(bytes32 dataKey) internal pure returns (uint256) {
-        uint256 count = 32;
+        uint256 nByte = 32;
 
         // CHECK each bytes of the data key, starting from the end (right to left)
         // skip each empty bytes `0x00` and continue searching until we find the first non-empty byte
-        while (count > 0 && dataKey[--count] == 0x00) continue;
+        while (nByte > 0 && dataKey[--nByte] == 0x00) continue;
 
-        return 32 - count;
+        return 32 - nByte;
     }
 
     function _requirePermissions(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -612,13 +612,13 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     function _countTrailingZeroBytes(bytes32 key) internal pure returns (uint256) {
-        uint256 index = 31;
+        uint256 count = 32;
 
         // CHECK each bytes of the key, starting from the end (right to left)
         // skip each empty bytes `0x00` to find the first non-empty byte
-        while (key[index] == 0x00 && index != 0) index--;
+        while (count > 0 && key[count - 1] == 0x00) count--;
 
-        return 32 - (index + 1);
+        return 32 - count;
     }
 
     function _requirePermissions(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -615,8 +615,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         uint256 nByte = 32;
 
         // CHECK each bytes of the data key, starting from the end (right to left)
-        // skip each empty bytes `0x00` and continue searching until we find the first non-empty byte
-        while (nByte > 0 && dataKey[--nByte] == 0x00) continue;
+        // skip each empty bytes `0x00` until we find the first non-empty byte
+        while (nByte > 0 && dataKey[nByte - 1] == 0x00) nByte--;
 
         return 32 - nByte;
     }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -611,12 +611,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         revert NotAllowedFunction(from, functionSelector);
     }
 
-    function _countTrailingZeroBytes(bytes32 key) internal pure returns (uint256) {
+    function _countTrailingZeroBytes(bytes32 dataKey) internal pure returns (uint256) {
         uint256 count = 32;
 
-        // CHECK each bytes of the key, starting from the end (right to left)
-        // skip each empty bytes `0x00` to find the first non-empty byte
-        while (count > 0 && key[count - 1] == 0x00) count--;
+        // CHECK each bytes of the data key, starting from the end (right to left)
+        // skip each empty bytes `0x00` and continue searching until we find the first non-empty byte
+        while (count > 0 && dataKey[--count] == 0x00) continue;
 
         return 32 - count;
     }


### PR DESCRIPTION
# What does this PR introduce?

The former tests for **AllowedERC725YKeys** were not checking the right and expected behaviour when one of the allowed ERC725Y key in the list for the caller is `bytes32(0)`.


## 🐛 Fix

In `LSP6KeyManagerCore`, the function `_countTrailingZeroBytes(...)` does not check the byte at the index properly.

Refactored this function to ensure the function works properly when `key == `bytes32(0)`, while optimising for gas usage.

## 🧪 Tests

Add additional test with an allowed data key that contains one single byte (e.g: `0xaa00000000...00000000`), to check that looking for a specific `nByte` at a byte index inside the allowed data key works properly.

