### PR TITLE
refactor: construct typeIds based on mapping keyType

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -200,20 +200,20 @@ const PERMISSIONS = {
 }
 
 const LSP1_TYPE_IDS = {
-	// keccak256('LSP7TokensSender')
-	LSP7_TOKENSENDER: '0x40b8bec57d7b5ff0dbd9e9acd0a47dfeb0101e1a203766f5ccab00445fbf39e9',
-	// keccak256('LSP7TokensRecipient')
-	LSP7_TOKENRECIPIENT: '0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f',
-	// keccak256('LSP8TokensSender')
-	LSP8_TOKENSENDER: '0x3724c94f0815e936299cca424da4140752198e0beb7931a6e0925d11bc97544c',
-	// keccak256('LSP8TokensRecipient')
-	LSP8_TOKENRECIPIENT: '0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01',
-	// keccak256("LSP14OwnershipTransferStarted")
-	LSP14_OwnershipTransferStarted: '0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
-	// keccak256("LSP14OwnershipTransferred_SenderNotification")
-	LSP14_OwnershipTransferred_SenderNotification: '0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
-	// keccak256("LSP14OwnershipTransferred_RecipientNotification")
-	LSP14_OwnershipTransferred_RecipientNotification: '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_SenderNotification'))
+	LSP7_TOKENSENDER: '0x0cfc51aec37c55a4d0b10000429ac7a06903dbc9c13dfcb3c9d11df8194581fa',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_RecipientNotification'))
+	LSP7_TOKENRECIPIENT: '0x0cfc51aec37c55a4d0b1000020804611b3e2ea21c480dc465142210acf4a2485',
+		// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
+	LSP8_TOKENSENDER: '0x0cfc51aec37c55a4d0b10000b23eae7e6d1564b295b4c3e3be402d9a2f0776c5',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_RecipientNotification'))
+	LSP8_TOKENRECIPIENT: '0x0cfc51aec37c55a4d0b100000b084a55ebf70fd3c06fd755269dac2212c4d3f0',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferStarted'))
+	LSP14_OwnershipTransferStarted: '0x0cfc51aec37c55a4d0b10000ee9a7c0924f740a2ca33d59b7f0c2929821ea983',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_SenderNotification'))
+	LSP14_OwnershipTransferred_SenderNotification: '0x0cfc51aec37c55a4d0b10000a124442e1cc7b52d8e2ede2787d43527dc1f3ae0',
+	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_RecipientNotification'))
+	LSP14_OwnershipTransferred_RecipientNotification: '0x0cfc51aec37c55a4d0b10000e32c7debcb817925ba4883fdbfc52797187f28f7',
 };
 
 // ----------

--- a/contracts/LSP14Ownable2Step/LSP14Constants.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Constants.sol
@@ -5,11 +5,11 @@ bytes4 constant _INTERFACEID_LSP14 = 0x94be5999;
 
 // --- Type IDs
 
-// keccak256(LSP14OwnershipTransferStarted)
-bytes32 constant _TYPEID_LSP14_OwnershipTransferStarted = 0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferStarted'))
+bytes32 constant _TYPEID_LSP14_OwnershipTransferStarted = 0x0cfc51aec37c55a4d0b10000ee9a7c0924f740a2ca33d59b7f0c2929821ea983;
 
-// keccak256(LSP14OwnershipTransferred_SenderNotification)
-bytes32 constant _TYPEID_LSP14_OwnershipTransferred_SenderNotification = 0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_SenderNotification'))
+bytes32 constant _TYPEID_LSP14_OwnershipTransferred_SenderNotification = 0x0cfc51aec37c55a4d0b10000a124442e1cc7b52d8e2ede2787d43527dc1f3ae0;
 
-// keccak256(LSP14OwnershipTransferred_RecipientNotification)
-bytes32 constant _TYPEID_LSP14_OwnershipTransferred_RecipientNotification = 0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_RecipientNotification'))
+bytes32 constant _TYPEID_LSP14_OwnershipTransferred_RecipientNotification = 0x0cfc51aec37c55a4d0b10000e32c7debcb817925ba4883fdbfc52797187f28f7;

