### PR TITLE
refactor!: switch the returnedValue with the receivedData values in UniversalReceiver Event

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -466,10 +466,10 @@ const EventSignatures = {
 		/**
 		 * event UniversalReceiver(
 		 *    address indexed from,
-		 * 	  uint256 value,
+		 * 	  uint256 indexed value,
 		 *    bytes32 indexed typeId,
-		 *    bytes indexed returnedValue,
-		 *    bytes receivedData
+		 *    bytes receivedData,
+		 *    bytes returnedValue
 		 * );
 		 *
 		 * signature = keccak256('UniversalReceiver(address,uint256,bytes32,bytes,bytes)')

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -158,7 +158,7 @@ abstract contract LSP0ERC725AccountCore is
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, data);
             }
         }
-        emit UniversalReceiver(msg.sender, msg.value, typeId, returnValue, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, returnValue);
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -135,13 +135,13 @@ abstract contract LSP0ERC725AccountCore is
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * @dev Forwards the call to the UniversalReceiverDelegate if set.
      * @param typeId The type of call received.
-     * @param data The data received.
+     * @param receivedData The data received.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata data)
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
         public
         payable
         virtual
-        returns (bytes memory returnValue)
+        returns (bytes memory returnedValue)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
@@ -154,11 +154,11 @@ abstract contract LSP0ERC725AccountCore is
                     _INTERFACEID_LSP1_DELEGATE
                 )
             ) {
-                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
-                    .universalReceiverDelegate(msg.sender, msg.value, typeId, data);
+                returnedValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                    .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
-        emit UniversalReceiver(msg.sender, msg.value, typeId, data, returnValue);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValue);
     }
 
     /**

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
@@ -12,7 +12,7 @@ interface ILSP1UniversalReceiver {
      * @param value The amount sent to the universalReceiver function
      * @param typeId The hash of a specific standard or a hook
      * @param receivedData The arbitrary data passed to universalReceiver function
-     * @param returnedValue The return value of universalReceiver function
+     * @param returnedValue The value returned by the universalReceiver function
      */
     event UniversalReceiver(
         address indexed from,

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
@@ -11,15 +11,15 @@ interface ILSP1UniversalReceiver {
      * @param from The address calling the universalReceiver function
      * @param value The amount sent to the universalReceiver function
      * @param typeId The hash of a specific standard or a hook
-     * @param returnedValue The return value of universalReceiver function
      * @param receivedData The arbitrary data passed to universalReceiver function
+     * @param returnedValue The return value of universalReceiver function
      */
     event UniversalReceiver(
         address indexed from,
-        uint256 value,
+        uint256 indexed value,
         bytes32 indexed typeId,
-        bytes indexed returnedValue,
-        bytes receivedData
+        bytes receivedData,
+        bytes returnedValue
     );
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -152,13 +152,13 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * @dev Forwards the call to the UniversalReceiverDelegate if set.
      * @param typeId The type of call received.
-     * @param data The data received.
+     * @param receivedData The data received.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata data)
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
         public
         payable
         virtual
-        returns (bytes memory returnValue)
+        returns (bytes memory returnedValue)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
 
@@ -171,11 +171,11 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
                     _INTERFACEID_LSP1_DELEGATE
                 )
             ) {
-                returnValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
-                    .universalReceiverDelegate(msg.sender, msg.value, typeId, data);
+                returnedValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                    .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
-        emit UniversalReceiver(msg.sender, msg.value, typeId, data, returnValue);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValue);
     }
 
     // ERC173 - Modified ClaimOwnership

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -175,7 +175,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, ClaimOwnership, ILSP1Univers
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, data);
             }
         }
-        emit UniversalReceiver(msg.sender, msg.value, typeId, returnValue, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, returnValue);
     }
 
     // ERC173 - Modified ClaimOwnership

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -51,10 +51,10 @@ export const shouldBehaveLikeLSP1 = (
             valueSent,
             // typeId
             LSP1_HOOK_PLACEHOLDER,
-            // returnedValue
-            "0x",
             // receivedData
-            data
+            data,
+            // returnedValue
+            "0x"
           );
       });
     });
@@ -76,9 +76,9 @@ export const shouldBehaveLikeLSP1 = (
               valueSent,
               // typeId
               LSP1_HOOK_PLACEHOLDER,
-              // returnedValue
-              "0x",
               // receivedData
+              "0x",
+              // returnedValue
               "0x"
             );
         });
