### PR TITLE
fix: [QSP-14] Revert when revoking non-existing operators 

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -15,6 +15,8 @@ error LSP8CannotSendToAddressZero();
 
 error LSP8CannotSendToFromAddress();
 
+error LSP8NonExistingOperator(address _address, bytes32 tokenId);
+
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 error LSP8InvalidTransferBatch();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -218,7 +218,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         address tokenOwner,
         bytes32 tokenId
     ) internal virtual {
-        _operators[tokenId].remove(operator);
+        bool isRemoved = _operators[tokenId].remove(operator);
+        if (!isRemoved) revert LSP8NonExistingOperator(operator, tokenId);
         emit RevokedOperator(operator, tokenOwner, tokenId);
     }
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -26,6 +26,7 @@ import {
   INTERFACE_IDS,
   SupportedStandards,
 } from "../../constants";
+import { token } from "../../types/@openzeppelin/contracts";
 
 export type LSP8TestAccounts = {
   owner: SignerWithAddress;
@@ -425,6 +426,20 @@ export const shouldBehaveLikeLSP8 = (
               context.lsp8,
               "LSP8CannotUseAddressZeroAsOperator"
             );
+          });
+        });
+
+        describe("when address provided to revoke is not an existing operator", () => {
+          it("should revert", async () => {
+            const operator = context.accounts.anyone.address;
+            const tokenId = mintedTokenId;
+
+            await expect(context.lsp8.revokeOperator(operator, tokenId))
+              .to.be.revertedWithCustomError(
+                context.lsp8,
+                "LSP8NonExistingOperator"
+              )
+              .withArgs(operator, tokenId);
           });
         });
       });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -17,16 +17,12 @@ import {
 // helpers
 import { tokenIdAsBytes32 } from "../utils/tokens";
 
-// errors
-import { customRevertErrorMessage } from "../utils/errors";
-
 // constants
 import {
   ERC725YKeys,
   INTERFACE_IDS,
   SupportedStandards,
 } from "../../constants";
-import { token } from "../../types/@openzeppelin/contracts";
 
 export type LSP8TestAccounts = {
   owner: SignerWithAddress;


### PR DESCRIPTION
## What does this PR introduce?
- Adding a check for non-existing operators, to revert when users try to remove a non-existing operator.

Description: When the user calls _revokeOperator() with a non-existing operator, the function will terminate successfully and with an incorrectly emitted event.

Added tests to support the new behavior.
