### PR TITLE
fix: [QSP - Best Practices] clean TODO comments + add extra permission checks and support in LSP6

### DIFF
--- a/contracts/Helpers/Tokens/LSP7InitTester.sol
+++ b/contracts/Helpers/Tokens/LSP7InitTester.sol
@@ -15,9 +15,6 @@ contract LSP7InitTester is LSP7DigitalAssetInit {
         _mint(to, amount, force, data);
     }
 
-    /**
-     * TODO: add burnable as extension or preset
-     */
     function burn(
         address from,
         uint256 amount,

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -57,21 +57,6 @@ abstract contract LSP0ERC725AccountCore is
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
     }
 
-    //    TODO to be discussed
-    //    function fallback()
-    //    public
-    //    {
-    //        address to = owner();
-    //        assembly {
-    //            calldatacopy(0, 0, calldatasize())
-    //            let result := staticcall(gas(), to, 0, calldatasize(), 0, 0)
-    //            returndatacopy(0, 0, returndatasize())
-    //            switch result
-    //            case 0  { revert (0, returndatasize()) }
-    //            default { return (0, returndatasize()) }
-    //        }
-    //    }
-
     // ERC165
 
     /**

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -59,12 +59,6 @@ contract LSP1UniversalReceiverDelegateUP is
         ) {
             result = _tokenAndVaultHandling(sender, typeId);
         }
-
-        /* @TODO
-          else if() {
-            result = FollowerHandling(sender, typeId, data);
-            }
-        */
     }
 
     // --- Overrides

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -46,6 +46,14 @@ error NotAllowedFunction(address from, bytes4 disallowedFunction);
 error NotAllowedERC725YKey(address from, bytes32 disallowedKey);
 
 /**
+ * @dev reverts when `dataKey` is a bytes32 that does not adhere to any of the
+ *      permission data keys specified by the LSP6 standard
+ *
+ * @param dataKey the dataKey that does not match with any of the standard LSP6 permission data keys
+ */
+error NotRecognisedPermissionKey(bytes32 dataKey);
+
+/**
  * @dev reverts when the address provided as a target (= account) linked to this KeyManager is invalid
  *      e.g. address(0)
  */

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -470,16 +470,14 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             ? false
             : permissions.hasPermission(_extractSuperPermissionFromOperation(operationType));
 
-        if (isCallDataPresent) {
-            // prettier-ignore
-            hasSuperOperation || _requirePermissions(from, permissions, _extractPermissionFromOperation(operationType));
+        if (isCallDataPresent && !hasSuperOperation) {
+            _requirePermissions(from, permissions, _extractPermissionFromOperation(operationType));
         }
 
         bool hasSuperTransferValue = permissions.hasPermission(_PERMISSION_SUPER_TRANSFERVALUE);
 
-        if (value != 0) {
-            // prettier-ignore
-            hasSuperTransferValue || _requirePermissions(from, permissions, _PERMISSION_TRANSFERVALUE);
+        if (value != 0 && !hasSuperTransferValue) {
+            _requirePermissions(from, permissions, _PERMISSION_TRANSFERVALUE);
         }
 
         // Skip on contract creation (CREATE or CREATE2)
@@ -625,7 +623,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         address from,
         bytes32 addressPermissions,
         bytes32 permissionRequired
-    ) internal pure returns (bool) {
+    ) internal pure {
         if (!addressPermissions.hasPermission(permissionRequired)) {
             string memory permissionErrorString = _getPermissionErrorString(permissionRequired);
             revert NotAuthorised(from, permissionErrorString);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -473,7 +473,6 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         uint256 operationType = uint256(bytes32(payload[4:36]));
         require(operationType < 5, "LSP6KeyManager: invalid operation type");
 
-        // TODO: if re-enable delegatecall, add check to ensure owner() + initialized() are not overriden after delegatecall
         require(
             operationType != OPERATION_DELEGATECALL,
             "LSP6KeyManager: operation DELEGATECALL is currently disallowed"

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -223,7 +223,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     }
 
     function _clearOperators(address tokenOwner, bytes32 tokenId) internal virtual {
-        // TODO: here is a good example of why having multiple operators will be expensive.. we
+        // here is a good example of why having multiple operators will be expensive.. we
         // need to clear them on token transfer
         //
         // NOTE: this may cause a tx to fail if there is too many operators to clear, in which case

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -192,6 +192,35 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           const result = await context.universalProfile["getData(bytes32)"](key);
           expect(ethers.utils.getAddress(result)).to.equal(value);
         });
+
+        // this include any permission data key that start with bytes6(keccak256('AddressPermissions'))
+        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
+          it("should revert", async () => {
+            let beneficiary = context.accounts[8];
+
+            // AddressPermissions:MyCustomPermissions:<address>
+            let key =
+              "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+
+            // the value does not matter in the case of the test here
+            let value =
+              "0x0000000000000000000000000000000000000000000000000000000000000008";
+
+            let payload = context.universalProfile.interface.encodeFunctionData(
+              "setData(bytes32,bytes)",
+              [key, value]
+            );
+
+            await expect(
+              context.keyManager.connect(context.owner).execute(payload)
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotRecognisedPermissionKey"
+              )
+              .withArgs(key.toLowerCase());
+          });
+        });
       });
 
       describe("when caller is an address with permission ADDPERMISSIONS", () => {
@@ -290,6 +319,35 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(canOnlyAddPermissions.address, "CHANGEPERMISSIONS");
+        });
+
+        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
+          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+            // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
+            let beneficiary = context.accounts[8];
+
+            // AddressPermissions:MyCustomPermissions:<address>
+            let key =
+              "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+
+            // the value does not matter in the case of the test here
+            let value =
+              "0x0000000000000000000000000000000000000000000000000000000000000008";
+
+            let payload = context.universalProfile.interface.encodeFunctionData(
+              "setData(bytes32,bytes)",
+              [key, value]
+            );
+
+            await expect(
+              context.keyManager.connect(canOnlyAddPermissions).execute(payload)
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotRecognisedPermissionKey"
+              )
+              .withArgs(key.toLowerCase());
+          });
         });
       });
 
