### PR TITLE
refactor!: [WP-C2] Change the verification logic of AllowedERC725YKeys in LSP6

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -234,10 +234,6 @@ const Errors = {
 			error: 'InvalidABIEncodedArray(bytes,string)',
 			message: 'LSP2Utils: Invalid ABI encoded array',
 		},
-		'0x3d330f3e': {
-			error: 'InvalidCompactBytesArray(bytes)',
-			message: 'LSP2Utils: Invalid Compact Bytes Array',
-		},
 	},
 	LSP4: {
 		'0x85c169bd': {
@@ -300,6 +296,10 @@ const Errors = {
 		'0x7f8cf29e': {
 			error: 'NoERC725YDataKeysAllowed()',
 			message: 'LSP6: caller has no AllowedERC725YDataKeys',
+		},
+		'0x7231ac57': {
+			error: 'InvalidEncodedAllowedERC725YKeys(bytes)',
+			message: 'LSP2Utils: Invalid Compact Bytes Array',
 		},
 	},
 	LSP7: {

--- a/constants.js
+++ b/constants.js
@@ -293,6 +293,14 @@ const Errors = {
 			error: 'InvalidERC725Function(bytes4)',
 			message: 'LSP6: unknown or invalid ERC725 function selector',
 		},
+		'0x7f8cf29e': {
+			error: 'NoERC725YDataKeysAllowed()',
+			message: 'LSP6: caller has no AllowedERC725YDataKeys',
+		},
+		'0x08d4e973': {
+			error: 'InvalidCompactedAllowedERC725YDataKeys()',
+			message: 'LSP6: the CompactedAllowedERC725YDataKeys are not properly encoded',
+		},
 	},
 	LSP7: {
 		'0xc5e194ab': {

--- a/constants.js
+++ b/constants.js
@@ -293,8 +293,8 @@ const Errors = {
 			error: 'InvalidERC725Function(bytes4)',
 			message: 'LSP6: unknown or invalid ERC725 function selector',
 		},
-		'0x7f8cf29e': {
-			error: 'NoERC725YDataKeysAllowed()',
+		'0xed7fa509': {
+			error: 'NoERC725YDataKeysAllowed(address)',
 			message: 'LSP6: caller has no AllowedERC725YDataKeys',
 		},
 		'0x7231ac57': {

--- a/constants.js
+++ b/constants.js
@@ -234,6 +234,10 @@ const Errors = {
 			error: 'InvalidABIEncodedArray(bytes,string)',
 			message: 'LSP2Utils: Invalid ABI encoded array',
 		},
+		'0x3d330f3e': {
+			error: 'InvalidCompactBytesArray(bytes)',
+			message: 'LSP2Utils: Invalid Compact Bytes Array',
+		},
 	},
 	LSP4: {
 		'0x85c169bd': {
@@ -296,10 +300,6 @@ const Errors = {
 		'0x7f8cf29e': {
 			error: 'NoERC725YDataKeysAllowed()',
 			message: 'LSP6: caller has no AllowedERC725YDataKeys',
-		},
-		'0x08d4e973': {
-			error: 'InvalidCompactedAllowedERC725YDataKeys()',
-			message: 'LSP6: the CompactedAllowedERC725YDataKeys are not properly encoded',
 		},
 	},
 	LSP7: {

--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 // libraries
 import {LSP6Utils} from "../../LSP6KeyManager/LSP6Utils.sol";
+import {LSP2Utils} from "../../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // modules
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
@@ -46,24 +47,24 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         pure
         returns (bool)
     {
-        return super._checkValidCompactBytesArray(compactBytesArray);
+        return LSP2Utils.isValidCompactBytesArray(compactBytesArray);
     }
 
     function verifyAllowedERC725YSingleKey(
-        address _from,
+        address from,
         bytes32 inputKey,
         bytes memory allowedERC725YKeysFor
     ) public pure returns (bool) {
-        super._verifyAllowedERC725YSingleKey(_from, inputKey, allowedERC725YKeysFor);
+        super._verifyAllowedERC725YSingleKey(from, inputKey, allowedERC725YKeysFor);
         return true;
     }
 
     function verifyAllowedERC725YKeys(
-        address _from,
-        bytes32[] memory _inputKeys,
+        address from,
+        bytes32[] memory inputKeys,
         bytes memory allowedERC725YKeysCompacted
-    ) public view returns (bool) {
-        super._verifyAllowedERC725YKeys(_from, _inputKeys, allowedERC725YKeysCompacted);
+    ) public pure returns (bool) {
+        super._verifyAllowedERC725YKeys(from, inputKeys, allowedERC725YKeysCompacted);
         return true;
     }
 

--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -42,12 +42,8 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         super._verifyAllowedFunction(_sender, _function);
     }
 
-    function checkValidCompactBytesArray(bytes memory compactBytesArray)
-        public
-        pure
-        returns (bool)
-    {
-        return LSP2Utils.isValidCompactBytesArray(compactBytesArray);
+    function isCompactBytesArray(bytes memory compactBytesArray) public pure returns (bool) {
+        return LSP2Utils.isCompactBytesArray(compactBytesArray);
     }
 
     function verifyAllowedERC725YSingleKey(

--- a/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Helpers/KeyManager/KeyManagerInternalsTester.sol
@@ -41,8 +41,30 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         super._verifyAllowedFunction(_sender, _function);
     }
 
-    function verifyAllowedERC725YKeys(address _from, bytes32[] memory _inputKeys) public view {
-        super._verifyAllowedERC725YKeys(_from, _inputKeys);
+    function checkValidCompactBytesArray(bytes memory compactBytesArray)
+        public
+        pure
+        returns (bool)
+    {
+        return super._checkValidCompactBytesArray(compactBytesArray);
+    }
+
+    function verifyAllowedERC725YSingleKey(
+        address _from,
+        bytes32 inputKey,
+        bytes memory allowedERC725YKeysFor
+    ) public pure returns (bool) {
+        super._verifyAllowedERC725YSingleKey(_from, inputKey, allowedERC725YKeysFor);
+        return true;
+    }
+
+    function verifyAllowedERC725YKeys(
+        address _from,
+        bytes32[] memory _inputKeys,
+        bytes memory allowedERC725YKeysCompacted
+    ) public view returns (bool) {
+        super._verifyAllowedERC725YKeys(_from, _inputKeys, allowedERC725YKeysCompacted);
+        return true;
     }
 
     function hasPermission(bytes32 _addressPermission, bytes32 _permissions)

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
@@ -9,6 +9,7 @@ pragma solidity ^0.8.0;
 error InvalidABIEncodedArray(bytes value, string valueType);
 
 /**
- * @dev reverts when the AllowedERC725YDataKeys are not encoded properly using the CompactBytesArray
+ * @dev reverts when `value` is not encoded properly using the CompactBytesArray
+ * @param value the value to check for an CompactBytesArray
  */
 error InvalidCompactBytesArray(bytes value);

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
@@ -7,9 +7,3 @@ pragma solidity ^0.8.0;
  * @param valueType the type of the value to check for an abi-encoded array
  */
 error InvalidABIEncodedArray(bytes value, string valueType);
-
-/**
- * @dev reverts when `value` is not encoded properly using the CompactBytesArray
- * @param value the value to check for an CompactBytesArray
- */
-error InvalidCompactBytesArray(bytes value);

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Errors.sol
@@ -7,3 +7,8 @@ pragma solidity ^0.8.0;
  * @param valueType the type of the value to check for an abi-encoded array
  */
 error InvalidABIEncodedArray(bytes value, string valueType);
+
+/**
+ * @dev reverts when the AllowedERC725YDataKeys are not encoded properly using the CompactBytesArray
+ */
+error InvalidCompactBytesArray(bytes value);

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -273,6 +273,7 @@ library LSP2Utils {
         pure
         returns (bool isValid)
     {
+        if (compactBytesArray.length == 0) return false;
         /**
          * Pointer will always land on these values:
          *
@@ -294,10 +295,10 @@ library LSP2Utils {
          */
         while (pointer < compactBytesArray.length) {
             uint256 elementLength = uint256(uint8(bytes1(compactBytesArray[pointer])));
-            if (elementLength == 0) pointer = compactBytesArray.length + 1;
+            if (elementLength == 0) return false;
             pointer += elementLength + 1;
         }
-        if (pointer == compactBytesArray.length && compactBytesArray.length != 0) isValid = true;
+        if (pointer == compactBytesArray.length) isValid = true;
     }
 
     /**

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -268,11 +268,7 @@ library LSP2Utils {
     /**
      * @dev Verify the validity of the `compactBytesArray` according to LSP2
      */
-    function isCompactBytesArray(bytes memory compactBytesArray)
-        internal
-        pure
-        returns (bool isValid)
-    {
+    function isCompactBytesArray(bytes memory compactBytesArray) internal pure returns (bool) {
         if (compactBytesArray.length == 0) return false;
         /**
          * Pointer will always land on these values:
@@ -298,7 +294,7 @@ library LSP2Utils {
             if (elementLength == 0) return false;
             pointer += elementLength + 1;
         }
-        if (pointer == compactBytesArray.length) isValid = true;
+        if (pointer == compactBytesArray.length) return true;
     }
 
     /**

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -268,7 +268,7 @@ library LSP2Utils {
     /**
      * @dev Verify the validity of the `compactBytesArray` according to LSP2
      */
-    function isValidCompactBytesArray(bytes memory compactBytesArray)
+    function isCompactBytesArray(bytes memory compactBytesArray)
         internal
         pure
         returns (bool isValid)

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -266,6 +266,40 @@ library LSP2Utils {
     }
 
     /**
+     * @dev Verify the validity of the `compactBytesArray` according to LSP2
+     */
+    function isValidCompactBytesArray(bytes memory compactBytesArray)
+        internal
+        pure
+        returns (bool isValid)
+    {
+        /**
+         * Pointer will always land on these values:
+         *
+         * ↓↓
+         * 03 a00000
+         * 05 fff83a0011
+         * 20 aa0000000000000000000000000000000000000000000000000000000000cafe
+         * 12 bb000000000000000000000000000000beef
+         * 19 cc00000000000000000000000000000000000000000000deed
+         * ↑↑
+         *
+         * The pointer can only land on the length of the following bytes value.
+         */
+        uint256 pointer;
+
+        /**
+         * Check each length byte and make sure that when you reach the last length byte.
+         * Make sure that the last length describes exactly the last bytes value and you do not get out of bounds.
+         */
+        while (pointer < compactBytesArray.length) {
+            uint256 elementLength = uint256(uint8(bytes1(compactBytesArray[pointer])));
+            pointer += elementLength + 1;
+        }
+        if (pointer == compactBytesArray.length && compactBytesArray.length != 0) isValid = true;
+    }
+
+    /**
      * @dev Will return unchecked incremented uint256
      *      can be used to save gas when iterating over loops
      */

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -294,6 +294,7 @@ library LSP2Utils {
          */
         while (pointer < compactBytesArray.length) {
             uint256 elementLength = uint256(uint8(bytes1(compactBytesArray[pointer])));
+            if (elementLength == 0) pointer = compactBytesArray.length + 1;
             pointer += elementLength + 1;
         }
         if (pointer == compactBytesArray.length && compactBytesArray.length != 0) isValid = true;

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -32,7 +32,7 @@ bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742
 bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742de2bf3efa94a3; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
 
 // bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedERC725YKeys')) 
-bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b485; // AddressPermissions:AllowedERC725YKeys:<address> --> CompactBytesArray
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b485; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes[CompactBytesArray]
 
 // DEFAULT PERMISSIONS VALUES
 // NB: the SUPER PERMISSIONS allow to not check for:

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -32,7 +32,7 @@ bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDFUNCTIONS_PREFIX = 0x4b80742
 bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDSTANDARDS_PREFIX = 0x4b80742de2bf3efa94a3; // AddressPermissions:AllowedStandards:<address> --> bytes4[]
 
 // bytes6(keccak256('AddressPermissions')) + bytes4(keccak256('AllowedERC725YKeys')) 
-bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b485; // AddressPermissions:AllowedERC725YKeys:<address> --> bytes32[]
+bytes10 constant _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDERC725YKEYS_PREFIX = 0x4b80742de2bf90b8b485; // AddressPermissions:AllowedERC725YKeys:<address> --> CompactBytesArray
 
 // DEFAULT PERMISSIONS VALUES
 // NB: the SUPER PERMISSIONS allow to not check for:

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -84,3 +84,9 @@ error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invali
  * @dev reverts if there are no AllowedERC725YDataKeys set for the caller
  */
 error NoERC725YDataKeysAllowed();
+
+/**
+ * @dev reverts when `value` is not encoded properly using the CompactBytesArray
+ * @param value the value to check for an CompactBytesArray
+ */
+error InvalidEncodedAllowedERC725YKeys(bytes value);

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -79,3 +79,13 @@ error InvalidERC725Function(bytes4 invalidFunction);
  * @param invalidValue the invalid value that was attempted to be set under AddressPermissions[index]
  */
 error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invalidValue);
+
+/**
+ * @dev reverts if there are no AllowedERC725YDataKeys set for the caller
+ */
+error NoERC725YDataKeysAllowed();
+
+/**
+ * @dev reverts when the AllowedERC725YDataKeys are not encoded properly using the CompactBytesArray
+ */
+error InvalidCompactedAllowedERC725YDataKeys();

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -84,8 +84,3 @@ error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invali
  * @dev reverts if there are no AllowedERC725YDataKeys set for the caller
  */
 error NoERC725YDataKeysAllowed();
-
-/**
- * @dev reverts when the AllowedERC725YDataKeys are not encoded properly using the CompactBytesArray
- */
-error InvalidCompactedAllowedERC725YDataKeys();

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -82,8 +82,9 @@ error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invali
 
 /**
  * @dev reverts if there are no AllowedERC725YDataKeys set for the caller
+ * @param from the address that has no AllowedERC725YDataKeys
  */
-error NoERC725YDataKeysAllowed();
+error NoERC725YDataKeysAllowed(address from);
 
 /**
  * @dev reverts when `value` is not encoded properly using the CompactBytesArray

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -466,7 +466,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @dev Verify if the `inputKey` is present in `allowedERC725KeysCompacted` stored on the `from`'s ERC725Y contract
      */
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
-        if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed();
+        if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed(from);
         if (!LSP2Utils.isCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidEncodedAllowedERC725YKeys(allowedERC725YKeysCompacted);
 
         /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -468,7 +468,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @dev Verify the validity of the `compactBytesArray` according to LSP2
      */
     function _checkValidCompactBytesArray(bytes memory compactBytesArray)
-        public
+        internal
         pure
         returns (bool isValid)
     {

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -364,7 +364,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             // AddressPermissions:AllowedERC725YKeys:<address>
             if (!isClearingArray && !LSP2Utils.isValidCompactBytesArray(dataValue)) {
-                revert InvalidCompactBytesArray(dataValue);
+                revert InvalidEncodedAllowedERC725YKeys(dataValue);
             }
 
             bytes memory storedAllowedERC725YKeys = ERC725Y(target).getData(dataKey);
@@ -469,7 +469,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      */
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
         if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed();
-        if (!LSP2Utils.isValidCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidCompactBytesArray(allowedERC725YKeysCompacted);
+        if (!LSP2Utils.isValidCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidEncodedAllowedERC725YKeys(allowedERC725YKeysCompacted);
 
         /**
          * pointer will always land on these values:

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -177,7 +177,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify the permissions of the _from address that want to interact with the `target`
+     * @dev verify the permissions of the _from abddress that want to interact with the `target`
      * @param from the address making the request
      * @param payload the payload that will be run on `target`
      */
@@ -470,8 +470,6 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
         if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed();
         if (!LSP2Utils.isValidCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidCompactBytesArray(allowedERC725YKeysCompacted);
-        
-        bool foundAllowedKey;
 
         /**
          * pointer will always land on these values:
@@ -497,7 +495,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
          *  first  |  second  |  third
          *  length |  length  |  length
          */
-        while (!foundAllowedKey && pointer < allowedERC725YKeysCompacted.length) {
+        while (pointer < allowedERC725YKeysCompacted.length) {
             /**
              * save the length of the following allowed key
              * which is saved in `allowedERC725YKeys[pointer]`
@@ -544,14 +542,14 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             if (allowedKey == (inputKey & mask)) {
                 // voila you found the key ;)
-                foundAllowedKey = true;
+                return;
             } else {
                 // move the pointer to the first index of the first fixed key
                 pointer += length + 1;
             }
         }
 
-        if (!foundAllowedKey) revert NotAllowedERC725YKey(from, inputKey);
+        revert NotAllowedERC725YKey(from, inputKey);
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -251,8 +251,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev verify if `_from` has the required permissions to set some dataKeys
-     * on the linked target
+     * @dev verify if `_from` has the required permissions to set some dataKeys on the linked target
      * @param from the address who want to set the dataKeys
      * @param permissions the permissions
      * @param inputKey the dataKey being set
@@ -290,7 +289,6 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         _requirePermissions(from, permissions, _PERMISSION_SETDATA);
 
         bytes memory allowedERC725YKeysCompacted = ERC725Y(target).getAllowedERC725YKeysFor(from);
-        
         _verifyAllowedERC725YKeys(from, inputKeys, allowedERC725YKeysCompacted);
     }
 
@@ -465,7 +463,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     }
 
     /**
-     * @dev Verify if the `inputKey` is present in `alloedERC725KeysCompacted` stored on the `from`'s ERC725Y contract
+     * @dev Verify if the `inputKey` is present in `allowedERC725KeysCompacted` stored on the `from`'s ERC725Y contract
      */
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
         if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed();
@@ -502,19 +500,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
              */
             uint256 length = uint256(uint8(bytes1(allowedERC725YKeysCompacted[pointer])));
 
-            /**
-             * if `length` is zero, skip everything an move to next key
-             */
-            if (length == 0) {
-                pointer += length + 1;
-                continue;
-            }
-
             /*
              * transform the allowed key situated from `pointer + 1` until `pointer + 1 + length` to a bytes32 value
              * E.g. 0xfff83a -> 0xfff83a0000000000000000000000000000000000000000000000000000000000
              */
-            //bytes32 allowedKey = bytes32(allowedERC725YKeysCompacted[pointer + 1:pointer + 1 + length]);
             bytes32 allowedKey = bytes32(allowedERC725YKeysCompacted.slice(
                 pointer + 1,
                 length

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -363,7 +363,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             bool isClearingArray = dataValue.length == 0;
 
             // AddressPermissions:AllowedERC725YKeys:<address>
-            if (!isClearingArray && !LSP2Utils.isValidCompactBytesArray(dataValue)) {
+            if (!isClearingArray && !LSP2Utils.isCompactBytesArray(dataValue)) {
                 revert InvalidEncodedAllowedERC725YKeys(dataValue);
             }
 
@@ -469,7 +469,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      */
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
         if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed();
-        if (!LSP2Utils.isValidCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidEncodedAllowedERC725YKeys(allowedERC725YKeysCompacted);
+        if (!LSP2Utils.isCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidEncodedAllowedERC725YKeys(allowedERC725YKeysCompacted);
 
         /**
          * pointer will always land on these values:

--- a/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
@@ -1,168 +1,728 @@
-import { expect } from "chai";
 import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
 
-// constants
-import {
-  SupportedStandards,
-  ERC725YKeys,
-  ALL_PERMISSIONS,
-  PERMISSIONS,
-} from "../../../constants";
-
-// setup
+import { BytesLike } from "ethers";
 import { LSP6InternalsTestContext } from "../../utils/context";
-import { setupKeyManagerHelper } from "../../utils/fixtures";
 
-// helpers
-import { abiCoder } from "../../utils/helpers";
+export type DataKey = {
+  length: BytesLike;
+  key: BytesLike;
+};
 
 export const testAllowedERC725YKeysInternals = (
   buildContext: () => Promise<LSP6InternalsTestContext>
 ) => {
-  let context: LSP6InternalsTestContext;
-
-  describe("keyType: Singleton", () => {
-    let controllerCanSetOneKey: SignerWithAddress;
-
-    const customKey1 = ethers.utils.keccak256(
-      ethers.utils.toUtf8Bytes("CustomKey1")
-    );
-
-    const encodedAllowedERC725YKeys = abiCoder.encode(
-      ["bytes32[]"],
-      [[customKey1]]
-    );
-
-    beforeEach(async () => {
+  describe.only("Testing CheckAllowedERC725YKeys", () => {
+    let context: LSP6InternalsTestContext;
+    let dataKeys: {
+      firstDynamicKey: DataKey;
+      secondDynamicKey: DataKey;
+      thirdDynamicKey: DataKey;
+      fourthDynamicKey: DataKey;
+      firstFixedKey: DataKey;
+      secondFixedKey: DataKey;
+      thirdFixedKey: DataKey;
+      fourthFixedKey: DataKey;
+    };
+    let dataKeysToCheck: BytesLike[];
+    let compactBytesArray_2d: BytesLike;
+    let compactBytesArray_2f: BytesLike;
+    let compactBytesArray_2d_2f: BytesLike;
+    let compactBytesArray_mixed_d_f: BytesLike;
+    before(async () => {
       context = await buildContext();
-
-      controllerCanSetOneKey = context.accounts[1];
-
-      const permissionKeys = [
-        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-          context.owner.address.substring(2),
-        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-          controllerCanSetOneKey.address.substring(2),
-        ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-          controllerCanSetOneKey.address.substring(2),
+      dataKeys = {
+        firstDynamicKey: {
+          length: "0x11",
+          key: "0xaf449139942203369080622073bf7f2dab",
+        },
+        secondDynamicKey: {
+          length: "0x01",
+          key: "0x1c",
+        },
+        thirdDynamicKey: {
+          length: "0x1c",
+          key: "0x4f042128e305e375c54b8782c3f9f1bde93f3586649d48db9c68beef",
+        },
+        fourthDynamicKey: {
+          length: "0x15",
+          key: "0xe6e8c1d23558e2a87caf19b7cc928eff323881d3e6",
+        },
+        firstFixedKey: {
+          length: "0x20",
+          key: "0xcbfb606f69bb97c04cbaea2a8b7cb13a2e229fafa3fb3be6db11d96ee3add114",
+        },
+        secondFixedKey: {
+          length: "0x20",
+          key: "0xa2c116feaaf87e499ac78081e8ce74b0a85627265144d605904971a89f81220a",
+        },
+        thirdFixedKey: {
+          length: "0x20",
+          key: "0x7b68176ed8c5774f16c8040df3f2c4aac9959612242613785716c4263670fe18",
+        },
+        fourthFixedKey: {
+          length: "0x20",
+          key: "0x2b58178172d258515ef1d9e7c467f6f6a09510e863ef5ad383dbfc50721183df",
+        },
+      };
+      dataKeysToCheck = [
+        "0x6fae27edb0b5020ca98b9af9014331fcc79241c7f12d6afbcaea07f00e53b45d",
+        "0xfd63b8f031e1f4c43fbb4956e08c686aa350a051d4d3e77a1e1c7f70366207b2",
+        "0xf4fafa18dc0e9916a17a5d14b39a4dc68fb56cfaf964aceca8456b424331adb4",
+        "0x92f9ce0fd87f5477d0aec48786bfebf80a51700879505dea17852f0777b114d3",
+        "0x0c02c965d192a6666110f3806dc2cd489ce2f7ca43f08a9ff33ad74d2fb30dc7",
+        "0x108eae0761cc2f55fab5acf94bc557dd0e550e60be19de83c513cd17821227a8",
+        "0xe2bfbedc99949767be4c79d5d10deaffc1c207560d29e4070f450faabb562d3b",
+        "0xe5f29667509d955384331154d9fa3b9e53ae230c44e722983a42f4d9608ef9b6",
+        "0x9fedfe7c7366c70c52b6f11531196d0c5baa77abd16117ae30dc4eeb16dd6da2",
+        "0x8741530fb57ca8556c5e7b45ffac62c178d8c0ff070ff1c99652e3f099997fa6",
       ];
-
-      const permissionValues = [
-        ALL_PERMISSIONS,
-        PERMISSIONS.SETDATA,
-        encodedAllowedERC725YKeys,
-      ];
-
-      await setupKeyManagerHelper(context, permissionKeys, permissionValues);
+      compactBytesArray_2d =
+        dataKeys.firstDynamicKey.length +
+        dataKeys.firstDynamicKey.key.toString().substring(2) +
+        dataKeys.secondDynamicKey.length.toString().substring(2) +
+        dataKeys.secondDynamicKey.key.toString().substring(2);
+      compactBytesArray_2f =
+        dataKeys.firstFixedKey.length +
+        dataKeys.firstFixedKey.key.toString().substring(2) +
+        dataKeys.secondFixedKey.length.toString().substring(2) +
+        dataKeys.secondFixedKey.key.toString().substring(2);
+      compactBytesArray_2d_2f =
+        dataKeys.firstDynamicKey.length +
+        dataKeys.firstDynamicKey.key.toString().substring(2) +
+        dataKeys.secondDynamicKey.length.toString().substring(2) +
+        dataKeys.secondDynamicKey.key.toString().substring(2) +
+        dataKeys.firstFixedKey.length.toString().substring(2) +
+        dataKeys.firstFixedKey.key.toString().substring(2) +
+        dataKeys.secondFixedKey.length.toString().substring(2) +
+        dataKeys.secondFixedKey.key.toString().substring(2);
+      compactBytesArray_mixed_d_f =
+        dataKeys.firstDynamicKey.length +
+        dataKeys.firstDynamicKey.key.toString().substring(2) +
+        dataKeys.firstFixedKey.length.toString().substring(2) +
+        dataKeys.firstFixedKey.key.toString().substring(2) +
+        dataKeys.secondDynamicKey.length.toString().substring(2) +
+        dataKeys.secondDynamicKey.key.toString().substring(2) +
+        dataKeys.thirdDynamicKey.length.toString().substring(2) +
+        dataKeys.thirdDynamicKey.key.toString().substring(2) +
+        dataKeys.secondFixedKey.length.toString().substring(2) +
+        dataKeys.secondFixedKey.key.toString().substring(2) +
+        dataKeys.fourthDynamicKey.length.toString().substring(2) +
+        dataKeys.fourthDynamicKey.key.toString().substring(2) +
+        dataKeys.thirdFixedKey.length.toString().substring(2) +
+        dataKeys.thirdFixedKey.key.toString().substring(2);
     });
 
-    describe("getAllowedERC725YKeysFor(...)", () => {
-      it("should return the same list of allowed ERC725Y Keys", async () => {
-        let bytesResult =
-          await context.keyManagerInternalTester.getAllowedERC725YKeysFor(
-            controllerCanSetOneKey.address
+    describe("`checkValidCompactBytesArray(..)`", () => {
+      it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys", async () => {
+        const result =
+          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+            compactBytesArray_2d
           );
 
-        let [decodedResult] = abiCoder.decode(["bytes32[]"], bytesResult);
+        expect(result).to.be.true;
+      });
 
-        const expectedResult = [customKey1];
+      it("Verifying the validity of a CompactBytesArray containing 2 fixed keys", async () => {
+        const result =
+          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+            compactBytesArray_2f
+          );
 
-        expect(decodedResult).to.deep.equal(expectedResult);
+        expect(result).to.be.true;
+      });
+
+      it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", async () => {
+        const result =
+          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+            compactBytesArray_2d_2f
+          );
+
+        expect(result).to.be.true;
+      });
+
+      it("Verifying the validity of a CompactBytesArray with mixed dynamic and fixed keys", async () => {
+        const result =
+          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+            compactBytesArray_mixed_d_f
+          );
+
+        expect(result).to.be.true;
       });
     });
 
-    describe("verifyAllowedERC725YKeys(...)", () => {
-      it("should revert even if list contains one allowed key", async () => {
-        let inputKeys = [
-          customKey1,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-        ];
+    describe("`verifyAllowedERC725YSingleKey(..)`", () => {
+      describe("checking a CompactBytesArray containing 2 dynamic keys", () => {
+        it("checking first dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.firstDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.firstDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
 
-        await expect(
-          context.keyManagerInternalTester.verifyAllowedERC725YKeys(
-            controllerCanSetOneKey.address,
-            inputKeys
-          )
-        )
-          .to.be.revertedWithCustomError(
-            context.keyManagerInternalTester,
-            "NotAllowedERC725YKey"
-          )
-          .withArgs(controllerCanSetOneKey.address, inputKeys[1]);
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.secondDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.secondDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking 10 random data keys: all should return false", async () => {
+          for (let i = 0; i < 10; i++) {
+            const dataKeyToCheck = dataKeysToCheck[i];
+
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+                context.universalProfile.address,
+                dataKeyToCheck,
+                compactBytesArray_2d
+              )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManagerInternalTester,
+                "NotAllowedERC725YKey"
+              )
+              .withArgs(context.universalProfile.address, dataKeyToCheck);
+          }
+        });
+      });
+
+      describe("checking a CompactBytesArray containing 2 fixed keys", () => {
+        it("checking first fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.firstFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.secondFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking 10 random data keys: all should return false", async () => {
+          for (let i = 0; i < 10; i++) {
+            const dataKeyToCheck = dataKeysToCheck[i];
+
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+                context.universalProfile.address,
+                dataKeyToCheck,
+                compactBytesArray_2f
+              )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManagerInternalTester,
+                "NotAllowedERC725YKey"
+              )
+              .withArgs(context.universalProfile.address, dataKeyToCheck);
+          }
+        });
+      });
+
+      describe("checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", () => {
+        it("checking first dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.firstDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.firstDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.secondDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.secondDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking first fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.firstFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.secondFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_2d_2f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking 10 random data keys: all should return false", async () => {
+          for (let i = 0; i < 10; i++) {
+            const dataKeyToCheck = dataKeysToCheck[i];
+
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+                context.universalProfile.address,
+                dataKeyToCheck,
+                compactBytesArray_2d_2f
+              )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManagerInternalTester,
+                "NotAllowedERC725YKey"
+              )
+              .withArgs(context.universalProfile.address, dataKeyToCheck);
+          }
+        });
+      });
+
+      describe("checking a CompactBytesArray containing mixed dynamic and fixed keys", () => {
+        it("checking first dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.firstDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.firstDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.secondDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.secondDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking third dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.thirdDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.thirdDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking fourth dynamic key: should return true", async () => {
+          const checkedDataKey =
+            dataKeys.fourthDynamicKey.key +
+            ethers.utils
+              .hexlify(
+                ethers.utils.randomBytes(
+                  ethers.BigNumber.from(32)
+                    .sub(dataKeys.fourthDynamicKey.length)
+                    .toNumber()
+                )
+              )
+              .substring(2);
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking first fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.firstFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking second fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.secondFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking third fixed key: should return true", async () => {
+          const checkedDataKey = dataKeys.thirdFixedKey.key;
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+              context.universalProfile.address,
+              checkedDataKey,
+              compactBytesArray_mixed_d_f
+            );
+
+          expect(result).to.be.true;
+        });
+
+        it("checking 10 random data keys: all should return false", async () => {
+          for (let i = 0; i < 10; i++) {
+            const dataKeyToCheck = dataKeysToCheck[i];
+
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+                context.universalProfile.address,
+                dataKeyToCheck,
+                compactBytesArray_mixed_d_f
+              )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManagerInternalTester,
+                "NotAllowedERC725YKey"
+              )
+              .withArgs(context.universalProfile.address, dataKeyToCheck);
+          }
+        });
       });
     });
-  });
 
-  describe("_countZeroBytes(...)", () => {
-    beforeEach(async () => {
-      context = await buildContext();
-    });
+    describe("`verifyAllowedERC725YKeys(..)`", () => {
+      describe("checking a CompactBytesArray containing 2 dynamic keys", () => {
+        it("checking an array of valid keys: should return true", async () => {
+          const checkedDataKeys = [
+            dataKeys.firstDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.firstDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.secondDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.secondDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+          ];
 
-    describe("test against LSP2 key types", () => {
-      const SINGLETON_KEY = ERC725YKeys.LSP3["LSP3Profile"];
-
-      const ARRAY_KEY =
-        ERC725YKeys.LSP4["LSP4Creators[]"].index + "00".repeat(16);
-
-      const MAPPING_KEY =
-        SupportedStandards.LSP3UniversalProfile.key.substring(0, 34) +
-        "00".repeat(16);
-
-      const BYTES20_MAPPING_KEY =
-        ERC725YKeys.LSP5["LSP5ReceivedAssetsMap"].substring(0, 18) +
-        "00".repeat(24);
-
-      it(
-        "Singleton: should return 0 for `LSP3Profile` -> " + SINGLETON_KEY,
-        async () => {
-          let result =
-            await context.keyManagerInternalTester.countTrailingZeroBytes(
-              SINGLETON_KEY
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              checkedDataKeys,
+              compactBytesArray_2d
             );
 
-          expect(result).to.equal(0);
-        }
-      );
+          expect(result).to.be.true;
+        });
 
-      it(
-        "Array: should return 16 for `LSP4Creators[]` -> " + ARRAY_KEY,
-        async () => {
-          let result =
-            await context.keyManagerInternalTester.countTrailingZeroBytes(
-              ARRAY_KEY
+        it("checking an array of invalid keys: all should return false", async () => {
+          await expect(
+            context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              dataKeysToCheck,
+              compactBytesArray_2d
+            )
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManagerInternalTester,
+              "NotAllowedERC725YKey"
+            )
+            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+        });
+      });
+
+      describe("checking a CompactBytesArray containing 2 fixed keys", () => {
+        it("checking an array of valid keys: should return true", async () => {
+          const checkedDataKeys = [
+            dataKeys.firstFixedKey.key,
+            dataKeys.secondFixedKey.key,
+          ];
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              checkedDataKeys,
+              compactBytesArray_2f
             );
 
-          expect(result).to.equal(16);
-        }
-      );
+          expect(result).to.be.true;
+        });
 
-      it(
-        "Mapping: should return 16 for `SupportedStandards:...` -> " +
-          MAPPING_KEY,
-        async () => {
-          let result =
-            await context.keyManagerInternalTester.countTrailingZeroBytes(
-              MAPPING_KEY
+        it("checking an array of invalid keys: all should return false", async () => {
+          await expect(
+            context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              dataKeysToCheck,
+              compactBytesArray_2f
+            )
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManagerInternalTester,
+              "NotAllowedERC725YKey"
+            )
+            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+        });
+      });
+
+      describe("checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", () => {
+        it("checking an array of valid keys: should return true", async () => {
+          const checkedDataKeys = [
+            dataKeys.firstDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.firstDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.secondDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.secondDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.firstFixedKey.key,
+            dataKeys.secondFixedKey.key,
+          ];
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              checkedDataKeys,
+              compactBytesArray_2d_2f
             );
 
-          expect(result).to.equal(16);
-        }
-      );
+          expect(result).to.be.true;
+        });
 
-      it(
-        "Bytes20Mapping: should return 16 for `LSP5ReceivedAssetsMap:...` -> " +
-          BYTES20_MAPPING_KEY,
-        async () => {
-          let result =
-            await context.keyManagerInternalTester.countTrailingZeroBytes(
-              BYTES20_MAPPING_KEY
+        it("checking an array of invalid keys: all should return false", async () => {
+          await expect(
+            context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              dataKeysToCheck,
+              compactBytesArray_2d_2f
+            )
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManagerInternalTester,
+              "NotAllowedERC725YKey"
+            )
+            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+        });
+      });
+
+      describe("checking a CompactBytesArray containing mixed dynamic and fixed keys", () => {
+        it("checking an array of valid keys: should return true", async () => {
+          const checkedDataKeys = [
+            dataKeys.firstDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.firstDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.firstFixedKey.key,
+            dataKeys.secondDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.secondDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.thirdDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.thirdDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.secondFixedKey.key,
+            dataKeys.fourthDynamicKey.key +
+              ethers.utils
+                .hexlify(
+                  ethers.utils.randomBytes(
+                    ethers.BigNumber.from(32)
+                      .sub(dataKeys.fourthDynamicKey.length)
+                      .toNumber()
+                  )
+                )
+                .substring(2),
+            dataKeys.thirdFixedKey.key,
+          ];
+
+          const result =
+            await context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              checkedDataKeys,
+              compactBytesArray_mixed_d_f
             );
 
-          expect(result).to.equal(24);
-        }
-      );
+          expect(result).to.be.true;
+        });
+
+        it("checking an array of invalid keys: all should return false", async () => {
+          await expect(
+            context.keyManagerInternalTester.verifyAllowedERC725YKeys(
+              context.universalProfile.address,
+              dataKeysToCheck,
+              compactBytesArray_mixed_d_f
+            )
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManagerInternalTester,
+              "NotAllowedERC725YKey"
+            )
+            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+        });
+      });
     });
   });
 };

--- a/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
@@ -12,7 +12,7 @@ export type DataKey = {
 export const testAllowedERC725YKeysInternals = (
   buildContext: () => Promise<LSP6InternalsTestContext>
 ) => {
-  describe.only("Testing CheckAllowedERC725YKeys", () => {
+  describe("Testing CheckAllowedERC725YKeys", () => {
     let context: LSP6InternalsTestContext;
     let dataKeys: {
       firstDynamicKey: DataKey;

--- a/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
@@ -24,7 +24,7 @@ export const testAllowedERC725YKeysInternals = (
       thirdFixedKey: DataKey;
       fourthFixedKey: DataKey;
     };
-    let dataKeysToCheck: BytesLike[];
+    let dataKeysToReturn: BytesLike[];
     let compactBytesArray_2d: BytesLike;
     let compactBytesArray_2f: BytesLike;
     let compactBytesArray_2d_2f: BytesLike;
@@ -65,7 +65,7 @@ export const testAllowedERC725YKeysInternals = (
           key: "0x2b58178172d258515ef1d9e7c467f6f6a09510e863ef5ad383dbfc50721183df",
         },
       };
-      dataKeysToCheck = [
+      dataKeysToReturn = [
         "0x6fae27edb0b5020ca98b9af9014331fcc79241c7f12d6afbcaea07f00e53b45d",
         "0xfd63b8f031e1f4c43fbb4956e08c686aa350a051d4d3e77a1e1c7f70366207b2",
         "0xf4fafa18dc0e9916a17a5d14b39a4dc68fb56cfaf964aceca8456b424331adb4",
@@ -114,7 +114,7 @@ export const testAllowedERC725YKeysInternals = (
     });
 
     describe("`isCompactBytesArray(..)`", () => {
-      it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys", async () => {
+      it("should return true for a CompactBytesArray containing 2 dynamic keys", async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2d
@@ -123,7 +123,7 @@ export const testAllowedERC725YKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("Verifying the validity of a CompactBytesArray containing 2 fixed keys", async () => {
+      it("should return true for a CompactBytesArray containing 2 fixed keys", async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2f
@@ -132,7 +132,7 @@ export const testAllowedERC725YKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", async () => {
+      it("should return true for a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2d_2f
@@ -141,7 +141,7 @@ export const testAllowedERC725YKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("Verifying the validity of a CompactBytesArray with mixed dynamic and fixed keys", async () => {
+      it("should return true for a CompactBytesArray with mixed dynamic and fixed keys", async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_mixed_d_f
@@ -201,7 +201,7 @@ export const testAllowedERC725YKeysInternals = (
 
         it("checking 10 random data keys: all should return false", async () => {
           for (let i = 0; i < 10; i++) {
-            const dataKeyToCheck = dataKeysToCheck[i];
+            const dataKeyToCheck = dataKeysToReturn[i];
 
             await expect(
               context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
@@ -248,7 +248,7 @@ export const testAllowedERC725YKeysInternals = (
 
         it("checking 10 random data keys: all should return false", async () => {
           for (let i = 0; i < 10; i++) {
-            const dataKeyToCheck = dataKeysToCheck[i];
+            const dataKeyToCheck = dataKeysToReturn[i];
 
             await expect(
               context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
@@ -341,7 +341,7 @@ export const testAllowedERC725YKeysInternals = (
 
         it("checking 10 random data keys: all should return false", async () => {
           for (let i = 0; i < 10; i++) {
-            const dataKeyToCheck = dataKeysToCheck[i];
+            const dataKeyToCheck = dataKeysToReturn[i];
 
             await expect(
               context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
@@ -493,7 +493,7 @@ export const testAllowedERC725YKeysInternals = (
 
         it("checking 10 random data keys: all should return false", async () => {
           for (let i = 0; i < 10; i++) {
-            const dataKeyToCheck = dataKeysToCheck[i];
+            const dataKeyToCheck = dataKeysToReturn[i];
 
             await expect(
               context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
@@ -552,7 +552,7 @@ export const testAllowedERC725YKeysInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YKeys(
               context.universalProfile.address,
-              dataKeysToCheck,
+              dataKeysToReturn,
               compactBytesArray_2d
             )
           )
@@ -560,7 +560,7 @@ export const testAllowedERC725YKeysInternals = (
               context.keyManagerInternalTester,
               "NotAllowedERC725YKey"
             )
-            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+            .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
@@ -585,7 +585,7 @@ export const testAllowedERC725YKeysInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YKeys(
               context.universalProfile.address,
-              dataKeysToCheck,
+              dataKeysToReturn,
               compactBytesArray_2f
             )
           )
@@ -593,7 +593,7 @@ export const testAllowedERC725YKeysInternals = (
               context.keyManagerInternalTester,
               "NotAllowedERC725YKey"
             )
-            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+            .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
@@ -638,7 +638,7 @@ export const testAllowedERC725YKeysInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YKeys(
               context.universalProfile.address,
-              dataKeysToCheck,
+              dataKeysToReturn,
               compactBytesArray_2d_2f
             )
           )
@@ -646,7 +646,7 @@ export const testAllowedERC725YKeysInternals = (
               context.keyManagerInternalTester,
               "NotAllowedERC725YKey"
             )
-            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+            .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
@@ -712,7 +712,7 @@ export const testAllowedERC725YKeysInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YKeys(
               context.universalProfile.address,
-              dataKeysToCheck,
+              dataKeysToReturn,
               compactBytesArray_mixed_d_f
             )
           )
@@ -720,7 +720,7 @@ export const testAllowedERC725YKeysInternals = (
               context.keyManagerInternalTester,
               "NotAllowedERC725YKey"
             )
-            .withArgs(context.universalProfile.address, dataKeysToCheck[0]);
+            .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
     });

--- a/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YKeys.internal.ts
@@ -113,10 +113,10 @@ export const testAllowedERC725YKeysInternals = (
         dataKeys.thirdFixedKey.key.toString().substring(2);
     });
 
-    describe("`checkValidCompactBytesArray(..)`", () => {
+    describe("`isCompactBytesArray(..)`", () => {
       it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys", async () => {
         const result =
-          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+          await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2d
           );
 
@@ -125,7 +125,7 @@ export const testAllowedERC725YKeysInternals = (
 
       it("Verifying the validity of a CompactBytesArray containing 2 fixed keys", async () => {
         const result =
-          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+          await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2f
           );
 
@@ -134,7 +134,7 @@ export const testAllowedERC725YKeysInternals = (
 
       it("Verifying the validity of a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", async () => {
         const result =
-          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+          await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_2d_2f
           );
 
@@ -143,7 +143,7 @@ export const testAllowedERC725YKeysInternals = (
 
       it("Verifying the validity of a CompactBytesArray with mixed dynamic and fixed keys", async () => {
         const result =
-          await context.keyManagerInternalTester.callStatic.checkValidCompactBytesArray(
+          await context.keyManagerInternalTester.callStatic.isCompactBytesArray(
             compactBytesArray_mixed_d_f
           );
 

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -8,13 +8,13 @@ import { ALL_PERMISSIONS, ERC725YKeys, PERMISSIONS } from "../../../constants";
 // setup
 import { LSP6TestContext } from "../../utils/context";
 import { setupKeyManager } from "../../utils/fixtures";
-import { encodeCompactedBytes, decodeCompactBytes } from "../../utils/helpers";
 
 // helpers
-import { abiCoder, getRandomString } from "../../utils/helpers";
-
-// types
-import { BytesLike } from "ethers";
+import {
+  encodeCompactedBytes,
+  decodeCompactBytes,
+  getRandomString,
+} from "../../utils/helpers";
 
 export const shouldBehaveLikeAllowedERC725YKeys = (
   buildContext: () => Promise<LSP6TestContext>

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -63,8 +63,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         PERMISSIONS.SETDATA,
         encodeCompactedBytes([customKey1]),
         encodeCompactedBytes([customKey2, customKey3, customKey4]),
-        //abiCoder.encode(["bytes32[]"], [[customKey1]]),
-        //abiCoder.encode(["bytes32[]"], [[customKey2, customKey3, customKey4]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -76,7 +74,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetOneKey.address.substring(2)
         );
-        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
         let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.have.lengthOf(1);
@@ -87,7 +84,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetManyKeys.address.substring(2)
         );
-        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
         let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.have.lengthOf(3);
@@ -98,7 +94,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetOneKey.address.substring(2)
         );
-        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
         let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.include(customKey1);
@@ -109,7 +104,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetManyKeys.address.substring(2)
         );
-        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
         let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.contain(customKey2);
@@ -1086,7 +1080,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         encodeCompactedBytes([supportedStandardKey]),
-        //abiCoder.encode(["bytes32[]"], [[supportedStandardKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1475,7 +1468,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         encodeCompactedBytes([allowedArrayKey]),
-        //abiCoder.encode(["bytes32[]"], [[allowedArrayKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1703,7 +1695,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         encodeCompactedBytes([customKey1, customKey2, zeroKey]),
-        //abiCoder.encode(["bytes32[]"], [[customKey1, customKey2, zeroKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1784,9 +1775,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
             "NotAllowedERC725YKey"
           )
           .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
-
-        //const result = await context.universalProfile["getData(bytes32)"](key);
-        //expect(result).to.equal(value);
       });
     });
   });
@@ -1814,7 +1802,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         encodeCompactedBytes([allowedDataKey]),
-        //abiCoder.encode(["bytes32[]"], [[allowedDataKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -11,7 +11,7 @@ import { setupKeyManager } from "../../utils/fixtures";
 
 // helpers
 import {
-  encodeCompactedBytes,
+  encodeCompactBytesArray,
   decodeCompactBytes,
   getRandomString,
 } from "../../utils/helpers";
@@ -61,8 +61,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         PERMISSIONS.SETDATA,
-        encodeCompactedBytes([customKey1]),
-        encodeCompactedBytes([customKey2, customKey3, customKey4]),
+        encodeCompactBytesArray([customKey1]),
+        encodeCompactBytesArray([customKey2, customKey3, customKey4]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1079,7 +1079,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        encodeCompactedBytes([supportedStandardKey]),
+        encodeCompactBytesArray([supportedStandardKey]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1467,7 +1467,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        encodeCompactedBytes([allowedArrayKey]),
+        encodeCompactBytesArray([allowedArrayKey]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1694,7 +1694,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        encodeCompactedBytes([customKey1, customKey2, zeroKey]),
+        encodeCompactBytesArray([customKey1, customKey2, zeroKey]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1801,7 +1801,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        encodeCompactedBytes([allowedDataKey]),
+        encodeCompactBytesArray([allowedDataKey]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -8,9 +8,13 @@ import { ALL_PERMISSIONS, ERC725YKeys, PERMISSIONS } from "../../../constants";
 // setup
 import { LSP6TestContext } from "../../utils/context";
 import { setupKeyManager } from "../../utils/fixtures";
+import { encodeCompactedBytes, decodeCompactBytes } from "../../utils/helpers";
 
 // helpers
 import { abiCoder, getRandomString } from "../../utils/helpers";
+
+// types
+import { BytesLike } from "ethers";
 
 export const shouldBehaveLikeAllowedERC725YKeys = (
   buildContext: () => Promise<LSP6TestContext>
@@ -57,8 +61,10 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
         PERMISSIONS.SETDATA,
-        abiCoder.encode(["bytes32[]"], [[customKey1]]),
-        abiCoder.encode(["bytes32[]"], [[customKey2, customKey3, customKey4]]),
+        encodeCompactedBytes([customKey1]),
+        encodeCompactedBytes([customKey2, customKey3, customKey4]),
+        //abiCoder.encode(["bytes32[]"], [[customKey1]]),
+        //abiCoder.encode(["bytes32[]"], [[customKey2, customKey3, customKey4]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -70,7 +76,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetOneKey.address.substring(2)
         );
-        let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.have.lengthOf(1);
       });
@@ -80,7 +87,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetManyKeys.address.substring(2)
         );
-        let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.have.lengthOf(3);
       });
@@ -90,7 +98,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetOneKey.address.substring(2)
         );
-        let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.include(customKey1);
       });
@@ -100,7 +109,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             controllerCanSetManyKeys.address.substring(2)
         );
-        let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        //let [decodedResult] = abiCoder.decode(["bytes32[]"], result);
+        let decodedResult = decodeCompactBytes(result);
 
         expect(decodedResult).to.contain(customKey2);
         expect(decodedResult).to.contain(customKey3);
@@ -1044,8 +1054,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
     let controllerCanSetMappingKeys: SignerWithAddress;
 
     // all mapping keys starting with: SupportedStandards:...
-    const supportedStandardKey =
-      "0xeafec4d89fa9619884b6b8913562645500000000000000000000000000000000";
+    const supportedStandardKey = "0xeafec4d89fa9619884b6b89135626455";
 
     // SupportedStandards:LSPX
     const LSPXKey =
@@ -1076,7 +1085,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        abiCoder.encode(["bytes32[]"], [[supportedStandardKey]]),
+        encodeCompactedBytes([supportedStandardKey]),
+        //abiCoder.encode(["bytes32[]"], [[supportedStandardKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1430,8 +1440,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
   describe("keyType: Array", () => {
     let controllerCanSetArrayKeys: SignerWithAddress;
 
-    const allowedArrayKey =
-      "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000000";
+    const allowedArrayKey = "0x868affce801d08a5948eebc349a5c8ff";
 
     // keccak256("MyArray[]")
     const arrayKeyLength =
@@ -1465,7 +1474,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        abiCoder.encode(["bytes32[]"], [[allowedArrayKey]]),
+        encodeCompactedBytes([allowedArrayKey]),
+        //abiCoder.encode(["bytes32[]"], [[allowedArrayKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1692,7 +1702,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        abiCoder.encode(["bytes32[]"], [[customKey1, customKey2, zeroKey]]),
+        encodeCompactedBytes([customKey1, customKey2, zeroKey]),
+        //abiCoder.encode(["bytes32[]"], [[customKey1, customKey2, zeroKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -1751,7 +1762,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         ),
       },
     ].forEach((testCase) => {
-      it(`should pass when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
+      it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
         const key = testCase.datakeyToSet;
         const value = ethers.utils.hexlify(
           ethers.utils.toUtf8Bytes("some value for " + key)
@@ -1763,12 +1774,19 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
             [key, value]
           );
 
-        await context.keyManager
-          .connect(controllerCanSetSomeKeys)
-          .execute(setDataPayload);
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NotAllowedERC725YKey"
+          )
+          .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
 
-        const result = await context.universalProfile["getData(bytes32)"](key);
-        expect(result).to.equal(value);
+        //const result = await context.universalProfile["getData(bytes32)"](key);
+        //expect(result).to.equal(value);
       });
     });
   });
@@ -1776,8 +1794,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
   describe("one single byte as an allowed data key (e.g: 0xaa0000...0000", () => {
     let controllerCanSetSomeKeys: SignerWithAddress;
 
-    const allowedDataKey =
-      "0xaa00000000000000000000000000000000000000000000000000000000000000";
+    const allowedDataKey = "0xaa";
 
     before(async () => {
       context = await buildContext();
@@ -1796,7 +1813,8 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
       const permissionValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.SETDATA,
-        abiCoder.encode(["bytes32[]"], [[allowedDataKey]]),
+        encodeCompactedBytes([allowedDataKey]),
+        //abiCoder.encode(["bytes32[]"], [[allowedDataKey]]),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);

--- a/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
@@ -124,11 +124,7 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         context.owner.address.substring(2),
     ];
 
-    const values = [
-      ARRAY_LENGTH.ONE,
-      context.owner.address,
-      ALL_PERMISSIONS,
-    ];
+    const values = [ARRAY_LENGTH.ONE, context.owner.address, ALL_PERMISSIONS];
 
     expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
       values
@@ -146,10 +142,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
       ]);
 
       await expect(
-        context.keyManager
-          .connect(context.owner)
-          .execute(mintPayload)
-      ).to.be.revertedWithCustomError(
+        context.keyManager.connect(context.owner).execute(mintPayload)
+      )
+        .to.be.revertedWithCustomError(
           context.keyManager,
           "InvalidERC725Function"
         )
@@ -166,7 +161,8 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         context.keyManager
           .connect(context.owner)
           .execute(renounceOwnershipPayload)
-      ).to.be.revertedWithCustomError(
+      )
+        .to.be.revertedWithCustomError(
           context.keyManager,
           "InvalidERC725Function"
         )
@@ -175,13 +171,12 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
   });
 
   describe("using transferOwnership(..) in LSP7 through LSP6", () => {
-
     it("should change the owner of LSP7 contract", async () => {
       const LSP7 = context.token as LSP7Mintable;
-      const transferOwnershipPayload =
-      LSP7.interface.encodeFunctionData("transferOwnership", [
-          newOwner.address,
-        ]);
+      const transferOwnershipPayload = LSP7.interface.encodeFunctionData(
+        "transferOwnership",
+        [newOwner.address]
+      );
 
       await context.keyManager
         .connect(context.owner)
@@ -203,12 +198,8 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
       );
 
       await expect(
-        context.keyManager
-          .connect(context.owner)
-          .execute(payload)
-      ).to.be.revertedWith(
-        "Ownable: caller is not the owner"
-      );
+        context.keyManager.connect(context.owner).execute(payload)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("should allow the new owner to call setData(..)", async () => {
@@ -221,9 +212,7 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
       await context.token
         .connect(newOwner)
-        ["setData(bytes32,bytes)"](
-          key, value
-        );
+        ["setData(bytes32,bytes)"](key, value);
 
       expect(await context.token["getData(bytes32)"](key)).to.equal(value);
     });
@@ -238,10 +227,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
       ]);
 
       await expect(
-        context.keyManager
-          .connect(context.owner)
-          .execute(mintPayload)
-      ).to.be.revertedWithCustomError(
+        context.keyManager.connect(context.owner).execute(mintPayload)
+      )
+        .to.be.revertedWithCustomError(
           context.keyManager,
           "InvalidERC725Function"
         )
@@ -251,17 +239,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     it("should allow the new owner to call mint(..)", async () => {
       const LSP7 = context.token as LSP7Mintable;
 
-      await LSP7
-        .connect(newOwner)
-        .mint(
-          context.owner.address,
-          1,
-          true,
-          "0x",
-        );
+      await LSP7.connect(newOwner).mint(context.owner.address, 1, true, "0x");
 
-      expect(await LSP7.balanceOf(context.owner.address))
-        .to.equal(1);
+      expect(await LSP7.balanceOf(context.owner.address)).to.equal(1);
     });
 
     it("`transferOwnership(..)` -> should revert with 'caller is not the owner' error.", async () => {
@@ -274,16 +254,14 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         context.keyManager
           .connect(context.owner)
           .execute(transferOwnershipPayload)
-      ).to.be.revertedWith(
-        "Ownable: caller is not the owner"
-      );
+      ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("should allow the new owner to call transferOwnership(..)", async () => {
       await context.token
         .connect(newOwner)
         .transferOwnership(anotherNewOwner.address);
-      
+
       expect(await context.token.owner()).to.equal(anotherNewOwner.address);
     });
 
@@ -295,7 +273,8 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         context.keyManager
           .connect(context.owner)
           .execute(renounceOwnershipPayload)
-      ).to.be.revertedWithCustomError(
+      )
+        .to.be.revertedWithCustomError(
           context.keyManager,
           "InvalidERC725Function"
         )
@@ -303,12 +282,11 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     });
 
     it("should allow the new owner to call renounceOwnership(..)", async () => {
-      await context.token
-        .connect(anotherNewOwner)
-        .renounceOwnership();
+      await context.token.connect(anotherNewOwner).renounceOwnership();
 
-      expect(await context.token.owner())
-        .to.equal(ethers.constants.AddressZero);
+      expect(await context.token.owner()).to.equal(
+        ethers.constants.AddressZero
+      );
     });
   });
 
@@ -347,9 +325,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           PERMISSIONS.CHANGEOWNER,
         ];
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should revert if the caller doesn't have CHANGEOWNER permission when using `transferOwnership(..)`", async () => {
@@ -362,7 +340,8 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           context.keyManager
             .connect(addressCanChangePermissions)
             .execute(transferOwnershipPayload)
-        ).to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
           .withArgs(addressCanChangePermissions.address);
       });
 
@@ -423,9 +402,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           PERMISSIONS.CHANGEPERMISSIONS,
         ];
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should revert if caller doesn't have CHANGEPERMISSION permission", async () => {
@@ -439,10 +418,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         );
 
         await expect(
-          context.keyManager
-            .connect(addressCanChangeOwner)
-            .execute(payload)
-        ).to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          context.keyManager.connect(addressCanChangeOwner).execute(payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(addressCanChangeOwner.address, "CHANGEPERMISSIONS");
       });
 
@@ -456,7 +434,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           [key, value]
         );
 
-        await context.keyManager.connect(addressCanChangePermissions).execute(payload);
+        await context.keyManager
+          .connect(addressCanChangePermissions)
+          .execute(payload);
 
         expect(await context.token["getData(bytes32)"](key)).to.equal(value);
       });
@@ -471,7 +451,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           [key, value]
         );
 
-        await context.keyManager.connect(addressCanChangePermissions).execute(payload);
+        await context.keyManager
+          .connect(addressCanChangePermissions)
+          .execute(payload);
 
         expect(await context.token["getData(bytes32)"](key)).to.equal(value);
       });
@@ -517,9 +499,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           PERMISSIONS.ADDPERMISSIONS,
         ];
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should be allowed to add a new controller with some permissions", async () => {
@@ -532,12 +514,14 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           [key, value]
         );
 
-        await context.keyManager.connect(addressCanAddPermissions).execute(payload);
+        await context.keyManager
+          .connect(addressCanAddPermissions)
+          .execute(payload);
 
         expect(await context.token["getData(bytes32)"](key)).to.equal(value);
       });
 
-      it("should not be authorized to edit permissions of an wxisting controller (e.g: removing permissions)", async () => {
+      it("should not be authorized to edit permissions of an existing controller (e.g: removing permissions)", async () => {
         const key =
           ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           addressCanSetData.address.substring(2);
@@ -548,10 +532,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         );
 
         await expect(
-          context.keyManager
-            .connect(addressCanAddPermissions)
-            .execute(payload)
-        ).to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          context.keyManager.connect(addressCanAddPermissions).execute(payload)
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(addressCanAddPermissions.address, "CHANGEPERMISSIONS");
       });
 
@@ -570,9 +553,15 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     });
 
     describe("testing SETDATA permission", () => {
-      const firstRandomSringKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString"));
-      const secondRandomSringKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SecondRandomString"));
-      const notAllowedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Not Allowed ERC725Y data key"));
+      const firstRandomSringKey = ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes("FirstRandomString")
+      );
+      const secondRandomSringKey = ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes("SecondRandomString")
+      );
+      const notAllowedKey = ethers.utils.keccak256(
+        ethers.utils.toUtf8Bytes("Not Allowed ERC725Y data key")
+      );
 
       before(async () => {
         await addControllerWithPermission(
@@ -618,9 +607,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           PERMISSIONS.SETDATA,
         ];
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should allow second controller to use setData", async () => {
@@ -642,11 +631,7 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           addressCanSetData.address.substring(2);
         const value = abiCoder.encode(
           ["bytes32[]"],
-          [
-            [
-              firstRandomSringKey.substring(0, 34) + "0".repeat(31) + "0",
-            ],
-          ]
+          [[firstRandomSringKey.substring(0, 34)]]
         );
         const payload = context.token.interface.encodeFunctionData(
           "setData(bytes32,bytes)",
@@ -688,9 +673,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
         await context.keyManager.connect(addressCanSetData).execute(payload);
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should revert when trying to change a key that is not allowed", async () => {
@@ -722,17 +707,13 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         );
 
         await expect(
-          context.keyManager
-            .connect(addressCanSetData)
-            .execute(payload)
-        ).to.be.revertedWithCustomError(
+          context.keyManager.connect(addressCanSetData).execute(payload)
+        )
+          .to.be.revertedWithCustomError(
             context.keyManager,
             "NotAllowedERC725YKey"
           )
-          .withArgs(
-            addressCanSetData.address,
-            notAllowedKey
-          );
+          .withArgs(addressCanSetData.address, notAllowedKey);
       });
     });
 
@@ -765,12 +746,10 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           );
 
         await expect(
-          context.keyManager
-            .connect(context.owner)
-            .execute(payload)
+          context.keyManager.connect(context.owner).execute(payload)
         ).to.be.revertedWith(
-            "LSP6: Unknown Error occured when calling the linked target contract"
-          );
+          "LSP6: Unknown Error occured when calling the linked target contract"
+        );
       });
     });
 
@@ -824,9 +803,9 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           PERMISSIONS.SIGN,
         ];
 
-        expect(
-          await context.token["getData(bytes32[])"](keys)
-        ).to.deep.equal(values);
+        expect(await context.token["getData(bytes32[])"](keys)).to.deep.equal(
+          values
+        );
       });
 
       it("should be allowed to sign messages for the token contract", async () => {

--- a/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
@@ -622,10 +622,12 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
         await expect(
           context.keyManager.connect(addressCanSetData).execute(payload)
-        ).to.be.revertedWithCustomError(
-          context.keyManager,
-          "NoERC725YDataKeysAllowed"
-        );
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NoERC725YDataKeysAllowed"
+          )
+          .withArgs(addressCanSetData.address);
       });
 
       it("should restrict second controller with AllowedERC725YKeys", async () => {

--- a/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
@@ -19,7 +19,7 @@ import {
   PERMISSIONS,
   ERC1271_VALUES,
 } from "../../../constants";
-import { ARRAY_LENGTH, encodeCompactedBytes } from "../../utils/helpers";
+import { ARRAY_LENGTH, encodeCompactBytesArray } from "../../utils/helpers";
 import { BytesLike } from "ethers";
 
 export type LSP6ControlledToken = {
@@ -632,7 +632,7 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         const key =
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
           addressCanSetData.address.substring(2);
-        const value = encodeCompactedBytes([
+        const value = encodeCompactBytesArray([
           firstRandomSringKey.substring(0, 34),
         ]);
         const payload = context.token.interface.encodeFunctionData(

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -18,7 +18,7 @@ import { setupKeyManager } from "../../utils/fixtures";
 import {
   abiCoder,
   combinePermissions,
-  encodeCompactedBytes,
+  encodeCompactBytesArray,
 } from "../../utils/helpers";
 
 export const shouldBehaveLikePermissionChangeOrAddPermissions = (
@@ -2374,7 +2374,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       let permissionValues = [
         PERMISSIONS.ADDPERMISSIONS,
         PERMISSIONS.CHANGEPERMISSIONS,
-        encodeCompactedBytes([
+        encodeCompactBytesArray([
           ERC725YKeys.LSP3["LSP3Profile"],
           // prettier-ignore
           ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
@@ -2394,7 +2394,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactedBytes([
+          let value = encodeCompactBytesArray([
             ERC725YKeys.LSP3["LSP3Profile"],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
@@ -2419,7 +2419,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactedBytes([ERC725YKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([
+            ERC725YKeys.LSP3["LSP3Profile"],
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2481,7 +2483,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             newController.address.substr(2);
 
-          let value = encodeCompactedBytes([
+          let value = encodeCompactBytesArray([
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 1")),
             // prettier-ignore
@@ -2533,7 +2535,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactedBytes([
+          let value = encodeCompactBytesArray([
             ERC725YKeys.LSP3["LSP3Profile"],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
@@ -2560,7 +2562,9 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactedBytes([ERC725YKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([
+            ERC725YKeys.LSP3["LSP3Profile"],
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2628,7 +2632,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             newController.address.substr(2);
 
-          let value = encodeCompactedBytes([
+          let value = encodeCompactBytesArray([
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 1")),
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 2")),
           ]);

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2858,10 +2858,12 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canSetDataAndAddPermissions)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataAndAddPermissions.address);
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions + decrement AddressPermissions[].length by -1", async () => {
@@ -3002,10 +3004,12 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canSetDataAndChangePermissions)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataAndChangePermissions.address);
         });
 
         it("(should fail): 2 x keys + change 2 x existing permissions", async () => {
@@ -3036,10 +3040,12 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canSetDataAndChangePermissions)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataAndChangePermissions.address);
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions", async () => {

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2468,7 +2468,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactBytesArray"
+            "InvalidEncodedAllowedERC725YKeys"
           );
         });
       });
@@ -2520,7 +2520,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactBytesArray"
+            "InvalidEncodedAllowedERC725YKeys"
           );
         });
       });
@@ -2615,7 +2615,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               .execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactBytesArray"
+            "InvalidEncodedAllowedERC725YKeys"
           );
         });
       });
@@ -2667,7 +2667,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               .execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactBytesArray"
+            "InvalidEncodedAllowedERC725YKeys"
           );
         });
       });

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2468,7 +2468,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactedAllowedERC725YDataKeys"
+            "InvalidCompactBytesArray"
           );
         });
       });
@@ -2520,7 +2520,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactedAllowedERC725YDataKeys"
+            "InvalidCompactBytesArray"
           );
         });
       });
@@ -2615,7 +2615,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               .execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactedAllowedERC725YDataKeys"
+            "InvalidCompactBytesArray"
           );
         });
       });
@@ -2667,7 +2667,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               .execute(payload)
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidCompactedAllowedERC725YDataKeys"
+            "InvalidCompactBytesArray"
           );
         });
       });

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2973,7 +2973,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
         });
       });
 
-      describe("when caller is an address with permission SETDATA + CHANGEPERMISSIONS", () => {
+      describe("when caller is an address with permission SETDATA + CHANGEPERMISSIONS + no Allowed ERC725Y Keys", () => {
         it("(should fail): 2 x keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -15,7 +15,11 @@ import { LSP6TestContext } from "../../utils/context";
 import { setupKeyManager } from "../../utils/fixtures";
 
 // helpers
-import { abiCoder, combinePermissions } from "../../utils/helpers";
+import {
+  abiCoder,
+  combinePermissions,
+  encodeCompactedBytes,
+} from "../../utils/helpers";
 
 export const shouldBehaveLikePermissionChangeOrAddPermissions = (
   buildContext: () => Promise<LSP6TestContext>
@@ -2332,7 +2336,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
     });
   });
 
-  describe("setting Allowed ERC725YKeys", () => {
+  describe.only("setting Allowed ERC725YKeys", () => {
     let canOnlyAddPermissions: SignerWithAddress,
       canOnlyChangePermissions: SignerWithAddress;
 
@@ -2370,16 +2374,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       let permissionValues = [
         PERMISSIONS.ADDPERMISSIONS,
         PERMISSIONS.CHANGEPERMISSIONS,
-        abiCoder.encode(
-          ["bytes32[]"],
-          [
-            [
-              ERC725YKeys.LSP3["LSP3Profile"],
-              // prettier-ignore
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
-            ],
-          ]
-        ),
+        encodeCompactedBytes([
+          ERC725YKeys.LSP3["LSP3Profile"],
+          // prettier-ignore
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+        ]),
         "0x11223344",
         "0x0000000000000000000000000000000000000000000000000000000000000000",
         "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -2395,18 +2394,13 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [
-              [
-                ERC725YKeys.LSP3["LSP3Profile"],
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
-              ],
-            ]
-          );
+          let value = encodeCompactedBytes([
+            ERC725YKeys.LSP3["LSP3Profile"],
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2425,10 +2419,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [[ERC725YKeys.LSP3["LSP3Profile"]]]
-          );
+          let value = encodeCompactedBytes([ERC725YKeys.LSP3["LSP3Profile"]]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2492,17 +2483,12 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             newController.address.substr(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [
-              [
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 1")),
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 2")),
-              ],
-            ]
-          );
+          let value = encodeCompactedBytes([
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 1")),
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 2")),
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2534,12 +2520,10 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await expect(
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "InvalidABIEncodedArray"
-            )
-            .withArgs(value, "bytes32");
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "InvalidCompactedAllowedERC725YDataKeys"
+          );
         });
       });
     });
@@ -2551,18 +2535,13 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [
-              [
-                ERC725YKeys.LSP3["LSP3Profile"],
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
-                // prettier-ignore
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
-              ],
-            ]
-          );
+          let value = encodeCompactedBytes([
+            ERC725YKeys.LSP3["LSP3Profile"],
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+            // prettier-ignore
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2583,10 +2562,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [[ERC725YKeys.LSP3["LSP3Profile"]]]
-          );
+          let value = encodeCompactedBytes([ERC725YKeys.LSP3["LSP3Profile"]]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2656,19 +2632,10 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             newController.address.substr(2);
 
-          let value = abiCoder.encode(
-            ["bytes32[]"],
-            [
-              [
-                ethers.utils.keccak256(
-                  ethers.utils.toUtf8Bytes("My Custom Key 1")
-                ),
-                ethers.utils.keccak256(
-                  ethers.utils.toUtf8Bytes("My Custom Key 2")
-                ),
-              ],
-            ]
-          );
+          let value = encodeCompactedBytes([
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 1")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 2")),
+          ]);
 
           let payload = context.universalProfile.interface.encodeFunctionData(
             "setData(bytes32,bytes)",
@@ -2860,7 +2827,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission SETDATA + ADDPERMISSIONS", () => {
-        it("(should pass): 2 x keys + add 2 x new permissions + increment AddressPermissions[].length by +2", async () => {
+        it("(should fail): 2 x keys + add 2 x new permissions + increment AddressPermissions[].length by +2", async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
@@ -2889,13 +2856,14 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await context.keyManager
-            .connect(canSetDataAndAddPermissions)
-            .execute(payload);
-
-          // prettier-ignore
-          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
-          expect(fetchedResult).to.deep.equal(values);
+          await expect(
+            context.keyManager
+              .connect(canSetDataAndAddPermissions)
+              .execute(payload)
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "NoERC725YDataKeysAllowed"
+          );
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions + decrement AddressPermissions[].length by -1", async () => {
@@ -3006,7 +2974,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission SETDATA + CHANGEPERMISSIONS", () => {
-        it("(should pass): 2 x keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
+        it("(should fail): 2 x keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
             ethers.utils.keccak256(
@@ -3032,16 +3000,17 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await context.keyManager
-            .connect(canSetDataAndChangePermissions)
-            .execute(payload);
-
-          // prettier-ignore
-          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
-          expect(fetchedResult).to.deep.equal(values);
+          await expect(
+            context.keyManager
+              .connect(canSetDataAndChangePermissions)
+              .execute(payload)
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "NoERC725YDataKeysAllowed"
+          );
         });
 
-        it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
+        it("(should fail): 2 x keys + change 2 x existing permissions", async () => {
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
             ethers.utils.keccak256(
@@ -3065,13 +3034,14 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await context.keyManager
-            .connect(canSetDataAndChangePermissions)
-            .execute(payload);
-
-          // prettier-ignore
-          const fetchedResult = await context.universalProfile["getData(bytes32[])"](keys);
-          expect(fetchedResult).to.deep.equal(values);
+          await expect(
+            context.keyManager
+              .connect(canSetDataAndChangePermissions)
+              .execute(payload)
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "NoERC725YDataKeysAllowed"
+          );
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions", async () => {

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -2336,7 +2336,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
     });
   });
 
-  describe.only("setting Allowed ERC725YKeys", () => {
+  describe("setting Allowed ERC725YKeys", () => {
     let canOnlyAddPermissions: SignerWithAddress,
       canOnlyChangePermissions: SignerWithAddress;
 
@@ -2433,7 +2433,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .withArgs(canOnlyAddPermissions.address, "CHANGEPERMISSIONS");
         });
 
-        it("should fail when trying to clear the array completely", async () => {
+        it("should fail when trying to clear the CompactedBytesArray completely", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
@@ -2452,7 +2452,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .withArgs(canOnlyAddPermissions.address, "CHANGEPERMISSIONS");
         });
 
-        it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
+        it("should fail when setting an invalid CompactedBytesArray", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
@@ -2466,17 +2466,15 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
 
           await expect(
             context.keyManager.connect(canOnlyAddPermissions).execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "InvalidABIEncodedArray"
-            )
-            .withArgs(value, "bytes32");
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "InvalidCompactedAllowedERC725YDataKeys"
+          );
         });
       });
 
       describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YKeys:...", () => {
-        it("should pass when setting a valid abi-encoded array of bytes32[]", async () => {
+        it("should pass when setting a valid CompactedBytesArray", async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
@@ -2504,7 +2502,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid abi-encoded array of bytes32[] (random bytes)", async () => {
+        it("should fail when setting an invalid CompactedBytesArray (random bytes)", async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
@@ -2578,7 +2576,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when trying to clear the array completely", async () => {
+        it("should pass when trying to clear the CompactedBytesArray completely", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
@@ -2599,7 +2597,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
+        it("should fail when setting an invalid CompactedBytesArray", async () => {
           let key =
             ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             beneficiary.address.substring(2);
@@ -2615,12 +2613,10 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canOnlyChangePermissions)
               .execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "InvalidABIEncodedArray"
-            )
-            .withArgs(value, "bytes32");
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "InvalidCompactedAllowedERC725YDataKeys"
+          );
         });
       });
 
@@ -2651,7 +2647,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             .withArgs(canOnlyChangePermissions.address, "ADDPERMISSIONS");
         });
 
-        it("should fail when setting an invalid abi-encoded array of bytes32[]", async () => {
+        it("should fail when setting an invalid CompactedBytesArray", async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
@@ -2669,12 +2665,10 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             context.keyManager
               .connect(canOnlyChangePermissions)
               .execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "InvalidABIEncodedArray"
-            )
-            .withArgs(value, "bytes32");
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "InvalidCompactedAllowedERC725YDataKeys"
+          );
         });
       });
     });

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -810,7 +810,7 @@ export const shouldBehaveLikePermissionSetData = (
       expect(result).to.equal(PERMISSIONS.SETDATA);
     });
 
-    it("Alice's UP should't be able to `setData(...)` on Bob's UP when it doesn't have any AllowedERC725YDataKeys", async () => {
+    it.only("Alice's UP should't be able to `setData(...)` on Bob's UP when it doesn't have any AllowedERC725YDataKeys", async () => {
       let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Alice's Key"));
       let value = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes("Alice's Value")
@@ -844,7 +844,7 @@ export const shouldBehaveLikePermissionSetData = (
           bobContext.keyManager,
           "NoERC725YDataKeysAllowed"
         )
-        .withArgs(alice.address);
+        .withArgs(aliceContext.universalProfile.address);
     });
 
     it("Alice's UP should be able to `setData(...)` on Bob's UP when it has AllowedERC725YDataKeys", async () => {

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -23,7 +23,7 @@ import {
   generateKeysAndValues,
   getRandomAddresses,
   combinePermissions,
-  encodeCompactedBytes,
+  encodeCompactBytesArray,
   abiCoder,
 } from "../../utils/helpers";
 
@@ -60,7 +60,7 @@ export const shouldBehaveLikePermissionSetData = (
       const permissionsValues = [
         ALL_PERMISSIONS,
         combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.CALL),
-        encodeCompactedBytes([
+        encodeCompactBytesArray([
           ERC725YKeys.LSP1.LSP1UniversalReceiverDelegate,
           ERC725YKeys.LSP3.LSP3Profile,
           ERC725YKeys.LSP12["LSP12IssuedAssets[]"].index,
@@ -271,7 +271,7 @@ export const shouldBehaveLikePermissionSetData = (
         });
       });
 
-      describe("For address that has permission SETDATA with AlloedERC725YDataKeys", () => {
+      describe("For address that has permission SETDATA with AllowedERC725YDataKeys", () => {
         it("(should pass): adding 5 singleton keys", async () => {
           let elements = {
             MyFirstKey: "aaaaaaaaaa",
@@ -375,7 +375,7 @@ export const shouldBehaveLikePermissionSetData = (
         });
       });
 
-      describe("For address that has permission SETDATA without AlloedERC725YDataKeys", () => {
+      describe("For address that has permission SETDATA without AllowedERC725YDataKeys", () => {
         it("(should revert): adding 5 singleton keys", async () => {
           let elements = {
             MyFirstKey: "aaaaaaaaaa",
@@ -598,7 +598,7 @@ export const shouldBehaveLikePermissionSetData = (
           contractCanSetData.address.substring(2),
       ];
 
-      const compactedAllowedERC725YDataKeys = encodeCompactedBytes([
+      const compactedAllowedERC725YDataKeys = encodeCompactBytesArray([
         "0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1",
         ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Key")),
       ]);
@@ -843,17 +843,16 @@ export const shouldBehaveLikePermissionSetData = (
         ethers.utils.toUtf8Bytes("Alice's Value")
       );
 
-      // Adding `key` to AlloedERC725YDataKeys for Alice
+      // Adding `key` to AllowedERC725YDataKeys for Alice
       const payload = bobContext.universalProfile.interface.encodeFunctionData(
         "setData(bytes32,bytes)",
         [
           ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
             aliceContext.universalProfile.address.substring(2),
-          encodeCompactedBytes([key]),
+          encodeCompactBytesArray([key]),
         ]
       );
       await bobContext.keyManager.connect(bob).execute(payload);
-      // move on with the test
 
       let finalSetDataPayload =
         bobContext.universalProfile.interface.encodeFunctionData(
@@ -908,7 +907,7 @@ export const shouldBehaveLikePermissionSetData = (
 
       const permissionValues = [
         PERMISSIONS.SUPER_SETDATA,
-        encodeCompactedBytes(allowedERC725YKeys),
+        encodeCompactBytesArray(allowedERC725YKeys),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -606,8 +606,11 @@ export const shouldBehaveLikePermissionSetData = (
           contractCanSetData.address.substring(2),
       ];
 
+      const hardcodedDataKey =
+        "0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1";
+
       const compactedAllowedERC725YDataKeys = encodeCompactBytesArray([
-        "0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1",
+        hardcodedDataKey,
         ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Key")),
       ]);
 
@@ -810,7 +813,7 @@ export const shouldBehaveLikePermissionSetData = (
       expect(result).to.equal(PERMISSIONS.SETDATA);
     });
 
-    it.only("Alice's UP should't be able to `setData(...)` on Bob's UP when it doesn't have any AllowedERC725YDataKeys", async () => {
+    it("Alice's UP should't be able to `setData(...)` on Bob's UP when it doesn't have any AllowedERC725YDataKeys", async () => {
       let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Alice's Key"));
       let value = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes("Alice's Value")

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -143,10 +143,12 @@ export const shouldBehaveLikePermissionSetData = (
             context.keyManager
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
@@ -396,10 +398,12 @@ export const shouldBehaveLikePermissionSetData = (
             context.keyManager
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
         it("(should revert): adding 10 LSP12IssuedAssets", async () => {
@@ -427,10 +431,12 @@ export const shouldBehaveLikePermissionSetData = (
             context.keyManager
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
         it("(should revert): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
@@ -468,10 +474,12 @@ export const shouldBehaveLikePermissionSetData = (
             context.keyManager
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .execute(payload)
-          ).to.be.revertedWithCustomError(
-            context.keyManager,
-            "NoERC725YDataKeysAllowed"
-          );
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NoERC725YDataKeysAllowed"
+            )
+            .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
@@ -831,10 +839,12 @@ export const shouldBehaveLikePermissionSetData = (
         aliceContext.keyManager
           .connect(alice)
           .execute(aliceUniversalProfilePayload)
-      ).to.be.revertedWithCustomError(
-        bobContext.keyManager,
-        "NoERC725YDataKeysAllowed"
-      );
+      )
+        .to.be.revertedWithCustomError(
+          bobContext.keyManager,
+          "NoERC725YDataKeysAllowed"
+        )
+        .withArgs(alice.address);
     });
 
     it("Alice's UP should be able to `setData(...)` on Bob's UP when it has AllowedERC725YDataKeys", async () => {

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -137,7 +137,7 @@ export async function setupProfileWithKeyManagerWithURD(
         EOA.address,
         lsp1universalReceiverDelegateUP.address,
         ALL_PERMISSIONS,
-        ethers.utils.hexZeroPad(PERMISSIONS.SETDATA, 32),
+        ethers.utils.hexZeroPad(PERMISSIONS.SUPER_SETDATA, 32),
         lsp1universalReceiverDelegateUP.address,
       ]
     );

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, BytesLike } from "ethers";
 import { ethers } from "hardhat";
 
 export const abiCoder = ethers.utils.defaultAbiCoder;
@@ -126,4 +126,35 @@ export function combinePermissions(..._permissions: string[]) {
   });
 
   return ethers.utils.hexZeroPad(result.toHexString(), 32);
+}
+
+export function encodeCompactedBytes(inputKeys: BytesLike[]) {
+  let compactBytesArray = "0x";
+  for (let i = 0; i < inputKeys.length; i++) {
+    compactBytesArray +=
+      ethers.utils
+        .hexlify([inputKeys[i].toString().substring(2).length / 2])
+        .substring(2) + inputKeys[i].toString().substring(2);
+  }
+  return compactBytesArray;
+}
+
+export function decodeCompactBytes(compactBytesArray: BytesLike) {
+  let pointer: number = 2;
+  let keysToExport: BytesLike[] = [];
+  while (pointer < compactBytesArray.length) {
+    const length = ethers.BigNumber.from(
+      "0x" + compactBytesArray.toString().substring(pointer, pointer + 2)
+    ).toNumber();
+
+    keysToExport.push(
+      "0x" +
+        compactBytesArray
+          .toString()
+          .substring(pointer + 2, pointer + 2 * (length + 1))
+    );
+
+    pointer += 2 * (length + 1);
+  }
+  return keysToExport;
 }

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -128,7 +128,7 @@ export function combinePermissions(..._permissions: string[]) {
   return ethers.utils.hexZeroPad(result.toHexString(), 32);
 }
 
-export function encodeCompactedBytes(inputKeys: BytesLike[]) {
+export function encodeCompactBytesArray(inputKeys: BytesLike[]) {
   let compactBytesArray = "0x";
   for (let i = 0; i < inputKeys.length; i++) {
     compactBytesArray +=


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGE!

### Main

- Change in how we store the: `AllowedERC725YKeys` in the ERC725Y storage:
      - before: `bytes32[] encoded array`
     - now: `compactedBytesArray` 

- Change in how we check the `AllowedERC725YKeys` in the LSP6KeyManager according to `compactedBytesArray` type.

### Periphery:
- Add new custom error to `constant.js`

## Rational

<img width="866" alt="9A9E65E3-4CF5-4C52-A77F-D288F1EF4B5B" src="https://user-images.githubusercontent.com/62855857/199459526-09b7c720-9c20-4d00-8444-59c1cd7a08f4.png">

