### PR TITLE
refactor!: use `uint8` instead of `uint256` in LSP7 decimals

### DIFF
--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -60,7 +60,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * no way affects any of the arithmetic of the contract, including
      * {balanceOf} and {transfer}.
      */
-    function decimals() external view returns (uint256);
+    function decimals() external view returns (uint8);
 
     /**
      * @dev Returns the number of existing tokens.
@@ -126,7 +126,10 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * Operators can send and burn tokens on behalf of their owners. The tokenOwner is their own
      * operator.
      */
-    function authorizedAmountFor(address operator, address tokenOwner) external view returns (uint256);
+    function authorizedAmountFor(address operator, address tokenOwner)
+        external
+        view
+        returns (uint256);
 
     // --- Transfer functionality
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -45,7 +45,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function decimals() public view override returns (uint256) {
+    function decimals() public view override returns (uint8) {
         return _isNonDivisible ? 0 : 18;
     }
 


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ Breaking Change

- Use `uint8` instead of `uint256` in LSP7 decimals

We don't need `uint256` for decimals, `uint8` is more than enough. With `uint8`, decimals can be used up to 255.
Most implementations use 18 as a decimal number. 

Reference PR in LIP: https://github.com/lukso-network/LIPs/pull/121

