### PR TITLE
fix: [WP-M8] LSP7 allow zero-value transfers for `transfer(..)`, `mint(..)` and `burn(..)`

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -97,6 +97,10 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiverDelega
     ) internal returns (bytes memory result) {
         // if it's a token transfer (LSP7/LSP8)
         if (typeId != _TYPEID_LSP14_OwnershipTransferred_RecipientNotification) {
+            // if the amount sent is 0, then do not update the keys
+            uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
+            if (balance == 0) return "LSP1: balance not updated";
+
             (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP5Utils
                 .generateReceivedAssetKeys(msg.sender, notifier, notifierMapKey, interfaceID);
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -53,6 +53,10 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiverDel
         bytes memory notifierMapValue = IERC725Y(msg.sender).getData(notifierMapKey);
 
         if (isReceiving) {
+            // if the amount sent is 0, then do not update the keys
+            uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
+            if (balance == 0) return "LSP1: balance not updated";
+
             // if the map value is already set, then do nothing
             if (bytes12(notifierMapValue) != bytes12(0))
                 return "URD: asset received is already registered";

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -208,8 +208,6 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        if (amount == 0) revert LSP7MintAmountIsZero();
-
         if (to == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }
@@ -242,8 +240,6 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 amount,
         bytes memory data
     ) internal virtual {
-        if (amount == 0) revert LSP7BurnAmountIsZero();
-
         if (from == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }
@@ -291,8 +287,6 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) internal virtual {
-        if (amount == 0) revert LSP7TransferAmountIsZero();
-
         if (from == address(0) || to == address(0)) {
             revert LSP7CannotSendWithAddressZero();
         }

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -25,21 +25,6 @@ error LSP7AmountExceedsAuthorizedAmount(
 error LSP7CannotUseAddressZeroAsOperator();
 
 /**
- * @dev reverts when one tries to mint 0 tokens.
- */
-error LSP7MintAmountIsZero();
-
-/**
- * @dev reverts when one tries to burn 0 tokens.
- */
-error LSP7BurnAmountIsZero();
-
-/**
- * @dev reverts when one tries to transfer 0 tokens.
- */
-error LSP7TransferAmountIsZero();
-
-/**
  * @dev reverts when one tries to send tokens to or from the zero address.
  */
 error LSP7CannotSendWithAddressZero();

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -14,12 +14,6 @@ error LSP7AmountExceedsAuthorizedAmount(
 
 error LSP7CannotUseAddressZeroAsOperator();
 
-error LSP7MintAmountIsZero();
-
-error LSP7BurnAmountIsZero();
-
-error LSP7TransferAmountIsZero();
-
 error LSP7CannotSendWithAddressZero();
 
 error LSP7CannotSendToSelf();

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -163,7 +163,16 @@ export const shouldBehaveLikeLSP1Delegate = (
             lsp7TokenA
               .connect(context.accounts.random)
               .mint(context.universalProfile1.address, 0, false, "0x")
-          ).to.be.revertedWithCustomError(lsp7TokenA, "LSP7MintAmountIsZero");
+          )
+            .to.emit(lsp7TokenA, "Transfer")
+            .withArgs(
+              context.accounts.random.address,
+              ethers.constants.AddressZero,
+              context.universalProfile1.address,
+              0,
+              false,
+              "0x"
+            );
 
           const result = await context.universalProfile1["getData(bytes32)"](
             ERC725YKeys.LSP5["LSP5ReceivedAssets[]"].length
@@ -307,7 +316,16 @@ export const shouldBehaveLikeLSP1Delegate = (
               .execute(
                 callPayload(context.universalProfile1, lsp7TokenA.address, abi)
               )
-          ).to.be.revertedWithCustomError(lsp7TokenA, "LSP7BurnAmountIsZero");
+          )
+            .to.emit(lsp7TokenA, "Transfer")
+            .withArgs(
+              context.universalProfile1.address,
+              context.universalProfile1.address,
+              ethers.constants.AddressZero,
+              "0",
+              false,
+              "0x"
+            );
 
           // CHECK that LSP5ReceivedAssets[] has not changed
           expect(
@@ -467,10 +485,16 @@ export const shouldBehaveLikeLSP1Delegate = (
                 false,
                 "0x"
               )
-          ).to.be.revertedWithCustomError(
-            lsp7TokenA,
-            "LSP7TransferAmountIsZero"
-          );
+          )
+            .to.emit(lsp7TokenA, "Transfer")
+            .withArgs(
+              context.accounts.random.address,
+              context.accounts.random.address,
+              context.universalProfile1.address,
+              0,
+              false,
+              "0x"
+            );
 
           // CHECK that LSP5ReceivedAssets[] has not changed
           expect(


### PR DESCRIPTION
## What does this PR introduce?

In this PR:
- We allow zero-value transfers, mints and burns in LSP7
- We introduce a check in LSP1 that verifies if the recipient's balance is updated, in order to register a new asset