### PR TITLE
fix!: add check for `amount != 0` when transferring LSP7 tokens

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -208,6 +208,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
+        if (amount == 0) revert LSP7MintAmountIsZero();
+
         if (to == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }
@@ -240,6 +242,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 amount,
         bytes memory data
     ) internal virtual {
+        if (amount == 0) revert LSP7BurnAmountIsZero();
+
         if (from == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }
@@ -287,6 +291,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
+        if (amount == 0) revert LSP7TransferAmountIsZero();
+
         if (from == address(0) || to == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -14,6 +14,12 @@ error LSP7AmountExceedsAuthorizedAmount(
 
 error LSP7CannotUseAddressZeroAsOperator();
 
+error LSP7MintAmountIsZero();
+
+error LSP7BurnAmountIsZero();
+
+error LSP7TransferAmountIsZero();
+
 error LSP7CannotSendWithAddressZero();
 
 error LSP7CannotSendToSelf();

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -79,6 +79,37 @@ export const shouldBehaveLikeLSP7 = (
   });
 
   describe("when minting tokens", () => {
+    describe("when `amount == 0`", () => {
+      it("should revert if `force == false`", async () => {
+        const txParams = {
+          to: context.accounts.anotherTokenReceiver.address,
+          amount: 0,
+          force: false,
+          data: "0x",
+        };
+
+        await expect(
+          context.lsp7
+            .connect(context.accounts.anyone)
+            .mint(txParams.to, txParams.amount, txParams.force, txParams.data)
+        ).to.be.revertedWithCustomError(context.lsp7, "LSP7MintAmountIsZero");
+      });
+
+      it("should revert if `force == true`", async () => {
+        const txParams = {
+          to: context.accounts.anotherTokenReceiver.address,
+          amount: 0,
+          force: true,
+          data: "0x",
+        };
+
+        await expect(
+          context.lsp7
+            .connect(context.accounts.anyone)
+            .mint(txParams.to, txParams.amount, txParams.force, txParams.data)
+        ).to.be.revertedWithCustomError(context.lsp7, "LSP7MintAmountIsZero");
+      });
+    });
     describe("when `to` is the zero address", () => {
       it("should revert", async () => {
         const txParams = {
@@ -692,6 +723,44 @@ export const shouldBehaveLikeLSP7 = (
             });
           });
 
+          describe("when `amount == 0`", () => {
+            it("should revert with `force == false`", async () => {
+              const caller = context.accounts.anyone;
+
+              const txParams = {
+                from: context.accounts.anyone.address,
+                to: context.accounts.anotherTokenReceiver.address,
+                amount: ethers.BigNumber.from(0),
+                force: false,
+                data: "0x",
+              };
+              const expectedError = "LSP7TransferAmountIsZero";
+
+              await transferFailScenario(txParams, caller, {
+                error: expectedError,
+                args: [],
+              });
+            });
+
+            it("should revert with `force == true`", async () => {
+              const caller = context.accounts.anyone;
+
+              const txParams = {
+                from: context.accounts.anyone.address,
+                to: context.accounts.anotherTokenReceiver.address,
+                amount: ethers.BigNumber.from(0),
+                force: true,
+                data: "0x",
+              };
+              const expectedError = "LSP7TransferAmountIsZero";
+
+              await transferFailScenario(txParams, caller, {
+                error: expectedError,
+                args: [],
+              });
+            });
+          });
+
           describe("when operator does not have enough authorized amount", () => {
             it("should revert", async () => {
               const operator = context.accounts.operatorWithLowAuthorizedAmount;
@@ -1271,6 +1340,18 @@ export const shouldBehaveLikeLSP7 = (
   });
 
   describe("burn", () => {
+    describe("when `amount == 0`", () => {
+      it("should revert", async () => {
+        const caller = context.accounts.anyone;
+        const amount = 0;
+
+        await expect(
+          context.lsp7
+            .connect(caller)
+            .burn(ethers.constants.AddressZero, amount, "0x")
+        ).to.be.revertedWithCustomError(context.lsp7, "LSP7BurnAmountIsZero");
+      });
+    });
     describe("when caller is the `from` address", () => {
       describe("when using address(0) as `from` address", () => {
         it("should revert", async () => {


### PR DESCRIPTION
# What does this PR introduce?

⚠️ 🐛 **Bug Fix**

## What is the current behaviour?

Anyone (EOA or contract) can register the address of any `LSP7DigitalAsset` token contract inside the `LSP5ReceivedAssets[]` of any Universal Profile by performing the following.

1. Find a deployed LSP7 token contract.
2. call the `transfer(...)` function with the following parameters:

- `from`: the caller address
- `to`: the address of the Universal Profile to register (= spam) the `LSP5ReceivedAssets[]` list.
- `amount`: **`0`**. Specify the amount as **zero**.

`force` (default to `false`) and `data` parameters are not relevant in this context.

This will bypass all the checks inside the internal `_transfer(...)` function and register the LSP7 token address inside the `LSP5ReceivedAssets[]` list of the recipient Universal Profile.

As a result, any address can disorganise the `LSP5ReceivedAssets[]` list of any UP.

## What is the new behaviour?

- Add a check to ensure the `amount` passed as a parameter is not 0.
- This issue can also be run via the `mint(...)` function, so add an additional check on the internal `_mint(...)` function.
-  For consistency, add extra check in the internal `_burn(...)` to sanitize the inputs. The external call to the `universalReceiver(...)` functions of the UP will have no effects in this case, but this is to prevent unnecessary gas usage.

