### PR TITLE
fix!: [WP-L12] - LSP-6: change parameter of `getNonce(address,uint256)` to a `uint128` -> `getNonce(address,uint128)`

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -20,7 +20,7 @@ const INTERFACE_IDS = {
 	LSP0ERC725Account: '0xdca05671',
 	LSP1UniversalReceiver: '0x6bb56a14',
 	LSP1UniversalReceiverDelegate: '0xa245bbda',
-	LSP6KeyManager: '0xc403d48f',
+	LSP6KeyManager: '0xf9150d55',
 	LSP7DigitalAsset: '0x5fcaac27',
 	LSP8IdentifiableDigitalAsset: '0x49399145',
 	LSP9Vault: '0xca86ec0f',
@@ -203,19 +203,26 @@ const PERMISSIONS = {
 
 const LSP1_TYPE_IDS = {
 	// keccak256('LSP7Tokens_SenderNotification')
-	LSP7Tokens_SenderNotification: '0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
+	LSP7Tokens_SenderNotification:
+		'0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
 	// keccak256('LSP7Tokens_RecipientNotification')
-	LSP7Tokens_RecipientNotification: '0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
+	LSP7Tokens_RecipientNotification:
+		'0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
 	// keccak256('LSP8Tokens_SenderNotification')
-	LSP8Tokens_SenderNotification: '0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
+	LSP8Tokens_SenderNotification:
+		'0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
 	// keccak256('LSP8Tokens_RecipientNotification')
-	LSP8Tokens_RecipientNotification: '0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
+	LSP8Tokens_RecipientNotification:
+		'0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
 	// keccak256('LSP14OwnershipTransferStarted')
-	LSP14OwnershipTransferStarted: '0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
+	LSP14OwnershipTransferStarted:
+		'0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
 	// keccak256('LSP14OwnershipTransferred_SenderNotification')
-	LSP14OwnershipTransferred_SenderNotification: '0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
+	LSP14OwnershipTransferred_SenderNotification:
+		'0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
 	// keccak256('LSP14OwnershipTransferred_RecipientNotification')
-	LSP14OwnershipTransferred_RecipientNotification: '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
+	LSP14OwnershipTransferred_RecipientNotification:
+		'0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
 };
 
 // ----------

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -25,12 +25,12 @@ interface ILSP6KeyManager is
     function target() external view returns (address);
 
     /**
-     * @notice get latest nonce for `from` for channel ID: `channelId`
+     * @notice get latest nonce for `from` in channel ID: `channelId`
      * @dev use channel ID = 0 for sequential nonces, any other number for out-of-order execution (= execution in parallel)
-     * @param from caller address
-     * @param channelId channel id
+     * @param from the caller or signer address
+     * @param channelId the channel id to retrieve the nonce from
      */
-    function getNonce(address from, uint256 channelId) external view returns (uint256);
+    function getNonce(address from, uint128 channelId) external view returns (uint256);
 
     /**
      * @notice execute the following payload on the ERC725Account: `payload`

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = 0xc403d48f;
+bytes4 constant _INTERFACEID_LSP6 = 0xf9150d55;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -72,9 +72,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function getNonce(address from, uint256 channelId) public view returns (uint256) {
-        uint128 nonceId = uint128(_nonceStore[from][channelId]);
-        return (uint256(channelId) << 128) | nonceId;
+    function getNonce(address from, uint128 channelId) public view returns (uint256) {
+        uint256 nonceInChannel = _nonceStore[from][channelId];
+        return (channelId << 128) | nonceInChannel;
     }
 
     /**

--- a/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
@@ -46,6 +46,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
+  describe("when calling `getNonce(...)` with a channel ID greater than 2 ** 128", () => {
+    it("should revert", async () => {
+      let channelId = ethers.BigNumber.from(2).pow(129);
+
+      await expect(context.keyManager.getNonce(signer.address, channelId)).to.be
+        .reverted;
+    });
+  });
+
   describe("testing sequential nonces (channel = 0)", () => {
     let channelId = 0;
     let latestNonce;


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

Because of the left bit shifting occurring to generate the idx (= concatenation of channel ID + nonce on a specific channel), the maximum `channelId` that can be provided to the function `getNonce(...)` is the max value of a `uint128`.

Otherwise, the explicit casting will result in wrapping back to 0 and lead to an invalid nonce value for a specific channel ID.

- In the function `getNonce(...)`, change the type of the `channelId` parameter from `uint256` -> `uint128`.
- ⚠️ **update the interface ID of LSP6KeyManager**, since the change in the function signature from `getNonce(address,uint256)` to `getNonce(address,uint128)`.

![image](https://user-images.githubusercontent.com/31145285/197529372-22a49a92-10be-4f1f-9da6-85d72653e8b3.png)