@@ -100,9 +100,9 @@ export const shouldBehaveLikeLSP1 = (
               valueSent,
               // typeId
               LSP1_HOOK_PLACEHOLDER,
-              // returnedValue
-              "0x",
               // receivedData
+              "0x",
+              // returnedValue
               "0x"
             );
         });
@@ -148,13 +148,10 @@ export const shouldBehaveLikeLSP1 = (
         );
 
         // typeId
-        expect(receipt.logs[0].topics[2]).to.equal(LSP1_HOOK_PLACEHOLDER);
+        expect(receipt.logs[0].topics[3]).to.equal(LSP1_HOOK_PLACEHOLDER);
 
-        // value + receivedData (any parameter not index)
-        const dataField = abiCoder.encode(
-          ["uint256", "bytes"],
-          [valueSent.toHexString(), "0x"]
-        );
+        // receivedData + returnedValue (any parameter not index)
+        const dataField = abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]);
         expect(receipt.logs[0].data).to.equal(dataField);
       });
     });
@@ -184,9 +181,9 @@ export const shouldBehaveLikeLSP1 = (
               valueSent,
               // typeId
               LSP1_HOOK_PLACEHOLDER,
-              // returnedValue
-              "0x",
               // receivedData
+              "0x",
+              // returnedValue
               "0x"
             );
         });
@@ -209,9 +206,9 @@ export const shouldBehaveLikeLSP1 = (
               valueSent,
               // typeId
               LSP1_HOOK_PLACEHOLDER,
-              // returnedValue
-              "0x",
               // receivedData
+              "0x",
+              // returnedValue
               "0x"
             );
         });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -124,35 +124,21 @@ export const shouldBehaveLikeLSP1 = (
       it("should emit a UniversalReceiver(...) event with correct topics", async () => {
         let caller = context.accounts[2];
 
-        let tx = await context.lsp1Implementation
-          .connect(caller)
-          .universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x", {
-            value: valueSent,
-          });
-
-        let receipt = await tx.wait();
-
-        // event should come from the lsp1Implementation
-        expect(receipt.logs[0].address).to.equal(
-          context.lsp1Implementation.address
-        );
-
-        // should be the Universal Receiver event (= event signature)
-        expect(receipt.logs[0].topics[0]).to.equal(
-          EventSignatures.LSP1["UniversalReceiver"]
-        );
-
-        // from
-        expect(receipt.logs[0].topics[1]).to.equal(
-          ethers.utils.hexZeroPad(caller.address.toLowerCase(), 32)
-        );
-
-        // typeId
-        expect(receipt.logs[0].topics[3]).to.equal(LSP1_HOOK_PLACEHOLDER);
-
-        // receivedData + returnedValue (any parameter not index)
-        const dataField = abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]);
-        expect(receipt.logs[0].data).to.equal(dataField);
+        await expect(
+          context.lsp1Implementation
+            .connect(caller)
+            .universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x", {
+              value: valueSent,
+            })
+        )
+          .to.emit(context.lsp1Implementation, "UniversalReceiver")
+          .withArgs(
+            caller.address,
+            valueSent,
+            LSP1_HOOK_PLACEHOLDER,
+            "0x",
+            "0x"
+          );
       });
     });
 

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -293,7 +293,9 @@ export const shouldBehaveLikeLSP9 = (
             0,
             LSP1_TYPE_IDS.LSP9_VAULTPENDINGOWNER,
             "0x",
-            "LSP1: typeId out of scope"
+            ethers.utils.hexlify(
+              ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+            )
           );
       });
     });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -292,8 +292,8 @@ export const shouldBehaveLikeLSP9 = (
             context.lsp9Vault.address,
             0,
             LSP1_TYPE_IDS.LSP9_VAULTPENDINGOWNER,
-            "LSP1: typeId out of scope",
-            "0x"
+            "0x",
+            "LSP1: typeId out of scope"
           );
       });
     });


### PR DESCRIPTION
## What does this PR introduce?
- Marking the value field as indexed
- Remove the indexed from the returnedValue
- Switch between receivedData and returnedValue parameters.

Before: 
```js
event UniversalReceiver(
     address indexed from,
     uint256 value,
     bytes32 indexed typeId,
     bytes indexed returnedValue,
     bytes receivedData,
);
```
Now: 

```js
event UniversalReceiver(
     address indexed from,
     uint256 indexed value,
     bytes32 indexed typeId,
     bytes receivedData,
     bytes returnedValue
);
```

Note: Event signature will not change since both switched parameters are bytes.