### PR TITLE
refactor!: Change `isOperatorFor(..)` to `authorizedAmountFor(..)` in LSP7

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -21,7 +21,7 @@ const INTERFACE_IDS = {
 	LSP1UniversalReceiver: '0x6bb56a14',
 	LSP1UniversalReceiverDelegate: '0xa245bbda',
 	LSP6KeyManager: '0xc403d48f',
-	LSP7DigitalAsset: '0xe33f65c3',
+	LSP7DigitalAsset: '0x5fcaac27',
 	LSP8IdentifiableDigitalAsset: '0x49399145',
 	LSP9Vault: '0x8c1d44f6',
 	ClaimOwnership: '0xd225f160',

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -94,7 +94,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
      *
      *
-     * See {isOperatorFor}.
+     * See {authorizedAmountFor}.
      *
      * Requirements
      *
@@ -108,7 +108,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param operator The address to revoke as an operator.
      * @dev Removes `operator` address as an operator of callers tokens.
      *
-     * See {isOperatorFor}.
+     * See {authorizedAmountFor}.
      *
      * Requirements
      *
@@ -126,7 +126,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * Operators can send and burn tokens on behalf of their owners. The tokenOwner is their own
      * operator.
      */
-    function isOperatorFor(address operator, address tokenOwner) external view returns (uint256);
+    function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256);
 
     // --- Transfer functionality
 

--- a/contracts/LSP7DigitalAsset/LSP7Constants.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP7 = 0xe33f65c3;
+bytes4 constant _INTERFACEID_LSP7 = 0x5fcaac27;
 
 // --- Token Hooks
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -94,7 +94,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function isOperatorFor(address operator, address tokenOwner)
+    function authorizedAmountFor(address operator, address tokenOwner)
         public
         view
         virtual
@@ -160,7 +160,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * amount is zero then the operator is being revoked, otherwise the operator amount is being
      * modified.
      *
