### PR TITLE
feat: add routing (= external call ) to additional contract in `universalReceiver(...)` function based on typeId

### DIFF
--- a/contracts/Helpers/ABIEncoder.sol
+++ b/contracts/Helpers/ABIEncoder.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+contract ABIEncoder {
+    function encode(bytes memory a, bytes memory b)
+        public
+        returns (bytes memory c, uint256 gasUsed)
+    {
+        uint256 gasUsed1 = gasleft();
+        c = abi.encode(a, b);
+        uint256 gasUsed2 = gasleft();
+        gasUsed = gasUsed1 - gasUsed2;
+    }
+
+    function decode(bytes memory c) public pure returns (bytes memory a, bytes memory b) {
+        (a, b) = abi.decode(c, (bytes, bytes));
+    }
+}

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -141,44 +141,46 @@ abstract contract LSP0ERC725AccountCore is
 
     /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
-     * @dev Forwards the call to the UniversalReceiverDelegate if set.
+     * Forwards the call to the addresses stored in the ERC725Y storage under the LSP1UniversalReceiverDelegate
+     * Key and the typeId Key (param) respectivelly. The call will be discarded if no addresses were set.
+     *
      * @param typeId The type of call received.
      * @param receivedData The data received.
-     * @return returnedValue The ABI encoded return value of the LSP1UniversalReceiverDelegate call
-     * and the LSP1TypeIdDelegate call
+     * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
+     * and the LSP1TypeIdDelegate call.
      */
     function universalReceiver(bytes32 typeId, bytes calldata receivedData)
         public
         payable
         virtual
-        returns (bytes memory returnedValue)
+        returns (bytes memory returnedValues)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
-        bytes memory returnedValue1;
+        bytes memory resultMainDelegate;
 
         if (lsp1DelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
             if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                returnedValue1 = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                resultMainDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
 
         bytes memory lsp1TypeIdDelegateValue = _getData(typeId);
-        bytes memory returnedValue2;
+        bytes memory resultTypeIdDelegate;
 
         if (lsp1TypeIdDelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(lsp1TypeIdDelegateValue));
 
             if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                returnedValue2 = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                resultTypeIdDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
 
-        returnedValue = abi.encode(returnedValue1, returnedValue2);
-        emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValue);
+        returnedValues = abi.encode(resultMainDelegate, resultTypeIdDelegate);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValues);
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -142,7 +142,7 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * Forwards the call to the addresses stored in the ERC725Y storage under the LSP1UniversalReceiverDelegate
-     * Key and the typeId Key (param) respectivelly. The call will be discarded if no addresses were set.
+     * Key and the typeId Key (param) respectively. The call will be discarded if no addresses were set.
      *
      * @param typeId The type of call received.
      * @param receivedData The data received.

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -156,13 +156,13 @@ abstract contract LSP0ERC725AccountCore is
         returns (bytes memory returnedValues)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
