### PR TITLE
refactor: disallow DELEGATECALL operation in LSP9Vault

### DIFF
--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -23,7 +23,12 @@ import {ClaimOwnership} from "../Custom/ClaimOwnership.sol";
 // constants
 import {_INTERFACEID_CLAIM_OWNERSHIP} from "../Custom/IClaimOwnership.sol";
 
-import "@erc725/smart-contracts/contracts/constants.sol";
+import {
+    OPERATION_CALL,
+    OPERATION_STATICCALL,
+    OPERATION_CREATE,
+    OPERATION_CREATE2
+} from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _INTERFACEID_LSP1,
     _INTERFACEID_LSP1_DELEGATE,

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.0;
 
 // interfaces
-import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
-import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 import {
     ILSP1UniversalReceiverDelegate
@@ -15,8 +13,8 @@ import {GasLib} from "../Utils/GasLib.sol";
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // modules
-import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
-import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
+import {ERC725XCore, IERC725X} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
+import {ERC725YCore, IERC725Y} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {ClaimOwnership} from "../Custom/ClaimOwnership.sol";
 

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -153,6 +153,21 @@ export const shouldBehaveLikeLSP9 = (
     });
   });
 
+  describe("when testing setting execute", () => {
+    describe("when executing operation (4) DELEGATECALL", () => {
+      it("should revert with unknow operation type string error", async () => {
+        await expect(
+          context.lsp9Vault.execute(
+            OPERATION_TYPES.DELEGATECALL,
+            context.accounts.random.address,
+            0,
+            "0x"
+          )
+        ).to.be.revertedWith("ERC725X: Unknown operation type");
+      });
+    });
+  });
+
   describe("when using vault with UniversalProfile", () => {
     describe("when transferring ownership of the vault to the universalProfile", () => {
       before(async () => {


### PR DESCRIPTION
## What does this PR introduce?
- Overriding execute function in LSP9Vault and disallowing the use of delegatecall, since it's a dangerous operation and could lead to the destruction of the vault.

The use of delegatecall in LSP9 is totally optional. 
Referring to the [LSP9 specs](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-9-Vault.md), it's mention that an LSP9Vault must include the following operation: CALL, CREATE, CREATE2, STATICCALL and CAN include the operation DELEGATECALL.