### PR TITLE
fix: emit `OwnershipTransferStarted` and `Executed` events before external calls

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -203,22 +203,27 @@ const PERMISSIONS = {
 
 const LSP1_TYPE_IDS = {
 	// keccak256('LSP7Tokens_SenderNotification')
-	LSP7Tokens_SenderNotification: '0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
+	LSP7Tokens_SenderNotification:
+		'0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
 	// keccak256('LSP7Tokens_RecipientNotification')
-	LSP7Tokens_RecipientNotification: '0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
+	LSP7Tokens_RecipientNotification:
+		'0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
 	// keccak256('LSP8Tokens_SenderNotification')
-	LSP8Tokens_SenderNotification: '0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
+	LSP8Tokens_SenderNotification:
+		'0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
 	// keccak256('LSP8Tokens_RecipientNotification')
-	LSP8Tokens_RecipientNotification: '0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
+	LSP8Tokens_RecipientNotification:
+		'0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
 	// keccak256('LSP14OwnershipTransferStarted')
-	LSP14OwnershipTransferStarted: '0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
+	LSP14OwnershipTransferStarted:
+		'0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
 	// keccak256('LSP14OwnershipTransferred_SenderNotification')
-	LSP14OwnershipTransferred_SenderNotification: '0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
+	LSP14OwnershipTransferred_SenderNotification:
+		'0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
 	// keccak256('LSP14OwnershipTransferred_RecipientNotification')
-	LSP14OwnershipTransferred_RecipientNotification: '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
+	LSP14OwnershipTransferred_RecipientNotification:
+		'0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
 };
-
-// ----------
 
 const Errors = {
 	LSP2: {
@@ -394,8 +399,6 @@ const Errors = {
 		},
 	},
 };
-
-// ----------
 
 const EventSignatures = {
 	ERC173: {

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -99,16 +99,17 @@ abstract contract LSP14Ownable2Step is OwnableUnset {
      */
     function _transferOwnership(address newOwner) internal virtual {
         if (newOwner == address(this)) revert CannotTransferOwnershipToSelf();
+        
         _pendingOwner = newOwner;
-
         address currentOwner = owner();
-        _notifyUniversalReceiver(newOwner, _TYPEID_LSP14_OwnershipTransferStarted, "");
+        emit OwnershipTransferStarted(currentOwner, newOwner);
+        
+        _notifyUniversalReceiver(newOwner, _TYPEID_LSP14_OwnershipTransferStarted, "");  
         require(
             currentOwner == owner(),
             "LSP14: newOwner MUST accept ownership in a separate transaction"
         );
 
-        emit OwnershipTransferStarted(currentOwner, newOwner);
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -140,9 +140,11 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
       */
      function _executePayload(bytes calldata payload) internal returns (bytes memory) {
 
-         // solhint-disable avoid-low-level-calls
-         (bool success, bytes memory returnData) = target.call{value: msg.value, gas: gasleft()}(
-             payload
+        emit Executed(msg.value, bytes4(payload));
+
+        // solhint-disable avoid-low-level-calls
+        (bool success, bytes memory returnData) = target.call{value: msg.value, gas: gasleft()}(
+            payload
         );
         bytes memory result = Address.verifyCallResult(
             success,
@@ -150,8 +152,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             "LSP6: Unknown Error occured when calling the linked target contract"
         );
 
-         emit Executed(msg.value, bytes4(payload));
-         return result.length != 0 ? abi.decode(result, (bytes)) : result;
+        return result.length != 0 ? abi.decode(result, (bytes)) : result;
 
      }
 

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -68,28 +68,13 @@ export const shouldBehaveLikePermissionDeploy = (
         .connect(context.owner)
         .callStatic.execute(payload);
 
-      let tx = await context.keyManager.connect(context.owner).execute(payload);
-      let receipt = await tx.wait();
-
-      // should be the ContractCreated event (= event signature)
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.ERC725X["ContractCreated"]
-      );
-
-      // operation type
-      expect(receipt.logs[0].topics[1]).to.equal(
-        ethers.utils.hexZeroPad(OPERATION_TYPES.CREATE, 32)
-      );
-
-      // address of contract created
-      expect(receipt.logs[0].topics[2]).to.equal(
-        ethers.utils.hexZeroPad(expectedContractAddress, 32)
-      );
-
-      // value
-      expect(receipt.logs[0].topics[3]).to.equal(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32)
-      );
+      await expect(context.keyManager.connect(context.owner).execute(payload))
+        .to.emit(context.universalProfile, "ContractCreated")
+        .withArgs(
+          OPERATION_TYPES.CREATE,
+          ethers.utils.getAddress(expectedContractAddress),
+          0
+        );
     });
 
     it("should be allowed to deploy a contract TargetContract via CREATE2", async () => {
@@ -113,22 +98,13 @@ export const shouldBehaveLikePermissionDeploy = (
         contractBytecodeToDeploy
       ).toLowerCase();
 
-      let tx = await context.keyManager.connect(context.owner).execute(payload);
-
-      let receipt = await tx.wait();
-
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.ERC725X["ContractCreated"]
-      );
-      expect(receipt.logs[0].topics[1]).to.equal(
-        ethers.utils.hexZeroPad(OPERATION_TYPES.CREATE2, 32)
-      );
-      expect(receipt.logs[0].topics[2]).to.equal(
-        ethers.utils.hexZeroPad(preComputedAddress, 32)
-      );
-      expect(receipt.logs[0].topics[3]).to.equal(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32)
-      );
+      await expect(context.keyManager.connect(context.owner).execute(payload))
+        .to.emit(context.universalProfile, "ContractCreated")
+        .withArgs(
+          OPERATION_TYPES.CREATE2,
+          ethers.utils.getAddress(preComputedAddress),
+          0
+        );
     });
   });
 
