### PR TITLE
docs [QSP-9]: Add comments about Allowance Double-Spend Exploit in LSP7 Natspec

### DIFF
--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -84,11 +84,15 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param amount The amount of tokens operator has access to.
      * @dev Sets `amount` as the amount of tokens `operator` address has access to from callers tokens.
      *
-     * To increase or decrease the authorized amount of an operator, it's advised to call
-     * {revokeOperator} first, and then re-call {authorizeOperator} with the new amount
-     * to avoid front-running and Allowance Double-Spend Exploit
-     * Check more information here:
+     * To avoid front-running and Allowance Double-Spend Exploit when
+     * increasing or decreasing the authorized amount of an operator,
+     * it is advised to:
+     *     1. call {revokeOperator} first, and
+     *     2. then re-call {authorizeOperator} with the new amount
+     *
+     * for more information, see:
      * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
+     *
      *
      * See {isOperatorFor}.
      *

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -84,6 +84,12 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param amount The amount of tokens operator has access to.
      * @dev Sets `amount` as the amount of tokens `operator` address has access to from callers tokens.
      *
+     * To increase or decrease the authorized amount of an operator, it's advised to call
+     * {revokeOperator} first, and then re-call {authorizeOperator} with the new amount
+     * to avoid front-running and Allowance Double-Spend Exploit
+     * Check more information here:
+     * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
+     *
      * See {isOperatorFor}.
      *
      * Requirements

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -69,6 +69,12 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
     /**
      * @inheritdoc ILSP7DigitalAsset
+     *
+     * @dev To increase or decrease the authorized amount of an operator, it's advised to call
+     * {revokeOperator} first, and then re-call {authorizeOperator} with the new amount
+     * to avoid front-running and Allowance Double-Spend Exploit
+     * Check more information here:
+     * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
      */
     function authorizeOperator(address operator, uint256 amount) public virtual override {
         _updateOperator(msg.sender, operator, amount);

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -70,11 +70,15 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      *
-     * @dev To increase or decrease the authorized amount of an operator, it's advised to call
-     * {revokeOperator} first, and then re-call {authorizeOperator} with the new amount
-     * to avoid front-running and Allowance Double-Spend Exploit
-     * Check more information here:
+     * @dev To avoid front-running and Allowance Double-Spend Exploit when
+     * increasing or decreasing the authorized amount of an operator,
+     * it is advised to:
+     *     1. call {revokeOperator} first, and
+     *     2. then re-call {authorizeOperator} with the new amount
+     *
+     * for more information, see:
      * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
+     *
      */
     function authorizeOperator(address operator, uint256 amount) public virtual override {
         _updateOperator(msg.sender, operator, amount);


### PR DESCRIPTION
## What does this PR introduce?
- Adding comments about Allowance Double-Spend Exploit in LSP7 Natspec in `authorizeOperator(..)` function.

This is just for warning, later actions to be discussed if we want to include `increaseAuthorizedAmount` function and `decreaseAuthorizedAmount` in implementation or/and specs.