### PR TITLE
feat: [WP-H2] Add msg.value to LSP6 signed message

### DIFF
--- a/contracts/Helpers/TargetContract.sol
+++ b/contracts/Helpers/TargetContract.sol
@@ -31,6 +31,11 @@ contract TargetContract {
         name = _name;
     }
 
+    function setNamePayable(string memory _name) public payable {
+        require(msg.value >= 50, "Not enough value provided");
+        name = _name;
+    }
+
     function revertCall() public pure {
         revert("TargetContract:revertCall: this function has reverted!");
     }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -115,6 +115,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             block.chainid,
             address(this), // needs to be signed for this keyManager
             nonce,
+            msg.value,
             payload
         );
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -18,6 +18,7 @@ import {
   shouldBehaveLikeAllowedStandards,
   shouldBehaveLikeAllowedERC725YKeys,
   shouldBehaveLikeMultiChannelNonce,
+  shouldBehaveLikeExecuteRelayCall,
   testSecurityScenarios,
   otherTestScenarios,
 } from "./tests";
@@ -86,6 +87,10 @@ export const shouldBehaveLikeLSP6 = (
 
   describe("Multi Channel nonces", () => {
     shouldBehaveLikeMultiChannelNonce(buildContext);
+  });
+
+  describe("Execute Relay Call", () => {
+    shouldBehaveLikeExecuteRelayCall(buildContext);
   });
 
   describe("miscellaneous", () => {

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -217,13 +217,15 @@ export const shouldBehaveLikeAllowedFunctions = (
             ]);
 
           const HARDHAT_CHAINID = 31337;
+          let valueToSend = 0;
 
           let hash = ethers.utils.solidityKeccak256(
-            ["uint256", "address", "uint256", "bytes"],
+            ["uint256", "address", "uint256", "uint256", "bytes"],
             [
               HARDHAT_CHAINID,
               context.keyManager.address,
               nonce,
+              valueToSend,
               executeRelayCallPayload,
             ]
           );
@@ -235,7 +237,8 @@ export const shouldBehaveLikeAllowedFunctions = (
           await context.keyManager.executeRelayCall(
             signature,
             nonce,
-            executeRelayCallPayload
+            executeRelayCallPayload,
+            { value: valueToSend }
           );
           let endResult = await targetContract.callStatic.getName();
           expect(endResult).to.equal(newName);
@@ -260,13 +263,15 @@ export const shouldBehaveLikeAllowedFunctions = (
             ]);
 
           const HARDHAT_CHAINID = 31337;
+          let valueToSend = 0;
 
           let hash = ethers.utils.solidityKeccak256(
-            ["uint256", "address", "uint256", "bytes"],
+            ["uint256", "address", "uint256", "uint256", "bytes"],
             [
               HARDHAT_CHAINID,
               context.keyManager.address,
               nonce,
+              valueToSend,
               executeRelayCallPayload,
             ]
           );
@@ -279,7 +284,8 @@ export const shouldBehaveLikeAllowedFunctions = (
             context.keyManager.executeRelayCall(
               signature,
               nonce,
-              executeRelayCallPayload
+              executeRelayCallPayload,
+              { value: valueToSend }
             )
           )
             .to.be.revertedWithCustomError(

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -1,0 +1,367 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+import { TargetContract, TargetContract__factory } from "../../../types";
+
+// constants
+import {
+  ALL_PERMISSIONS,
+  ERC725YKeys,
+  OPERATION_TYPES,
+  PERMISSIONS,
+} from "../../../constants";
+
+// helpers
+import { combinePermissions } from "../../utils/helpers";
+
+// setup
+import { LSP6TestContext } from "../../utils/context";
+import { setupKeyManager } from "../../utils/fixtures";
+import { provider } from "../../utils/helpers";
+
+export const shouldBehaveLikeExecuteRelayCall = (
+  buildContext: () => Promise<LSP6TestContext>
+) => {
+  let context: LSP6TestContext;
+
+  let signer: SignerWithAddress,
+    relayer: SignerWithAddress,
+    random: SignerWithAddress;
+  let targetContract: TargetContract;
+
+  before(async () => {
+    context = await buildContext();
+
+    signer = context.accounts[1];
+    relayer = context.accounts[2];
+    random = context.accounts[3];
+
+    targetContract = await new TargetContract__factory(
+      context.accounts[0]
+    ).deploy();
+
+    const permissionKeys = [
+      ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        context.owner.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        signer.address.substring(2),
+    ];
+
+    const permissionsValues = [
+      ALL_PERMISSIONS,
+      combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
+    ];
+
+    await setupKeyManager(context, permissionKeys, permissionsValues);
+  });
+
+  describe("When testing executeRelayCall(..)", () => {
+    describe("When testing signed message", () => {
+      describe("When testing msg.value", () => {
+        describe("When sending more than the signed msg.value", () => {
+          it("should revert by recovering a non permissioned address", async () => {
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
+
+            let latestNonce = await context.keyManager.callStatic.getNonce(
+              signer.address,
+              0
+            );
+
+            let valueToSign = 5;
+
+            const signedMessageParams = {
+              chainId: 31337, // HARDHAT_CHAINID
+              address: context.keyManager.address,
+              nonce: latestNonce,
+              Msgvalue: valueToSign,
+              payload: executeRelayCallPayload,
+            };
+
+            let valueToSendFromRelayer = 10;
+
+            let hash = ethers.utils.solidityKeccak256(
+              ["uint256", "address", "uint256", "uint256", "bytes"],
+              [
+                signedMessageParams.chainId,
+                signedMessageParams.address,
+                signedMessageParams.nonce,
+                signedMessageParams.Msgvalue,
+                signedMessageParams.payload,
+              ]
+            );
+
+            let signature = await signer.signMessage(
+              ethers.utils.arrayify(hash)
+            );
+
+            await expect(
+              context.keyManager.executeRelayCall(
+                signature,
+                signedMessageParams.nonce,
+                signedMessageParams.payload,
+                { value: valueToSendFromRelayer }
+              )
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoPermissionsSet"
+            );
+          });
+        });
+        describe("When sending 0 while msg.value signed > 0", () => {
+          it("should revert by recovering a non permissioned address", async () => {
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
+
+            let latestNonce = await context.keyManager.callStatic.getNonce(
+              signer.address,
+              0
+            );
+
+            let valueToSign = 5;
+
+            const signedMessageParams = {
+              chainId: 31337, // HARDHAT_CHAINID
+              address: context.keyManager.address,
+              nonce: latestNonce,
+              Msgvalue: valueToSign,
+              payload: executeRelayCallPayload,
+            };
+
+            let valueToSendFromRelayer = 0;
+
+            let hash = ethers.utils.solidityKeccak256(
+              ["uint256", "address", "uint256", "uint256", "bytes"],
+              [
+                signedMessageParams.chainId,
+                signedMessageParams.address,
+                signedMessageParams.nonce,
+                signedMessageParams.Msgvalue,
+                signedMessageParams.payload,
+              ]
+            );
+
+            let signature = await signer.signMessage(
+              ethers.utils.arrayify(hash)
+            );
+
+            await expect(
+              context.keyManager
+                .connect(relayer)
+                .executeRelayCall(
+                  signature,
+                  signedMessageParams.nonce,
+                  signedMessageParams.payload,
+                  { value: valueToSendFromRelayer }
+                )
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoPermissionsSet"
+            );
+          });
+        });
+        describe("When sending exact msg.value like the one that is signed", () => {
+          it("should pass", async () => {
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
+
+            let latestNonce = await context.keyManager.callStatic.getNonce(
+              signer.address,
+              0
+            );
+
+            let valueToSendFromRelayer = 10;
+
+            const signedMessageParams = {
+              chainId: 31337, // HARDHAT_CHAINID
+              address: context.keyManager.address,
+              nonce: latestNonce,
+              Msgvalue: valueToSendFromRelayer,
+              payload: executeRelayCallPayload,
+            };
+
+            let hash = ethers.utils.solidityKeccak256(
+              ["uint256", "address", "uint256", "uint256", "bytes"],
+              [
+                signedMessageParams.chainId,
+                signedMessageParams.address,
+                signedMessageParams.nonce,
+                signedMessageParams.Msgvalue,
+                signedMessageParams.payload,
+              ]
+            );
+
+            const balanceOfUpBefore = await provider.getBalance(
+              context.universalProfile.address
+            );
+
+            let signature = await signer.signMessage(
+              ethers.utils.arrayify(hash)
+            );
+
+            await context.keyManager
+              .connect(relayer)
+              .executeRelayCall(
+                signature,
+                signedMessageParams.nonce,
+                signedMessageParams.payload,
+                { value: valueToSendFromRelayer }
+              );
+
+            const balanceOfUpAfter = await provider.getBalance(
+              context.universalProfile.address
+            );
+
+            expect(balanceOfUpBefore.add(valueToSendFromRelayer)).to.equal(
+              balanceOfUpAfter
+            );
+          });
+        });
+        describe("When UP have 0 value and interacting with contract that require value", () => {
+          describe("When interacting without sending any value from KeyManager but with sending from UP", () => {
+            it("should revert", async () => {
+              let nameToSet = "Alice";
+              let targetContractPayload =
+                targetContract.interface.encodeFunctionData("setNamePayable", [
+                  nameToSet,
+                ]);
+
+              let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+
+              let latestNonce = await context.keyManager.callStatic.getNonce(
+                signer.address,
+                0
+              );
+
+              let executeRelayCallPayload =
+                context.universalProfile.interface.encodeFunctionData(
+                  "execute",
+                  [
+                    OPERATION_TYPES.CALL,
+                    targetContract.address,
+                    requiredValueForExecution,
+                    targetContractPayload,
+                  ]
+                );
+
+              let valueToSendFromRelayer = 0;
+
+              const signedMessageParams = {
+                chainId: 31337, // HARDHAT_CHAINID
+                address: context.keyManager.address,
+                nonce: latestNonce,
+                Msgvalue: valueToSendFromRelayer,
+                payload: executeRelayCallPayload,
+              };
+
+              let hash = ethers.utils.solidityKeccak256(
+                ["uint256", "address", "uint256", "uint256", "bytes"],
+                [
+                  signedMessageParams.chainId,
+                  signedMessageParams.address,
+                  signedMessageParams.nonce,
+                  signedMessageParams.Msgvalue,
+                  signedMessageParams.payload,
+                ]
+              );
+
+              let signature = await signer.signMessage(
+                ethers.utils.arrayify(hash)
+              );
+
+              await expect(
+                context.keyManager
+                  .connect(relayer)
+                  .executeRelayCall(
+                    signature,
+                    latestNonce,
+                    executeRelayCallPayload,
+                    { value: valueToSendFromRelayer }
+                  )
+              ).to.be.revertedWith("ERC725X: insufficient balance");
+            });
+          });
+          describe("When interacting with execution cost from KeyManager with sending from UP", () => {
+            it("should pass", async () => {
+              let nameToSet = "Alice";
+              let targetContractPayload =
+                targetContract.interface.encodeFunctionData("setNamePayable", [
+                  nameToSet,
+                ]);
+
+              let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+
+              let latestNonce = await context.keyManager.callStatic.getNonce(
+                signer.address,
+                0
+              );
+
+              let executeRelayCallPayload =
+                context.universalProfile.interface.encodeFunctionData(
+                  "execute",
+                  [
+                    OPERATION_TYPES.CALL,
+                    targetContract.address,
+                    requiredValueForExecution,
+                    targetContractPayload,
+                  ]
+                );
+
+              let valueToSendFromRelayer = 51;
+
+              const signedMessageParams = {
+                chainId: 31337, // HARDHAT_CHAINID
+                address: context.keyManager.address,
+                nonce: latestNonce,
+                Msgvalue: valueToSendFromRelayer,
+                payload: executeRelayCallPayload,
+              };
+
+              let hash = ethers.utils.solidityKeccak256(
+                ["uint256", "address", "uint256", "uint256", "bytes"],
+                [
+                  signedMessageParams.chainId,
+                  signedMessageParams.address,
+                  signedMessageParams.nonce,
+                  signedMessageParams.Msgvalue,
+                  signedMessageParams.payload,
+                ]
+              );
+
+              let signature = await signer.signMessage(
+                ethers.utils.arrayify(hash)
+              );
+
+              await context.keyManager
+                .connect(relayer)
+                .executeRelayCall(
+                  signature,
+                  latestNonce,
+                  executeRelayCallPayload,
+                  { value: valueToSendFromRelayer }
+                );
+              const result = await targetContract.callStatic.getName();
+              expect(result).to.equal(nameToSet);
+            });
+          });
+        });
+      });
+    });
+  });
+};

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -80,7 +80,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               chainId: 31337, // HARDHAT_CHAINID
               address: context.keyManager.address,
               nonce: latestNonce,
-              Msgvalue: valueToSign,
+              msgValue: valueToSign,
               payload: executeRelayCallPayload,
             };
 
@@ -92,7 +92,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 signedMessageParams.chainId,
                 signedMessageParams.address,
                 signedMessageParams.nonce,
-                signedMessageParams.Msgvalue,
+                signedMessageParams.msgValue,
                 signedMessageParams.payload,
               ]
             );
