### PR TITLE
fix:  Reset `pendingOwner` whenever `renounceOwnership(..)` is used.

### DIFF
--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -63,7 +63,7 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
     function _claimOwnership() internal virtual {
         require(msg.sender == pendingOwner, "ClaimOwnership: caller is not the pendingOwner");
         _setOwner(pendingOwner);
-        pendingOwner = address(0);
+        delete pendingOwner;
     }
 
     function _transferOwnership(address newOwner) internal virtual {

--- a/contracts/Custom/ClaimOwnership.sol
+++ b/contracts/Custom/ClaimOwnership.sol
@@ -92,5 +92,6 @@ abstract contract ClaimOwnership is IClaimOwnership, OwnableUnset {
 
         _setOwner(address(0));
         delete _renounceOwnershipStartedAt;
+        delete pendingOwner;
     }
 }

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -323,6 +323,19 @@ export const shouldBehaveLikeClaimOwnership = (
           .to.equal(context.deployParams.owner.address);
       });
 
+      it("should not reset the pendingOwner", async () => {
+        await context.contract
+          .connect(context.deployParams.owner)
+          .transferOwnership(newOwner.address);
+
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
+        
+        expect(await context.contract.pendingOwner())
+          .to.equal(newOwner.address);
+      });
+
     });
 
     describe("when calling renounceOwnership() the second time", () => {
@@ -391,7 +404,8 @@ export const shouldBehaveLikeClaimOwnership = (
 
         expect(
           ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()
-        ).to.equal(tx.blockNumber);
+        )
+          .to.equal(tx.blockNumber);
       });
 
       it("should reset the pendingOwner whenever renounceOwnership(..) is confirmed", async () => {

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -132,7 +132,7 @@ export const shouldBehaveLikeClaimOwnership = (
         await network.provider.send("hardhat_mine", [ethers.utils.hexValue(1000)]);
       });
 
-      it.only("should disallow using claimOwnership after renounceOwnership", async () => {
+      it("should disallow using claimOwnership after renounceOwnership", async () => {
         await context.contract
           .connect(context.deployParams.owner)
           .renounceOwnership();

--- a/tests/ClaimOwnership.behaviour.ts
+++ b/tests/ClaimOwnership.behaviour.ts
@@ -126,6 +126,31 @@ export const shouldBehaveLikeClaimOwnership = (
         expect(accountBalanceAfter).to.be.lt(accountBalanceBefore);
       });
     });
+
+    describe("it should not allow transfer-renounce-claim behavior", () => {
+      before(async () => {
+        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(1000)]);
+      });
+
+      it.only("should disallow using claimOwnership after renounceOwnership", async () => {
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
+        
+        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(100)]);
+        
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
+
+        const claimAfterRenounce = context.contract
+          .connect(newOwner)
+          .claimOwnership();
+        
+        await expect(claimAfterRenounce)
+          .to.be.revertedWith("ClaimOwnership: caller is not the pendingOwner");
+      });
+    });
   });
 
   describe("when non-owner call transferOwnership(...)", () => {
@@ -274,125 +299,125 @@ export const shouldBehaveLikeClaimOwnership = (
     before(async () => {
       // mine 1,000 blocks
       await network.provider.send("hardhat_mine", [ethers.utils.hexValue(1000)]);
-  });
+    });
   
-  beforeEach(async () => {
+    beforeEach(async () => {
       context = await buildContext();
-  });
+    });
 
-  describe("when calling renounceOwnership() with a non-owner account", () => {
+    describe("when calling renounceOwnership() with a non-owner account", () => {
       it("should revert with custom message", async () => {
-          const tx = context.contract
-              .connect(context.accounts[1])
-              .renounceOwnership();
+        const tx = context.contract
+          .connect(context.accounts[1])
+          .renounceOwnership();
           
-          await expect(tx).to.be.revertedWith("Ownable: caller is not the owner");
+        await expect(tx).to.be.revertedWith("Ownable: caller is not the owner");
       })
-  })
+    })
 
-  describe("when calling renounceOwnership() the first time", () => {
+    describe("when calling renounceOwnership() the first time", () => {
       
       it("should instantiate the renounceOwnership process correctly", async () => {
-          let tx = await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        let tx = await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await tx.wait();
+        await tx.wait();
       
-          const _renounceOwnershipStartedAtAfter = await provider.getStorageAt(context.contract.address, 2);
+        const _renounceOwnershipStartedAtAfter = await provider.getStorageAt(context.contract.address, 2);
 
-          expect(
-              ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()
-          ).to.equal(tx.blockNumber);
+        expect(
+          ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()
+        ).to.equal(tx.blockNumber);
       });
       
       it("should have emitted a RenounceOwnershipInitiated event", async () => {
-          await expect(
-              context.contract.connect(context.deployParams.owner).renounceOwnership()
-          ).to.emit(
-              context.contract, "RenounceOwnershipInitiated"
-          );
+        await expect(
+          context.contract.connect(context.deployParams.owner).renounceOwnership()
+        ).to.emit(
+          context.contract, "RenounceOwnershipInitiated"
+        );
       });
 
       it("should not change the current owner", async () => {
-          await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
       
-          expect(await context.contract.owner())
-              .to.equal(context.deployParams.owner.address);
+        expect(await context.contract.owner())
+          .to.equal(context.deployParams.owner.address);
       });
 
-  });
+    });
 
-  describe("when calling renounceOwnership() the second time", () => {
+    describe("when calling renounceOwnership() the second time", () => {
       
       it("should revert if called in the delay period", async () => {
-          const renounceOwnershipOnce = await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        const renounceOwnershipOnce = await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x62"]); // skip 98 blocks
+        await network.provider.send("hardhat_mine", ["0x62"]); // skip 98 blocks
 
-          const renounceOwnershipSecond = context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        const renounceOwnershipSecond = context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await expect(renounceOwnershipSecond)
-              .to.be.revertedWithCustomError(
-                  context.contract,
-                  "NotInRenounceOwnershipInterval"
-              )
-              .withArgs(
-                  (await renounceOwnershipOnce).blockNumber + 100,
-                  (await renounceOwnershipOnce).blockNumber + 200
-              );
-
-          expect(await context.contract.owner()).to.equal(
-              context.deployParams.owner.address
+        await expect(renounceOwnershipSecond)
+          .to.be.revertedWithCustomError(
+            context.contract,
+            "NotInRenounceOwnershipInterval"
+          )
+          .withArgs(
+            (await renounceOwnershipOnce).blockNumber + 100,
+            (await renounceOwnershipOnce).blockNumber + 200
           );
+
+        expect(await context.contract.owner()).to.equal(
+          context.deployParams.owner.address
+        );
       });
 
       it("should pass if called afer the delay nad before the confirmation period end", async () => {
-          await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
+        await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
 
-          const renounceOwnershipSecond = context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        const renounceOwnershipSecond = context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await expect(renounceOwnershipSecond)
-              .to.emit(context.contract, "OwnershipTransferred")
-              .withArgs(context.deployParams.owner.address, ethers.constants.AddressZero);
+        await expect(renounceOwnershipSecond)
+          .to.emit(context.contract, "OwnershipTransferred")
+          .withArgs(context.deployParams.owner.address, ethers.constants.AddressZero);
 
-          expect(await context.contract.owner()).to.equal(
-              ethers.constants.AddressZero
-          );
+        expect(await context.contract.owner()).to.equal(
+          ethers.constants.AddressZero
+        );
       });
 
       it("should initialize again if the confirmation period passed", async () => {
 
-          await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0xc8"]); // skip 200 blocks
+        await network.provider.send("hardhat_mine", ["0xc8"]); // skip 200 blocks
 
-          let tx = await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
+        let tx = await context.contract
+          .connect(context.deployParams.owner)
+          .renounceOwnership();
 
-          await tx.wait();
+        await tx.wait();
       
-          const _renounceOwnershipStartedAtAfter = await provider.getStorageAt(context.contract.address, 2);
+        const _renounceOwnershipStartedAtAfter = await provider.getStorageAt(context.contract.address, 2);
 
-          expect(
-              ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()
-          ).to.equal(tx.blockNumber);
+        expect(
+          ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()
+        ).to.equal(tx.blockNumber);
       });
+    });
   });
-  })
 };


### PR DESCRIPTION
## What does this PR introduce?

This PR fixes the bug described in this [tweet](https://twitter.com/pcaversaccio/status/1569373269228142592?t=3i66r7ZBWTL6ZwWREA6MCQ&s=19). Also there is a test added to check that this behaviour is not happening.

Unwanted behaviour:

Step 1: Using `transferOwnership(..)` to set a `pendingOwner`.
Step 2: Using `renounceOwnerhisp(..)` which updates the `owner` but not the `pendingOwner`.
Step 3: Using `claimOwnership(..)` which will make `pendingOwner` the `owner`.

In this way one could renounce ownership of the contract for the public but whenever it is the most profitable the `pendingOwner` will be able to claim ownership of the contract.

To mitigate this unwanted behaviour the `pendingOwner` is reseted whenever `renounceOwnership(..)` is used.