### PR TITLE
refactor: [QSP-7] Use `bytes10` instead of `bytes12` for Mapping.. KeyTypes

### DIFF
--- a/contracts/LSP10ReceivedVaults/LSP10Constants.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Constants.sol
@@ -6,5 +6,5 @@ pragma solidity ^0.8.0;
 // keccak256('LSP10Vaults[]')
 bytes32 constant _LSP10_VAULTS_ARRAY_KEY = 0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06;
 
-// bytes10(keccak256('LSP10VaultsMap')) + bytes2(0)
-bytes12 constant _LSP10_VAULTS_MAP_KEY_PREFIX = 0x192448c3c0f88c7f238c0000;
+// bytes10(keccak256('LSP10VaultsMap'))
+bytes10 constant _LSP10_VAULTS_MAP_KEY_PREFIX = 0x192448c3c0f88c7f238c;

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/Handling/TokenAndVaultHandling.sol
@@ -39,7 +39,7 @@ abstract contract TokenAndVaultHandling {
         (
             bool isReceiving,
             bytes32 arrayLengthKey,
-            bytes12 mapPrefix,
+            bytes10 mapPrefix,
             bytes4 interfaceID
         ) = LSP1Utils.getTransferDetails(typeId);
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/Handling/TokenHandling.sol
@@ -29,7 +29,7 @@ abstract contract TokenHandling {
         (
             bool isReceiving,
             bytes32 arrayLengthKey,
-            bytes12 mapPrefix,
+            bytes10 mapPrefix,
             bytes4 interfaceID
         ) = LSP1Utils.getTransferDetails(typeId);
 

--- a/contracts/LSP1UniversalReceiver/LSP1Utils.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Utils.sol
@@ -32,7 +32,7 @@ library LSP1Utils {
         returns (
             bool isReceiving,
             bytes32 arrayKey,
-            bytes12 mapPrefix,
+            bytes10 mapPrefix,
             bytes4 interfaceId
         )
     {

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -20,7 +20,7 @@ library LSP2Utils {
      * @dev Generates a data key of keyType Singleton
      * @param keyName The string to hash to generate a Singleton data key
      * @return a bytes32 dataKey
-     * 
+     *
      */
     function generateSingletonKey(string memory keyName) internal pure returns (bytes32) {
         return keccak256(bytes(keyName));
@@ -28,7 +28,7 @@ library LSP2Utils {
 
     /**
      * @dev Generates a data key of keyType Array by hashing `keyName`.
-     * @param keyName The string that will be used to generate an data key of keyType Array 
+     * @param keyName The string that will be used to generate an data key of keyType Array
      */
     function generateArrayKey(string memory keyName) internal pure returns (bytes32) {
         bytes memory dataKey = bytes(keyName);
@@ -110,16 +110,16 @@ library LSP2Utils {
 
     /**
      * @dev Generate a data key of keyType Mapping
-     * <keyPrefix>:<bytes20Value>
+     * <bytes10keyPrefix>:<bytes2(0)>:<bytes20Value>
      * @param keyPrefix First part of the data key of keyType Mapping
      * @param bytes20Value Second part of the data key of keyType Mapping
      */
-    function generateMappingKey(bytes12 keyPrefix, bytes20 bytes20Value)
+    function generateMappingKey(bytes10 keyPrefix, bytes20 bytes20Value)
         internal
         pure
         returns (bytes32)
     {
-        bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
+        bytes memory generatedKey = bytes.concat(keyPrefix, bytes2(0), bytes20Value);
         return bytes32(generatedKey);
     }
 
@@ -152,16 +152,16 @@ library LSP2Utils {
 
     /**
      * @dev Generate a data key of keyType MappingWithGrouping
-     * <keyPrefix>:<bytes20Value>
+     * <bytes10keyPrefix>:<bytes2(0)>:<bytes20Value>
      * @param keyPrefix Used for the first part of the data key of keyType MappingWithGrouping
      * @param bytes20Value Used for the first last of the data key of keyType MappingWithGrouping
      */
-    function generateMappingWithGroupingKey(bytes12 keyPrefix, bytes20 bytes20Value)
+    function generateMappingWithGroupingKey(bytes10 keyPrefix, bytes20 bytes20Value)
         internal
         pure
         returns (bytes32)
     {
-        bytes memory generatedKey = bytes.concat(keyPrefix, bytes20Value);
+        bytes memory generatedKey = bytes.concat(keyPrefix, bytes2(0), bytes20Value);
         return bytes32(generatedKey);
     }
 

--- a/contracts/LSP5ReceivedAssets/LSP5Constants.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Constants.sol
@@ -6,5 +6,5 @@ pragma solidity ^0.8.0;
 // keccak256('LSP5ReceivedAssets[]')
 bytes32 constant _LSP5_RECEIVED_ASSETS_ARRAY_KEY = 0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b;
 
-// bytes10(keccak256('LSP5ReceivedAssetsMap')) + bytes2(0)
-bytes12 constant _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX = 0x812c4334633eb816c80d0000;
+// bytes10(keccak256('LSP5ReceivedAssetsMap'))
+bytes10 constant _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX = 0x812c4334633eb816c80d;

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -108,7 +108,7 @@ library LSP5Utils {
     function removeMapAndArrayKey(
         IERC725Y account,
         bytes32 arrayLengthKey,
-        bytes12 mapKeyPrefix,
+        bytes10 mapKeyPrefix,
         bytes32 mapKeyToRemove,
         bytes memory mapValue
     ) internal view returns (bytes32[] memory keys, bytes[] memory values) {
@@ -209,7 +209,7 @@ library LSP5Utils {
     function removeMapAndArrayKeyViaKeyManager(
         IERC725Y account,
         bytes32 arrayLengthKey,
-        bytes12 mapKeyPrefix,
+        bytes10 mapKeyPrefix,
         bytes32 mapKeyToRemove,
         bytes memory mapValue,
         address keyManager

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -17,20 +17,20 @@ bytes16 constant _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX = 0xdf30dba06db6a30e65
 // AddressPermissions:...
 bytes6 constant _LSP6KEY_ADDRESSPERMISSIONS_PREFIX = 0x4b80742de2bf;
 
-// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('Permissions')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX = 0x4b80742de2bf82acb3630000; // AddressPermissions:Permissions:<address> --> bytes32
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('Permissions')) 
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX = 0x4b80742de2bf82acb363; // AddressPermissions:Permissions:<address> --> bytes32
 
-// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedAddresses')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX = 0x4b80742de2bfc6dd6b3c0000; // AddressPermissions:AllowedAddresses:<address> --> address[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedAddresses')) 
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX = 0x4b80742de2bfc6dd6b3c; // AddressPermissions:AllowedAddresses:<address> --> address[]
 
-// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedFunctions')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742de2bf8efea1e80000; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedFunctions')) 
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742de2bf8efea1e8; // AddressPermissions:AllowedFunctions:<address> --> bytes4[]
 
-// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedStandards')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742de2bf3efa94a30000; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedStandards')) 
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742de2bf3efa94a3; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
 
-// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedERC725YKeys')) + bytes2(0)
-bytes12 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b4850000; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes32[]
+// bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedERC725YKeys')) 
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b485; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes32[]
 
 // DEFAULT PERMISSIONS VALUES
 bytes32 constant _PERMISSION_CHANGEOWNER        = 0x0000000000000000000000000000000000000000000000000000000000000001;


### PR DESCRIPTION
## What does this PR introduce?
Using `bytes10` instead of `bytes12` in LSP2Utils functions and all function that uses LSP2 and making sure to have bytes2(0) as hardcoded function logic.

According to the documentation, data keys of type "Mapping" and "MappingWithGrouping" are formatted such that there are two empty bytes between the first ten bytes and the last twenty bytes. However, the versions of the functions generateMappingKey and generateMappingWithGroupingKey that use byte inputs take bytes12 for the first part of the key without ensuring that there are two empty bytes as per the specification. 