-        bytes memory resultMainDelegate;
+        bytes memory resultDefaultDelegate;
 
         if (lsp1DelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
             if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                resultMainDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                resultDefaultDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
@@ -171,15 +171,15 @@ abstract contract LSP0ERC725AccountCore is
         bytes memory resultTypeIdDelegate;
 
         if (lsp1TypeIdDelegateValue.length >= 20) {
-            address universalReceiverDelegate = address(bytes20(lsp1TypeIdDelegateValue));
+            address typeIdDelegate = address(bytes20(lsp1TypeIdDelegateValue));
 
-            if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                resultTypeIdDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+            if (typeIdDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
+                resultTypeIdDelegate = ILSP1UniversalReceiverDelegate(typeIdDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
 
-        returnedValues = abi.encode(resultMainDelegate, resultTypeIdDelegate);
+        returnedValues = abi.encode(resultDefaultDelegate, resultTypeIdDelegate);
         emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValues);
     }
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -44,6 +44,7 @@ abstract contract LSP0ERC725AccountCore is
     IERC1271,
     ILSP1UniversalReceiver
 {
+    using ERC165Checker for address;
     /**
      * @notice Emitted when receiving native tokens
      * @param sender The address of the sender
@@ -143,6 +144,8 @@ abstract contract LSP0ERC725AccountCore is
      * @dev Forwards the call to the UniversalReceiverDelegate if set.
      * @param typeId The type of call received.
      * @param receivedData The data received.
+     * @return returnedValue The ABI encoded return value of the LSP1UniversalReceiverDelegate call
+     * and the LSP1TypeIdDelegate call
      */
     function universalReceiver(bytes32 typeId, bytes calldata receivedData)
         public
@@ -151,20 +154,30 @@ abstract contract LSP0ERC725AccountCore is
         returns (bytes memory returnedValue)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
+        bytes memory returnedValue1;
 
         if (lsp1DelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
-            if (
-                ERC165Checker.supportsERC165Interface(
-                    universalReceiverDelegate,
-                    _INTERFACEID_LSP1_DELEGATE
-                )
-            ) {
-                returnedValue = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+            if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
+                returnedValue1 = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
+
+        bytes memory lsp1TypeIdDelegateValue = _getData(typeId);
+        bytes memory returnedValue2;
+
+        if (lsp1TypeIdDelegateValue.length >= 20) {
+            address universalReceiverDelegate = address(bytes20(lsp1TypeIdDelegateValue));
+
+            if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
+                returnedValue2 = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                    .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
+            }
+        }
+
+        returnedValue = abi.encode(returnedValue1, returnedValue2);
         emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValue);
     }
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -147,7 +147,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
     /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * Forwards the call to the addresses stored in the ERC725Y storage under the LSP1UniversalReceiverDelegate
-     * Key and the typeId Key (param) respectivelly. The call will be discarded if no addresses were set.
+     * Key and the typeId Key (param) respectively. The call will be discarded if no addresses are set.
      *
      * @param typeId The type of call received.
      * @param receivedData The data received.

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -161,13 +161,13 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
         returns (bytes memory returnedValues)
     {
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
-        bytes memory resultMainDelegate;
+        bytes memory resultDefaultDelegate;
 
         if (lsp1DelegateValue.length >= 20) {
             address universalReceiverDelegate = address(bytes20(lsp1DelegateValue));
 
             if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                resultMainDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+                resultDefaultDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
@@ -176,15 +176,15 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
         bytes memory resultTypeIdDelegate;
 
         if (lsp1TypeIdDelegateValue.length >= 20) {
-            address universalReceiverDelegate = address(bytes20(lsp1TypeIdDelegateValue));
+            address typeIdDelegate = address(bytes20(lsp1TypeIdDelegateValue));
 
-            if (universalReceiverDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
-                resultTypeIdDelegate = ILSP1UniversalReceiverDelegate(universalReceiverDelegate)
+            if (typeIdDelegate.supportsERC165Interface(_INTERFACEID_LSP1_DELEGATE)) {
+                resultTypeIdDelegate = ILSP1UniversalReceiverDelegate(typeIdDelegate)
                     .universalReceiverDelegate(msg.sender, msg.value, typeId, receivedData);
             }
         }
 
-        returnedValues = abi.encode(resultMainDelegate, resultTypeIdDelegate);
+        returnedValues = abi.encode(resultDefaultDelegate, resultTypeIdDelegate);
         emit UniversalReceiver(msg.sender, msg.value, typeId, receivedData, returnedValues);
     }
 

--- a/tests/Helpers/ABIEncoder.test.ts
+++ b/tests/Helpers/ABIEncoder.test.ts
@@ -1,0 +1,187 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { ABIEncoder, ABIEncoder__factory } from "../../types";
+
+describe("ABI Encoder Contract", () => {
+  let accounts: SignerWithAddress[];
+  let contract: ABIEncoder;
+
+  before(async () => {
+    accounts = await ethers.getSigners();
+    contract = await new ABIEncoder__factory(accounts[0]).deploy();
+  });
+
+  const verifyResult = async (txParameterA, txParameterB) => {
+    const [c, gasUsed] = await contract.callStatic.encode(
+      txParameterA,
+      txParameterB
+    );
+    const [a, b] = await contract.callStatic.decode(c);
+    expect(a).to.equal(txParameterA);
+    expect(b).to.equal(txParameterB);
+  };
+
+  const checkGasCost = async (txParameterA, txParameterB) => {
+    const [c, gasUsed] = await contract.callStatic.encode(
+      txParameterA,
+      txParameterB
+    );
+    return gasUsed.toNumber();
+  };
+
+  describe("Checking the encoding works", () => {
+    it("Encoding empty bytes", async () => {
+      const txParams = {
+        a: "0x",
+        b: "0x",
+      };
+
+      await verifyResult(txParams.a, txParams.b);
+    });
+
+    it("Encoding one empty bytes with non empty bytes", async () => {
+      const txParams = {
+        a: "0xaabbccdd",
+        b: "0x",
+      };
+
+      await verifyResult(txParams.a, txParams.b);
+    });
+
+    it("Encoding non empty bytes with non empty bytes", async () => {
+      const txParams = {
+        a: "0xaabbccdd",
+        b: "0xaabbccdd",
+      };
+
+      await verifyResult(txParams.a, txParams.b);
+    });
+  });
+
+  describe("Checking the gas cost", () => {
+    describe("General cases", () => {
+      it("Encoding small amount of bytes in one param", async () => {
+        const txParams = {
+          a: "0xaabbccdd",
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding larger amount of bytes in one param", async () => {
+        const txParams = {
+          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding very large amount of bytes in one param", async () => {
+        const txParams = {
+          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+      it("Encoding small amount of bytes in both param", async () => {
+        const txParams = {
+          a: "0xaabbccdd",
+          b: "0xaabbccdd",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding larger amount of bytes in both param", async () => {
+        const txParams = {
+          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          b: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding very large amount of bytes in both param", async () => {
+        const txParams = {
+          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          b: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+    });
+    describe("LSP1 Specific Cases", () => {
+      it("Encoding URD response when typeId out of scope with empty bytes", async () => {
+        const txParams = {
+          a: ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+          ),
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding URD response when owner is not a KM with empty bytes", async () => {
+        const txParams = {
+          a: ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes(
+              "LSP1: account owner is not a LSP6KeyManager"
+            )
+          ),
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding URD response when asset already exist with empty bytes", async () => {
+        const txParams = {
+          a: ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes(
+              "LSP1: asset received is already registered"
+            )
+          ),
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding URD response when asset is not registered with empty bytes", async () => {
+        const txParams = {
+          a: ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")
+          ),
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding URD response when full balance was not sent with empty bytes", async () => {
+        const txParams = {
+          a: ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("LSP1: full balance is not sent")
+          ),
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+
+      it("Encoding URD response when the data is successfully set with empty bytes", async () => {
+        const txParams = {
+          a: "0x",
+          b: "0x",
+        };
+
+        const result = await checkGasCost(txParams.a, txParams.b);
+      });
+    });
+  });
+});

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -54,7 +54,7 @@ export const shouldBehaveLikeLSP1 = (
             // receivedData
             data,
             // returnedValue
-            "0x"
+            abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
           );
       });
     });
@@ -79,7 +79,7 @@ export const shouldBehaveLikeLSP1 = (
               // receivedData
               "0x",
               // returnedValue
-              "0x"
+              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
             );
         });
       });
@@ -103,7 +103,7 @@ export const shouldBehaveLikeLSP1 = (
               // receivedData
               "0x",
               // returnedValue
-              "0x"
+              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
             );
         });
       });
@@ -137,7 +137,7 @@ export const shouldBehaveLikeLSP1 = (
             valueSent,
             LSP1_HOOK_PLACEHOLDER,
             "0x",
-            "0x"
+            abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
           );
       });
     });