@@ -150,21 +126,13 @@ export const shouldBehaveLikePermissionDeploy = (
         .connect(addressCanDeploy)
         .callStatic.execute(payload);
 
-      let tx = await context.keyManager.connect(context.owner).execute(payload);
-      let receipt = await tx.wait();
-
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.ERC725X["ContractCreated"]
-      );
-      expect(receipt.logs[0].topics[1]).to.equal(
-        ethers.utils.hexZeroPad(OPERATION_TYPES.CREATE, 32)
-      );
-      expect(receipt.logs[0].topics[2]).to.equal(
-        ethers.utils.hexZeroPad(expectedContractAddress, 32)
-      );
-      expect(receipt.logs[0].topics[3]).to.equal(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32)
-      );
+      await expect(context.keyManager.connect(context.owner).execute(payload))
+        .to.emit(context.universalProfile, "ContractCreated")
+        .withArgs(
+          OPERATION_TYPES.CREATE,
+          ethers.utils.getAddress(expectedContractAddress),
+          0
+        );
     });
 
     it("should be allowed to deploy a contract TargetContract via CREATE2", async () => {
@@ -188,24 +156,15 @@ export const shouldBehaveLikePermissionDeploy = (
         contractBytecodeToDeploy
       ).toLowerCase();
 
-      let tx = await context.keyManager
-        .connect(addressCanDeploy)
-        .execute(payload);
-
-      let receipt = await tx.wait();
-
-      expect(receipt.logs[0].topics[0]).to.equal(
-        EventSignatures.ERC725X["ContractCreated"]
-      );
-      expect(receipt.logs[0].topics[1]).to.equal(
-        ethers.utils.hexZeroPad(OPERATION_TYPES.CREATE2, 32)
-      );
-      expect(receipt.logs[0].topics[2]).to.equal(
-        ethers.utils.hexZeroPad(preComputedAddress, 32)
-      );
-      expect(receipt.logs[0].topics[3]).to.equal(
-        ethers.utils.hexZeroPad(ethers.utils.hexlify(0), 32)
-      );
+      await expect(
+        context.keyManager.connect(addressCanDeploy).execute(payload)
+      )
+        .to.emit(context.universalProfile, "ContractCreated")
+        .withArgs(
+          OPERATION_TYPES.CREATE2,
+          ethers.utils.getAddress(preComputedAddress),
+          0
+        );
     });
   });
 


### PR DESCRIPTION
# What does this PR introduce?

## Overview

In the LSP14Ownable2Step, the function `transferOwnership(...)` performs 3 steps that are similar to the check-effect-interaction pattern.

1. **check** -> validate the required inputs provided as arguments (the `newOwner` is not the address of the contract itself).
2. **effect** -> perform write operations on the contract and blockchain state.
        2.a) set up the  `pendingOwner` as the `newOwner`.
        2.b) emit an event `OwnershipTransferStarted` which write to the blockchain logs.
3. **interactions** -> if the pending owner is a contract that implements the LSP1, notify the pending owner through an **external call** to its `universalReceiver(...)` function.

Written in this order, the steps appear to follow clearly the check-effect-interaction pattern in the right order. However, in the current implementation, **the event `OwnershipTransferStarted` occurs only AFTER the external call happens** ❗ 

> see: https://github.com/lukso-network/lsp-smart-contracts/blob/eb9919fb82414657b721cfb6e70f06659366af52/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L100-L112

The same issue occurs on the `LSP6KeyManagerCore` contract. The `Executed` event gets emitted after the external call. If a re-entrant call occurs on the `execute(...)` / `executeRelayCall(...)` functions _(e.g: the LSP1Delegate contract)_, the 2 x `Executed` events will appear in the logs in the wrong order. The 2nd `Executed` event (from the re-entrant call) will be emitted and appear first.

## Potential issue

### Events emitted out of order

The check-effect-interaction pattern often applies to contract state, meaning the 2nd step **effect** often refers to **making necessary updates to the contract state**. 

Events are often not considered as an "effect". However, events are state changing operation. They do not change the state of the contract directly, but they do change the state of the blockchain by writing in the receipt logs.

If any event is emitted in the contract being called, this will lead to an incorrect order of emitted events. 

This might be a low severity issue, but it can lead to undefined behaviour in certain Dapps that listen for events and want to react and interact with the contracts depending on the order of the emitted events.

### Running out of gas

If the external call consumes most of the remaining gas left, if the call the succeed but there is not enough gas left after the external to emit the event, this will lead the tx to fail and revert, although the external call was successful.

## References

This issue was reported in the Liquidity audit report from Trail Of Bits. See page 23.

> https://github.com/trailofbits/publications/blob/master/reviews/Liquity.pdf

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/31145285/194851127-a37cd9aa-4274-4bfd-87ba-0da89db33246.png">