@@ -135,7 +135,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               chainId: 31337, // HARDHAT_CHAINID
               address: context.keyManager.address,
               nonce: latestNonce,
-              Msgvalue: valueToSign,
+              msgValue: valueToSign,
               payload: executeRelayCallPayload,
             };
 
@@ -147,7 +147,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 signedMessageParams.chainId,
                 signedMessageParams.address,
                 signedMessageParams.nonce,
-                signedMessageParams.Msgvalue,
+                signedMessageParams.msgValue,
                 signedMessageParams.payload,
               ]
             );
@@ -192,7 +192,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               chainId: 31337, // HARDHAT_CHAINID
               address: context.keyManager.address,
               nonce: latestNonce,
-              Msgvalue: valueToSendFromRelayer,
+              msgValue: valueToSendFromRelayer,
               payload: executeRelayCallPayload,
             };
 
@@ -202,7 +202,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 signedMessageParams.chainId,
                 signedMessageParams.address,
                 signedMessageParams.nonce,
-                signedMessageParams.Msgvalue,
+                signedMessageParams.msgValue,
                 signedMessageParams.payload,
               ]
             );
@@ -234,7 +234,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
         });
         describe("When UP have 0 value and interacting with contract that require value", () => {
-          describe("When interacting without sending any value from KeyManager but with sending from UP", () => {
+          describe("When relayer don't fund the UP so it's balance is greater than the value param of execute(..)", () => {
             it("should revert", async () => {
               let nameToSet = "Alice";
               let targetContractPayload =
@@ -266,7 +266,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 chainId: 31337, // HARDHAT_CHAINID
                 address: context.keyManager.address,
                 nonce: latestNonce,
-                Msgvalue: valueToSendFromRelayer,
+                msgValue: valueToSendFromRelayer,
                 payload: executeRelayCallPayload,
               };
 
@@ -276,7 +276,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   signedMessageParams.chainId,
                   signedMessageParams.address,
                   signedMessageParams.nonce,
-                  signedMessageParams.Msgvalue,
+                  signedMessageParams.msgValue,
                   signedMessageParams.payload,
                 ]
               );
@@ -297,7 +297,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               ).to.be.revertedWith("ERC725X: insufficient balance");
             });
           });
