### PR TITLE
docs: update smart contracts natspec

### DIFF
--- a/contracts/LSP10ReceivedVaults/LSP10Utils.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Utils.sol
@@ -178,6 +178,9 @@ library LSP10Utils {
         }
     }
 
+    /**
+     * @dev returns the index from a maping
+     */
     function extractIndexFromMap(bytes memory mapValue) internal pure returns (uint64) {
         bytes memory val = BytesLib.slice(mapValue, 4, 8);
         return BytesLib.toUint64(val, 0);

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -181,6 +181,9 @@ library LSP5Utils {
         }
     }
 
+    /**
+     * @dev returns the index from a maping
+     */
     function extractIndexFromMap(bytes memory mapValue) internal pure returns (uint64) {
         bytes memory val = BytesLib.slice(mapValue, 4, 8);
         return BytesLib.toUint64(val, 0);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -693,15 +693,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes32 permissionRequired
     ) internal pure {
         if (!addressPermissions.hasPermission(permissionRequired)) {
-            string memory permissionErrorString = _getPermissionErrorString(permissionRequired);
+            string memory permissionErrorString = _getPermissionName(permissionRequired);
             revert NotAuthorised(from, permissionErrorString);
         }
     }
 
     /**
-     * @dev returns the `errorName` depending on the `permission` given
+     * @dev returns the name of the permission as a string
      */
-    function _getPermissionErrorString(bytes32 permission)
+    function _getPermissionName(bytes32 permission)
         internal
         pure
         returns (string memory errorMessage)

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -248,12 +248,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `_from` has the required permissions to set some keys
+     * @dev verify if `_from` has the required permissions to set some dataKeys
      * on the linked ERC725Account
-     * @param from the address who want to set the keys
+     * @param from the address who want to set the dataKeys
      * @param permissions the permissions
