### PR TITLE
fix: update the logic inside universalReceiver function and revert typeId changes

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -200,20 +200,20 @@ const PERMISSIONS = {
 }
 
 const LSP1_TYPE_IDS = {
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_SenderNotification'))
-	LSP7_TOKENSENDER: '0x0cfc51aec37c55a4d0b10000429ac7a06903dbc9c13dfcb3c9d11df8194581fa',
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_RecipientNotification'))
-	LSP7_TOKENRECIPIENT: '0x0cfc51aec37c55a4d0b1000020804611b3e2ea21c480dc465142210acf4a2485',
-		// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
-	LSP8_TOKENSENDER: '0x0cfc51aec37c55a4d0b10000b23eae7e6d1564b295b4c3e3be402d9a2f0776c5',
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_RecipientNotification'))
-	LSP8_TOKENRECIPIENT: '0x0cfc51aec37c55a4d0b100000b084a55ebf70fd3c06fd755269dac2212c4d3f0',
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferStarted'))
-	LSP14_OwnershipTransferStarted: '0x0cfc51aec37c55a4d0b10000ee9a7c0924f740a2ca33d59b7f0c2929821ea983',
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_SenderNotification'))
-	LSP14_OwnershipTransferred_SenderNotification: '0x0cfc51aec37c55a4d0b10000a124442e1cc7b52d8e2ede2787d43527dc1f3ae0',
-	// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_RecipientNotification'))
-	LSP14_OwnershipTransferred_RecipientNotification: '0x0cfc51aec37c55a4d0b10000e32c7debcb817925ba4883fdbfc52797187f28f7',
+	// keccak256('LSP7Tokens_SenderNotification')
+	LSP7Tokens_SenderNotification: '0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
+	// keccak256('LSP7Tokens_RecipientNotification')
+	LSP7Tokens_RecipientNotification: '0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
+	// keccak256('LSP8Tokens_SenderNotification')
+	LSP8Tokens_SenderNotification: '0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
+	// keccak256('LSP8Tokens_RecipientNotification')
+	LSP8Tokens_RecipientNotification: '0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
+	// keccak256('LSP14OwnershipTransferStarted')
+	LSP14OwnershipTransferStarted: '0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
+	// keccak256('LSP14OwnershipTransferred_SenderNotification')
+	LSP14OwnershipTransferred_SenderNotification: '0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
+	// keccak256('LSP14OwnershipTransferred_RecipientNotification')
+	LSP14OwnershipTransferred_RecipientNotification: '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
 };
 
 // ----------