-          describe("When interacting with execution cost from KeyManager with sending from UP", () => {
+          describe("When relayer fund the UP so it's balance is greater than the value param of execute(..)", () => {
             it("should pass", async () => {
               let nameToSet = "Alice";
               let targetContractPayload =
@@ -329,7 +329,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 chainId: 31337, // HARDHAT_CHAINID
                 address: context.keyManager.address,
                 nonce: latestNonce,
-                Msgvalue: valueToSendFromRelayer,
+                msgValue: valueToSendFromRelayer,
                 payload: executeRelayCallPayload,
               };
 
@@ -339,7 +339,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   signedMessageParams.chainId,
                   signedMessageParams.address,
                   signedMessageParams.nonce,
-                  signedMessageParams.Msgvalue,
+                  signedMessageParams.msgValue,
                   signedMessageParams.payload,
                 ]
               );

--- a/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
@@ -86,13 +86,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             latestNonce,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -102,7 +104,8 @@ export const shouldBehaveLikeMultiChannelNonce = (
         await context.keyManager.executeRelayCall(
           signature,
           latestNonce,
-          executeRelayCallPayload
+          executeRelayCallPayload,
+          { value: valueToSend }
         );
 
         let fetchedName = await targetContract.callStatic.getName();
@@ -146,13 +149,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -161,7 +166,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -195,13 +202,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -210,7 +219,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -249,13 +260,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -264,7 +277,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -298,13 +313,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -313,7 +330,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -352,13 +371,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -367,7 +388,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -401,13 +424,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -416,7 +441,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(
@@ -451,13 +478,15 @@ export const shouldBehaveLikeMultiChannelNonce = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonceBefore,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -466,7 +495,9 @@ export const shouldBehaveLikeMultiChannelNonce = (
 
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload);
+          .executeRelayCall(signature, nonceBefore, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         let fetchedName = await targetContract.callStatic.getName();
         let nonceAfter = await context.keyManager.callStatic.getNonce(

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -216,13 +216,15 @@ export const shouldBehaveLikePermissionCall = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonce,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -234,7 +236,8 @@ export const shouldBehaveLikePermissionCall = (
         await context.keyManager.executeRelayCall(
           signature,
           nonce,
-          executeRelayCallPayload
+          executeRelayCallPayload,
+          { value: valueToSend }
         );
 
         const result = await targetContract.callStatic.getName();
@@ -264,13 +267,15 @@ export const shouldBehaveLikePermissionCall = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonce,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -282,7 +287,8 @@ export const shouldBehaveLikePermissionCall = (
         await context.keyManager.executeRelayCall(
           signature,
           nonce,
-          executeRelayCallPayload
+          executeRelayCallPayload,
+          { value: valueToSend }
         );
 
         const result = await targetContract.callStatic.getName();
@@ -312,13 +318,15 @@ export const shouldBehaveLikePermissionCall = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonce,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -331,7 +339,8 @@ export const shouldBehaveLikePermissionCall = (
           context.keyManager.executeRelayCall(
             signature,
             nonce,
-            executeRelayCallPayload
+            executeRelayCallPayload,
+            { value: valueToSend }
           )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -233,10 +233,17 @@ export const shouldBehaveLikePermissionDeploy = (
         );
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
-          [HARDHAT_CHAINID, context.keyManager.address, nonce, payload]
+          ["uint256", "address", "uint256", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonce,
+            valueToSend,
+            payload,
+          ]
         );
 
         let signature = await addressCannotDeploy.signMessage(
@@ -246,7 +253,7 @@ export const shouldBehaveLikePermissionDeploy = (
         await expect(
           context.keyManager
             .connect(addressCannotDeploy)
-            .executeRelayCall(signature, nonce, payload)
+            .executeRelayCall(signature, nonce, payload, { value: valueToSend })
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(addressCannotDeploy.address, "DEPLOY");
@@ -274,10 +281,17 @@ export const shouldBehaveLikePermissionDeploy = (
         );
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
-          [HARDHAT_CHAINID, context.keyManager.address, nonce, payload]
+          ["uint256", "address", "uint256", "uint256", "bytes"],
+          [
+            HARDHAT_CHAINID,
+            context.keyManager.address,
+            nonce,
+            valueToSend,
+            payload,
+          ]
         );
 
         let signature = await addressCannotDeploy.signMessage(
@@ -287,7 +301,7 @@ export const shouldBehaveLikePermissionDeploy = (
         await expect(
           context.keyManager
             .connect(addressCannotDeploy)
-            .executeRelayCall(signature, nonce, payload)
+            .executeRelayCall(signature, nonce, payload, { value: valueToSend })
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(addressCannotDeploy.address, "DEPLOY");

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -114,14 +114,22 @@ export const testSecurityScenarios = (
 
     it("via `executeRelayCall()`", async () => {
       const HARDHAT_CHAINID = 31337;
+      let valueToSend = 0;
+
       let nonce = await context.keyManager.getNonce(context.owner.address, 0);
 
       let payload =
         context.universalProfile.interface.getSighash("renounceOwnership");
 
       let hash = ethers.utils.solidityKeccak256(
-        ["uint256", "address", "uint256", "bytes"],
-        [HARDHAT_CHAINID, context.keyManager.address, nonce, payload]
+        ["uint256", "address", "uint256", "uint256", "bytes"],
+        [
+          HARDHAT_CHAINID,
+          context.keyManager.address,
+          nonce,
+          valueToSend,
+          payload,
+        ]
       );
 
       let signature = await context.owner.signMessage(
@@ -131,7 +139,7 @@ export const testSecurityScenarios = (
       await expect(
         context.keyManager
           .connect(context.owner)
-          .executeRelayCall(signature, nonce, payload)
+          .executeRelayCall(signature, nonce, payload, { value: valueToSend })
       )
         .to.be.revertedWithCustomError(
           context.keyManager,
@@ -205,13 +213,15 @@ export const testSecurityScenarios = (
           ]);
 
         const HARDHAT_CHAINID = 31337;
+        let valueToSend = 0;
 
         let hash = ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "bytes"],
+          ["uint256", "address", "uint256", "uint256", "bytes"],
           [
             HARDHAT_CHAINID,
             context.keyManager.address,
             nonce,
+            valueToSend,
             executeRelayCallPayload,
           ]
         );
@@ -221,7 +231,9 @@ export const testSecurityScenarios = (
         // first call
         await context.keyManager
           .connect(relayer)
-          .executeRelayCall(signature, nonce, executeRelayCallPayload);
+          .executeRelayCall(signature, nonce, executeRelayCallPayload, {
+            value: valueToSend,
+          });
 
         // 2nd call = replay attack
         await expect(

--- a/tests/LSP6KeyManager/tests/index.ts
+++ b/tests/LSP6KeyManager/tests/index.ts
@@ -15,3 +15,4 @@ export * from "./MultiChannelNonce.test";
 export * from "./OtherScenarios.test";
 export * from "./Security.test";
 export * from "./LSP6ControlledToken.test";
+export * from "./ExecuteRelayCall.test";


### PR DESCRIPTION
## What does this PR introduce?
- [x] Adding `msg.value` to the LSP6 signed message to avoid front-running and security issues related to `DELEGATECALL` Operation.
- [x] Add `msg.value` to the current tests
- [x] Add more tests to cover the case of sending value through `executeRelayCall`  