-     * @param inputKeys the data keys being set
-     * containing a list of keys-value pairs
+     * @param inputKeys the dataKeys being set
+     * containing a list of key-value pairs
      */
     function _verifyCanSetData(
         address from,
@@ -269,35 +269,34 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `_from` has the required permissions to set some
-     * permissions on the linked ERC725Account
-     * @param key the key whose value will be updated
-     * @param value the updated value for the key
-     * @param from the address who want to set the keys
-     * @param permissions the permissions
+     * @dev verify if `_from` is authorised to set some permissions for an address on the linked ERC725Account
+     * @param dataKey the dataKey whose dataValue will be updated
+     * @param dataValue the updated dataValue for the dataKey
+     * @param from the address who want to set the dataKeys
+     * @param permissions the permissions of 'from' for checking if authorised to set permissions related dataKeys.
      */
     function _verifyCanSetPermissions(
-        bytes32 key,
-        bytes memory value,
+        bytes32 dataKey,
+        bytes memory dataValue,
         address from,
         bytes32 permissions
     ) internal view virtual {
         // prettier-ignore
-        if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX) {
+        if (bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX) {
 
-            // key = AddressPermissions:Permissions:<address>
-            _verifyCanSetBytes32Permissions(key, from, permissions);
+            // dataKey = AddressPermissions:Permissions:<address>
+            _verifyCanSetBytes32Permissions(dataKey, from, permissions);
 
-        } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX) {
+        } else if (bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDADDRESSES_PREFIX) {
 
-            bool isClearingArray = value.length == 0;
+            bool isClearingArray = dataValue.length == 0;
 
             // AddressPermissions:AllowedAddresses:<address>
-            if (!isClearingArray && !LSP2Utils.isEncodedArrayOfAddresses(value)) {
-                revert InvalidABIEncodedArray(value, "address");
+            if (!isClearingArray && !LSP2Utils.isEncodedArrayOfAddresses(dataValue)) {
+                revert InvalidABIEncodedArray(dataValue, "address");
             }
 
-            bytes memory storedAllowedAddresses = ERC725Y(target).getData(key);
+            bytes memory storedAllowedAddresses = ERC725Y(target).getData(dataKey);
 
             if (storedAllowedAddresses.length == 0) {
 
@@ -310,18 +309,18 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
 
         } else if (
-            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX ||
-            bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX
+            bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX ||
+            bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX
         ) {
-            bool isClearingArray = value.length == 0;
+            bool isClearingArray = dataValue.length == 0;
 
             // AddressPermissions:AllowedFunctions:<address>
             // AddressPermissions:AllowedStandards:<address>
-            if (!isClearingArray && !LSP2Utils.isBytes4EncodedArray(value)) {
-                revert InvalidABIEncodedArray(value, "bytes4");
+            if (!isClearingArray && !LSP2Utils.isBytes4EncodedArray(dataValue)) {
+                revert InvalidABIEncodedArray(dataValue, "bytes4");
             }
 
-            bytes memory storedAllowedBytes4 = ERC725Y(target).getData(key);
+            bytes memory storedAllowedBytes4 = ERC725Y(target).getData(dataKey);
 
             if (storedAllowedBytes4.length == 0) {
 
@@ -333,16 +332,16 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             }
 
-        } else if (bytes12(key) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX) {
+        } else if (bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX) {
 
-            bool isClearingArray = value.length == 0;
+            bool isClearingArray = dataValue.length == 0;
 
             // AddressPermissions:AllowedERC725YKeys:<address>
-            if (!isClearingArray && !LSP2Utils.isEncodedArray(value)) {
-                revert InvalidABIEncodedArray(value, "bytes32");
+            if (!isClearingArray && !LSP2Utils.isEncodedArray(dataValue)) {
+                revert InvalidABIEncodedArray(dataValue, "bytes32");
             }
 
-            bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(key);
+            bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(dataKey);
 
             if (storedAllowedERC725YKeys.length == 0) {
 
@@ -355,43 +354,43 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
         } else {
             /**
-             * if bytes6(key) != bytes6(keccak256("AddressPermissions"))
-             * this is not a standard permission key according to LSP6
+             * if bytes6(dataKey) != bytes6(keccak256("AddressPermissions"))
+             * this is not a standard permission dataKey according to LSP6
              * so we revert execution
              * 
-             * @dev to implement custom permissions keys, consider overriding 
+             * @dev to implement custom permissions dataKeys, consider overriding 
              * this function and implement specific checks
              * 
              *      // AddressPermissions:MyCustomPermissions:<address>
              *      bytes12 CUSTOM_PERMISSION_PREFIX = 0x4b80742de2bf9e659ba40000
              *
-             *      if (bytes12(key) == CUSTOM_PERMISSION_PREFIX) {
+             *      if (bytes12(dataKey) == CUSTOM_PERMISSION_PREFIX) {
              *          // custom logic
              *      }
              *      super._verifyCanSetPermissions(...)
              */
-            revert NotRecognisedPermissionKey(key);
+            revert NotRecognisedPermissionKey(dataKey);
         }
     }
 
     /**
      * @dev verify if `_from` has the required permissions to either
      * add or change permissions of another address
-     * @param key the key whose value will be updated
-     * @param from the address who want to set the keys
+     * @param dataKey the dataKey whose value will be updated
+     * @param from the address who want to set the dataKeys
      * @param callerPermissions the caller's permission's BitArray
      */
     function _verifyCanSetBytes32Permissions(
-        bytes32 key,
+        bytes32 dataKey,
         address from,
         bytes32 callerPermissions
     ) internal view {
-        if (bytes32(ERC725Y(target).getData(key)) == bytes32(0)) {
-            // if there is nothing stored under this data key,
+        if (bytes32(ERC725Y(target).getData(dataKey)) == bytes32(0)) {
+            // if there is nothing stored under this data dataKey,
             // we are trying to ADD permissions for a NEW address
             _requirePermissions(from, callerPermissions, _PERMISSION_ADDPERMISSIONS);
         } else {
-            // if there are already some permissions stored under this data key,
+            // if there are already some permissions stored under this data dataKey,
             // we are trying to CHANGE the permissions of an address
             // (that has already some EXISTING permissions set)
             _requirePermissions(from, callerPermissions, _PERMISSION_CHANGEPERMISSIONS);
@@ -401,21 +400,21 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @dev verify if `_from` has the required permissions to update the
      * permissions array
-     * @param key the key whose value will be updated
-     * @param value the updated value for the key
-     * @param from the address who want to set the keys
+     * @param dataKey the dataKey whose dataValue will be updated
+     * @param dataValue the updated dataValue for the dataKey
+     * @param from the address who want to set the dataKeys
      * @param permissions the permissions
      */
     function _verifyCanSetPermissionsArray(
-        bytes32 key,
-        bytes memory value,
+        bytes32 dataKey,
+        bytes memory dataValue,
         address from,
         bytes32 permissions
     ) internal view {
-        // key = AddressPermissions[] -> array length
-        if (key == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY) {
-            uint256 arrayLength = uint256(bytes32(ERC725Y(target).getData(key)));
-            uint256 newLength = uint256(bytes32(value));
+        // dataKey = AddressPermissions[] -> array length
+        if (dataKey == _LSP6KEY_ADDRESSPERMISSIONS_ARRAY) {
+            uint256 arrayLength = uint256(bytes32(ERC725Y(target).getData(dataKey)));
+            uint256 newLength = uint256(bytes32(dataValue));
 
             if (newLength > arrayLength) {
                 _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
@@ -426,8 +425,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             return;
         }
         
-        // key = AddressPermissions[index] -> array index
-        bytes memory valueAtIndex = ERC725Y(target).getData(key);
+        // dataKey = AddressPermissions[index] -> array index
+        bytes memory valueAtIndex = ERC725Y(target).getData(dataKey);
 
         if (valueAtIndex.length == 0) {
             _requirePermissions(from, permissions, _PERMISSION_ADDPERMISSIONS);
@@ -435,15 +434,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             _requirePermissions(from, permissions, _PERMISSION_CHANGEPERMISSIONS);
         }
         
-        if (value.length != 20) {
-            revert AddressPermissionArrayIndexValueNotAnAddress(key, value);
+        if (dataValue.length != 20) {
+            revert AddressPermissionArrayIndexValueNotAnAddress(dataKey, dataValue);
         }
     }
 
     /**
      * @dev verify if `from` is allowed to change the `inputKey`
-     * @param from the address who want to set the keys
-     * @param inputKeys the key that is verified
+     * @param from the address who want to set the dataKeys
+     * @param inputKeys the dataKey that is verified
      */
     function _verifyAllowedERC725YKeys(address from, bytes32[] memory inputKeys) internal view {
         bytes memory allowedERC725YKeysEncoded = ERC725Y(target).getAllowedERC725YKeysFor(from);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -669,7 +669,15 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev returns the index of the last non-empty byte, meaning != `0x00`
+     * @dev iterates over the zero-bytes of the `dataKey` starting from the end.
+     * 
+     *         stop the iteration here ─┐     start the iteration here ─┐
+     *                                  ↓                               ↓
+     * 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
+     *                                  ↑
+     *           return the index here ─┘
+     * 
+     * @return index of the last non-empty byte
      */
     function _countTrailingZeroBytes(bytes32 dataKey) internal pure returns (uint256) {
         uint256 nByte = 32;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -669,15 +669,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev iterates over the zero-bytes of the `dataKey` starting from the end.
-     * 
-     *         stop the iteration here ─┐     start the iteration here ─┐
-     *                                  ↓                               ↓
-     * 0xffffffffffffffffffffffffffffffff00000000000000000000000000000000
-     *                                  ↑
-     *           return the index here ─┘
-     * 
-     * @return index of the last non-empty byte
+     * @dev return the number of zero bytes (0x00) appended at the end of `dataKey`.
+     * e.g: for `dataKey` = 0xffffffffffffffff000000000000000000000000000000000000000000000000
+     *      the function will return 24
+     * @return the number of trailing zero bytes
      */
     function _countTrailingZeroBytes(bytes32 dataKey) internal pure returns (uint256) {
         uint256 nByte = 32;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -268,6 +268,14 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         _verifyAllowedERC725YKeys(from, inputKeys);
     }
 
+    /**
+     * @dev verify if `_from` has the required permissions to set some
+     * permissions on the linked ERC725Account
+     * @param key the key whose value will be updated
+     * @param value the updated value for the key
+     * @param from the address who want to set the keys
+     * @param permissions the permissions
+     */
     function _verifyCanSetPermissions(
         bytes32 key,
         bytes memory value,
@@ -366,6 +374,13 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         }
     }
 
+    /**
+     * @dev verify if `_from` has the required permissions to either
+     * add or change permissions of another address
+     * @param key the key whose value will be updated
+     * @param from the address who want to set the keys
+     * @param callerPermissions the caller's permission's BitArray
+     */
     function _verifyCanSetBytes32Permissions(
         bytes32 key,
         address from,
@@ -383,6 +398,14 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         }
     }
 
+    /**
+     * @dev verify if `_from` has the required permissions to update the
+     * permissions array
+     * @param key the key whose value will be updated
+     * @param value the updated value for the key
+     * @param from the address who want to set the keys
+     * @param permissions the permissions
+     */
     function _verifyCanSetPermissionsArray(
         bytes32 key,
         bytes memory value,
@@ -417,6 +440,11 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         }
     }
 
+    /**
+     * @dev verify if `from` is allowed to change the `inputKey`
+     * @param from the address who want to set the keys
+     * @param inputKeys the key that is verified
+     */
     function _verifyAllowedERC725YKeys(address from, bytes32[] memory inputKeys) internal view {
         bytes memory allowedERC725YKeysEncoded = ERC725Y(target).getAllowedERC725YKeysFor(from);
 
@@ -553,6 +581,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         else if (operationType == OPERATION_DELEGATECALL) return _PERMISSION_DELEGATECALL;
     }
 
+    /**
+     * @dev returns the `superPermission` needed for a specific `operationType` of the `execute(..)`
+     */
     function _extractSuperPermissionFromOperation(uint256 operationType)
         internal
         pure
@@ -638,6 +669,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         revert NotAllowedFunction(from, functionSelector);
     }
 
+    /**
+     * @dev returns the index of the last non-empty byte, meaning != `0x00`
+     */
     function _countTrailingZeroBytes(bytes32 dataKey) internal pure returns (uint256) {
         uint256 nByte = 32;
 
@@ -648,6 +682,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         return 32 - nByte;
     }
 
+    /**
+     * @dev revert if `from`'s `addressPermissions` doesn't contain `permissionsRequired`
+     * @param from the caller address
+     * @param addressPermissions the caller's permissions BitArray
+     * @param permissionRequired the required permission
+     */
     function _requirePermissions(
         address from,
         bytes32 addressPermissions,
@@ -659,6 +699,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         }
     }
 
+    /**
+     * @dev returns the `errorName` depending on the `permission` given
+     */
     function _getPermissionErrorString(bytes32 permission)
         internal
         pure

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -249,7 +249,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
     /**
      * @dev verify if `_from` has the required permissions to set some dataKeys
-     * on the linked ERC725Account
+     * on the linked target
      * @param from the address who want to set the dataKeys
      * @param permissions the permissions
      * @param inputKeys the dataKeys being set
@@ -269,7 +269,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `_from` is authorised to set some permissions for an address on the linked ERC725Account
+     * @dev verify if `_from` is authorised to set some permissions for an address on the linked target
      * @param dataKey the dataKey whose dataValue will be updated
      * @param dataValue the updated dataValue for the dataKey
      * @param from the address who want to set the dataKeys
@@ -497,7 +497,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
     /**
      * @dev verify if `from` has the required permissions to make an external call
-     * via the linked ERC725Account
+     * via the linked target
      * @param from the address who want to run the execute function on the ERC725Account
      * @param permissions the permissions of the caller
      * @param payload the ABI encoded payload `target.execute(...)`
@@ -594,7 +594,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `from` is authorised to interact with address `to` via the linked ERC725Account
+     * @dev verify if `from` is authorised to interact with address `to` via the linked target
      * @param from the caller address
      * @param to the address to interact with
      */
@@ -643,7 +643,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `from` is authorised to use the linked ERC725Account
+     * @dev verify if `from` is authorised to use the linked target
      * to run a specific function `functionSelector` at a target contract
      * @param from the caller address
      * @param functionSelector the bytes4 function selector of the function to run

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -16,9 +16,10 @@ library LSP6Utils {
     using LSP2Utils for bytes12;
 
     /**
-     * @dev returns the permissions of the `caller` for the ERC725Y `target`
-     * @param target a valid `IERC725Y` interface
-     * @param caller the controller address
+     * @dev read the permissions of a `caller` on an ERC725Y `target` contract.
+     * @param target an `IERC725Y` contract where to read the permissions.
+     * @param caller the controller address to read the permissions from.
+     * @return a `bytes32` BitArray containing the permissions of a controller address.
      */
     function getPermissionsFor(IERC725Y target, address caller) internal view returns (bytes32) {
         bytes memory permissions = target.getData(
@@ -32,9 +33,10 @@ library LSP6Utils {
     }
 
     /**
-     * @dev returns the allowed addresses of the `caller` for the ERC725Y `target`
-     * @param target a valid `IERC725Y` interface
-     * @param caller the controller address
+     * @dev read the allowed addresses of a `caller` on an ERC725Y `target` contract.
+     * @param target an `IERC725Y` contract where to read the permissions.
+     * @param caller the controller address to read the permissions from.
+     * @return an encoded `bytes` value which contains an array of allowed addresses (to interact with) for the controller address.
      */
     function getAllowedAddressesFor(IERC725Y target, address caller)
         internal
@@ -51,9 +53,10 @@ library LSP6Utils {
     }
 
     /**
-     * @dev returns the allowed functions of the `caller` for the ERC725Y `target`
-     * @param target a valid `IERC725Y` interface
-     * @param caller the controller address
+     * @dev read the allowed functions of a `caller` on an ERC725Y `target` contract.
+     * @param target an `IERC725Y` contract where to read the permissions.
+     * @param caller the controller address to read the permissions from.
+     * @return an encoded `bytes` value which contains an array of allowed function signatures (to interact with) for the controller address.
      */
     function getAllowedFunctionsFor(IERC725Y target, address caller)
         internal
@@ -70,9 +73,10 @@ library LSP6Utils {
     }
 
     /**
-     * @dev returns the allowed standards of the `caller` for the ERC725Y `target`
-     * @param target a valid `IERC725Y` interface
-     * @param caller the controller address
+     * @dev read the allowed standards of a `caller` on an ERC725Y `target` contract.
+     * @param target an `IERC725Y` contract where to read the permissions.
+     * @param caller the controller address to read the permissions from.
+     * @return an encoded `bytes` value which contains an array of allowed standards/interfaceIds (to interact with) for the controller address.
      */
     function getAllowedStandardsFor(IERC725Y target, address caller)
         internal
@@ -89,9 +93,10 @@ library LSP6Utils {
     }
 
     /**
-     * @dev returns the allowed ERC725Y keys of the `caller` for the ERC725Y `target`
-     * @param target a valid `IERC725Y` interface
-     * @param caller the controller address
+     * @dev read the allowed ERC725Y keys of a `caller` on an ERC725Y `target` contract.
+     * @param target an `IERC725Y` contract where to read the permissions.
+     * @param caller the controller address to read the permissions from.
+     * @return an encoded `bytes` value which contains an array of allowed ERC725 keys (to interact with) for the controller address.
      */
     function getAllowedERC725YKeysFor(IERC725Y target, address caller)
         internal

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -36,7 +36,7 @@ library LSP6Utils {
      * @dev read the allowed addresses of a `caller` on an ERC725Y `target` contract.
      * @param target an `IERC725Y` contract where to read the permissions.
      * @param caller the controller address to read the permissions from.
-     * @return an encoded `bytes` value which contains an array of allowed addresses (to interact with) for the controller address.
+     * @return an abi-encoded array of addresses that the controller address is allowed to interact with.
      */
     function getAllowedAddressesFor(IERC725Y target, address caller)
         internal
@@ -56,7 +56,7 @@ library LSP6Utils {
      * @dev read the allowed functions of a `caller` on an ERC725Y `target` contract.
      * @param target an `IERC725Y` contract where to read the permissions.
      * @param caller the controller address to read the permissions from.
-     * @return an encoded `bytes` value which contains an array of allowed function signatures (to interact with) for the controller address.
+     * @return an abi-encoded array of functions selectors that the controller address is allowed to interact with.
      */
     function getAllowedFunctionsFor(IERC725Y target, address caller)
         internal
@@ -76,7 +76,7 @@ library LSP6Utils {
      * @dev read the allowed standards of a `caller` on an ERC725Y `target` contract.
      * @param target an `IERC725Y` contract where to read the permissions.
      * @param caller the controller address to read the permissions from.
-     * @return an encoded `bytes` value which contains an array of allowed standards/interfaceIds (to interact with) for the controller address.
+     * @return an abi-encoded array of allowed interface ids that the controller address is allowed to interact with.
      */
     function getAllowedStandardsFor(IERC725Y target, address caller)
         internal
@@ -96,7 +96,7 @@ library LSP6Utils {
      * @dev read the allowed ERC725Y keys of a `caller` on an ERC725Y `target` contract.
      * @param target an `IERC725Y` contract where to read the permissions.
      * @param caller the controller address to read the permissions from.
-     * @return an encoded `bytes` value which contains an array of allowed ERC725 keys (to interact with) for the controller address.
+     * @return an abi-encoded array of allowed ERC725 keys that the controller address is allowed to interact with.
      */
     function getAllowedERC725YKeysFor(IERC725Y target, address caller)
         internal

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -15,6 +15,11 @@ import "../LSP6KeyManager/LSP6Constants.sol";
 library LSP6Utils {
     using LSP2Utils for bytes12;
 
+    /**
+     * @dev returns the permissions of the `caller` for the ERC725Y `target`
+     * @param target a valid `IERC725Y` interface
+     * @param caller the controller address
+     */
     function getPermissionsFor(IERC725Y target, address caller) internal view returns (bytes32) {
         bytes memory permissions = target.getData(
             LSP2Utils.generateMappingWithGroupingKey(
@@ -26,6 +31,11 @@ library LSP6Utils {
         return bytes32(permissions);
     }
 
+    /**
+     * @dev returns the allowed addresses of the `caller` for the ERC725Y `target`
+     * @param target a valid `IERC725Y` interface
+     * @param caller the controller address
+     */
     function getAllowedAddressesFor(IERC725Y target, address caller)
         internal
         view
@@ -40,6 +50,11 @@ library LSP6Utils {
             );
     }
 
+    /**
+     * @dev returns the allowed functions of the `caller` for the ERC725Y `target`
+     * @param target a valid `IERC725Y` interface
+     * @param caller the controller address
+     */
     function getAllowedFunctionsFor(IERC725Y target, address caller)
         internal
         view
@@ -54,6 +69,11 @@ library LSP6Utils {
             );
     }
 
+    /**
+     * @dev returns the allowed standards of the `caller` for the ERC725Y `target`
+     * @param target a valid `IERC725Y` interface
+     * @param caller the controller address
+     */
     function getAllowedStandardsFor(IERC725Y target, address caller)
         internal
         view
@@ -68,6 +88,11 @@ library LSP6Utils {
             );
     }
 
+    /**
+     * @dev returns the allowed ERC725Y keys of the `caller` for the ERC725Y `target`
+     * @param target a valid `IERC725Y` interface
+     * @param caller the controller address
+     */
     function getAllowedERC725YKeysFor(IERC725Y target, address caller)
         internal
         view
@@ -97,6 +122,12 @@ library LSP6Utils {
         return (addressPermission & permissionToCheck) == permissionToCheck;
     }
 
+    /**
+     * @dev use the `setData(bytes32[],bytes[])` via the KeyManager of the target
+     * @param keyManagerAddress the address of the KeyManager
+     * @param keys the array of data keys
+     * @param values the array of data values
+     */
     function setDataViaKeyManager(
         address keyManagerAddress,
         bytes32[] memory keys,

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev reverts when sending an `amount` of tokens bigger than the current `balance` of the `tokenOwner`
+ * @dev reverts when sending an `amount` of tokens bigger than the current `balance` of the `tokenOwner`.
  */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
 /**
  * @dev reverts when one of the operators of `tokenOwner` tries to send
- * an `amount` of tokens which is bigger than the current `authorizedAmount`
+ * an `amount` of tokens which is bigger than the current `authorizedAmount`.
  */
 error LSP7AmountExceedsAuthorizedAmount(
     address tokenOwner,
@@ -20,48 +20,48 @@ error LSP7AmountExceedsAuthorizedAmount(
 );
 
 /**
- * @dev reverts when one tries to set the zero address as operator
+ * @dev reverts when one tries to set the zero address as operator.
  */
 error LSP7CannotUseAddressZeroAsOperator();
 
 /**
- * @dev reverts when one tries to mint 0 tokens
+ * @dev reverts when one tries to mint 0 tokens.
  */
 error LSP7MintAmountIsZero();
 
 /**
- * @dev reverts when one tries to burn 0 tokens
+ * @dev reverts when one tries to burn 0 tokens.
  */
 error LSP7BurnAmountIsZero();
 
 /**
- * @dev reverts when one tries to transfer 0 tokens
+ * @dev reverts when one tries to transfer 0 tokens.
  */
 error LSP7TransferAmountIsZero();
 
 /**
- * @dev reverts when one tries to send tokens to or from the zero address
+ * @dev reverts when one tries to send tokens to or from the zero address.
  */
 error LSP7CannotSendWithAddressZero();
 
 /**
- * @dev reverts when one tries to send tokens to itself
+ * @dev reverts when one tries to send tokens to itself.
  */
 error LSP7CannotSendToSelf();
 
 /**
- * @dev reverts when the parameters used for `transferBatch` have different lengths
+ * @dev reverts when the parameters used for `transferBatch` have different lengths.
  */
 error LSP7InvalidTransferBatch();
 
 /**
  * @dev reverts when the `tokenReceiver` is not implementing LSP1
- * this is the case only when `bool force` is set as `false`
+ * this is the case only when `bool force` is set as `false`.
  */
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
  * @dev reverts when the `tokenReceiver` is an EOA
- * this is the case only when `bool force` is set as `false`
+ * this is the case only when `bool force` is set as `false`.
  */
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -20,7 +20,7 @@ error LSP7AmountExceedsAuthorizedAmount(
 );
 
 /**
- * @dev reverts when one tries to set an operator the zero address
+ * @dev reverts when one tries to set the zero address as operator
  */
 error LSP7CannotUseAddressZeroAsOperator();
 

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev reverts when one tries to send an `amount` of tokens
- * which is bigger than the current `balance` of the `tokenOwner`
+ * @dev reverts when sending an `amount` of tokens bigger than the current `balance` of the `tokenOwner`
  */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
@@ -51,8 +50,7 @@ error LSP7CannotSendWithAddressZero();
 error LSP7CannotSendToSelf();
 
 /**
- * @dev reverts when the parameters used for `transferBatch` are not suitable
- * meaning that the arrays: `from`, `to`, `amount` and `data` have differnet lengths
+ * @dev reverts when the parameters used for `transferBatch` have different lengths
  */
 error LSP7InvalidTransferBatch();
 

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -3,8 +3,16 @@ pragma solidity ^0.8.0;
 
 // --- Errors
 
+/**
+ * @dev tx is reverted with this error if the `amount` of tokens which are to be transferred
+ * from `tokenOwner` is bigger than the current `balance` of the `tokenOwner`
+ */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
+/**
+ * @dev tx is reverted with this error if one of the operators of `tokenOwner` tries to send
+ * an `amount` of tokens which is bigger than the current `authorizedAmount`
+ */
 error LSP7AmountExceedsAuthorizedAmount(
     address tokenOwner,
     uint256 authorizedAmount,
@@ -12,20 +20,50 @@ error LSP7AmountExceedsAuthorizedAmount(
     uint256 amount
 );
 
+/**
+ * @dev tx is reverted with this error if one tries to set an operator the zero address
+ */
 error LSP7CannotUseAddressZeroAsOperator();
 
+/**
+ * @dev tx is reverted with this error if one tries to mint 0 tokens
+ */
 error LSP7MintAmountIsZero();
 
+/**
+ * @dev tx is reverted with this error if one tries to burn 0 tokens
+ */
 error LSP7BurnAmountIsZero();
 
+/**
+ * @dev tx is reverted with this error if one tries to transfer 0 tokens
+ */
 error LSP7TransferAmountIsZero();
 
+/**
+ * @dev tx is reverted with this error if one tries to send tokens to or from the zero address
+ */
 error LSP7CannotSendWithAddressZero();
 
+/**
+ * @dev tx is reverted with this error if one tries to send tokens to itself
+ */
 error LSP7CannotSendToSelf();
 
+/**
+ * @dev tx is reverted with this error if the parameters used for `transferBatch` are not adecvate
+ * meaning that the arrays: `from`, `to`, `amount` and `data` have differnet lengths
+ */
 error LSP7InvalidTransferBatch();
 
+/**
+ * @dev tx is reverted with this error if the `tokenReceiver` is not implementing LSP1
+ * this is the case only when `bool force` is set as `false`
+ */
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
+/**
+ * @dev tx is reverted with this error if the `tokenReceiver` is an EOA
+ * this is the case only when `bool force` is set as `false`
+ */
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev reverts when the `amount` of tokens which are to be transferred
- * from `tokenOwner` is bigger than the current `balance` of the `tokenOwner`
+ * @dev reverts when one tries to send an `amount` of tokens
+ * which is bigger than the current `balance` of the `tokenOwner`
  */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
@@ -51,7 +51,7 @@ error LSP7CannotSendWithAddressZero();
 error LSP7CannotSendToSelf();
 
 /**
- * @dev reverts when the parameters used for `transferBatch` are not adecvate
+ * @dev reverts when the parameters used for `transferBatch` are not suitable
  * meaning that the arrays: `from`, `to`, `amount` and `data` have differnet lengths
  */
 error LSP7InvalidTransferBatch();

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev reverts when sending an `amount` of tokens bigger than the current `balance` of the `tokenOwner`.
+ * @dev reverts when sending an `amount` of tokens larger than the current `balance` of the `tokenOwner`.
  */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
 /**
- * @dev reverts when one of the operators of `tokenOwner` tries to send
- * an `amount` of tokens which is bigger than the current `authorizedAmount`.
+ * @dev reverts when `operator` of `tokenOwner` send an `amount` of tokens
+ * larger than the `authorizedAmount`.
  */
 error LSP7AmountExceedsAuthorizedAmount(
     address tokenOwner,
@@ -20,7 +20,7 @@ error LSP7AmountExceedsAuthorizedAmount(
 );
 
 /**
- * @dev reverts when one tries to set the zero address as operator.
+ * @dev reverts when trying to set the zero address as an operator.
  */
 error LSP7CannotUseAddressZeroAsOperator();
 
@@ -45,7 +45,7 @@ error LSP7TransferAmountIsZero();
 error LSP7CannotSendWithAddressZero();
 
 /**
- * @dev reverts when one tries to send tokens to itself.
+ * @dev reverts when specifying the same address for `from` or `to` in a token transfer.
  */
 error LSP7CannotSendToSelf();
 
@@ -55,13 +55,13 @@ error LSP7CannotSendToSelf();
 error LSP7InvalidTransferBatch();
 
 /**
- * @dev reverts when the `tokenReceiver` is not implementing LSP1
- * this is the case only when `bool force` is set as `false`.
+ * @dev reverts if the `tokenReceiver` does not implement LSP1
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
- * @dev reverts when the `tokenReceiver` is an EOA
- * this is the case only when `bool force` is set as `false`.
+ * @dev reverts if the `tokenReceiver` is an EOA
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev tx is reverted with this error if the `amount` of tokens which are to be transferred
+ * @dev reverts when the `amount` of tokens which are to be transferred
  * from `tokenOwner` is bigger than the current `balance` of the `tokenOwner`
  */
 error LSP7AmountExceedsBalance(uint256 balance, address tokenOwner, uint256 amount);
 
 /**
- * @dev tx is reverted with this error if one of the operators of `tokenOwner` tries to send
+ * @dev reverts when one of the operators of `tokenOwner` tries to send
  * an `amount` of tokens which is bigger than the current `authorizedAmount`
  */
 error LSP7AmountExceedsAuthorizedAmount(
@@ -21,49 +21,49 @@ error LSP7AmountExceedsAuthorizedAmount(
 );
 
 /**
- * @dev tx is reverted with this error if one tries to set an operator the zero address
+ * @dev reverts when one tries to set an operator the zero address
  */
 error LSP7CannotUseAddressZeroAsOperator();
 
 /**
- * @dev tx is reverted with this error if one tries to mint 0 tokens
+ * @dev reverts when one tries to mint 0 tokens
  */
 error LSP7MintAmountIsZero();
 
 /**
- * @dev tx is reverted with this error if one tries to burn 0 tokens
+ * @dev reverts when one tries to burn 0 tokens
  */
 error LSP7BurnAmountIsZero();
 
 /**
- * @dev tx is reverted with this error if one tries to transfer 0 tokens
+ * @dev reverts when one tries to transfer 0 tokens
  */
 error LSP7TransferAmountIsZero();
 
 /**
- * @dev tx is reverted with this error if one tries to send tokens to or from the zero address
+ * @dev reverts when one tries to send tokens to or from the zero address
  */
 error LSP7CannotSendWithAddressZero();
 
 /**
- * @dev tx is reverted with this error if one tries to send tokens to itself
+ * @dev reverts when one tries to send tokens to itself
  */
 error LSP7CannotSendToSelf();
 
 /**
- * @dev tx is reverted with this error if the parameters used for `transferBatch` are not adecvate
+ * @dev reverts when the parameters used for `transferBatch` are not adecvate
  * meaning that the arrays: `from`, `to`, `amount` and `data` have differnet lengths
  */
 error LSP7InvalidTransferBatch();
 
 /**
- * @dev tx is reverted with this error if the `tokenReceiver` is not implementing LSP1
+ * @dev reverts when the `tokenReceiver` is not implementing LSP1
  * this is the case only when `bool force` is set as `false`
  */
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
- * @dev tx is reverted with this error if the `tokenReceiver` is an EOA
+ * @dev reverts when the `tokenReceiver` is an EOA
  * this is the case only when `bool force` is set as `false`
  */
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -4,63 +4,63 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev reverts when `tokenId` doesn't exist
+ * @dev reverts when `tokenId` has not been minted.
  */
 error LSP8NonExistentTokenId(bytes32 tokenId);
 
 /**
- * @dev reverts when `caller` != `tokenOwner` of the `tokenId`
+ * @dev reverts when `caller` != `tokenOwner` of the `tokenId`.
  */
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `caller` is not an operator for `tokenId`
+ * @dev reverts when `caller` is not an operator for `tokenId`.
  */
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `operator` is already an authorized to transfer the `tokenId`
+ * @dev reverts when `operator` is already authorized for the `tokenId`.
  */
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 
 /**
- * @dev reverts when one tries to set the zero address as operator
+ * @dev reverts when trying to set the zero address as an operator.
  */
 error LSP8CannotUseAddressZeroAsOperator();
 
 /**
- * @dev reverts when one tries to send token to zero address
+ * @dev reverts when one tries to send token to zero address.
  */
 error LSP8CannotSendToAddressZero();
 
 /**
- * @dev reverts when one tries to send token to itself
+ * @dev reverts when specifying the same address for `from` and `to` in a token transfer.
  */
 error LSP8CannotSendToSelf();
 
 /**
- * @dev reverts when `_address` is not a operator for the `tokenId`
+ * @dev reverts when `operator` is not an operator for the `tokenId`.
  */
-error LSP8NonExistingOperator(address _address, bytes32 tokenId);
+error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 
 /**
- * @dev reverts when `tokenId` is already minted
+ * @dev reverts when `tokenId` has already been minted.
  */
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 /**
- * @dev reverts when the parameters used for `transferBatch` have different lengths
+ * @dev reverts when the parameters used for `transferBatch` have different lengths.
  */
 error LSP8InvalidTransferBatch();
 
 /**
  * @dev reverts when the `tokenReceiver` is not implementing LSP1
- * this is the case only when `bool force` is set as `false`
+ * this is the case only when `bool force` is set as `false`.
  */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
  * @dev reverts when the `tokenReceiver` is an EOA
- * this is the case only when `bool force` is set as `false`
+ * this is the case only when `bool force` is set as `false`.
  */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -3,26 +3,65 @@ pragma solidity ^0.8.0;
 
 // --- Errors
 
+/**
+ * @dev tx is reverted with this error if `tokenId` doesn't exist
+ */
 error LSP8NonExistentTokenId(bytes32 tokenId);
 
+/**
+ * @dev tx is reverted with this error if `caller` != `tokenOwner` of the `tokenId`
+ */
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
+/**
+ * @dev tx is reverted with this error if `caller` is not an operator for `tokenId`
+ */
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
+/**
+ * @dev tx is reverted with this error if `operator` is already an authorized to trnafer the `tokenId`
+ */
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 
+/**
+ * @dev tx is reverted with this error if one tries to authorize the zero address as operator
+ */
 error LSP8CannotUseAddressZeroAsOperator();
 
+/**
+ * @dev tx is reverted with this error if one tries to send token to zero address
+ */
 error LSP8CannotSendToAddressZero();
 
+/**
+ * @dev tx is reverted with this error if one tries to send token to itself
+ */
 error LSP8CannotSendToSelf();
 
+/**
+ * @dev tx is reverted with this error if `_address` is not a operator for the `tokenId`
+ */
 error LSP8NonExistingOperator(address _address, bytes32 tokenId);
 
+/**
+ * @dev tx is reverted with this error if `tokenId` is already minted
+ */
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
+/**
+ * @dev tx is reverted with this error if the parameters used for `transferBatch` are not adecvate
+ * meaning that the arrays: `from`, `to`, `tokenId` and `data` have differnet lengths
+ */
 error LSP8InvalidTransferBatch();
 
+/**
+ * @dev tx is reverted with this error if the `tokenReceiver` is not implementing LSP1
+ * this is the case only when `bool force` is set as `false`
+ */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
+/**
+ * @dev tx is reverted with this error if the `tokenReceiver` is an EOA
+ * this is the case only when `bool force` is set as `false`
+ */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -9,12 +9,12 @@ pragma solidity ^0.8.0;
 error LSP8NonExistentTokenId(bytes32 tokenId);
 
 /**
- * @dev reverts when `caller` != `tokenOwner` of the `tokenId`.
+ * @dev reverts when `caller` is not the `tokenOwner` of the `tokenId`.
  */
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `caller` is not an operator for `tokenId`.
+ * @dev reverts when `caller` is not an allowed operator for `tokenId`.
  */
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
@@ -29,7 +29,7 @@ error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 error LSP8CannotUseAddressZeroAsOperator();
 
 /**
- * @dev reverts when one tries to send token to zero address.
+ * @dev reverts when trying to send token to the zero address.
  */
 error LSP8CannotSendToAddressZero();
 
@@ -54,13 +54,13 @@ error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 error LSP8InvalidTransferBatch();
 
 /**
- * @dev reverts when the `tokenReceiver` is not implementing LSP1
- * this is the case only when `bool force` is set as `false`.
+ * @dev reverts if the `tokenReceiver` does not implement LSP1
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
- * @dev reverts when the `tokenReceiver` is an EOA
- * this is the case only when `bool force` is set as `false`.
+ * @dev reverts if the `tokenReceiver` is an EOA
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -4,64 +4,64 @@ pragma solidity ^0.8.0;
 // --- Errors
 
 /**
- * @dev tx is reverted with this error if `tokenId` doesn't exist
+ * @dev reverts when `tokenId` doesn't exist
  */
 error LSP8NonExistentTokenId(bytes32 tokenId);
 
 /**
- * @dev tx is reverted with this error if `caller` != `tokenOwner` of the `tokenId`
+ * @dev reverts when `caller` != `tokenOwner` of the `tokenId`
  */
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
 /**
- * @dev tx is reverted with this error if `caller` is not an operator for `tokenId`
+ * @dev reverts when `caller` is not an operator for `tokenId`
  */
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
 /**
- * @dev tx is reverted with this error if `operator` is already an authorized to trnafer the `tokenId`
+ * @dev reverts when `operator` is already an authorized to trnafer the `tokenId`
  */
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 
 /**
- * @dev tx is reverted with this error if one tries to authorize the zero address as operator
+ * @dev reverts when one tries to authorize the zero address as operator
  */
 error LSP8CannotUseAddressZeroAsOperator();
 
 /**
- * @dev tx is reverted with this error if one tries to send token to zero address
+ * @dev reverts when one tries to send token to zero address
  */
 error LSP8CannotSendToAddressZero();
 
 /**
- * @dev tx is reverted with this error if one tries to send token to itself
+ * @dev reverts when one tries to send token to itself
  */
 error LSP8CannotSendToSelf();
 
 /**
- * @dev tx is reverted with this error if `_address` is not a operator for the `tokenId`
+ * @dev reverts when `_address` is not a operator for the `tokenId`
  */
 error LSP8NonExistingOperator(address _address, bytes32 tokenId);
 
 /**
- * @dev tx is reverted with this error if `tokenId` is already minted
+ * @dev reverts when `tokenId` is already minted
  */
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 /**
- * @dev tx is reverted with this error if the parameters used for `transferBatch` are not adecvate
+ * @dev reverts when the parameters used for `transferBatch` are not adecvate
  * meaning that the arrays: `from`, `to`, `tokenId` and `data` have differnet lengths
  */
 error LSP8InvalidTransferBatch();
 
 /**
- * @dev tx is reverted with this error if the `tokenReceiver` is not implementing LSP1
+ * @dev reverts when the `tokenReceiver` is not implementing LSP1
  * this is the case only when `bool force` is set as `false`
  */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(address tokenReceiver);
 
 /**
- * @dev tx is reverted with this error if the `tokenReceiver` is an EOA
+ * @dev reverts when the `tokenReceiver` is an EOA
  * this is the case only when `bool force` is set as `false`
  */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -19,7 +19,7 @@ error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `operator` is already an authorized to trnafer the `tokenId`
+ * @dev reverts when `operator` is already an authorized to transfer the `tokenId`
  */
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -24,7 +24,7 @@ error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 
 /**
- * @dev reverts when one tries to authorize the zero address as operator
+ * @dev reverts when one tries to set the zero address as operator
  */
 error LSP8CannotUseAddressZeroAsOperator();
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -49,7 +49,7 @@ error LSP8NonExistingOperator(address _address, bytes32 tokenId);
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 /**
- * @dev reverts when the parameters used for `transferBatch` are not adecvate
+ * @dev reverts when the parameters used for `transferBatch` are not suitable
  * meaning that the arrays: `from`, `to`, `tokenId` and `data` have differnet lengths
  */
 error LSP8InvalidTransferBatch();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -49,8 +49,7 @@ error LSP8NonExistingOperator(address _address, bytes32 tokenId);
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 /**
- * @dev reverts when the parameters used for `transferBatch` are not suitable
- * meaning that the arrays: `from`, `to`, `tokenId` and `data` have differnet lengths
+ * @dev reverts when the parameters used for `transferBatch` have different lengths
  */
 error LSP8InvalidTransferBatch();
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -137,12 +137,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function isOperatorFor(address operator, bytes32 tokenId)
-        public
-        view
-        virtual
-        returns (bool)
-    {
+    function isOperatorFor(address operator, bytes32 tokenId) public view virtual returns (bool) {
         _existsOrError(tokenId);
 
         return _isOperatorOrOwner(operator, tokenId);
@@ -151,17 +146,16 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function getOperatorsOf(bytes32 tokenId)
-        public
-        view
-        virtual
-        returns (address[] memory)
-    {
+    function getOperatorsOf(bytes32 tokenId) public view virtual returns (address[] memory) {
         _existsOrError(tokenId);
 
         return _operators[tokenId].values();
     }
 
+    /**
+     * @dev verifies if the `caller` is operator or owner for the `tokenId`
+     * @return true if `caller` is either operator or owner
+     */
     function _isOperatorOrOwner(address caller, bytes32 tokenId)
         internal
         view
@@ -215,6 +209,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         }
     }
 
+    /**
+     * @dev removes `operator` from the list of operatrs of the `tokenId`
+     */
     function _revokeOperator(
         address operator,
         address tokenOwner,
@@ -225,6 +222,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         emit RevokedOperator(operator, tokenOwner, tokenId);
     }
 
+    /**
+     * @dev clear all the operators of the `tokenId`
+     */
     function _clearOperators(address tokenOwner, bytes32 tokenId) internal virtual {
         // here is a good example of why having multiple operators will be expensive.. we
         // need to clear them on token transfer

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -210,7 +210,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     }
 
     /**
-     * @dev removes `operator` from the list of operators of the `tokenId`
+     * @dev removes `operator` from the list of operators for the `tokenId`
      */
     function _revokeOperator(
         address operator,
@@ -223,7 +223,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     }
 
     /**
-     * @dev clear all the operators of the `tokenId`
+     * @dev clear all the operators for the `tokenId`
      */
     function _clearOperators(address tokenOwner, bytes32 tokenId) internal virtual {
         // here is a good example of why having multiple operators will be expensive.. we

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -210,7 +210,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     }
 
     /**
-     * @dev removes `operator` from the list of operatrs of the `tokenId`
+     * @dev removes `operator` from the list of operators of the `tokenId`
      */
     function _revokeOperator(
         address operator,


### PR DESCRIPTION
## What does this PR introduce?

In this PR we add some natspec in the following contracts:

- LSP5Utils.sol
- LSP6KeyManagerCore.sol
- LSP6Utils.sol
- LSP7Errors.sol
- LSP8IdentifiableDigitalAssetCore.sol
- LSP8Errors.sol
- LSP10Utils.sol