-     * See {isOperatorFor}.
+     * See {authorizedAmountFor}.
      *
      * Emits either {AuthorizedOperator} or {RevokedOperator} event.
      *

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
@@ -38,7 +38,7 @@ abstract contract LSP7CompatibleERC20Core is
         override
         returns (uint256)
     {
-        return isOperatorFor(operator, tokenOwner);
+        return authorizedAmountFor(operator, tokenOwner);
     }
 
     /**

--- a/docs/ILSP7CappedSupply.md
+++ b/docs/ILSP7CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7CompatibilityForERC20.md
+++ b/docs/ILSP7CompatibilityForERC20.md
@@ -58,7 +58,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -128,10 +128,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -159,7 +159,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7DigitalAsset.md
+++ b/docs/ILSP7DigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/ILSP7Mintable.md
+++ b/docs/ILSP7Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -138,7 +138,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupply.md
+++ b/docs/LSP7CappedSupply.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -147,7 +147,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupplyCore.md
+++ b/docs/LSP7CappedSupplyCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupplyInit.md
+++ b/docs/LSP7CappedSupplyInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token max supply
 |---|---|---|
 | tokenSupplyCap_ | uint256 | The Token max supply
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupplyInitAbstract.md
+++ b/docs/LSP7CappedSupplyInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token max supply
 |---|---|---|
 | tokenSupplyCap_ | uint256 | The Token max supply
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupplyInitTester.md
+++ b/docs/LSP7CappedSupplyInitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -121,10 +121,10 @@ Sets the token max supply
 |---|---|---|
 | tokenSupplyCap_ | uint256 | The Token max supply
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -197,7 +197,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CappedSupplyTester.md
+++ b/docs/LSP7CappedSupplyTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -105,10 +105,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -181,7 +181,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20.md
+++ b/docs/LSP7CompatibilityForERC20.md
@@ -128,10 +128,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -204,7 +204,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20Core.md
+++ b/docs/LSP7CompatibilityForERC20Core.md
@@ -128,10 +128,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -204,7 +204,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20Init.md
+++ b/docs/LSP7CompatibilityForERC20Init.md
@@ -144,10 +144,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -220,7 +220,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20InitAbstract.md
+++ b/docs/LSP7CompatibilityForERC20InitAbstract.md
@@ -144,10 +144,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -220,7 +220,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20InitTester.md
+++ b/docs/LSP7CompatibilityForERC20InitTester.md
@@ -162,10 +162,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -256,7 +256,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7CompatibilityForERC20Tester.md
+++ b/docs/LSP7CompatibilityForERC20Tester.md
@@ -146,10 +146,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -240,7 +240,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7DigitalAsset.md
+++ b/docs/LSP7DigitalAsset.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -147,7 +147,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7DigitalAssetCore.md
+++ b/docs/LSP7DigitalAssetCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -119,7 +119,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7DigitalAssetInit.md
+++ b/docs/LSP7DigitalAssetInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7DigitalAssetInitAbstract.md
+++ b/docs/LSP7DigitalAssetInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -163,7 +163,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7InitTester.md
+++ b/docs/LSP7InitTester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -122,10 +122,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -200,7 +200,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7Mintable.md
+++ b/docs/LSP7Mintable.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -166,7 +166,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7MintableCore.md
+++ b/docs/LSP7MintableCore.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -88,10 +88,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -138,7 +138,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7MintableInit.md
+++ b/docs/LSP7MintableInit.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -182,7 +182,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7MintableInitAbstract.md
+++ b/docs/LSP7MintableInitAbstract.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -104,10 +104,10 @@ Sets the token-Metadata and register LSP7InterfaceId
 |---|---|---|
 | _newOwner | address | the owner of the contract
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -182,7 +182,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/docs/LSP7Tester.md
+++ b/docs/LSP7Tester.md
@@ -18,7 +18,7 @@ function authorizeOperator(address operator, uint256 amount) external nonpayable
 
 
 
-*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
+*Sets `amount` as the amount of tokens `operator` address has access to from callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits an {AuthorizedOperator} event.*
 
 #### Parameters
 
@@ -106,10 +106,10 @@ Gets array of data at multiple given keys
 |---|---|---|
 | values | bytes[] | The array of data stored at multiple keys
 
-### isOperatorFor
+### authorizedAmountFor
 
 ```solidity
-function isOperatorFor(address operator, address tokenOwner) external view returns (uint256)
+function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256)
 ```
 
 
@@ -184,7 +184,7 @@ function revokeOperator(address operator) external nonpayable
 
 
 
-*Removes `operator` address as an operator of callers tokens. See {isOperatorFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
+*Removes `operator` address as an operator of callers tokens. See {authorizedAmountFor}. Requirements - `operator` cannot be the zero address. Emits a {RevokedOperator} event.*
 
 #### Parameters
 

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -207,7 +207,7 @@ export const shouldBehaveLikeLSP7 = (
             .withArgs(operator, tokenOwner, amount);
 
           expect(
-            await context.lsp7.isOperatorFor(operator, tokenOwner)
+            await context.lsp7.authorizedAmountFor(operator, tokenOwner)
           ).to.equal(amount);
         });
 
@@ -233,7 +233,7 @@ export const shouldBehaveLikeLSP7 = (
               .withArgs(operator, tokenOwner, amount);
 
             expect(
-              await context.lsp7.isOperatorFor(operator, tokenOwner)
+              await context.lsp7.authorizedAmountFor(operator, tokenOwner)
             ).to.equal(amount);
           });
         });
@@ -263,9 +263,9 @@ export const shouldBehaveLikeLSP7 = (
 
         // pre-conditions
         await context.lsp7.authorizeOperator(operator, amount);
-        expect(await context.lsp7.isOperatorFor(operator, tokenOwner)).to.equal(
-          amount
-        );
+        expect(
+          await context.lsp7.authorizedAmountFor(operator, tokenOwner)
+        ).to.equal(amount);
 
         // effects
         const tx = await context.lsp7.revokeOperator(operator);
@@ -274,9 +274,9 @@ export const shouldBehaveLikeLSP7 = (
           .withArgs(operator, tokenOwner);
 
         // post-conditions
-        expect(await context.lsp7.isOperatorFor(operator, tokenOwner)).to.equal(
-          ethers.constants.Zero
-        );
+        expect(
+          await context.lsp7.authorizedAmountFor(operator, tokenOwner)
+        ).to.equal(ethers.constants.Zero);
       });
     });
 
@@ -293,11 +293,11 @@ export const shouldBehaveLikeLSP7 = (
       });
     });
 
-    describe("isOperatorFor", () => {
+    describe("authorizedAmountFor", () => {
       describe("when operator is the token owner", () => {
         it("should return the balance of the token owner", async () => {
           expect(
-            await context.lsp7.isOperatorFor(
+            await context.lsp7.authorizedAmountFor(
               context.accounts.owner.address,
               context.accounts.owner.address
             )
@@ -310,7 +310,7 @@ export const shouldBehaveLikeLSP7 = (
       describe("when operator has not been authorized", () => {
         it("should return zero", async () => {
           expect(
-            await context.lsp7.isOperatorFor(
+            await context.lsp7.authorizedAmountFor(
               context.accounts.operator.address,
               context.accounts.owner.address
             )
@@ -326,7 +326,7 @@ export const shouldBehaveLikeLSP7 = (
           );
 
           expect(
-            await context.lsp7.isOperatorFor(
+            await context.lsp7.authorizedAmountFor(
               context.accounts.operator.address,
               context.accounts.owner.address
             )
@@ -346,14 +346,14 @@ export const shouldBehaveLikeLSP7 = (
           );
 
           expect(
-            await context.lsp7.isOperatorFor(
+            await context.lsp7.authorizedAmountFor(
               context.accounts.operator.address,
               context.accounts.owner.address
             )
           ).to.equal(context.initialSupply);
 
           expect(
-            await context.lsp7.isOperatorFor(
+            await context.lsp7.authorizedAmountFor(
               context.accounts.operatorWithLowAuthorizedAmount.address,
               context.accounts.owner.address
             )
@@ -408,7 +408,7 @@ export const shouldBehaveLikeLSP7 = (
           // pre-conditions
           const preFromBalanceOf = await context.lsp7.balanceOf(from);
           const preToBalanceOf = await context.lsp7.balanceOf(to);
-          const preIsOperatorFor = await context.lsp7.isOperatorFor(
+          const preIsOperatorFor = await context.lsp7.authorizedAmountFor(
             operator.address,
             from
           );
@@ -429,7 +429,7 @@ export const shouldBehaveLikeLSP7 = (
           expect(postToBalanceOf).to.equal(preToBalanceOf.add(amount));
 
           if (operator.address !== from) {
-            const postIsOperatorFor = await context.lsp7.isOperatorFor(
+            const postIsOperatorFor = await context.lsp7.authorizedAmountFor(
               operator.address,
               from
             );
@@ -691,7 +691,7 @@ export const shouldBehaveLikeLSP7 = (
                 data: "0x",
               };
               const expectedError = "LSP7AmountExceedsAuthorizedAmount";
-              const operatorAmount = await context.lsp7.isOperatorFor(
+              const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
                 txParams.from
               );
@@ -720,14 +720,17 @@ export const shouldBehaveLikeLSP7 = (
               data: "0x",
             };
             const expectedError = "LSP7AmountExceedsAuthorizedAmount";
-            const operatorAmount = await context.lsp7.isOperatorFor(
+            const operatorAmount = await context.lsp7.authorizedAmountFor(
               operator.address,
               txParams.from
             );
 
             // pre-conditions
             expect(
-              await context.lsp7.isOperatorFor(operator.address, txParams.from)
+              await context.lsp7.authorizedAmountFor(
+                operator.address,
+                txParams.from
+              )
             ).to.equal(ethers.constants.Zero);
 
             // effects
@@ -804,10 +807,11 @@ export const shouldBehaveLikeLSP7 = (
               expect(postBalanceOf).to.equal(amount[index]);
 
               if (operator.address !== from[index]) {
-                const postIsOperatorFor = await context.lsp7.isOperatorFor(
-                  operator.address,
-                  from[index]
-                );
+                const postIsOperatorFor =
+                  await context.lsp7.authorizedAmountFor(
+                    operator.address,
+                    from[index]
+                  );
                 expect(postIsOperatorFor).to.equal(
                   postIsOperatorFor.sub(amount[index])
                 );
@@ -1177,7 +1181,7 @@ export const shouldBehaveLikeLSP7 = (
                 data: ["0x"],
               };
               const expectedError = "LSP7AmountExceedsAuthorizedAmount";
-              const operatorAmount = await context.lsp7.isOperatorFor(
+              const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
                 txParams.from[0]
               );
@@ -1205,7 +1209,7 @@ export const shouldBehaveLikeLSP7 = (
                 data: ["0x"],
               };
               const expectedError = "LSP7AmountExceedsAuthorizedAmount";
-              const operatorAmount = await context.lsp7.isOperatorFor(
+              const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
                 txParams.from[0]
               );


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ Breaking Change

- Changes all the references to `isOperatorFor` in files related to LSP7 to `authorizedAmountFor` 
- Updates the `interfaceId` in the constants files to the new `interfaceId`.

## Why is this PR needed?

`isOperatorFor(address operator, address tokenOwner)` this method returns `uint256`, the amount of tokens that `operator` is authorised to spend on behalf of `tokenOwner`. The naming of the method is quite misleading as one would expect that `isOperatorFor` would return a `bool`. That’s why the name `authorizedAmountFor` would fit better in this context.