### PR TITLE
test: Add test for verifying that one cannot use `acceptOwnership` in the same trx as `transferOwnership`

### DIFF
--- a/contracts/Helpers/UPWithInstantAcceptOwnership.sol
+++ b/contracts/Helpers/UPWithInstantAcceptOwnership.sol
@@ -28,6 +28,6 @@ contract UPWithInstantAcceptOwnership is LSP0ERC725AccountCore {
         if (typeId == _TYPEID_LSP14_OwnershipTransferStarted) {
             LSP14Ownable2Step(msg.sender).acceptOwnership();
         }
-        returnedValue = LSP0ERC725AccountCore.universalReceiver(typeId, receivedData);
+        super.universalReceiver(typeId, receivedData);
     }
 }

--- a/contracts/Helpers/UPWithInstantAcceptOwnership.sol
+++ b/contracts/Helpers/UPWithInstantAcceptOwnership.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// modules
+import {LSP0ERC725AccountCore} from "../LSP0ERC725Account/LSP0ERC725AccountCore.sol";
+import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
+import {LSP14Ownable2Step} from "../LSP14Ownable2Step/LSP14Ownable2Step.sol";
+
+// constants
+import "../LSP14Ownable2Step/LSP14Constants.sol";
+
+contract UPWithInstantAcceptOwnership is LSP0ERC725AccountCore {
+    /**
+     * @notice Sets the owner of the contract
+     * @param newOwner the owner of the contract
+     */
+    constructor(address newOwner) payable {
+        OwnableUnset._setOwner(newOwner);
+    }
+
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        override
+        returns (bytes memory returnedValue)
+    {
+        if (typeId == _TYPEID_LSP14_OwnershipTransferStarted) {
+            LSP14Ownable2Step(msg.sender).acceptOwnership();
+        }
+        returnedValue = LSP0ERC725AccountCore.universalReceiver(typeId, receivedData);
+    }
+}

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -134,7 +134,7 @@ export const shouldBehaveLikeLSP14 = (
       });
     });
 
-    describe("when the URD of the `newOwner` calls `acceptOwnership`", () => {
+    describe("when `acceptOwnership(...)` is called in the same tx as `transferOwnership(...)`", () => {
       let upWithCustomURD: UPWithInstantAcceptOwnership;
       before(async () => {
         context = await buildContext();
@@ -143,7 +143,7 @@ export const shouldBehaveLikeLSP14 = (
         ).deploy(context.accounts[0].address);
       });
 
-      it("should revert with 'LSP14: newOwner MUST accept ownership in a separate transaction'", async () => {
+      it("should revert (e.g: if `universalReceiver(...)` function of `newOwner` calls directly `acceptOwnership(...)')", async () => {
         const ownershipTransfer = context.contract
           .connect(context.deployParams.owner)
           .transferOwnership(upWithCustomURD.address);

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -2,7 +2,13 @@ import { expect } from "chai";
 import { ethers, network } from "hardhat";
 
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { contracts, LSP0ERC725Account, LSP9Vault } from "../../types";
+import {
+  contracts,
+  LSP0ERC725Account,
+  LSP9Vault,
+  UPWithInstantAcceptOwnership__factory,
+  UPWithInstantAcceptOwnership,
+} from "../../types";
 
 // constants
 import { INTERFACE_IDS, OPERATION_TYPES } from "../../constants";
@@ -125,6 +131,26 @@ export const shouldBehaveLikeLSP14 = (
 
         // account balance should have gone down
         expect(accountBalanceAfter).to.be.lt(accountBalanceBefore);
+      });
+    });
+
+    describe("when the URD of the `newOwner` calls `acceptOwnership`", () => {
+      let upWithCustomURD: UPWithInstantAcceptOwnership;
+      before(async () => {
+        context = await buildContext();
+        upWithCustomURD = await new UPWithInstantAcceptOwnership__factory(
+          context.accounts[0]
+        ).deploy(context.accounts[0].address);
+      });
+
+      it("should revert with 'LSP14: newOwner MUST accept ownership in a separate transaction'", async () => {
+        const ownershipTransfer = context.contract
+          .connect(context.deployParams.owner)
+          .transferOwnership(upWithCustomURD.address);
+
+        await expect(ownershipTransfer).to.be.revertedWith(
+          "LSP14: newOwner MUST accept ownership in a separate transaction"
+        );
       });
     });
   });


### PR DESCRIPTION
## What does this PR introduce?

This PR creates a UP contract for testing, with a modified `universalReceiver(..)` which calls `acceptOwnership(..)` whenever the `universalReceiver(..)` is called with the specific typeId used to notify the new owner that he can accept ownership of a contract.
A new test is introduced that should make sure that the transaction is reverted whenever someone calls `trasferOwnership(..)` and `acceptOwnership(..)` is executed in the same block.