@@ -170,7 +170,7 @@ export const shouldBehaveLikeLSP1 = (
               // receivedData
               "0x",
               // returnedValue
-              "0x"
+              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
             );
         });
       });
@@ -195,7 +195,7 @@ export const shouldBehaveLikeLSP1 = (
               // receivedData
               "0x",
               // returnedValue
-              "0x"
+              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"])
             );
         });
       });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -124,17 +124,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.any)
           .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
 
-        expect(result).to.equal(
-          abiCoder.encode(
-            ["bytes", "bytes"],
-            [
-              ethers.utils.hexlify(
-                ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
-              ),
-              "0x",
-            ]
+        const [resultDelegate, resultTypeID] = abiCoder.decode(
+          ["bytes", "bytes"],
+          result
+        );
+
+        expect(resultDelegate).to.equal(
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
           )
         );
+
+        expect(resultTypeID).to.equal("0x");
       });
     });
   });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -20,6 +20,7 @@ import {
   ARRAY_LENGTH,
   TOKEN_ID,
   LSP1_HOOK_PLACEHOLDER,
+  abiCoder,
 } from "../utils/helpers";
 
 // constants
@@ -124,8 +125,14 @@ export const shouldBehaveLikeLSP1Delegate = (
           .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
 
         expect(result).to.equal(
-          ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+          abiCoder.encode(
+            ["bytes", "bytes"],
+            [
+              ethers.utils.hexlify(
+                ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+              ),
+              "0x",
+            ]
           )
         );
       });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -17,6 +17,7 @@ import {
   ARRAY_LENGTH,
   TOKEN_ID,
   LSP1_HOOK_PLACEHOLDER,
+  abiCoder,
 } from "../utils/helpers";
 
 // constants
