### PR TITLE
fix: Add Checks to ensure contract cannot be self owned with ClaimOwnership 

### DIFF
--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -49,7 +49,7 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     }
 
     function _claimOwnership() internal virtual {
-        require(msg.sender == pendingOwner, "OwnableClaim: caller is not the pendingOwner");
+        require(msg.sender == pendingOwner, "ClaimOwnership: caller is not the pendingOwner");
         _setOwner(pendingOwner);
         pendingOwner = address(0);
     }

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -13,6 +13,11 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
 
 error RenounceOwnershipAvailableAtBlockNumber(uint256 blockNumber);
 
+/**
+ * @dev reverts when trying to transfer ownership to the address(this)
+ */
+error CannotSelfTransferOwnership();
+
 abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     /**
      * @dev The block number saved in the first step for
@@ -50,6 +55,7 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     }
 
     function _transferOwnership(address newOwner) internal virtual {
+        if (newOwner == address(this)) revert CannotSelfTransferOwnership();
         pendingOwner = newOwner;
     }
 

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -150,7 +150,7 @@ export const shouldBehaveLikeClaimOwnership = (
 
       await expect(
         context.contract.connect(context.accounts[2]).claimOwnership()
-      ).to.be.revertedWith("OwnableClaim: caller is not the pendingOwner");
+      ).to.be.revertedWith("ClaimOwnership: caller is not the pendingOwner");
     });
 
     describe("when caller is the pending owner", () => {

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -72,6 +72,17 @@ export const shouldBehaveLikeClaimOwnership = (
       expect(pendingOwner).to.equal(overridenNewOwner.address);
     });
 
+    it("should revert when transferring Ownership to the contract itself", async () => {
+      await expect(
+        context.contract
+          .connect(context.deployParams.owner)
+          .transferOwnership(context.contract.address)
+      ).to.be.revertedWithCustomError(
+        context.contract,
+        "CannotSelfTransferOwnership"
+      );
+    });
+
     describe("it should still be allowed to call onlyOwner functions", () => {
       it("setData(...)", async () => {
         const key =

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -285,7 +285,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
       await expect(
         notPendingKeyManager.connect(context.owner).execute(payload)
-      ).to.be.revertedWith("OwnableClaim: caller is not the pendingOwner");
+      ).to.be.revertedWith("ClaimOwnership: caller is not the pendingOwner");
     });
   });
 


### PR DESCRIPTION
## What does this PR introduce?
- Introduce a check in ClaimOwnership contract, in the `transferOwnership(..)` to avoid setting the `address(this)` as _pendingOwner_.
- Adjust the contract name in other revert string