### PR TITLE
fix: [QSP-4] add requirements checks on `LSP4DigitalAssetMetadata` deployment + add tests for internal `_burn(...)` function in LSP8

### DIFF
--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -27,6 +27,8 @@ abstract contract LSP4DigitalAssetMetadata is ERC725Y {
         string memory symbol_,
         address newOwner_
     ) ERC725Y(newOwner_) {
+        require(newOwner_ != address(0), "LSP4: new owner cannot be the zero address");
+
         // set key SupportedStandards:LSP4DigitalAsset
         super._setData(_LSP4_SUPPORTED_STANDARDS_KEY, _LSP4_SUPPORTED_STANDARDS_VALUE);
 

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -22,6 +22,7 @@ abstract contract LSP4DigitalAssetMetadataInitAbstract is ERC725YInitAbstract {
         string memory symbol_,
         address newOwner_
     ) internal virtual onlyInitializing {
+        require(newOwner_ != address(0), "LSP4: new owner cannot be the zero address");
         ERC725YInitAbstract._initialize(newOwner_);
 
         // set SupportedStandards:LSP4DigitalAsset

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
@@ -1,5 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
+
 import { LSP7Tester__factory, LSP7InitTester__factory } from "../../types";
 
 import {
@@ -18,7 +19,7 @@ describe("LSP7", () => {
       const initialSupply = ethers.BigNumber.from("3");
       const deployParams = {
         name: "LSP7 - deployed with constructor",
-        symbol: "NFT",
+        symbol: "Token",
         newOwner: accounts.owner.address,
       };
 
@@ -35,13 +36,31 @@ describe("LSP7", () => {
     };
 
     describe("when deploying the contract", () => {
-      let context: LSP7TestContext;
+      it("should revert when deploying with address(0) as owner", async () => {
+        const accounts = await ethers.getSigners();
 
-      beforeEach(async () => {
-        context = await buildTestContext();
+        const deployParams = {
+          name: "LSP7 - deployed with constructor",
+          symbol: "Token",
+          newOwner: ethers.constants.AddressZero,
+        };
+
+        await expect(
+          new LSP7Tester__factory(accounts[0]).deploy(
+            deployParams.name,
+            deployParams.symbol,
+            deployParams.newOwner
+          )
+        ).to.be.revertedWith("LSP4: new owner cannot be the zero address");
       });
 
-      describe("when initializing the contract", () => {
+      describe("once the contract was deployed", () => {
+        let context: LSP7TestContext;
+
+        beforeEach(async () => {
+          context = await buildTestContext();
+        });
+
         shouldInitializeLikeLSP7(async () => {
           const { lsp7, deployParams } = context;
           return {
@@ -120,6 +139,17 @@ describe("LSP7", () => {
 
       beforeEach(async () => {
         context = await buildTestContext();
+      });
+
+      it("should revert when initializing with address(0) as owner", async () => {
+        await expect(
+          context.lsp7["initialize(string,string,address,bool)"](
+            context.deployParams.name,
+            context.deployParams.symbol,
+            ethers.constants.AddressZero,
+            false
+          )
+        ).to.be.revertedWith("LSP4: new owner cannot be the zero address");
       });
 
       describe("when initializing the contract", () => {

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -250,7 +250,7 @@ export const shouldBehaveLikeLSP8 = (
       });
 
       describe("when the given address does not owns some tokens", () => {
-        it("should empty list", async () => {
+        it("should return an empty list", async () => {
           expect(
             await context.lsp8.tokenIdsOf(context.accounts.anyone.address)
           ).to.be.deep.equal([]);
@@ -1380,6 +1380,106 @@ export const shouldBehaveLikeLSP8 = (
                 error: expectedError,
                 args: [txParams.tokenId[0].toString(), operator.address],
               });
+            });
+          });
+        });
+      });
+    });
+
+    describe("_burn", () => {
+      describe("when tokenId has not been minted", () => {
+        it("should revert", async () => {
+          await expect(context.lsp8.burn(neverMintedTokenId, "0x"))
+            .to.be.revertedWithCustomError(
+              context.lsp8,
+              "LSP8NonExistentTokenId"
+            )
+            .withArgs(neverMintedTokenId);
+        });
+      });
+
+      describe("when tokenId has been minted", () => {
+        describe("after burning a tokenId", () => {
+          it("should have decreased the total supply", async () => {
+            const totalSupplyBefore = await context.lsp8.totalSupply();
+
+            await context.lsp8.burn(mintedTokenId, "0x");
+
+            const totalSupplyAfter = await context.lsp8.totalSupply();
+
+            expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(1));
+          });
+
+          it("should have emitted a Transfer event with address(0) as `to` param", async () => {
+            await expect(context.lsp8.burn(mintedTokenId, "0x"))
+              .to.emit(context.lsp8, "Transfer")
+              .withArgs(
+                context.accounts.owner.address, // operator
+                context.accounts.owner.address, // tokenOwner
+                ethers.constants.AddressZero,
+                mintedTokenId,
+                false,
+                "0x"
+              );
+          });
+
+          describe("when calling `tokenOwnerOf(...)` for the burnt tokenId", () => {
+            it("should revert stating tokenId does not exist", async () => {
+              await context.lsp8.burn(mintedTokenId, "0x");
+
+              await expect(
+                context.lsp8.tokenOwnerOf(mintedTokenId)
+              ).to.be.revertedWithCustomError(
+                context.lsp8,
+                "LSP8NonExistentTokenId"
+              );
+            });
+          });
+
+          describe("when calling `tokenIdsOf(...)` with the initial owner address of the burnt token", () => {
+            it("should return a list of tokenIds that does not contain the burnt tokenId", async () => {
+              const tokenIdsOfOwnerBefore = await context.lsp8.tokenIdsOf(
+                context.accounts.owner.address
+              );
+              expect(tokenIdsOfOwnerBefore).to.contain(mintedTokenId);
+
+              await context.lsp8.burn(mintedTokenId, "0x");
+
+              const tokenIdsOfOwnerAfter = await context.lsp8.tokenIdsOf(
+                context.accounts.owner.address
+              );
+              expect(tokenIdsOfOwnerAfter).to.not.contain(mintedTokenId);
+            });
+          });
+
+          describe("when trying to get the operators for the burnt tokenId", () => {
+            it("should revert stating tokenId does not exist", async () => {
+              await context.lsp8.authorizeOperator(
+                context.accounts.operator.address,
+                mintedTokenId
+              );
+
+              await context.lsp8.authorizeOperator(
+                context.accounts.anotherOperator.address,
+                mintedTokenId
+              );
+
+              const operatorsForTokenIdBefore =
+                await context.lsp8.getOperatorsOf(mintedTokenId);
+
+              expect(operatorsForTokenIdBefore).to.deep.equal([
+                context.accounts.operator.address,
+                context.accounts.anotherOperator.address,
+              ]);
+
+              await context.lsp8.burn(mintedTokenId, "0x");
+
+              await expect(
+                context.lsp8.getOperatorsOf(mintedTokenId)
+              ).to.be.revertedWithCustomError(
+                context.lsp8,
+                "LSP8NonExistentTokenId"
+              );
             });
           });
         });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.test.ts
@@ -1,5 +1,7 @@
-import { LSP8Tester__factory, LSP8InitTester__factory } from "../../types";
+import { ethers } from "hardhat";
 import { expect } from "chai";
+
+import { LSP8Tester__factory, LSP8InitTester__factory } from "../../types";
 
 import {
   getNamedAccounts,
@@ -29,13 +31,31 @@ describe("LSP8", () => {
     };
 
     describe("when deploying the contract", () => {
-      let context: LSP8TestContext;
+      it("should revert when deploying with address(0) as owner", async () => {
+        const accounts = await ethers.getSigners();
 
-      beforeEach(async () => {
-        context = await buildTestContext();
+        const deployParams = {
+          name: "LSP8 - deployed with constructor",
+          symbol: "NFT",
+          newOwner: ethers.constants.AddressZero,
+        };
+
+        await expect(
+          new LSP8Tester__factory(accounts[0]).deploy(
+            deployParams.name,
+            deployParams.symbol,
+            ethers.constants.AddressZero
+          )
+        ).to.be.revertedWith("LSP4: new owner cannot be the zero address");
       });
 
-      describe("when initializing the contract", () => {
+      describe("once the contract was deployed", () => {
+        let context: LSP8TestContext;
+
+        beforeEach(async () => {
+          context = await buildTestContext();
+        });
+
         shouldInitializeLikeLSP8(async () => {
           const { lsp8, deployParams } = context;
 
@@ -87,6 +107,16 @@ describe("LSP8", () => {
 
       beforeEach(async () => {
         context = await buildTestContext();
+      });
+
+      it("should revert when initializing with address(0) as owner", async () => {
+        await expect(
+          context.lsp8["initialize(string,string,address)"](
+            context.deployParams.name,
+            context.deployParams.symbol,
+            ethers.constants.AddressZero
+          )
+        ).to.be.revertedWith("LSP4: new owner cannot be the zero address");
       });
 
       describe("when initializing the contract", () => {


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Fix

add requirements check in `LSP4DigitalAssetMetadata` and `LSP4DigitalAssetMetadataInitAbstract` to ensure the contract owner is not the zero address `address(0)`

## 🧪 Tests

Add additional tests to ensure correct behaviour of internal `_burn(...)` function from `LSP8IdentifiableDigitalAssetCore`.