@@ -416,6 +474,37 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           const result = await context.universalProfile["getData(bytes32)"](key);
           expect(ethers.utils.getAddress(result)).to.equal(value);
         });
+
+        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
+          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+            // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
+            let beneficiary = context.accounts[8];
+
+            // AddressPermissions:MyCustomPermissions:<address>
+            let key =
+              "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+
+            // the value does not matter in the case of the test here
+            let value =
+              "0x0000000000000000000000000000000000000000000000000000000000000008";
+
+            let payload = context.universalProfile.interface.encodeFunctionData(
+              "setData(bytes32,bytes)",
+              [key, value]
+            );
+
+            await expect(
+              context.keyManager
+                .connect(canOnlyChangePermissions)
+                .execute(payload)
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotRecognisedPermissionKey"
+              )
+              .withArgs(key.toLowerCase());
+          });
+        });
       });
 
       describe("when caller is an address with permission SETDATA", () => {
@@ -528,6 +617,35 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(canOnlySetData.address, "CHANGEPERMISSIONS");
+        });
+
+        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
+          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+            // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
+            let beneficiary = context.accounts[8];
+
+            // AddressPermissions:MyCustomPermissions:<address>
+            let key =
+              "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+
+            // the value does not matter in the case of the test here
+            let value =
+              "0x0000000000000000000000000000000000000000000000000000000000000008";
+
+            let payload = context.universalProfile.interface.encodeFunctionData(
+              "setData(bytes32,bytes)",
+              [key, value]
+            );
+
+            await expect(
+              context.keyManager.connect(canOnlySetData).execute(payload)
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotRecognisedPermissionKey"
+              )
+              .withArgs(key.toLowerCase());
+          });
         });
       });
 

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -210,45 +210,129 @@ export const shouldBehaveLikePermissionDeploy = (
   });
 
   describe("when caller is an address that does not have the permission DEPLOY", () => {
-    it("should revert when trying to deploy a contract via CREATE", async () => {
-      let contractBytecodeToDeploy = TargetContract__factory.bytecode;
+    describe("when calling via execute(...)", () => {
+      it("should revert when trying to deploy a contract via CREATE", async () => {
+        let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CREATE,
-          ethers.constants.AddressZero,
-          0,
-          contractBytecodeToDeploy,
-        ]
-      );
+        let payload = context.universalProfile.interface.encodeFunctionData(
+          "execute",
+          [
+            OPERATION_TYPES.CREATE,
+            ethers.constants.AddressZero,
+            0,
+            contractBytecodeToDeploy,
+          ]
+        );
 
-      await expect(
-        context.keyManager.connect(addressCannotDeploy).execute(payload)
-      )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCannotDeploy.address, "DEPLOY");
+        await expect(
+          context.keyManager.connect(addressCannotDeploy).execute(payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .withArgs(addressCannotDeploy.address, "CREATE");
+      });
+
+      it("should revert when trying to deploy a contract via CREATE2", async () => {
+        let contractBytecodeToDeploy = TargetContract__factory.bytecode;
+        let salt =
+          "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+
+        let payload = context.universalProfile.interface.encodeFunctionData(
+          "execute",
+          [
+            OPERATION_TYPES.CREATE2,
+            ethers.constants.AddressZero,
+            0,
+            contractBytecodeToDeploy + salt.substring(2),
+          ]
+        );
+
+        await expect(
+          context.keyManager.connect(addressCannotDeploy).execute(payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .withArgs(addressCannotDeploy.address, "CREATE2");
+      });
     });
-    it("should revert when trying to deploy a contract via CREATE2", async () => {
-      let contractBytecodeToDeploy = TargetContract__factory.bytecode;
-      let salt =
-        "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
 
-      let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CREATE2,
-          ethers.constants.AddressZero,
-          0,
-          contractBytecodeToDeploy + salt.substring(2),
-        ]
-      );
+    describe("when calling via executeRelayCall(...)", () => {
+      it("should revert when trying to deploy a contract via CREATE", async () => {
+        let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      await expect(
-        context.keyManager.connect(addressCannotDeploy).execute(payload)
-      )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCannotDeploy.address, "DEPLOY");
+        let nonce = await context.keyManager.callStatic.getNonce(
+          addressCannotDeploy.address,
+          0
+        );
+
+        let payload = context.universalProfile.interface.encodeFunctionData(
+          "execute",
+          [
+            OPERATION_TYPES.CREATE,
+            ethers.constants.AddressZero,
+            0,
+            contractBytecodeToDeploy,
+          ]
+        );
+
+        const HARDHAT_CHAINID = 31337;
+
+        let hash = ethers.utils.solidityKeccak256(
+          ["uint256", "address", "uint256", "bytes"],
+          [HARDHAT_CHAINID, context.keyManager.address, nonce, payload]
+        );
+
+        let signature = await addressCannotDeploy.signMessage(
+          ethers.utils.arrayify(hash)
+        );
+
+        await expect(
+          context.keyManager
+            .connect(addressCannotDeploy)
+            .executeRelayCall(signature, nonce, payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .withArgs(addressCannotDeploy.address, "CREATE");
+      });
+
+      it("should revert when trying to deploy a contract via CREATE2", async () => {
+        let contractBytecodeToDeploy = TargetContract__factory.bytecode;
+
+        let nonce = await context.keyManager.callStatic.getNonce(
+          addressCannotDeploy.address,
+          0
+        );
+
+        let salt =
+          "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+
+        let payload = context.universalProfile.interface.encodeFunctionData(
+          "execute",
+          [
+            OPERATION_TYPES.CREATE2,
+            ethers.constants.AddressZero,
+            0,
+            contractBytecodeToDeploy + salt.substring(2),
+          ]
+        );
+
+        const HARDHAT_CHAINID = 31337;
+
+        let hash = ethers.utils.solidityKeccak256(
+          ["uint256", "address", "uint256", "bytes"],
+          [HARDHAT_CHAINID, context.keyManager.address, nonce, payload]
+        );
+
+        let signature = await addressCannotDeploy.signMessage(
+          ethers.utils.arrayify(hash)
+        );
+
+        await expect(
+          context.keyManager
+            .connect(addressCannotDeploy)
+            .executeRelayCall(signature, nonce, payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .withArgs(addressCannotDeploy.address, "CREATE2");
+      });
     });
   });
 };


### PR DESCRIPTION
# What does this PR introduce?

Removed most of TODO that are not relevant anymore:
- about DELEGATECALL in KeyManager
- LSP1UniversalReceiverDelegateUP

## ⭐  Feat

- [x] add support for revert error when reverting for `NotAuthorised` permission related to contract deployment -> decode the payload and display `CREATE` or `CREATE2`

## 🐛 Fix

- [x] remove `return` statement in the internal function `_requirePermissions(...)` function in `LSP6KeyManagerCore`
- [x] add final `else` check in the internal function `_verifyCanSetPermissions(...)` to catch not recognised permission key  starting with `AddressPermissions:...` => added custom error `NotRecognisedPermissionKey`