### PR TITLE
fix: [WP-M9] LSP-2: `LSP2Utils.isEncodedArray()` Incomplete implementation

### DIFF
--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -202,10 +202,7 @@ library LSP2Utils {
     function isEncodedArray(bytes memory data) internal pure returns (bool) {
         uint256 nbOfBytes = data.length;
 
-        // 1) there must be at least 32 bytes to store the offset
-        if (nbOfBytes < 32) return false;
-
-        // 2) there must be at least 32 x length bytes after offset
+        // there must be at least 32 x length bytes after offset
         uint256 offset = uint256(bytes32(data));
         if (nbOfBytes < offset + 32) return false;
         uint256 arrayLength = data.toUint256(offset);

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -205,12 +205,9 @@ library LSP2Utils {
         // 1) there must be at least 32 bytes to store the offset
         if (nbOfBytes < 32) return false;
 
-        // 2) there must be at least the same number of bytes specified by
-        // the offset value (otherwise, the offset points to nowhere)
+        // 2) there must be at least 32 x length bytes after offset
         uint256 offset = uint256(bytes32(data));
-        if (nbOfBytes < offset) return false;
-
-        // 3) there must be at least 32 x length bytes after offset
+        if (nbOfBytes < offset + 32) return false;
         uint256 arrayLength = data.toUint256(offset);
 
         //   32 bytes word (= offset)

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -72,15 +72,26 @@ describe("LSP2Utils", () => {
     });
 
     describe("testing various non-zero bytes input", () => {
-      describe("when 32 bytes (e.g: a `uint256`)", () => {
-        it("should return false (value = 32)", async () => {
+      describe("when 32 bytes", () => {
+        it("should return false (`uint256` data = 32)", async () => {
           const data = abiCoder.encode(["uint256"], [32]);
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
 
-        it("should return false (value = 12345)", async () => {
+        it("should return false (`uint256` data = 12345)", async () => {
           const data = abiCoder.encode(["uint256"], [12345]);
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.false;
+        });
+
+        it("should return false (`bytes32` data = 0xcafecafecafecafe...)", async () => {
+          const data = abiCoder.encode(
+            ["bytes32"],
+            [
+              "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+            ]
+          );
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -6,6 +6,8 @@ import {
   LSP2UtilsLibraryTester__factory,
 } from "../../types";
 
+import { abiCoder } from "../utils/helpers";
+
 describe("LSP2Utils", () => {
   let accounts: SignerWithAddress[];
   let lsp2Utils: LSP2UtilsLibraryTester;
@@ -70,6 +72,20 @@ describe("LSP2Utils", () => {
     });
 
     describe("testing various non-zero bytes input", () => {
+      describe("when 32 bytes (e.g: a `uint256`)", () => {
+        it("should return false (value = 32)", async () => {
+          const data = abiCoder.encode(["uint256"], [32]);
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.false;
+        });
+
+        it("should return false (value = 12345)", async () => {
+          const data = abiCoder.encode(["uint256"], [12345]);
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.false;
+        });
+      });
+
       describe("when less than 32 bytes", () => {
         it("should return false with 4x random bytes", async () => {
           const data = "0xaabbccdd";


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug Fix

The function `isEncodedArray(...)` in `LSP2Utils` behaves incorrectly when the input argument is a bytes32 long value:

e.g:

- any `uint256` value (e.g: **32**, **12345**, ...)
- any `bytes32` value

This causes the function to revert with the following error.

![image](https://user-images.githubusercontent.com/31145285/197538808-e69b6f8c-02d3-4112-b039-31a31ba0b7a2.png)

This error originates from the `solidity-bytes-utils` library: https://github.com/GNSPS/solidity-bytes-utils/blob/6458fb2780a3092bc756e737f246be1de6d3d362/contracts/BytesLib.sol#L375

This PR fixes this behaviour.

![image](https://user-images.githubusercontent.com/31145285/197539466-e92a0a9e-3e47-4a3b-80ba-ae1faf7b612b.png)

![image](https://user-images.githubusercontent.com/31145285/197539511-0974fbda-876c-4d78-b8d3-1c69337e706a.png)

