### PR TITLE
fix: [QSP-3] Operator Could Clear Operator List in LSP8

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -168,6 +168,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
+     * - `from` and `to` cannot be the same addresses.
      * - `tokenId` token must be owned by `from`.
      * - If the caller is not `from`, it must be an operator of `tokenId`.
      *

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -168,7 +168,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * - `from` cannot be the zero address.
      * - `to` cannot be the zero address.
-     * - `from` and `to` cannot be the same addresses.
+     * - `from` and `to` cannot be the same address.
      * - `tokenId` token must be owned by `from`.
      * - If the caller is not `from`, it must be an operator of `tokenId`.
      *
@@ -198,6 +198,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      * - `from`, `to`, `tokenId` lists are the same length.
      * - no values in `from` can be the zero address.
      * - no values in `to` can be the zero address.
+     * - `from` and `to` cannot be the same address at the same index of each lists.
      * - each `tokenId` token must be owned by `from`.
      * - If the caller is not `from`, it must be an operator of each `tokenId`.
      *

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -13,6 +13,8 @@ error LSP8CannotUseAddressZeroAsOperator();
 
 error LSP8CannotSendToAddressZero();
 
+error LSP8CannotSendToFromAddress();
+
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 error LSP8InvalidTransferBatch();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -336,6 +336,10 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         bool force,
         bytes memory data
     ) internal virtual {
+        if (from == to) {
+            revert LSP8CannotSendToFromAddress();
+        }
+
         address tokenOwner = tokenOwnerOf(tokenId);
         if (tokenOwner != from) {
             revert LSP8NotTokenOwner(tokenOwner, tokenId, from);

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -775,6 +775,24 @@ export const shouldBehaveLikeLSP8 = (
                 });
               });
             });
+
+            describe("when `from == to` address (= sending to tokenId's owner itself)", () => {
+              it("should revert", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: context.accounts.owner.address,
+                  tokenId: mintedTokenId,
+                  force,
+                  data,
+                };
+                const expectedError = "LSP8CannotSendToFromAddress";
+
+                await transferFailScenario(txParams, operator, {
+                  error: expectedError,
+                  args: [],
+                });
+              });
+            });
           });
 
           describe("when force=false", () => {
@@ -856,6 +874,24 @@ export const shouldBehaveLikeLSP8 = (
                 });
               });
             });
+
+            // describe.only("when `from == to` address (= sending to tokenId's owner itself)", () => {
+            //   it("should revert", async () => {
+            //     const txParams = {
+            //       from: context.accounts.owner.address,
+            //       to: context.accounts.owner.address,
+            //       tokenId: mintedTokenId,
+            //       force,
+            //       data,
+            //     };
+            //     const expectedError = "LSP8CannotSendToFromAddress";
+
+            //     await transferFailScenario(txParams, operator, {
+            //       error: expectedError,
+            //       args: [],
+            //     });
+            //   });
+            // });
           });
         };
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -875,23 +875,23 @@ export const shouldBehaveLikeLSP8 = (
               });
             });
 
-            // describe.only("when `from == to` address (= sending to tokenId's owner itself)", () => {
-            //   it("should revert", async () => {
-            //     const txParams = {
-            //       from: context.accounts.owner.address,
-            //       to: context.accounts.owner.address,
-            //       tokenId: mintedTokenId,
-            //       force,
-            //       data,
-            //     };
-            //     const expectedError = "LSP8CannotSendToFromAddress";
+            describe("when `from == to` address (= sending to tokenId's owner itself)", () => {
+              it("should revert", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: context.accounts.owner.address,
+                  tokenId: mintedTokenId,
+                  force,
+                  data,
+                };
+                const expectedError = "LSP8CannotSendToFromAddress";
 
-            //     await transferFailScenario(txParams, operator, {
-            //       error: expectedError,
-            //       args: [],
-            //     });
-            //   });
-            // });
+                await transferFailScenario(txParams, operator, {
+                  error: expectedError,
+                  args: [],
+                });
+              });
+            });
           });
         };
 


### PR DESCRIPTION
# What does this PR introduce?

## What is the current behaviour?

In LSP8, an operator can only be revoked by the token owner via the `revokeOperator(...)` function.

However, any operator can revoke another operator, and all the operators related to the `tokenId` by calling the function `transfer(...)` function with the same address for `from` and `to` (`from == to`).

If the `transfer(...)` function above is called with these arguments, the operator list is cleared and the owner will still have the NFT. The effect would be equivalent to that the operator successfully revokes all operators.

## What is the expected (new) behaviour?

Disallow this behaviour and unexpected edge case from occurring by disallowing specifying the same address for `from` and `to` in the `_transfer(...)` internal function parameter.

