### PR TITLE
revert: revert message between CREATE/CREATE2 for DEPLOY permission

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -661,35 +661,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         if (permission == _PERMISSION_CALL) return "CALL";
         if (permission == _PERMISSION_STATICCALL) return "STATICCALL";
         if (permission == _PERMISSION_DELEGATECALL) return "DELEGATECALL";
-        if (permission == _PERMISSION_DEPLOY) {
-            // support to display CREATE or CREATE2 in the revert error
-            // althought CREATE and CREATE2 fall under the same permission ("DEPLOY"), 
-            // differentiate them when reverting to help debugging contract deployment that failed
-            uint256 operationType;
-            bytes memory payload;
-
-            bytes4 selector = msg.sig;
-            if (selector == ILSP6KeyManager.execute.selector) {
-                payload = abi.decode(msg.data[4:], (bytes));
-            }
-
-            if (selector == ILSP6KeyManager.executeRelayCall.selector) {
-                ( , , payload) = abi.decode(msg.data[4:], (bytes, uint256, bytes));
-            }
-
-            (operationType, , , ) = abi.decode(
-                BytesLib.slice({
-                    _bytes: payload,
-                    // discard first 4 bytes of the payload (= ERC725X.execute(...) selector)
-                    _start: 4, 
-                    _length: payload.length - 4
-                }), 
-                (uint256, address, uint256, bytes)
-            );
-
-            if (operationType == OPERATION_CREATE) return "CREATE";
-            if (operationType == OPERATION_CREATE2) return "CREATE2";
-        }
+        if (permission == _PERMISSION_DEPLOY) return "DEPLOY";
         if (permission == _PERMISSION_TRANSFERVALUE) return "TRANSFERVALUE";
         if (permission == _PERMISSION_SIGN) return "SIGN";
     }

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -228,7 +228,7 @@ export const shouldBehaveLikePermissionDeploy = (
           context.keyManager.connect(addressCannotDeploy).execute(payload)
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "CREATE");
+          .withArgs(addressCannotDeploy.address, "DEPLOY");
       });
 
       it("should revert when trying to deploy a contract via CREATE2", async () => {
@@ -250,7 +250,7 @@ export const shouldBehaveLikePermissionDeploy = (
           context.keyManager.connect(addressCannotDeploy).execute(payload)
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "CREATE2");
+          .withArgs(addressCannotDeploy.address, "DEPLOY");
       });
     });
 
@@ -290,7 +290,7 @@ export const shouldBehaveLikePermissionDeploy = (
             .executeRelayCall(signature, nonce, payload)
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "CREATE");
+          .withArgs(addressCannotDeploy.address, "DEPLOY");
       });
 
       it("should revert when trying to deploy a contract via CREATE2", async () => {
@@ -331,7 +331,7 @@ export const shouldBehaveLikePermissionDeploy = (
             .executeRelayCall(signature, nonce, payload)
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "CREATE2");
+          .withArgs(addressCannotDeploy.address, "DEPLOY");
       });
     });
   });


### PR DESCRIPTION
# What does this PR introduce?

Commit https://github.com/lukso-network/lsp-smart-contracts/pull/272/commits/8c89ddb0b67e858d6f543101f29d406cde6638cf introduces extra check to distinguish between CREATE/CREATE2 when reverting because the caller does not have the permission "DEPLOY".

Revert this change and simply use the revert string "DEPLOY", so to keep the custom `NotAuthorised(...)` based on the permissions, and not the operation type.