### PR TITLE
chore: remove redundant `override` keywords

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -115,7 +115,6 @@ abstract contract LSP0ERC725AccountCore is
     function isValidSignature(bytes32 dataHash, bytes memory signature)
         public
         view
-        override
         returns (bytes4 magicValue)
     {
         address _owner = owner();
@@ -146,7 +145,6 @@ abstract contract LSP0ERC725AccountCore is
         public
         payable
         virtual
-        override
         returns (bytes memory returnValue)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -48,7 +48,7 @@ contract LSP1UniversalReceiverDelegateUP is
         uint256 value, // solhint-disable no-unused-vars
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual override returns (bytes memory result) {
+    ) public virtual returns (bytes memory result) {
         if (
             typeId == _TYPEID_LSP7_TOKENSSENDER ||
             typeId == _TYPEID_LSP7_TOKENSRECIPIENT ||

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -41,7 +41,7 @@ contract LSP1UniversalReceiverDelegateVault is
         uint256 value, // solhint-disable no-unused-vars
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual override returns (bytes memory result) {
+    ) public virtual returns (bytes memory result) {
         if (
             typeId == _TYPEID_LSP7_TOKENSSENDER ||
             typeId == _TYPEID_LSP7_TOKENSRECIPIENT ||

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -55,7 +55,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     using ECDSA for bytes32;
     using ERC165Checker for address;
 
-    address public override target;
+    address public target;
     mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
 
     /**
@@ -71,7 +71,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address from, uint256 channelId) public view override returns (uint256) {
+    function getNonce(address from, uint256 channelId) public view returns (uint256) {
         uint128 nonceId = uint128(_nonceStore[from][channelId]);
         return (uint256(channelId) << 128) | nonceId;
     }
@@ -82,7 +82,6 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     function isValidSignature(bytes32 dataHash, bytes memory signature)
         public
         view
-        override
         returns (bytes4 magicValue)
     {
         address recoveredAddress = dataHash.recover(signature);
@@ -97,7 +96,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function execute(bytes calldata payload) public payable override returns (bytes memory) {
+    function execute(bytes calldata payload) public payable returns (bytes memory) {
         _verifyPermissions(msg.sender, payload);
 
         return _executePayload(payload);
@@ -110,7 +109,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes memory signature,
         uint256 nonce,
         bytes calldata payload
-    ) public payable override returns (bytes memory) {
+    ) public payable returns (bytes memory) {
         bytes memory blob = abi.encodePacked(
             block.chainid,
             address(this), // needs to be signed for this keyManager

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -45,14 +45,14 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function decimals() public view override returns (uint8) {
+    function decimals() public view returns (uint8) {
         return _isNonDivisible ? 0 : 18;
     }
 
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function totalSupply() public view override returns (uint256) {
+    function totalSupply() public view returns (uint256) {
         return _existingTokens;
     }
 
@@ -61,7 +61,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function balanceOf(address tokenOwner) public view override returns (uint256) {
+    function balanceOf(address tokenOwner) public view returns (uint256) {
         return _tokenOwnerBalances[tokenOwner];
     }
 
@@ -80,14 +80,14 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * https://docs.google.com/document/d/1YLPtQxZu1UAvO9cZ1O2RPXBbT0mooh4DYKjA_jp-RLM/
      *
      */
-    function authorizeOperator(address operator, uint256 amount) public virtual override {
+    function authorizeOperator(address operator, uint256 amount) public virtual {
         _updateOperator(msg.sender, operator, amount);
     }
 
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function revokeOperator(address operator) public virtual override {
+    function revokeOperator(address operator) public virtual {
         _updateOperator(msg.sender, operator, 0);
     }
 
@@ -98,7 +98,6 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         public
         view
         virtual
-        override
         returns (uint256)
     {
         if (tokenOwner == operator) {
@@ -119,7 +118,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 amount,
         bool force,
         bytes memory data
-    ) public virtual override {
+    ) public virtual {
         if (from == to) revert LSP7CannotSendToSelf();
 
         address operator = msg.sender;
@@ -144,7 +143,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256[] memory amount,
         bool force,
         bytes[] memory data
-    ) public virtual override {
+    ) public virtual {
         if (
             from.length != to.length || from.length != amount.length || from.length != data.length
         ) {

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyCore.sol
@@ -26,7 +26,7 @@ abstract contract LSP7CappedSupplyCore is LSP7DigitalAssetCore, ILSP7CappedSuppl
     /**
      * @inheritdoc ILSP7CappedSupply
      */
-    function tokenSupplyCap() public view virtual override returns (uint256) {
+    function tokenSupplyCap() public view virtual returns (uint256) {
         return _tokenSupplyCap;
     }
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20Core.sol
@@ -23,7 +23,7 @@ abstract contract LSP7CompatibleERC20Core is
     /**
      * @inheritdoc ILSP7CompatibleERC20
      */
-    function approve(address operator, uint256 amount) public virtual override returns (bool) {
+    function approve(address operator, uint256 amount) public virtual returns (bool) {
         authorizeOperator(operator, amount);
         return true;
     }
@@ -35,7 +35,6 @@ abstract contract LSP7CompatibleERC20Core is
         public
         view
         virtual
-        override
         returns (uint256)
     {
         return authorizedAmountFor(operator, tokenOwner);
@@ -60,7 +59,7 @@ abstract contract LSP7CompatibleERC20Core is
         address from,
         address to,
         uint256 amount
-    ) public virtual override returns (bool) {
+    ) public virtual returns (bool) {
         transfer(from, to, amount, true, "");
         return true;
     }

--- a/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
@@ -38,7 +38,7 @@ contract LSP7Mintable is LSP7DigitalAsset, ILSP7Mintable {
         uint256 amount,
         bool force,
         bytes memory data
-    ) public override onlyOwner {
+    ) public virtual onlyOwner {
         _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -30,7 +30,7 @@ abstract contract LSP7MintableInitAbstract is LSP7DigitalAssetInitAbstract, ILSP
         uint256 amount,
         bool force,
         bytes memory data
-    ) public override onlyOwner {
+    ) public virtual onlyOwner {
         _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -49,7 +49,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function totalSupply() public view override returns (uint256) {
+    function totalSupply() public view returns (uint256) {
         return _existingTokens;
     }
 
@@ -58,14 +58,14 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function balanceOf(address tokenOwner) public view override returns (uint256) {
+    function balanceOf(address tokenOwner) public view returns (uint256) {
         return _ownedTokens[tokenOwner].length();
     }
 
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function tokenOwnerOf(bytes32 tokenId) public view override returns (address) {
+    function tokenOwnerOf(bytes32 tokenId) public view returns (address) {
         address tokenOwner = _tokenOwners[tokenId];
 
         if (tokenOwner == address(0)) {
@@ -78,7 +78,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function tokenIdsOf(address tokenOwner) public view override returns (bytes32[] memory) {
+    function tokenIdsOf(address tokenOwner) public view returns (bytes32[] memory) {
         return _ownedTokens[tokenOwner].values();
     }
 
@@ -87,7 +87,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function authorizeOperator(address operator, bytes32 tokenId) public virtual override {
+    function authorizeOperator(address operator, bytes32 tokenId) public virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
         address caller = msg.sender;
 
@@ -113,7 +113,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function revokeOperator(address operator, bytes32 tokenId) public virtual override {
+    function revokeOperator(address operator, bytes32 tokenId) public virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
         address caller = msg.sender;
 
@@ -140,7 +140,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         public
         view
         virtual
-        override
         returns (bool)
     {
         _existsOrError(tokenId);
@@ -155,7 +154,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         public
         view
         virtual
-        override
         returns (address[] memory)
     {
         _existsOrError(tokenId);
@@ -185,7 +183,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public virtual override {
+    ) public virtual {
         address operator = msg.sender;
 
         if (!_isOperatorOrOwner(operator, tokenId)) {
@@ -204,7 +202,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         bytes32[] memory tokenId,
         bool force,
         bytes[] memory data
-    ) public virtual override {
+    ) public virtual {
         if (
             from.length != to.length || from.length != tokenId.length || from.length != data.length
         ) {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyCore.sol
@@ -26,7 +26,7 @@ abstract contract LSP8CappedSupplyCore is LSP8IdentifiableDigitalAssetCore, ILSP
     /**
      * @inheritdoc ILSP8CappedSupply
      */
-    function tokenSupplyCap() public view virtual override returns (uint256) {
+    function tokenSupplyCap() public view virtual returns (uint256) {
         return _tokenSupplyCap;
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721Core.sol
@@ -41,7 +41,7 @@ abstract contract LSP8CompatibleERC721Core is
      */
     function tokenURI(
         uint256 tokenId // solhint-disable no-unused-vars
-    ) public view virtual override returns (string memory) {
+    ) public view virtual returns (string memory) {
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36
@@ -54,27 +54,27 @@ abstract contract LSP8CompatibleERC721Core is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      */
-    function ownerOf(uint256 tokenId) public view virtual override returns (address) {
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
         return tokenOwnerOf(bytes32(tokenId));
     }
 
     /**
      * @inheritdoc ILSP8CompatibleERC721
      */
-    function approve(address operator, uint256 tokenId) public virtual override {
+    function approve(address operator, uint256 tokenId) public virtual {
         authorizeOperator(operator, bytes32(tokenId));
 
         emit Approval(tokenOwnerOf(bytes32(tokenId)), operator, tokenId);
     }
 
-    function setApprovalForAll(address operator, bool approved) public virtual override {
+    function setApprovalForAll(address operator, bool approved) public virtual {
         _setApprovalForAll(msg.sender, operator, approved);
     }
 
     /**
      * @inheritdoc ILSP8CompatibleERC721
      */
-    function getApproved(uint256 tokenId) public view virtual override returns (address) {
+    function getApproved(uint256 tokenId) public view virtual returns (address) {
         bytes32 tokenIdAsBytes32 = bytes32(tokenId);
         _existsOrError(tokenIdAsBytes32);
 
@@ -101,7 +101,6 @@ abstract contract LSP8CompatibleERC721Core is
         public
         view
         virtual
-        override
         returns (bool)
     {
         return _operatorApprovals[tokenOwner][operator];
@@ -116,7 +115,7 @@ abstract contract LSP8CompatibleERC721Core is
         address from,
         address to,
         uint256 tokenId
-    ) public virtual override {
+    ) public virtual {
         return _transfer(from, to, bytes32(tokenId), true, "");
     }
 
@@ -129,7 +128,7 @@ abstract contract LSP8CompatibleERC721Core is
         address from,
         address to,
         uint256 tokenId
-    ) public virtual override {
+    ) public virtual {
         return _transfer(from, to, bytes32(tokenId), false, "");
     }
 
@@ -142,7 +141,7 @@ abstract contract LSP8CompatibleERC721Core is
         address to,
         uint256 tokenId,
         bytes memory data
-    ) public virtual override {
+    ) public virtual {
         return _transfer(from, to, bytes32(tokenId), false, data);
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableCore.sol
@@ -21,7 +21,7 @@ abstract contract LSP8EnumerableCore is LSP8IdentifiableDigitalAssetCore, ILSP8E
     /**
      * @inheritdoc ILSP8Enumerable
      */
-    function tokenAt(uint256 index) public view override returns (bytes32) {
+    function tokenAt(uint256 index) public view returns (bytes32) {
         return _indexToken[index];
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
@@ -33,7 +33,7 @@ contract LSP8Mintable is LSP8IdentifiableDigitalAsset, ILSP8Mintable {
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public override onlyOwner {
+    ) public virtual onlyOwner {
         _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -32,7 +32,7 @@ abstract contract LSP8MintableInitAbstract is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public virtual override onlyOwner {
+    ) public virtual onlyOwner {
         _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -176,7 +176,6 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
         public
         payable
         virtual
-        override
         returns (bytes memory returnValue)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);


### PR DESCRIPTION
# What does this PR introduce?

Since solidity [0.8.8](https://github.com/ethereum/solidity/releases/tag/v0.8.8), the following language feature was introduced.

<img width="887" alt="Screenshot 2022-09-02 at 17 25 42" src="https://user-images.githubusercontent.com/31145285/188197878-3ed859cd-1393-484d-8f20-f4339fbe5ae0.png">

This makes most of the `override` keywords redundant since #275 upgraded the default solc compiler to 0.8.10 in `hardhat.config.ts`.

This PR cleanup the redundant and unecessary `override` modifiers, mostly for functions directly implemented from the LSP interfaces files.

