### PR TITLE
refactor: rename custom error ~`LSP8CannotSendToFromAddress`~ -> `LSP8CannotSendToSelf`

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -254,6 +254,14 @@ const Errors = {
 			error: 'NotAllowedERC725YKey(address,bytes32)',
 			message: 'LSP6: not allowed to set the ERC725Y data key.',
 		},
+		'0x0f7d735b': {
+			error: 'NotRecognisedPermissionKey(bytes32)',
+			message: 'LSP6: could not recognise the permission data key being set.',
+		},
+		'0xfc854579': {
+			error: 'InvalidLSP6Target()',
+			message: 'LSP6: cannot linked the Key Manager to address(0).',
+		},
 		'0xc9bd9eb9': {
 			error: 'InvalidRelayNonce(address,uint256,bytes)',
 			message: 'LSP6: invalid nonce provided for signer address',
@@ -323,6 +331,10 @@ const Errors = {
 		'0x24ecef4d': {
 			error: 'LSP8CannotSendToAddressZero()',
 			message: 'LSP8: cannot send to address(0).',
+		},
+		'0x5d67d6c1': {
+			error: 'LSP8CannotSendToSelf()',
+			message: 'LSP8: the `from` and `to` address cannot be the same on transfer.',
 		},
 		'0x34c7b511': {
 			error: 'LSP8TokenIdAlreadyMinted(bytes32)',

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -15,7 +15,7 @@ error LSP8CannotUseAddressZeroAsOperator();
 
 error LSP8CannotSendToAddressZero();
 
-error LSP8CannotSendToFromAddress();
+error LSP8CannotSendToSelf();
 
 error LSP8NonExistingOperator(address _address, bytes32 tokenId);
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -42,6 +42,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     // Mapping a `tokenId` to its authorized operator addresses.
     mapping(bytes32 => EnumerableSet.AddressSet) internal _operators;
 
+    mapping(address => EnumerableSet.Bytes32Set) internal _tokenIdsForOperator;
+
     // --- Token queries
 
     /**
@@ -339,7 +341,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         bytes memory data
     ) internal virtual {
         if (from == to) {
-            revert LSP8CannotSendToFromAddress();
+            revert LSP8CannotSendToSelf();
         }
 
         address tokenOwner = tokenOwnerOf(tokenId);

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -788,7 +788,7 @@ export const shouldBehaveLikeLSP8 = (
                   force,
                   data,
                 };
-                const expectedError = "LSP8CannotSendToFromAddress";
+                const expectedError = "LSP8CannotSendToSelf";
 
                 await transferFailScenario(txParams, operator, {
                   error: expectedError,
@@ -887,7 +887,7 @@ export const shouldBehaveLikeLSP8 = (
                   force,
                   data,
                 };
-                const expectedError = "LSP8CannotSendToFromAddress";
+                const expectedError = "LSP8CannotSendToSelf";
 
                 await transferFailScenario(txParams, operator, {
                   error: expectedError,


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

- [x] Rename the error introduced in #266 by `LSP8CannotSendToSelf` to provide a better explanation of what the error means.

## 🏗️  Build

- [x] add new custom error signature + description in `constants.js` file.