### PR TITLE
fix: [QSP-10] Revert when authorizing existing operators in LSP8

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -9,6 +9,8 @@ error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
+error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
+
 error LSP8CannotUseAddressZeroAsOperator();
 
 error LSP8CannotSendToAddressZero();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -102,7 +102,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
             return;
         }
 
-        _operators[tokenId].add(operator);
+        bool isAdded = _operators[tokenId].add(operator);
+        if (!isAdded) revert LSP8OperatorAlreadyAuthorized(operator, tokenId);
 
         emit AuthorizedOperator(operator, tokenOwner, tokenId);
     }

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -319,24 +319,17 @@ export const shouldBehaveLikeLSP8 = (
               );
             });
 
-            it("should succeed", async () => {
+            it("should revert", async () => {
               const operator = context.accounts.operator.address;
               const tokenOwner = context.accounts.owner.address;
               const tokenId = mintedTokenId;
 
-              await context.lsp8.authorizeOperator(operator, tokenId);
-
-              const tx = await context.lsp8.authorizeOperator(
-                operator,
-                tokenId
-              );
-
-              await expect(tx)
-                .to.emit(context.lsp8, "AuthorizedOperator")
-                .withArgs(operator, tokenOwner, tokenId);
-
-              expect(await context.lsp8.isOperatorFor(operator, tokenId)).to.be
-                .true;
+              await expect(context.lsp8.authorizeOperator(operator, tokenId))
+                .to.be.revertedWithCustomError(
+                  context.lsp8,
+                  "LSP8OperatorAlreadyAuthorized"
+                )
+                .withArgs(operator, tokenId);
             });
           });
 
@@ -969,16 +962,6 @@ export const shouldBehaveLikeLSP8 = (
         const anotherMintedTokenId = tokenIdAsBytes32("5555");
 
         beforeEach(async () => {
-          // setup so we can observe operators being cleared during transferBatch tests
-          await context.lsp8.authorizeOperator(
-            context.accounts.operator.address,
-            mintedTokenId
-          );
-          await context.lsp8.authorizeOperator(
-            context.accounts.anotherOperator.address,
-            mintedTokenId
-          );
-
           // setup so we can transfer multiple tokenIds during transferBatch test
           await context.lsp8.mint(
             context.accounts.owner.address,

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -321,7 +321,6 @@ export const shouldBehaveLikeLSP8 = (
 
             it("should revert", async () => {
               const operator = context.accounts.operator.address;
-              const tokenOwner = context.accounts.owner.address;
               const tokenId = mintedTokenId;
 
               await expect(context.lsp8.authorizeOperator(operator, tokenId))

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
@@ -516,10 +516,6 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
 
       describe("when many context.accounts have been approved for the tokenId", () => {
         it("should return the last new authorized operator", async () => {
-          // We approve the same account in the first and third approve call, with a different
-          // account in the second call as the last "new" approval.
-          // This is to highlight its not 100% the same behavior as ERC721 since that implementation
-          // has one active approval at a time, and LSP8 has a list of authorized operator addresses
           const operatorFirstAndThirdCall = context.accounts.operator.address;
           const operatorSecondCall = context.accounts.anotherOperator.address;
 
@@ -529,10 +525,6 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           );
           await context.lsp8CompatibleERC721.approve(
             operatorSecondCall,
-            tokenIdAsBytes32(mintedTokenId)
-          );
-          await context.lsp8CompatibleERC721.approve(
-            operatorFirstAndThirdCall,
             tokenIdAsBytes32(mintedTokenId)
           );
 


### PR DESCRIPTION
## What does this PR introduce?
- Adding a check for already authorized operators, to revert when users try to add the same address as operator.

Description: Users can call the function authorizeOperator(), multiple times with the same arguments. That will also cause the same event to be emitted multiple times. 

Existing tests testing the possibility to add the same operator were switched from allow behavior to revert behavior + removing useless lines of code (adding the same address as operator)