### PR TITLE
fix: add checks for ADD / CHANGE permissions when data key is `AddressPermissions[index]`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -72,3 +72,10 @@ error InvalidRelayNonce(address signer, uint256 invalidNonce, bytes signature);
  * @param invalidFunction the bytes4 selector of the invalid function
  */
 error InvalidERC725Function(bytes4 invalidFunction);
+
+/**
+ * @dev reverts when trying to set a value that is not 20 bytes long under AddressPermissions[index]
+ * @param dataKey the AddressPermissions[index] data key
+ * @param invalidValue the invalid value that was attempted to be set under AddressPermissions[index]
+ */
+error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invalidValue);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -402,9 +402,19 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             return;
         }
-
+        
         // key = AddressPermissions[index] -> array index
-        _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
+        bytes memory valueAtIndex = ERC725Y(target).getData(key);
+
+        if (valueAtIndex.length == 0) {
+            _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
+        } else {
+            _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
+        }
+        
+        if (value.length != 20) {
+            revert AddressPermissionArrayIndexValueNotAnAddress(key, value);
+        }
     }
 
     function _verifyAllowedERC725YKeys(address from, bytes32[] memory inputKeys) internal view {


### PR DESCRIPTION
# What does this PR introduce?

**Bug fix**

When the data key passed to the Key Manager is a key-value pair for `AddressPermissions[index]`, the current behaviour is that the caller/signer must have the permission `CHANGE PERMISSION`.

Add additional check to verify what is stored under this type of data key in the storage.

- if some value are set under `AddressPermissions[index]` = caller must have permission `CHANGE PERMISSION`.
- if no value is set under `AddressPermissions[index]` = caller must have permission `ADD PERMISSION`.