--- a/contracts/LSP7DigitalAsset/LSP7Constants.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Constants.sol
@@ -6,8 +6,8 @@ bytes4 constant _INTERFACEID_LSP7 = 0x5fcaac27;
 
 // --- Token Hooks
 
-// keccak256('LSP7TokensSender')
-bytes32 constant _TYPEID_LSP7_TOKENSSENDER = 0x40b8bec57d7b5ff0dbd9e9acd0a47dfeb0101e1a203766f5ccab00445fbf39e9;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_SenderNotification'))
+bytes32 constant _TYPEID_LSP7_TOKENSSENDER = 0x0cfc51aec37c55a4d0b10000429ac7a06903dbc9c13dfcb3c9d11df8194581fa;
 
-// keccak256('LSP7TokensRecipient')
-bytes32 constant _TYPEID_LSP7_TOKENSRECIPIENT = 0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_RecipientNotification'))
+bytes32 constant _TYPEID_LSP7_TOKENSRECIPIENT = 0x0cfc51aec37c55a4d0b1000020804611b3e2ea21c480dc465142210acf4a2485;

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
@@ -14,8 +14,8 @@ bytes12 constant _LSP8_METADATA_JSON_KEY_PREFIX = 0x9a26b4060ae7f7d5e3cd0000;
 
 // --- Token Hooks
 
-// keccak256('LSP8TokensSender')
-bytes32 constant _TYPEID_LSP8_TOKENSSENDER = 0x3724c94f0815e936299cca424da4140752198e0beb7931a6e0925d11bc97544c;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
+bytes32 constant _TYPEID_LSP8_TOKENSSENDER = 0x0cfc51aec37c55a4d0b10000b23eae7e6d1564b295b4c3e3be402d9a2f0776c5;
 
-// keccak256('LSP8TokensRecipient')
-bytes32 constant _TYPEID_LSP8_TOKENSRECIPIENT = 0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01;
+// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
+bytes32 constant _TYPEID_LSP8_TOKENSRECIPIENT = 0x0cfc51aec37c55a4d0b100000b084a55ebf70fd3c06fd755269dac2212c4d3f0;

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -18,6 +18,7 @@ import {
 import {
   ERC725YKeys,
   INTERFACE_IDS,
+  LSP1_TYPE_IDS,
   SupportedStandards,
 } from "../../constants";
 
@@ -506,8 +507,7 @@ export const shouldBehaveLikeLSP7 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId =
-                    "0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f";
+                  const typeId = LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "uint256", "bytes"],
                     [txParams.from, txParams.to, txParams.amount, txParams.data]
@@ -575,8 +575,7 @@ export const shouldBehaveLikeLSP7 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId =
-                    "0xdbe2c314e1aee2970c72666f2ebe8933a8575263ea71e5ff6a9178e95d47a26f";
+                  const typeId = LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "uint256", "bytes"],
                     [txParams.from, txParams.to, txParams.amount, txParams.data]

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -21,6 +21,7 @@ import { tokenIdAsBytes32 } from "../utils/tokens";
 import {
   ERC725YKeys,
   INTERFACE_IDS,
+  LSP1_TYPE_IDS,
   SupportedStandards,
 } from "../../constants";
 
@@ -713,8 +714,7 @@ export const shouldBehaveLikeLSP8 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId =
-                    "0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01";
+                  const typeId = LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "bytes32", "bytes"],
                     [
@@ -807,8 +807,7 @@ export const shouldBehaveLikeLSP8 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId =
-                    "0xc7a120a42b6057a0cbed111fbbfbd52fcd96748c04394f77fc2c3adbe0391e01";
+                  const typeId = LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "bytes32", "bytes"],
                     [


### PR DESCRIPTION
## What does this PR introduce?
- construct typeIds based on mapping keyType
- Update the typeIds in constant.js
- Remove hardoced constant in tests

TypeIds now are constructed as Mapping KeyType according to LSP2-ERC725YJSONSchema 

The usage of typeId in mapping form will make it more easy to identify which Keys and Values being set in the ERC725Y storage are relevant to a typeId based on the 10bytes prefix. 

This will also allow KeyManagers in the future to implement specific permission to set these kind of keys based on the fixed bytes10 prefix. 