### PR TITLE
docs: inline npm and coverage badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,4 @@
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/@lukso/lsp-smart-contracts">
-    <img alt="Version" src="https://badge.fury.io/js/@lukso%2Flsp-smart-contracts.svg" />
-  </a>
-  <a href='https://coveralls.io/github/lukso-network/lsp-smart-contracts?branch=develop'>
-    <img src='https://coveralls.io/repos/github/lukso-network/lsp-smart-contracts/badge.svg?branch=develop' alt='Coverage Status' />
-  </a>
-</p>
-
-# LSP Smart Contracts
+# LSP Smart Contracts &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp-smart-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp-smart-contracts) [![Coverage Status](https://coveralls.io/repos/github/lukso-network/lsp-smart-contracts/badge.svg?branch=develop)](https://coveralls.io/github/lukso-network/lsp-smart-contracts?branch=develop)
 
 The smart contracts reference implementation of the [LUKSO Standard Proposals (LSPs)](https://github.com/lukso-network/LIPs/tree/main/LSPs).
 


### PR DESCRIPTION
Change from this:

<img width="939" alt="image" src="https://user-images.githubusercontent.com/31145285/188200949-93d2ad05-5ff2-4198-bd07-84b45f9782b1.png">

To this:

<img width="927" alt="image" src="https://user-images.githubusercontent.com/31145285/188201024-6cfbb19b-df7d-49e6-b6d3-3876044cdb8b.png">