@@ -116,8 +117,14 @@ export const shouldBehaveLikeLSP1Delegate = (
             .callStatic.universalReceiver(Vault_TypeIds[i], "0x");
 
           expect(result).to.equal(
-            ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+            abiCoder.encode(
+              ["bytes", "bytes"],
+              [
+                ethers.utils.hexlify(
+                  ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+                ),
+                "0x",
+              ]
             )
           );
         }
@@ -131,8 +138,14 @@ export const shouldBehaveLikeLSP1Delegate = (
           .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
 
         expect(result).to.equal(
-          ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+          abiCoder.encode(
+            ["bytes", "bytes"],
+            [
+              ethers.utils.hexlify(
+                ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+              ),
+              "0x",
+            ]
           )
         );
       });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -116,17 +116,18 @@ export const shouldBehaveLikeLSP1Delegate = (
             .connect(context.accounts.any)
             .callStatic.universalReceiver(Vault_TypeIds[i], "0x");
 
-          expect(result).to.equal(
-            abiCoder.encode(
-              ["bytes", "bytes"],
-              [
-                ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
-                ),
-                "0x",
-              ]
+          const [resultDelegate, resultTypeID] = abiCoder.decode(
+            ["bytes", "bytes"],
+            result
+          );
+
+          expect(resultDelegate).to.equal(
+            ethers.utils.hexlify(
+              ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
             )
           );
+
+          expect(resultTypeID).to.equal("0x");
         }
       });
     });
@@ -137,17 +138,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.any)
           .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
 
-        expect(result).to.equal(
-          abiCoder.encode(
-            ["bytes", "bytes"],
-            [
-              ethers.utils.hexlify(
-                ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
-              ),
-              "0x",
-            ]
+        const [resultDelegate, resultTypeID] = abiCoder.decode(
+          ["bytes", "bytes"],
+          result
+        );
+
+        expect(resultDelegate).to.equal(
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
           )
         );
+
+        expect(resultTypeID).to.equal("0x");
       });
     });
   });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -12,7 +12,11 @@ import {
 } from "../../types";
 
 // helpers
-import { ARRAY_LENGTH, generateKeysAndValues } from "../utils/helpers";
+import {
+  ARRAY_LENGTH,
+  generateKeysAndValues,
+  abiCoder,
+} from "../utils/helpers";
 
 // fixtures
 import { callPayload } from "../utils/fixtures";
@@ -293,8 +297,14 @@ export const shouldBehaveLikeLSP9 = (
             0,
             LSP1_TYPE_IDS.LSP14_OwnershipTransferStarted,
             "0x",
-            ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+            abiCoder.encode(
+              ["bytes", "bytes"],
+              [
+                ethers.utils.hexlify(
+                  ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")
+                ),
+                "0x",
+              ]
             )
           );
       });


### PR DESCRIPTION
## What does this PR introduce?
- Adding routing to the universalReceiver function
- Add tests to check how ABI encoding works and gas costs
- Resolve test according to new behaviour