### PR TITLE
fix: [QSP-12] Add Checks to ensure target cannot be locked

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -46,6 +46,16 @@ error NotAllowedFunction(address from, bytes4 disallowedFunction);
 error NotAllowedERC725YKey(address from, bytes32 disallowedKey);
 
 /**
+ * @dev reverts when the target calls {claimOwnership} on itself
+ */
+error TargetCannotSelfClaimOwnership();
+
+/**
+ * @dev reverts when transferring ownership of the target to the target itself
+ */
+error CannotTransferOwnershipToTarget();
+
+/**
  * @dev reverts when `dataKey` is a bytes32 that does not adhere to any of the
  *      permission data keys specified by the LSP6 standard
  *

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -241,7 +241,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         } else if (erc725Function == OwnableUnset.transferOwnership.selector) {
             _verifyCanTransferOwnership(from, permissions, payload);
 
-        } else if(erc725Function == IClaimOwnership.claimOwnership.selector) {
+        } else if (erc725Function == IClaimOwnership.claimOwnership.selector) {
             _requirePermissions(from, permissions,_PERMISSION_CHANGEOWNER);
         } else {
             revert InvalidERC725Function(erc725Function);
@@ -502,7 +502,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         }
 
         // CHECK that claimOwnership cannot be called by target
-        if(to == target && bytes4(payload[164:168]) == IClaimOwnership.claimOwnership.selector)
+        if (to == target && bytes4(payload[164:168]) == IClaimOwnership.claimOwnership.selector)
          revert TargetCannotClaimOwnership();
 
         // Skip on contract creation (CREATE or CREATE2)

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -48,6 +48,25 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
   });
 
+  describe("when transferring Ownership to the target address", () => {
+    it("should revert", async () => {
+      const transferOwnershipPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "transferOwnership",
+          [context.universalProfile.address]
+        );
+
+      await expect(
+        context.keyManager
+          .connect(canChangeOwner)
+          .execute(transferOwnershipPayload)
+      ).to.be.revertedWithCustomError(
+        context.keyManager,
+        "CannotTransferOwnershipToTarget"
+      );
+    });
+  });
+
   describe("when upgrading to a new KeyManager via transferOwnership(...)", () => {
     let newKeyManager: LSP6KeyManager;
 

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -99,6 +99,26 @@ export const testSecurityScenarios = (
       .withArgs(addressWithNoPermissions.address);
   });
 
+  it("should revert when calling claimOwnership(..) of the target through execute(..)", async () => {
+    const claimOwnershipPayload =
+      context.universalProfile.interface.encodeFunctionData("claimOwnership");
+
+    const executePayload =
+      context.universalProfile.interface.encodeFunctionData("execute", [
+        OPERATION_TYPES.CALL,
+        context.universalProfile.address,
+        0,
+        claimOwnershipPayload,
+      ]);
+
+    await expect(
+      context.keyManager.connect(context.owner).execute(executePayload)
+    ).to.be.revertedWithCustomError(
+      context.keyManager,
+      "TargetCannotSelfClaimOwnership"
+    );
+  });
+
   describe("should revert when admin with ALL PERMISSIONS try to call `renounceOwnership(...)`", () => {
     it("via `execute(...)`", async () => {
       let payload =


### PR DESCRIPTION
## Current Behavior
- The KeyManager doesn't allow to call renounce ownership of the target, in this case, anyone wishing to renounce ownership needs to call `transferOwnership(..)` to another contract, then `claimOwnership(..)` and then `renounceOwnership(..)`.
In this way, the risk of locking the account is mitigated.

- @CJ42 pointed out that the target can be locked if we call `transferOwnership(..)` to the target itself, and then call `claimOwnership(..)` through the `execute(..)` function of the target. In this way, target will be owned by the target address and cannot be controlled.

## What does this PR introduce?
- Adding checks in the KeyManager to ensure that the address to `transferOwnership(..)` for (new potential owner), cannot be the address of the target itself, also restricting on the KeyManager level the `execute(..)` function to not call `claimOwnership(..)` on the target itself.

In this way, users wishing to lock their targets will need to repeat the same long process of `renounceOwnership(..)` which makes the risk of locking the account mitigated. 

- Added tests to support the new behavior.