### PR TITLE
feat: [QSP-12] Add two step process for `renounceOwnership(...)` in `ClaimOwnership` contract

### DIFF
--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -22,6 +22,8 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
      */
     address public override pendingOwner;
 
+    error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
+
     function claimOwnership() public virtual override {
         _claimOwnership();
     }
@@ -55,10 +57,7 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
         uint256 _delayBlocks = 100;
 
         if (_lastBlock <= block.number && (_lastBlock + _delayBlocks) > block.number) {
-            revert RenounceOwnershipPending(
-                "OwnableClaim: Renounce ownership can be confirmed at block",
-                _lastBlock + _delayBlocks
-            );
+            revert RenounceOwnershipAvailableAtBlockNumber(_lastBlock + _delayBlocks);
         } else if (
             (_lastBlock + _delayBlocks) <= block.number &&
             (_lastBlock + _delayBlocks * 2) > block.number

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -11,6 +11,8 @@ import {IClaimOwnership} from "./IClaimOwnership.sol";
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
+    error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
+
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     /**
      * @dev The block number saved in the first step for
@@ -28,8 +30,6 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
      * @dev The address that may use `claimOwnership()`
      */
     address public override pendingOwner;
-
-    error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
 
     function claimOwnership() public virtual override {
         _claimOwnership();

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -17,6 +17,13 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
      * renouncing ownership of the contract
      */
     uint256 private _lastBlock;
+
+    /**
+     * @dev The number of blocks needed to pass for successfully
+     * confirming `renounceOwnership()`
+     */
+    uint256 constant _delayBlocks = 100;
+
     /**
      * @dev The address that may use `claimOwnership()`
      */
@@ -51,11 +58,8 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
      * is more than 200 block back.
      * Execute `renounceOwnership` if the `_lastRenounceOwnershipBlock`
      * is less than 200 blocks back and more than 100 blocks.
-     *
      */
     function _renounceOwnership() internal virtual {
-        uint256 _delayBlocks = 100;
-
         if (_lastBlock <= block.number && (_lastBlock + _delayBlocks) > block.number) {
             revert RenounceOwnershipAvailableAtBlockNumber(_lastBlock + _delayBlocks);
         } else if (

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -11,7 +11,7 @@ import {IClaimOwnership} from "./IClaimOwnership.sol";
 // modules
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
-    error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
+error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
 
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     /**

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -31,4 +31,30 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     function _transferOwnership(address newOwner) internal virtual {
         pendingOwner = newOwner;
     }
+
+    /**
+     * @dev The block number saved in the first step for
+     * renouncing ownership of the contract
+     */
+    uint256 private _lastRenounceOwnershipBlock;
+
+    /**
+     * @dev Save the block number for the first step if `_lastRenounceOwnershipBlock`
+     * is more than 100 block back. And execute `renounceOwnership` otherwise.
+     * 
+     */
+    function renounceOwnership()
+        public
+        virtual
+        override
+        onlyOwner
+    {
+        if (_lastRenounceOwnershipBlock + 100 >= block.number) {
+            _setOwner(address(0));
+        }
+        else {
+            _lastRenounceOwnershipBlock = block.number;
+        }
+    }
+    
 }

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -49,12 +49,9 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
      * is more than 200 block back.
      * Execute `renounceOwnership` if the `_lastRenounceOwnershipBlock`
      * is less than 200 blocks back and more than 100 blocks.
-     * 
+     *
      */
-    function _renounceOwnership()
-        internal
-        virtual
-    {
+    function _renounceOwnership() internal virtual {
         uint256 _delayBlocks = 100;
 
         if (_lastBlock <= block.number && (_lastBlock + _delayBlocks) > block.number) {
@@ -62,7 +59,10 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
                 "OwnableClaim: Renounce ownership can be confirmed at block",
                 _lastBlock + _delayBlocks
             );
-        } else if ((_lastBlock + _delayBlocks) <= block.number && (_lastBlock + _delayBlocks * 2) > block.number) {
+        } else if (
+            (_lastBlock + _delayBlocks) <= block.number &&
+            (_lastBlock + _delayBlocks * 2) > block.number
+        ) {
             _setOwner(address(0));
             delete _lastBlock;
         } else {
@@ -70,5 +70,4 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
             emit RenounceOwnershipInitiated();
         }
     }
-    
 }

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -12,6 +12,14 @@ import {IClaimOwnership} from "./IClaimOwnership.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
+    /**
+     * @dev The block number saved in the first step for
+     * renouncing ownership of the contract
+     */
+    uint256 private _lastRenounceOwnershipBlock;
+    /**
+     * @dev The address that may use `claimOwnership()`
+     */
     address public override pendingOwner;
 
     function claimOwnership() public virtual override {
@@ -20,6 +28,10 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
 
     function transferOwnership(address newOwner) public virtual override onlyOwner {
         _transferOwnership(newOwner);
+    }
+
+    function renounceOwnership() public virtual override onlyOwner {
+        _renounceOwnership();
     }
 
     function _claimOwnership() internal virtual {
@@ -33,21 +45,13 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     }
 
     /**
-     * @dev The block number saved in the first step for
-     * renouncing ownership of the contract
-     */
-    uint256 private _lastRenounceOwnershipBlock;
-
-    /**
      * @dev Save the block number for the first step if `_lastRenounceOwnershipBlock`
      * is more than 100 block back. And execute `renounceOwnership` otherwise.
      * 
      */
-    function renounceOwnership()
-        public
+    function _renounceOwnership()
+        internal
         virtual
-        override
-        onlyOwner
     {
         if (_lastRenounceOwnershipBlock + 100 >= block.number) {
             _setOwner(address(0));

--- a/contracts/Custom/IClaimOwnership.sol
+++ b/contracts/Custom/IClaimOwnership.sol
@@ -5,9 +5,7 @@ bytes4 constant _INTERFACEID_CLAIM_OWNERSHIP = 0xd225f160;
 
 interface IClaimOwnership {
     event RenounceOwnershipInitiated();
-
-    error RenounceOwnershipPending(string errorText, uint256 blockNumber);
-
+    
     function pendingOwner() external view returns (address);
 
     function claimOwnership() external;

--- a/contracts/Custom/IClaimOwnership.sol
+++ b/contracts/Custom/IClaimOwnership.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.0;
 bytes4 constant _INTERFACEID_CLAIM_OWNERSHIP = 0xd225f160;
 
 interface IClaimOwnership {
+    event RenounceOwnershipInitiated();
+
+    error RenounceOwnershipPending(string errorText, uint256 blockNumber);
+
     function pendingOwner() external view returns (address);
 
     function claimOwnership() external;

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -91,6 +91,41 @@ abstract contract LSP0ERC725AccountCore is
         ClaimOwnership._transferOwnership(_newOwner);
     }
 
+    /**
+     * @dev The block number saved in the first step for
+     * renouncing ownership of the contract
+     */
+    uint256 private lastRenounceOwnershipBlock;
+
+    /**
+     * @dev Save the block number for of the first step 
+     * for renouncing ownership of the contract
+     */
+    function renounceOwnership()
+        public
+        virtual
+        override
+        onlyOwner
+    {
+        lastRenounceOwnershipBlock = block.number;
+    }
+
+    /**
+     * @dev Confirm renouncing ownersip of the contract
+     * Available only within the first 100 blocks after `renounceOwnership()`
+     */
+    function confirmRenounceOwnership()
+        public
+        virtual
+        onlyOwner
+    {
+        require(
+            lastRenounceOwnershipBlock + 100 >= block.number,
+            "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
+        );
+        _setOwner(address(0));
+    }
+
     // ERC1271
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -92,38 +92,15 @@ abstract contract LSP0ERC725AccountCore is
     }
 
     /**
-     * @dev The block number saved in the first step for
-     * renouncing ownership of the contract
-     */
-    uint256 private _lastRenounceOwnershipBlock;
-
-    /**
-     * @dev Save the block number for of the first step 
-     * for renouncing ownership of the contract
+     * @dev Renounce ownership of the contract in a 2-step process
      */
     function renounceOwnership()
         public
         virtual
-        override
+        override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        _lastRenounceOwnershipBlock = block.number;
-    }
-
-    /**
-     * @dev Confirm renouncing ownersip of the contract
-     * Available only within the first 100 blocks after `renounceOwnership()`
-     */
-    function confirmRenounceOwnership()
-        public
-        virtual
-        onlyOwner
-    {
-        require(
-            _lastRenounceOwnershipBlock + 100 >= block.number,
-            "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-        );
-        _setOwner(address(0));
+        ClaimOwnership.renounceOwnership();
     }
 
     // ERC1271

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -100,7 +100,7 @@ abstract contract LSP0ERC725AccountCore is
         override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        ClaimOwnership.renounceOwnership();
+        ClaimOwnership._renounceOwnership();
     }
 
     // ERC1271

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -95,7 +95,7 @@ abstract contract LSP0ERC725AccountCore is
      * @dev The block number saved in the first step for
      * renouncing ownership of the contract
      */
-    uint256 private lastRenounceOwnershipBlock;
+    uint256 private _lastRenounceOwnershipBlock;
 
     /**
      * @dev Save the block number for of the first step 
@@ -107,7 +107,7 @@ abstract contract LSP0ERC725AccountCore is
         override
         onlyOwner
     {
-        lastRenounceOwnershipBlock = block.number;
+        _lastRenounceOwnershipBlock = block.number;
     }
 
     /**
@@ -120,7 +120,7 @@ abstract contract LSP0ERC725AccountCore is
         onlyOwner
     {
         require(
-            lastRenounceOwnershipBlock + 100 >= block.number,
+            _lastRenounceOwnershipBlock + 100 >= block.number,
             "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
         );
         _setOwner(address(0));

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -125,7 +125,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        ClaimOwnership.renounceOwnership();
+        ClaimOwnership._renounceOwnership();
     }
 
     // ERC725

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -117,38 +117,15 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
     }
 
     /**
-     * @dev The block number saved in the first step for
-     * renouncing ownership of the contract
-     */
-    uint256 private __lastRenounceOwnershipBlock;
-
-    /**
-     * @dev Save the block number for of the first step 
-     * for renouncing ownership of the contract
+     * @dev Renounce ownership of the contract in a 2-step process
      */
     function renounceOwnership()
         public
         virtual
-        override
+        override(ClaimOwnership, OwnableUnset)
         onlyOwner
     {
-        __lastRenounceOwnershipBlock = block.number;
-    }
-
-    /**
-     * @dev Confirm renouncing ownersip of the contract
-     * Available only within the first 100 blocks after `renounceOwnership()`
-     */
-    function confirmRenounceOwnership()
-        public
-        virtual
-        onlyOwner
-    {
-        require(
-            __lastRenounceOwnershipBlock + 100 >= block.number,
-            "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-        );
-        _setOwner(address(0));
+        ClaimOwnership.renounceOwnership();
     }
 
     // ERC725

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -116,6 +116,41 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         _notifyVaultReceiver(msg.sender);
     }
 
+    /**
+     * @dev The block number saved in the first step for
+     * renouncing ownership of the contract
+     */
+    uint256 private lastRenounceOwnershipBlock;
+
+    /**
+     * @dev Save the block number for of the first step 
+     * for renouncing ownership of the contract
+     */
+    function renounceOwnership()
+        public
+        virtual
+        override
+        onlyOwner
+    {
+        lastRenounceOwnershipBlock = block.number;
+    }
+
+    /**
+     * @dev Confirm renouncing ownersip of the contract
+     * Available only within the first 100 blocks after `renounceOwnership()`
+     */
+    function confirmRenounceOwnership()
+        public
+        virtual
+        onlyOwner
+    {
+        require(
+            lastRenounceOwnershipBlock + 100 >= block.number,
+            "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
+        );
+        _setOwner(address(0));
+    }
+
     // ERC725
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -120,7 +120,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      * @dev The block number saved in the first step for
      * renouncing ownership of the contract
      */
-    uint256 private lastRenounceOwnershipBlock;
+    uint256 private __lastRenounceOwnershipBlock;
 
     /**
      * @dev Save the block number for of the first step 
@@ -132,7 +132,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         override
         onlyOwner
     {
-        lastRenounceOwnershipBlock = block.number;
+        __lastRenounceOwnershipBlock = block.number;
     }
 
     /**
@@ -145,7 +145,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         onlyOwner
     {
         require(
-            lastRenounceOwnershipBlock + 100 >= block.number,
+            __lastRenounceOwnershipBlock + 100 >= block.number,
             "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
         );
         _setOwner(address(0));

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -290,11 +290,11 @@ export const shouldBehaveLikeLSP9 = (
           .to.emit(context.lsp9Vault, "OwnershipTransferred")
           .withArgs(
             context.accounts.owner.address,
-            ethers.utils.hexZeroPad("0x", 20)
+            ethers.constants.AddressZero
           );
 
         expect(await context.lsp9Vault.owner()).to.equal(
-          ethers.utils.hexZeroPad("0x", 20)
+          ethers.constants.AddressZero
         );
       });
     });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -254,12 +254,9 @@ export const shouldBehaveLikeLSP9 = (
         await expect(renounceOwnershipSecond)
           .to.be.revertedWithCustomError(
             context.lsp9Vault,
-            "RenounceOwnershipPending"
+            "RenounceOwnershipAvailableAtBlockNumber"
           )
-          .withArgs(
-            "OwnableClaim: Renounce ownership can be confirmed at block",
-            (await renounceOwnershipOnce).blockNumber + 100
-          );
+          .withArgs((await renounceOwnershipOnce).blockNumber + 100);
 
         expect(await context.lsp9Vault.owner()).to.equal(
           context.accounts.owner.address

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -232,13 +232,12 @@ export const shouldBehaveLikeLSP9 = (
       });
 
       it("should fail to confirm renounce ownership directly", async () => {
-        const confirmingRenounceOwnership = context.lsp9Vault
+        await context.lsp9Vault
           .connect(context.accounts.owner)
-          .confirmRenounceOwnership();
+          .renounceOwnership();
 
-        await expect(confirmingRenounceOwnership).to.be.revertedWith(
-          "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(context.accounts.owner.address);
       });
 
       it("should fail to confirm if 100 blocks pass", async () => {
@@ -248,13 +247,12 @@ export const shouldBehaveLikeLSP9 = (
 
         await network.provider.send("hardhat_mine", ["0x64"]);
 
-        const confirmingRenounceOwnership = context.lsp9Vault
+        await context.lsp9Vault
           .connect(context.accounts.owner)
-          .confirmRenounceOwnership();
+          .renounceOwnership();
 
-        await expect(confirmingRenounceOwnership).to.be.revertedWith(
-          "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(context.accounts.owner.address);
       });
 
       it("should renounce ownership in a 2-step process 99 blocks after the initiation", async () => {
@@ -262,19 +260,17 @@ export const shouldBehaveLikeLSP9 = (
           .connect(context.accounts.owner)
           .renounceOwnership();
 
-        expect(await context.lsp9Vault.owner()).to.equal(
-          context.accounts.owner.address
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(context.accounts.owner.address);
 
         await network.provider.send("hardhat_mine", ["0x63"]);
 
         await context.lsp9Vault
           .connect(context.accounts.owner)
-          .confirmRenounceOwnership();
+          .renounceOwnership();
 
-        expect(await context.lsp9Vault.owner()).to.equal(
-          ethers.utils.hexZeroPad("0x", 20)
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(ethers.utils.hexZeroPad("0x", 20));
       });
 
       it("should renounce ownership in a 2-step process", async () => {
@@ -282,17 +278,15 @@ export const shouldBehaveLikeLSP9 = (
           .connect(context.accounts.owner)
           .renounceOwnership();
 
-        expect(await context.lsp9Vault.owner()).to.equal(
-          context.accounts.owner.address
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(context.accounts.owner.address);
 
         await context.lsp9Vault
           .connect(context.accounts.owner)
-          .confirmRenounceOwnership();
+          .renounceOwnership();
 
-        expect(await context.lsp9Vault.owner()).to.equal(
-          ethers.utils.hexZeroPad("0x", 20)
-        );
+        expect(await context.lsp9Vault.owner())
+          .to.equal(ethers.utils.hexZeroPad("0x", 20));
       });
     });
   });

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -256,13 +256,12 @@ export const shouldBehaveLikeLSP3 = (
     });
 
     it("should fail to confirm renounce ownership directly", async () => {
-      const confirmingRenounceOwnership = context.universalProfile
+      await context.universalProfile
         .connect(context.accounts[0])
-        .confirmRenounceOwnership();
+        .renounceOwnership();
 
-      await expect(confirmingRenounceOwnership).to.be.revertedWith(
-        "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(context.accounts[0].address);
     });
 
     it("should fail to confirm if 100 blocks pass", async () => {
@@ -272,13 +271,12 @@ export const shouldBehaveLikeLSP3 = (
 
       await network.provider.send("hardhat_mine", ["0x64"]);
 
-      const confirmingRenounceOwnership = context.universalProfile
+      await context.universalProfile
         .connect(context.accounts[0])
-        .confirmRenounceOwnership();
+        .renounceOwnership();
 
-      await expect(confirmingRenounceOwnership).to.be.revertedWith(
-        "ClaimOwnership: Cannot confirm renouncing ownership of the contract"
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(context.accounts[0].address);
     });
 
     it("should renounce ownership in a 2-step process 99 blocks after the initiation", async () => {
@@ -286,19 +284,17 @@ export const shouldBehaveLikeLSP3 = (
         .connect(context.accounts[0])
         .renounceOwnership();
 
-      expect(await context.universalProfile.owner()).to.equal(
-        context.accounts[0].address
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(context.accounts[0].address);
 
       await network.provider.send("hardhat_mine", ["0x63"]);
 
       await context.universalProfile
         .connect(context.accounts[0])
-        .confirmRenounceOwnership();
+        .renounceOwnership();
 
-      expect(await context.universalProfile.owner()).to.equal(
-        ethers.utils.hexZeroPad("0x", 20)
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(ethers.utils.hexZeroPad("0x", 20));
     });
 
     it("should renounce ownership in a 2-step process", async () => {
@@ -306,17 +302,15 @@ export const shouldBehaveLikeLSP3 = (
         .connect(context.accounts[0])
         .renounceOwnership();
 
-      expect(await context.universalProfile.owner()).to.equal(
-        context.accounts[0].address
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(context.accounts[0].address);
 
       await context.universalProfile
         .connect(context.accounts[0])
-        .confirmRenounceOwnership();
+        .renounceOwnership();
 
-      expect(await context.universalProfile.owner()).to.equal(
-        ethers.utils.hexZeroPad("0x", 20)
-      );
+      expect(await context.universalProfile.owner())
+        .to.equal(ethers.utils.hexZeroPad("0x", 20));
     });
   });
 };

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -278,12 +278,9 @@ export const shouldBehaveLikeLSP3 = (
       await expect(renounceOwnershipSecond)
         .to.be.revertedWithCustomError(
           context.universalProfile,
-          "RenounceOwnershipPending"
+          "RenounceOwnershipAvailableAtBlockNumber"
         )
-        .withArgs(
-          "OwnableClaim: Renounce ownership can be confirmed at block",
-          (await renounceOwnershipOnce).blockNumber + 100
-        );
+        .withArgs((await renounceOwnershipOnce).blockNumber + 100);
 
       expect(await context.universalProfile.owner()).to.equal(
         context.accounts[0].address

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -312,13 +312,10 @@ export const shouldBehaveLikeLSP3 = (
 
       await expect(renounceOwnershipSecond)
         .to.emit(context.universalProfile, "OwnershipTransferred")
-        .withArgs(
-          context.accounts[0].address,
-          ethers.utils.hexZeroPad("0x", 20)
-        );
+        .withArgs(context.accounts[0].address, ethers.constants.AddressZero);
 
       expect(await context.universalProfile.owner()).to.equal(
-        ethers.utils.hexZeroPad("0x", 20)
+        ethers.constants.AddressZero
       );
     });
   });


### PR DESCRIPTION
# What does this PR introduce?

This PR introduces a 2-step process for renouncing ownership of an LSP0ERC725UniversalProfile and LSP9Vault.
The method `renounceOwnership()` was overridden to save the the `block.number` to `_lastBlock` and confirming `renounceOwnership()` only if `_lastBlock + 100` <= `block.number` < `_lastBlock + 200`.
A new constant was added, `_delayBlocks` which defines the number of blocks to be delayed.

Tests were added to check if the desired behaviour was achieved.

## Link to the [issue](https://github.com/lukso-network/LIPs/issues/115)