### PR TITLE
fix: remove code length check in UniversalReceiverDelegate

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -28,9 +28,6 @@ abstract contract TokenAndVaultHandling {
         internal
         returns (bytes memory result)
     {
-        // avoid EOAs spamming the storage
-        if (caller.code.length == 0) return "";
-
         address keyManager = ERC725Y(msg.sender).owner();
         if (!ERC165Checker.supportsERC165Interface(keyManager, _INTERFACEID_LSP6)) return "";
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -24,9 +24,6 @@ import "../../../LSP9Vault/LSP9Constants.sol";
  */
 abstract contract TokenHandling {
     function _tokenHandling(address caller, bytes32 typeId) internal returns (bytes memory result) {
-        // avoid EOAs spamming the storage
-        if (caller.code.length == 0) return "";
-
         if (!ERC165Checker.supportsERC165Interface(msg.sender, _INTERFACEID_LSP9)) return "";
 
         (

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1678,6 +1678,29 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
     });
+
+    describe("when deploying vault to a UP directly", () => {
+      let lsp9VaultD: LSP9Vault;
+
+      before(async () => {
+        lsp9VaultD = await new LSP9Vault__factory(
+          context.accounts.random
+        ).deploy(context.universalProfile1.address);
+      });
+
+      it("should register the data key relevant to the vault deployed in the UP storage", async () => {
+        const [indexInMap, interfaceId, arrayLength, elementAddress] =
+          await getLSP10MapAndArrayKeysValue(
+            context.universalProfile1,
+            lsp9VaultD
+          );
+
+        expect(indexInMap).to.equal(1);
+        expect(interfaceId).to.equal(INTERFACE_IDS.LSP9Vault);
+        expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
+        expect(elementAddress).to.equal(lsp9VaultD.address);
+      });
+    });
   });
 };
 


### PR DESCRIPTION
## What does this PR introduce?
- Remove code length check in UniversalReceiverDelegate. 
This line of code was initially added to prevent EOAs from calling the `universalReceiver(..)` function with a receiving `typeId` (LSP7 || LSP8 || LSP9) and registering their addresses as assets in the storage.

The very interesting edge case for this code is:
When a call is made by a constructor of a contract, the code length will still be 0 since it's not returned yet. We do not want to block external calls from the constructor as we need this behavior to register the addresses of vaults inside the UP storage on deployment. Also, I think in the future, there will be some tokens minting inside the constructor, we want these tokens to also be registered inside the UP storage. That's why we should remove the code length check.

Another way to block the spamming of EOAs is by introducing an ERC165 check. This should be discussed internally first as it will make the transaction more expensive