### PR TITLE
fix: Remove variable silenter in Tokens

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -383,11 +383,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     function _beforeTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId
+        bytes32 tokenId // solhint-disable no-unused-vars
     ) internal virtual {
-        // silence compiler warning about unused variable
-        tokenId;
-
         // token being minted
         if (from == address(0)) {
             _existingTokens += 1;

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -39,10 +39,9 @@ abstract contract LSP8CompatibleERC721Core is
     /*
      * @inheritdoc ILSP8CompatibleERC721
      */
-    function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-        // silence compiler warning about unused variable
-        tokenId;
-
+    function tokenURI(
+        uint256 tokenId // solhint-disable no-unused-vars
+    ) public view virtual override returns (string memory) {
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36


### PR DESCRIPTION
## What does this PR introduce?

Replace variable silenter with `solhint-disable` in the LSP8 contract.