### PR TITLE
refactor: Separate `fallback()` and `receive()` functions in LSP0 & LSP9

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -55,8 +55,9 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executes on calls made with data included
-     * E.g. calls made with `call()`
+     * Executed when:
+     * - the first 4 bytes of the calldata do not match any publicly callable functions from the contract ABI.
+     * - receiving native tokens with some calldata.
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
@@ -65,8 +66,7 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executes on calls made without data included
-     * E.g. calls made via `send()`, `transfer()` or `call()`
+     * Executed when receiving native tokens with empty calldata.
      */
     receive() external payable virtual {
         emit ValueReceived(msg.sender, msg.value);

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -54,9 +54,21 @@ abstract contract LSP0ERC725AccountCore is
 
     /**
      * @dev Emits an event when receiving native tokens
+     *
+     * Executes on calls made with data included
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+    }
+
+    /**
+     * @dev Emits an event when receiving native tokens
+     *
+     * Executes on calls mae without data included
+     * E.g. calls made via `send()` or `transfer()`
+     */
+    receive() external payable virtual {
+        emit ValueReceived(msg.sender, msg.value);
     }
 
     // ERC165

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -56,6 +56,7 @@ abstract contract LSP0ERC725AccountCore is
      * @dev Emits an event when receiving native tokens
      *
      * Executes on calls made with data included
+     * E.g. calls made with `call()`
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
@@ -64,8 +65,8 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executes on calls mae without data included
-     * E.g. calls made via `send()` or `transfer()`
+     * Executes on calls made without data included
+     * E.g. calls made via `send()`, `transfer()` or `call()`
      */
     receive() external payable virtual {
         emit ValueReceived(msg.sender, msg.value);

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -71,9 +71,21 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
 
     /**
      * @dev Emits an event when receiving native tokens
+     *
+     * Executes on calls made with data included
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+    }
+
+    /**
+     * @dev Emits an event when receiving native tokens
+     *
+     * Executes on calls mae without data included
+     * E.g. calls made via `send()` or `transfer()`
+     */
+    receive() external payable virtual {
+        emit ValueReceived(msg.sender, msg.value);
     }
 
     // ERC725

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -72,8 +72,9 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executes on calls made with data included
-     * E.g. calls made with `call()`
+     * Executed when:
+     * - the first 4 bytes of the calldata do not match any publicly callable functions from the contract ABI.
+     * - receiving native tokens with some calldata.
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
@@ -82,8 +83,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executes on calls mae without data included
-     * E.g. calls made via `send()`, `transfer()` or `call()`
+     * Executed when receiving native tokens with empty calldata.
      */
     receive() external payable virtual {
         emit ValueReceived(msg.sender, msg.value);

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -73,6 +73,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
      * @dev Emits an event when receiving native tokens
      *
      * Executes on calls made with data included
+     * E.g. calls made with `call()`
      */
     fallback() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
@@ -82,7 +83,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
      * @dev Emits an event when receiving native tokens
      *
      * Executes on calls mae without data included
-     * E.g. calls made via `send()` or `transfer()`
+     * E.g. calls made via `send()`, `transfer()` or `call()`
      */
     receive() external payable virtual {
         emit ValueReceived(msg.sender, msg.value);


### PR DESCRIPTION
## What does this PR introduce?

This PR separates the `fallback()` and `receive()` functions for the safe of separating the concern in LSP0 & LSP9: 
- receiving data (arbitrary or not) with no value -> `fallback()`
- receiving data (arbitrary or not) with value -> `fallback()`
- receiving just value with no data -> `receive()`