### PR TITLE
feat: [QSP - Best Practices] Use `_uncheckedIncrement(..)` for saving gas when iterating loops

### DIFF
--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -237,7 +237,7 @@ library LSP2Utils {
 
         uint256 pointer = offset + 32;
 
-        for (uint256 ii = 0; ii < arrayLength; ii++) {
+        for (uint256 ii = 0; ii < arrayLength; ii = _uncheckedIncrement(ii)) {
             bytes32 key = data.toBytes32(pointer);
 
             // check that the leading bytes are zero bytes "00"
@@ -262,7 +262,7 @@ library LSP2Utils {
         uint256 arrayLength = data.toUint256(offset);
         uint256 pointer = offset + 32;
 
-        for (uint256 ii = 0; ii < arrayLength; ii++) {
+        for (uint256 ii = 0; ii < arrayLength; ii = _uncheckedIncrement(ii)) {
             bytes32 key = data.toBytes32(pointer);
 
             // check that the trailing bytes are zero bytes "00"
@@ -273,5 +273,15 @@ library LSP2Utils {
         }
 
         return true;
+    }
+
+    /**
+     * @dev Will return unchecked incremented uint256
+     *      can be used to save gas when iterating over loops
+     */
+    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
+        }
     }
 }

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -237,7 +237,7 @@ library LSP2Utils {
 
         uint256 pointer = offset + 32;
 
-        for (uint256 ii = 0; ii < arrayLength; ii = _uncheckedIncrement(ii)) {
+        for (uint256 ii = 0; ii < arrayLength; ii = uncheckedIncrement(ii)) {
             bytes32 key = data.toBytes32(pointer);
 
             // check that the leading bytes are zero bytes "00"
@@ -262,7 +262,7 @@ library LSP2Utils {
         uint256 arrayLength = data.toUint256(offset);
         uint256 pointer = offset + 32;
 
-        for (uint256 ii = 0; ii < arrayLength; ii = _uncheckedIncrement(ii)) {
+        for (uint256 ii = 0; ii < arrayLength; ii = uncheckedIncrement(ii)) {
             bytes32 key = data.toBytes32(pointer);
 
             // check that the trailing bytes are zero bytes "00"
@@ -279,7 +279,7 @@ library LSP2Utils {
      * @dev Will return unchecked incremented uint256
      *      can be used to save gas when iterating over loops
      */
-    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+    function uncheckedIncrement(uint256 i) internal pure returns (uint256) {
         unchecked {
             return i + 1;
         }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -207,7 +207,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             bool isSettingERC725YKeys = false;
 
             // loop through each ERC725Y data keys
-            for (uint256 ii = 0; ii < inputKeys.length; ii++) {
+            for (uint256 ii = 0; ii < inputKeys.length; ii = _uncheckedIncrement(ii)) {
                 bytes32 key = inputKeys[ii];
                 bytes memory value = inputValues[ii];
 
@@ -404,12 +404,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes32 mask;
 
         // loop through each allowed ERC725Y key retrieved from storage
-        for (uint256 ii = 0; ii < allowedERC725YKeys.length; ii++) {
+        for (uint256 ii = 0; ii < allowedERC725YKeys.length; ii = _uncheckedIncrement(ii)) {
             // required to know which part of the input key to compare against the allowed key
             zeroBytesCount = _countTrailingZeroBytes(allowedERC725YKeys[ii]);
 
             // loop through each keys given as input
-            for (uint256 jj = 0; jj < inputKeys.length; jj++) {
+            for (uint256 jj = 0; jj < inputKeys.length; jj = _uncheckedIncrement(jj)) {
                 // skip permissions keys that have been previously checked and "nulled"
                 if (inputKeys[jj] == bytes32(0)) continue;
 
@@ -433,7 +433,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
         }
 
-        for (uint256 ii = 0; ii < inputKeys.length; ii++) {
+        for (uint256 ii = 0; ii < inputKeys.length; ii = _uncheckedIncrement(ii)) {
             if (inputKeys[ii] != bytes32(0)) revert NotAllowedERC725YKey(from, inputKeys[ii]);
         }
     }
@@ -554,7 +554,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         address[] memory allowedAddressesList = abi.decode(allowedAddresses, (address[]));
 
-        for (uint256 ii = 0; ii < allowedAddressesList.length; ii++) {
+        for (uint256 ii = 0; ii < allowedAddressesList.length; ii = _uncheckedIncrement(ii)) {
             if (to == allowedAddressesList[ii]) return;
         }
         revert NotAllowedAddress(from, to);
@@ -579,7 +579,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         bytes4[] memory allowedStandardsList = abi.decode(allowedStandards, (bytes4[]));
 
-        for (uint256 ii = 0; ii < allowedStandardsList.length; ii++) {
+        for (uint256 ii = 0; ii < allowedStandardsList.length; ii = _uncheckedIncrement(ii)) {
             if (to.supportsERC165Interface(allowedStandardsList[ii])) return;
         }
         revert NotAllowedStandard(from, to);
@@ -605,7 +605,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
         bytes4[] memory allowedFunctionsList = abi.decode(allowedFunctions, (bytes4[]));
 
-        for (uint256 ii = 0; ii < allowedFunctionsList.length; ii++) {
+        for (uint256 ii = 0; ii < allowedFunctionsList.length; ii = _uncheckedIncrement(ii)) {
             if (functionSelector == allowedFunctionsList[ii]) return;
         }
         revert NotAllowedFunction(from, functionSelector);
@@ -648,5 +648,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         if (permission == _PERMISSION_DEPLOY) return "DEPLOY";
         if (permission == _PERMISSION_TRANSFERVALUE) return "TRANSFERVALUE";
         if (permission == _PERMISSION_SIGN) return "SIGN";
+    }
+
+    /**
+     * @dev Will return unchecked incremented uint256
+     *      can be used to save gas when iterating over loops
+     */
+    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
+        }
     }
 }

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -139,7 +139,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             revert LSP7InvalidTransferBatch();
         }
 
-        for (uint256 i = 0; i < from.length; i++) {
+        for (uint256 i = 0; i < from.length; i = _uncheckedIncrement(i)) {
             // using the public transfer function to handle updates to operator authorized amounts
             transfer(from[i], to[i], amount[i], force, data[i]);
         }
@@ -362,6 +362,16 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             } else {
                 revert LSP7NotifyTokenReceiverIsEOA(to);
             }
+        }
+    }
+
+    /**
+     * @dev Will return unchecked incremented uint256
+     *      can be used to save gas when iterating over loops
+     */
+    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
         }
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -208,7 +208,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
             revert LSP8InvalidTransferBatch();
         }
 
-        for (uint256 i = 0; i < from.length; i++) {
+        for (uint256 i = 0; i < from.length; i = _uncheckedIncrement(i)) {
             transfer(from[i], to[i], tokenId[i], force, data[i]);
         }
     }
@@ -232,7 +232,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         EnumerableSet.AddressSet storage operatorsForTokenId = _operators[tokenId];
 
         uint256 operatorListLength = operatorsForTokenId.length();
-        for (uint256 i = 0; i < operatorListLength; i++) {
+        for (uint256 i = 0; i < operatorListLength; i = _uncheckedIncrement(i)) {
             // we are emptying the list, always remove from index 0
             address operator = operatorsForTokenId.at(0);
             _revokeOperator(operator, tokenOwner, tokenId);
@@ -433,6 +433,16 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
             } else {
                 revert LSP8NotifyTokenReceiverIsEOA(to);
             }
+        }
+    }
+
+    /**
+     * @dev Will return unchecked incremented uint256
+     *      can be used to save gas when iterating over loops
+     */
+    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
         }
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -145,7 +145,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         onlyAllowed
     {
         require(dataKeys.length == dataValues.length, "Keys length not equal to values length");
-        for (uint256 i = 0; i < dataKeys.length; i++) {
+        for (uint256 i = 0; i < dataKeys.length; i = _uncheckedIncrement(i)) {
             _setData(dataKeys[i], dataValues[i]);
         }
     }
@@ -200,6 +200,16 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     function _notifyVaultReceiver(address receiver) internal virtual {
         if (ERC165Checker.supportsERC165Interface(receiver, _INTERFACEID_LSP1)) {
             ILSP1UniversalReceiver(receiver).universalReceiver(_TYPEID_LSP9_VAULTRECIPIENT, "");
+        }
+    }
+
+    /**
+     * @dev Will return unchecked incremented uint256
+     *      can be used to save gas when iterating over loops
+     */
+    function _uncheckedIncrement(uint256 i) internal pure returns (uint256) {
+        unchecked {
+            return i + 1;
         }
     }
 }


### PR DESCRIPTION
## What does this PR introduce?

Adding `_uncheckedIncrement(…)` to:
- `LSP2Utils.sol`
- `LSP6KeyManagerCore.sol`
- `LSP7DigitalAssetCore.sol`
- `LSP8IdentifiableDigitalAsset.sol`
- `LSP9VaultCore.sol`

As well as using the method in for loops.