--- a/constants.js
+++ b/constants.js
@@ -70,6 +70,8 @@ const SupportedStandards = {
  */
 const ERC725YKeys = {
 	LSP1: {
+		// bytes10(keccak256('LSP1UniversalReceiverDelegate'))
+		LSP1UniversalReceiverDelegatePrefix: '0x0cfc51aec37c55a4d0b1',
 		// keccak256('LSP1UniversalReceiverDelegate')
 		LSP1UniversalReceiverDelegate:
 			'0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// interfaces
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {_INTERFACEID_LSP1_DELEGATE} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+contract UniversalReceiverDelegateRevert is ERC165, ILSP1UniversalReceiverDelegate {
+    /**
+     * @inheritdoc ILSP1UniversalReceiverDelegate
+     * @dev Allows to register arrayKeys and Map of incoming vaults and assets and removing them after being sent
+     * @return result the return value of keyManager's execute function
+     */
+    function universalReceiverDelegate(
+        address notifier,
+        uint256 value, // solhint-disable no-unused-vars
+        bytes32 typeId,
+        bytes memory data // solhint-disable no-unused-vars
+    ) public virtual returns (bytes memory result) {
+        revert("I Revert");
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == _INTERFACEID_LSP1_DELEGATE || super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -12,6 +12,7 @@ import {
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
+import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // modules
 import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
@@ -28,6 +29,7 @@ import {
 import {
     _INTERFACEID_LSP1,
     _INTERFACEID_LSP1_DELEGATE,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
 } from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
@@ -180,7 +182,12 @@ abstract contract LSP0ERC725AccountCore is
             }
         }
 
-        bytes memory lsp1TypeIdDelegateValue = _getData(typeId);
+        bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
+            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+            bytes20(typeId)
+        );
+
+        bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
         bytes memory resultTypeIdDelegate;
 
         if (lsp1TypeIdDelegateValue.length >= 20) {

--- a/contracts/LSP14Ownable2Step/LSP14Constants.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Constants.sol
@@ -5,11 +5,11 @@ bytes4 constant _INTERFACEID_LSP14 = 0x94be5999;
 
 // --- Type IDs
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferStarted'))
-bytes32 constant _TYPEID_LSP14_OwnershipTransferStarted = 0x0cfc51aec37c55a4d0b10000ee9a7c0924f740a2ca33d59b7f0c2929821ea983;
+// keccak256('LSP14OwnershipTransferStarted')
+bytes32 constant _TYPEID_LSP14_OwnershipTransferStarted = 0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0;
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_SenderNotification'))
-bytes32 constant _TYPEID_LSP14_OwnershipTransferred_SenderNotification = 0x0cfc51aec37c55a4d0b10000a124442e1cc7b52d8e2ede2787d43527dc1f3ae0;
+// keccak256('LSP14OwnershipTransferred_SenderNotification')
+bytes32 constant _TYPEID_LSP14_OwnershipTransferred_SenderNotification = 0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c;
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP14OwnershipTransferred_RecipientNotification'))
-bytes32 constant _TYPEID_LSP14_OwnershipTransferred_RecipientNotification = 0x0cfc51aec37c55a4d0b10000e32c7debcb817925ba4883fdbfc52797187f28f7;
+// keccak256('LSP14OwnershipTransferred_RecipientNotification')
+bytes32 constant _TYPEID_LSP14_OwnershipTransferred_RecipientNotification = 0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c;

--- a/contracts/LSP1UniversalReceiver/LSP1Constants.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Constants.sol
@@ -7,5 +7,8 @@ bytes4 constant _INTERFACEID_LSP1_DELEGATE = 0xa245bbda;
 
 // --- ERC725Y Keys
 
+// bytes10(keccak256('LSP1UniversalReceiverDelegate'))
+bytes10 constant _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX = 0x0cfc51aec37c55a4d0b1;
+
 // keccak256('LSP1UniversalReceiverDelegate')
 bytes32 constant _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY = 0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47;

--- a/contracts/LSP7DigitalAsset/LSP7Constants.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Constants.sol
@@ -6,8 +6,8 @@ bytes4 constant _INTERFACEID_LSP7 = 0x5fcaac27;
 
 // --- Token Hooks
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_SenderNotification'))
-bytes32 constant _TYPEID_LSP7_TOKENSSENDER = 0x0cfc51aec37c55a4d0b10000429ac7a06903dbc9c13dfcb3c9d11df8194581fa;
+// keccak256('LSP7Tokens_SenderNotification')
+bytes32 constant _TYPEID_LSP7_TOKENSSENDER = 0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea;
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP7Tokens_RecipientNotification'))
-bytes32 constant _TYPEID_LSP7_TOKENSRECIPIENT = 0x0cfc51aec37c55a4d0b1000020804611b3e2ea21c480dc465142210acf4a2485;
+// keccak256('LSP7Tokens_RecipientNotification')
+bytes32 constant _TYPEID_LSP7_TOKENSRECIPIENT = 0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c;

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
@@ -14,8 +14,8 @@ bytes12 constant _LSP8_METADATA_JSON_KEY_PREFIX = 0x9a26b4060ae7f7d5e3cd0000;
 
 // --- Token Hooks
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
-bytes32 constant _TYPEID_LSP8_TOKENSSENDER = 0x0cfc51aec37c55a4d0b10000b23eae7e6d1564b295b4c3e3be402d9a2f0776c5;
+// keccak256('LSP8Tokens_SenderNotification')
+bytes32 constant _TYPEID_LSP8_TOKENSSENDER = 0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00;
 
-// bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0) + bytes20(keccak256('LSP8Tokens_SenderNotification'))
-bytes32 constant _TYPEID_LSP8_TOKENSRECIPIENT = 0x0cfc51aec37c55a4d0b100000b084a55ebf70fd3c06fd755269dac2212c4d3f0;
+// keccak256('LSP8Tokens_RecipientNotification')
+bytes32 constant _TYPEID_LSP8_TOKENSRECIPIENT = 0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d;

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -11,6 +11,7 @@ import {
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {GasLib} from "../Utils/GasLib.sol";
 import {ERC165Checker} from "../Custom/ERC165Checker.sol";
+import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // modules
 import {ERC725XCore, IERC725X} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
@@ -30,6 +31,7 @@ import {
 import {
     _INTERFACEID_LSP1,
     _INTERFACEID_LSP1_DELEGATE,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
 } from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP9} from "./LSP9Constants.sol";
@@ -185,7 +187,12 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
             }
         }
 
-        bytes memory lsp1TypeIdDelegateValue = _getData(typeId);
+        bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
+            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+            bytes20(typeId)
+        );
+
+        bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
         bytes memory resultTypeIdDelegate;
 
         if (lsp1TypeIdDelegateValue.length >= 20) {

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -95,12 +95,12 @@ export const shouldBehaveLikeLSP1Delegate = (
     describe("when calling with token/vault typeId", () => {
       it("should revert with custom error", async () => {
         let URD_TypeIds = [
-          LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT,
-          LSP1_TYPE_IDS.LSP7_TOKENSENDER,
-          LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT,
-          LSP1_TYPE_IDS.LSP8_TOKENSENDER,
-          LSP1_TYPE_IDS.LSP14_OwnershipTransferred_RecipientNotification,
-          LSP1_TYPE_IDS.LSP14_OwnershipTransferred_SenderNotification,
+          LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
+          LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
+          LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification,
+          LSP1_TYPE_IDS.LSP8Tokens_SenderNotification,
+          LSP1_TYPE_IDS.LSP14OwnershipTransferred_RecipientNotification,
+          LSP1_TYPE_IDS.LSP14OwnershipTransferred_SenderNotification,
         ];
 
         for (let i = 0; i < URD_TypeIds.length; i++) {

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -83,10 +83,10 @@ export const shouldBehaveLikeLSP1Delegate = (
     describe("when calling with tokens typeId", () => {
       it("should revert with custom error", async () => {
         let URD_TypeIds = [
-          LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT,
-          LSP1_TYPE_IDS.LSP7_TOKENSENDER,
-          LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT,
-          LSP1_TYPE_IDS.LSP8_TOKENSENDER,
+          LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
+          LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
+          LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification,
+          LSP1_TYPE_IDS.LSP8Tokens_SenderNotification,
         ];
 
         for (let i = 0; i < URD_TypeIds.length; i++) {
@@ -107,8 +107,8 @@ export const shouldBehaveLikeLSP1Delegate = (
     describe("when calling with vaults sender and recipient typeIds", () => {
       it("should pass and return typeId out of scope return value", async () => {
         let Vault_TypeIds = [
-          LSP1_TYPE_IDS.LSP14_OwnershipTransferred_RecipientNotification,
-          LSP1_TYPE_IDS.LSP14_OwnershipTransferred_SenderNotification,
+          LSP1_TYPE_IDS.LSP14OwnershipTransferred_RecipientNotification,
+          LSP1_TYPE_IDS.LSP14OwnershipTransferred_SenderNotification,
         ];
 
         for (let i = 0; i < Vault_TypeIds.length; i++) {

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -507,7 +507,7 @@ export const shouldBehaveLikeLSP7 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId = LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT;
+                  const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "uint256", "bytes"],
                     [txParams.from, txParams.to, txParams.amount, txParams.data]
@@ -575,7 +575,7 @@ export const shouldBehaveLikeLSP7 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId = LSP1_TYPE_IDS.LSP7_TOKENRECIPIENT;
+                  const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "uint256", "bytes"],
                     [txParams.from, txParams.to, txParams.amount, txParams.data]

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -714,7 +714,7 @@ export const shouldBehaveLikeLSP8 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId = LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT;
+                  const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "bytes32", "bytes"],
                     [
@@ -807,7 +807,7 @@ export const shouldBehaveLikeLSP8 = (
 
                   const tx = await transferSuccessScenario(txParams, operator);
 
-                  const typeId = LSP1_TYPE_IDS.LSP8_TOKENRECIPIENT;
+                  const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
                     ["address", "address", "bytes32", "bytes"],
                     [

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -295,7 +295,7 @@ export const shouldBehaveLikeLSP9 = (
           .withArgs(
             context.lsp9Vault.address,
             0,
-            LSP1_TYPE_IDS.LSP14_OwnershipTransferStarted,
+            LSP1_TYPE_IDS.LSP14OwnershipTransferStarted,
             "0x",
             abiCoder.encode(
               ["bytes", "bytes"],

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -48,9 +48,9 @@ describe("UniversalProfile", () => {
     const buildLSP1TestContext = async (): Promise<LSP1TestContext> => {
       const accounts = await ethers.getSigners();
 
-      const lsp1Implementation = (await new UniversalProfile__factory(
+      const lsp1Implementation = await new UniversalProfile__factory(
         accounts[0]
-      ).deploy(accounts[0].address)) as ILSP1UniversalReceiver;
+      ).deploy(accounts[0].address);
 
       const lsp1Checker = await new UniversalReceiverTester__factory(
         accounts[0]
@@ -160,7 +160,9 @@ describe("UniversalProfile", () => {
 
       const lsp1Implementation = universalProfileInit.attach(
         universalProfileProxy
-      ) as ILSP1UniversalReceiver;
+      );
+
+      await lsp1Implementation.initialize(accounts[0].address);
 
       const lsp1Checker = await new UniversalReceiverTester__factory(
         accounts[0]


### PR DESCRIPTION
## What does this PR introduce?
- Reverting the changes of the typeId
- Updating the logic of the universalReceiver so it constructs the Key of the typeId delegate from the typeId received.