### PR TITLE
fix: prevent operator allowance to decrease if `from` and `to` are the same address

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -288,6 +288,10 @@ const Errors = {
 			error: 'LSP7CannotSendWithAddressZero()',
 			message: 'LSP7: cannot send token with address(0).',
 		},
+		'0xb9afb000': {
+			error: 'LSP7CannotSendToSelf()',
+			message: 'LSP7: `from` and `to` address cannot be the same',
+		},
 		'0x263eee8d': {
 			error: 'LSP7InvalidTransferBatch()',
 			message: 'LSP7: invalid transfer batch.',

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -120,6 +120,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) public virtual override {
+        if (from == to) revert LSP7CannotSendToSelf();
+
         address operator = msg.sender;
         if (operator != from) {
             uint256 operatorAmount = _operatorAuthorizedAmount[from][operator];

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -16,6 +16,8 @@ error LSP7CannotUseAddressZeroAsOperator();
 
 error LSP7CannotSendWithAddressZero();
 
+error LSP7CannotSendToSelf();
+
 error LSP7InvalidTransferBatch();
 
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);


### PR DESCRIPTION
# What does this PR introduce?

🐛 **bug fix** 

## Current behaviour

A bug similar to #266 occurs in `LSP7DigitalAssetCore.sol`, when an operator makes a token transfer with the same address for `from` and `to`.

However for the same issue in LSP7: 

- the token balance of the `from` address would remain the same ✅ 
- the operator allowance would decrease by `amount`, although no tokens have actually been transferred. ❌ 🐛 

## New behaviour

- Prevent any caller to specify the same address for `from` and `to` when doing a token transfer.
- introduce a new custom error `LSP7CannotSendToSelf`, similar to the one introduced in #278.