### PR TITLE
fix: [QSP - Best Practices] refactor `deployCreate2Proxy(..)` to revert instead of refund caller

### DIFF
--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -134,7 +134,7 @@ contract UniversalFactory {
         } else {
             require(
                 msg.value == 0,
-                "UniversalFactory: Value cannot be sent to Proxies on deployment"
+                "UniversalFactory: value cannot be sent to the factory if initializeCallData is empty"
             );
         }
     }

--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -132,15 +132,10 @@ contract UniversalFactory {
                 "UniversalFactory: could not initialize the created contract"
             );
         } else {
-            // @todo check if this part make sense
-            // Return value sent
-            if (msg.value != 0) {
-                // solhint-disable avoid-low-level-calls
-                (bool success, bytes memory returnData) = payable(msg.sender).call{
-                    value: msg.value
-                }("");
-                Address.verifyCallResult(success, returnData, "UniversalFactory: Unknow Error");
-            }
+            require(
+                msg.value == 0,
+                "UniversalFactory: Value cannot be sent to Proxies on deployment"
+            );
         }
     }
 

--- a/tests/Factories/UniversalFactory.test.ts
+++ b/tests/Factories/UniversalFactory.test.ts
@@ -630,7 +630,7 @@ describe("UniversalFactory contract", () => {
               value: ethers.utils.parseEther("1300"),
             })
         ).to.be.revertedWith(
-          "UniversalFactory: Value cannot be sent to Proxies on deployment"
+          "UniversalFactory: value cannot be sent to the factory if initializeCallData is empty"
         );
       });
 


### PR DESCRIPTION
## What does this PR introduce?
- Revert when `(msg.value > 0) && (initiliazeCallData.length == 0)` instead of refunding the amount sent to the caller.

Check added at the end of the function to save gas when doing successful contract deployment instead of adding the check at the top.

- Edit tests to support the new behavior.