### PR TITLE
fix: [WP-M4] avoid "returnbomb" in ERC165Checker

### DIFF
--- a/contracts/Custom/ERC165Checker.sol
+++ b/contracts/Custom/ERC165Checker.sol
@@ -123,8 +123,24 @@ library ERC165Checker {
             IERC165.supportsInterface.selector,
             interfaceId
         );
-        (bool success, bytes memory result) = account.staticcall{gas: 30000}(encodedParams);
-        if (result.length < 32) return false;
-        return success && abi.decode(result, (uint256)) > 0;
+
+        bool success;
+        uint256 returnSize;
+        uint256 returnValue;
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            success := staticcall(
+                30000,
+                account,
+                add(encodedParams, 0x20),
+                mload(encodedParams),
+                0x00,
+                0x20
+            )
+            returnSize := returndatasize()
+            returnValue := mload(0x00)
+        }
+        return success && returnSize >= 0x20 && returnValue > 0;
     }
 }


### PR DESCRIPTION
<img width="723" alt="Screenshot 2022-10-24 at 14 11 53" src="https://user-images.githubusercontent.com/64636974/197526665-64f6eb4c-bf41-4b5c-bc34-b850681c61c6.png">
