### PR TITLE
build!: upgrade `@erc725/smart-contracts` dependency to 4.0.0

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -15,15 +15,15 @@ const INTERFACE_IDS = {
 	ERC721Metadata: '0x5b5e139f',
 	ERC777: '0xe58e113c',
 	ERC1155: '0xd9b67a26',
-	ERC725X: '0x44c028fe',
+	ERC725X: '0x570ef073',
 	ERC725Y: '0x714df77c',
-	LSP0ERC725Account: '0xdca05671',
+	LSP0ERC725Account: '0xcf6e8efc',
 	LSP1UniversalReceiver: '0x6bb56a14',
 	LSP1UniversalReceiverDelegate: '0xa245bbda',
 	LSP6KeyManager: '0xf9150d55',
 	LSP7DigitalAsset: '0xda1f85e4',
 	LSP8IdentifiableDigitalAsset: '0x622e7a01',
-	LSP9Vault: '0xca86ec0f',
+	LSP9Vault: '0xd9483482',
 	LSP14Ownable2Step: '0x94be5999',
 };
 

--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -6,10 +6,10 @@ import {UniversalProfile} from "../UniversalProfile.sol";
 import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
-import {SETDATA_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
+import {SETDATA_SELECTOR, OPERATION_0_CALL} from "@erc725/smart-contracts/contracts/constants.sol";
 
 contract Executor {
-    uint256 internal constant _OPERATION_CALL = 0;
+    uint256 internal constant OPERATION_0_CALL = 0;
 
     address internal constant _DUMMY_RECIPIENT = 0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe;
 
@@ -58,7 +58,7 @@ contract Executor {
 
         bytes memory erc725Payload = abi.encodeWithSelector(
             _universalProfile.execute.selector,
-            _OPERATION_CALL,
+            OPERATION_0_CALL,
             _DUMMY_RECIPIENT,
             amount,
             ""
@@ -72,7 +72,7 @@ contract Executor {
 
         bytes memory erc725Payload = abi.encodeWithSelector(
             _universalProfile.execute.selector,
-            _OPERATION_CALL,
+            OPERATION_0_CALL,
             _recipient,
             amount,
             ""
@@ -137,7 +137,7 @@ contract Executor {
 
         bytes memory erc725Payload = abi.encodeWithSelector(
             _universalProfile.execute.selector,
-            _OPERATION_CALL,
+            OPERATION_0_CALL,
             _DUMMY_RECIPIENT,
             amount,
             ""
@@ -158,7 +158,7 @@ contract Executor {
 
         bytes memory erc725Payload = abi.encodeWithSelector(
             _universalProfile.execute.selector,
-            _OPERATION_CALL,
+            OPERATION_0_CALL,
             _recipient,
             amount,
             ""

--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -13,8 +13,6 @@ import {
 } from "@erc725/smart-contracts/contracts/constants.sol";
 
 contract Executor {
-    uint256 internal constant OPERATION_0_CALL = 0;
-
     address internal constant _DUMMY_RECIPIENT = 0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe;
 
     LSP6KeyManager private _keyManager;

--- a/contracts/Helpers/Executor.sol
+++ b/contracts/Helpers/Executor.sol
@@ -6,7 +6,11 @@ import {UniversalProfile} from "../UniversalProfile.sol";
 import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";
 
 // constants
-import {SETDATA_SELECTOR, OPERATION_0_CALL} from "@erc725/smart-contracts/contracts/constants.sol";
+import {
+    SETDATA_SELECTOR,
+    EXECUTE_SELECTOR,
+    OPERATION_0_CALL
+} from "@erc725/smart-contracts/contracts/constants.sol";
 
 contract Executor {
     uint256 internal constant OPERATION_0_CALL = 0;
@@ -57,7 +61,7 @@ contract Executor {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(
-            _universalProfile.execute.selector,
+            EXECUTE_SELECTOR,
             OPERATION_0_CALL,
             _DUMMY_RECIPIENT,
             amount,
@@ -71,7 +75,7 @@ contract Executor {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(
-            _universalProfile.execute.selector,
+            EXECUTE_SELECTOR,
             OPERATION_0_CALL,
             _recipient,
             amount,
@@ -136,7 +140,7 @@ contract Executor {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(
-            _universalProfile.execute.selector,
+            EXECUTE_SELECTOR,
             OPERATION_0_CALL,
             _DUMMY_RECIPIENT,
             amount,
@@ -157,7 +161,7 @@ contract Executor {
         uint256 amount = 1 ether;
 
         bytes memory erc725Payload = abi.encodeWithSelector(
-            _universalProfile.execute.selector,
+            EXECUTE_SELECTOR,
             OPERATION_0_CALL,
             _recipient,
             amount,

--- a/contracts/Helpers/KeyManager/ERC725YDelegateCall.sol
+++ b/contracts/Helpers/KeyManager/ERC725YDelegateCall.sol
@@ -8,6 +8,6 @@ contract ERC725YDelegateCall is ERC725Y {
     constructor(address newOwner) ERC725Y(newOwner) {}
 
     function updateStorage(bytes32 key, bytes memory value) public {
-        store[key] = value;
+        _store[key] = value;
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 // interfaces
 import {ILSP6KeyManager} from "../../LSP6KeyManager/ILSP6KeyManager.sol";
-import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
 
 // modules
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
@@ -11,6 +10,7 @@ import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 // constants
+import {EXECUTE_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _TYPEID_LSP7_TOKENSSENDER,
     _TYPEID_LSP7_TOKENSRECIPIENT
@@ -42,7 +42,7 @@ contract UniversalReceiverDelegateTokenReentrant is ERC165Storage {
             if (data.length > 72) {
                 bytes memory tokenPayload = BytesLib.slice(data, 72, data.length - 72);
                 bytes memory executePayload = abi.encodeWithSelector(
-                    IERC725X.execute.selector,
+                    EXECUTE_SELECTOR,
                     0, // OPERATION CALL
                     sender, // TOKEN CONTRACT
                     0, // VALUE TO BE SENT

--- a/contracts/LSP0ERC725Account/LSP0Constants.sol
+++ b/contracts/LSP0ERC725Account/LSP0Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP0 = 0xdca05671;
+bytes4 constant _INTERFACEID_LSP0 = 0xcf6e8efc;
 bytes4 constant _INTERFACEID_ERC1271 = 0x1626ba7e;
 
 // ERC1271 - Standard Signature Validation

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -22,6 +22,7 @@ import {LSP14Ownable2Step} from "../LSP14Ownable2Step/LSP14Ownable2Step.sol";
 
 // constants
 import "@erc725/smart-contracts/contracts/constants.sol";
+import "@erc725/smart-contracts/contracts/errors.sol";
 import {
     _INTERFACEID_LSP0,
     _INTERFACEID_ERC1271,
@@ -123,8 +124,8 @@ abstract contract LSP0ERC725AccountCore is
     }
 
     /**
-     * @param operation The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3 DELEGATECALL = 4
-     * @param to The smart contract or address to interact with, `to` will be unused if a contract is created (operation 1 and 2)
+     * @param operationType The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3 DELEGATECALL = 4
+     * @param target The smart contract or address to interact with, `to` will be unused if a contract is created (operation 1 and 2)
      * @param value The amount of native tokens to transfer (in Wei).
      * @param data The call data, or the bytecode of the contract to deploy
      * @dev Executes any other smart contract.
@@ -135,41 +136,17 @@ abstract contract LSP0ERC725AccountCore is
      * Emits a {ValueReceived} event, when receives native token
      */
     function execute(
-        uint256 operation,
-        address to,
+        uint256 operationType,
+        address target,
         uint256 value,
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
-        require(address(this).balance >= value, "ERC725X: insufficient balance");
+        if (address(this).balance < value) {
+            revert ERC725X_InsufficientBalance(address(this).balance, value);
+        }
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
-        // CALL
-        if (operation == OPERATION_0_CALL) return _executeCall(to, value, data);
-
-        // Deploy with CREATE
-        if (operation == OPERATION_1_CREATE) return _deployCreate(to, value, data);
-
-        // Deploy with CREATE2
-        if (operation == OPERATION_2_CREATE2) return _deployCreate2(to, value, data);
-
-        // STATICCALL
-        if (operation == OPERATION_3_STATICCALL) return _executeStaticCall(to, value, data);
-
-        // DELEGATECALL
-        //
-        // WARNING! delegatecall is a dangerous operation type! use with EXTRA CAUTION
-        //
-        // delegate allows to call another deployed contract and use its functions
-        // to update the state of the current calling contract.
-        //
-        // this can lead to unexpected behaviour on the contract storage, such as:
-        // - updating any state variables (even if these are protected)
-        // - update the contract owner
-        // - run selfdestruct in the context of this contract
-        //
-        if (operation == OPERATION_4_DELEGATECALL) return _executeDelegateCall(to, value, data);
-
-        revert("ERC725X: Unknown operation type");
+        return _execute(operationType, target, value, data);
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -144,16 +144,16 @@ abstract contract LSP0ERC725AccountCore is
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
         // CALL
-        if (operation == OPERATION_CALL) return _executeCall(to, value, data);
+        if (operation == OPERATION_0_CALL) return _executeCall(to, value, data);
 
         // Deploy with CREATE
-        if (operation == OPERATION_CREATE) return _deployCreate(to, value, data);
+        if (operation == OPERATION_1_CREATE) return _deployCreate(to, value, data);
 
         // Deploy with CREATE2
-        if (operation == OPERATION_CREATE2) return _deployCreate2(to, value, data);
+        if (operation == OPERATION_2_CREATE2) return _deployCreate2(to, value, data);
 
         // STATICCALL
-        if (operation == OPERATION_STATICCALL) return _executeStaticCall(to, value, data);
+        if (operation == OPERATION_3_STATICCALL) return _executeStaticCall(to, value, data);
 
         // DELEGATECALL
         //
@@ -167,7 +167,7 @@ abstract contract LSP0ERC725AccountCore is
         // - update the contract owner
         // - run selfdestruct in the context of this contract
         //
-        if (operation == OPERATION_DELEGATECALL) return _executeDelegateCall(to, value, data);
+        if (operation == OPERATION_4_DELEGATECALL) return _executeDelegateCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");
     }
@@ -252,7 +252,7 @@ abstract contract LSP0ERC725AccountCore is
      * @dev SAVE GAS by emitting the DataChanged event with only the first 256 bytes of dataValue
      */
     function _setData(bytes32 dataKey, bytes memory dataValue) internal virtual override {
-        store[dataKey] = dataValue;
+        _store[dataKey] = dataValue;
         emit DataChanged(
             dataKey,
             dataValue.length <= 256 ? dataValue : BytesLib.slice(dataValue, 0, 256)

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -49,7 +49,7 @@ abstract contract LSP4DigitalAssetMetadata is ERC725Y {
         } else if (dataKey == _LSP4_TOKEN_SYMBOL_KEY) {
             revert LSP4TokenSymbolNotEditable();
         } else {
-            store[dataKey] = dataValue;
+            _store[dataKey] = dataValue;
             emit DataChanged(
                 dataKey,
                 dataValue.length <= 256 ? dataValue : BytesLib.slice(dataValue, 0, 256)

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -46,7 +46,7 @@ abstract contract LSP4DigitalAssetMetadataInitAbstract is ERC725YInitAbstract {
         } else if (dataKey == _LSP4_TOKEN_SYMBOL_KEY) {
             revert LSP4TokenSymbolNotEditable();
         } else {
-            store[dataKey] = dataValue;
+            _store[dataKey] = dataValue;
             emit DataChanged(
                 dataKey,
                 dataValue.length <= 256 ? dataValue : BytesLib.slice(dataValue, 0, 256)

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -28,14 +28,15 @@ import "./LSP6Errors.sol";
 // constants
 import {
     // ERC725X
-    OPERATION_CALL,
-    OPERATION_CREATE,
-    OPERATION_CREATE2,
-    OPERATION_STATICCALL,
-    OPERATION_DELEGATECALL,
+    OPERATION_0_CALL,
+    OPERATION_1_CREATE,
+    OPERATION_2_CREATE2,
+    OPERATION_3_STATICCALL,
+    OPERATION_4_DELEGATECALL,
     // ERC725Y
     SETDATA_SELECTOR,
-    SETDATA_ARRAY_SELECTOR
+    SETDATA_ARRAY_SELECTOR,
+    EXECUTE_SELECTOR
 } from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _INTERFACEID_ERC1271,
@@ -237,7 +238,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             if (isSettingERC725YKeys) {
                 _verifyCanSetData(from, permissions, inputKeys);
             }
-        } else if (erc725Function == IERC725X.execute.selector) {
+        } else if (erc725Function == EXECUTE_SELECTOR) {
             _verifyCanExecute(from, permissions, payload);
         } else if (
             erc725Function == OwnableUnset.transferOwnership.selector ||
@@ -526,14 +527,14 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         require(operationType < 5, "LSP6KeyManager: invalid operation type");
 
         require(
-            operationType != OPERATION_DELEGATECALL,
+            operationType != OPERATION_4_DELEGATECALL,
             "LSP6KeyManager: operation DELEGATECALL is currently disallowed"
         );
 
         uint256 value = uint256(bytes32(payload[68:100]));
 
         // prettier-ignore
-        bool isContractCreation = operationType == OPERATION_CREATE || operationType == OPERATION_CREATE2;
+        bool isContractCreation = operationType == OPERATION_1_CREATE || operationType == OPERATION_2_CREATE2;
         bool isCallDataPresent = payload.length > 164;
 
         // SUPER operation only applies to contract call, not contract creation
@@ -616,11 +617,11 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         pure
         returns (bytes32 permissionsRequired)
     {
-        if (operationType == OPERATION_CALL) return _PERMISSION_CALL;
-        else if (operationType == OPERATION_CREATE) return _PERMISSION_DEPLOY;
-        else if (operationType == OPERATION_CREATE2) return _PERMISSION_DEPLOY;
-        else if (operationType == OPERATION_STATICCALL) return _PERMISSION_STATICCALL;
-        else if (operationType == OPERATION_DELEGATECALL) return _PERMISSION_DELEGATECALL;
+        if (operationType == OPERATION_0_CALL) return _PERMISSION_CALL;
+        else if (operationType == OPERATION_1_CREATE) return _PERMISSION_DEPLOY;
+        else if (operationType == OPERATION_2_CREATE2) return _PERMISSION_DEPLOY;
+        else if (operationType == OPERATION_3_STATICCALL) return _PERMISSION_STATICCALL;
+        else if (operationType == OPERATION_4_DELEGATECALL) return _PERMISSION_DELEGATECALL;
     }
 
     /**
@@ -631,9 +632,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         pure
         returns (bytes32 superPermission)
     {
-        if (operationType == OPERATION_CALL) return _PERMISSION_SUPER_CALL;
-        else if (operationType == OPERATION_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
-        else if (operationType == OPERATION_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
+        if (operationType == OPERATION_0_CALL) return _PERMISSION_SUPER_CALL;
+        else if (operationType == OPERATION_3_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
+        else if (operationType == OPERATION_4_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
     }
 
 

--- a/contracts/LSP9Vault/LSP9Constants.sol
+++ b/contracts/LSP9Vault/LSP9Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP9 = 0xca86ec0f;
+bytes4 constant _INTERFACEID_LSP9 = 0xd9483482;
 
 // --- ERC725Y Keys
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -23,10 +23,10 @@ import {LSP14Ownable2Step} from "../LSP14Ownable2Step/LSP14Ownable2Step.sol";
 import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 
 import {
-    OPERATION_CALL,
-    OPERATION_STATICCALL,
-    OPERATION_CREATE,
-    OPERATION_CREATE2
+    OPERATION_0_CALL,
+    OPERATION_1_CREATE,
+    OPERATION_2_CREATE2,
+    OPERATION_3_STATICCALL
 } from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _INTERFACEID_LSP1,
@@ -125,16 +125,16 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
         // CALL
-        if (operation == OPERATION_CALL) return _executeCall(to, value, data);
+        if (operation == OPERATION_0_CALL) return _executeCall(to, value, data);
 
         // Deploy with CREATE
-        if (operation == OPERATION_CREATE) return _deployCreate(to, value, data);
+        if (operation == OPERATION_1_CREATE) return _deployCreate(to, value, data);
 
         // Deploy with CREATE2
-        if (operation == OPERATION_CREATE2) return _deployCreate2(to, value, data);
+        if (operation == OPERATION_2_CREATE2) return _deployCreate2(to, value, data);
 
         // STATICCALL
-        if (operation == OPERATION_STATICCALL) return _executeStaticCall(to, value, data);
+        if (operation == OPERATION_3_STATICCALL) return _executeStaticCall(to, value, data);
 
         revert("ERC725X: Unknown operation type");
     }
@@ -251,7 +251,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
      * @dev SAVE GAS by emitting the DataChanged event with only the first 256 bytes of dataValue
      */
     function _setData(bytes32 dataKey, bytes memory dataValue) internal virtual override {
-        store[dataKey] = dataValue;
+        _store[dataKey] = dataValue;
         emit DataChanged(
             dataKey,
             dataValue.length <= 256 ? dataValue : BytesLib.slice(dataValue, 0, 256)

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -247,7 +247,9 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
     }
 
     /**
-     * @dev disable operation type DELEGATECALL
+     * @dev disable operation type DELEGATECALL (4).
+     * NB: providing operation type DELEGATECALL (4) as argument will result
+     * in custom error ERC725X_UnknownOperationType(4)
      */
     function _execute(
         uint256 operationType,

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -20,8 +20,7 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
 import {LSP14Ownable2Step} from "../LSP14Ownable2Step/LSP14Ownable2Step.sol";
 
 // constants
-import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
-
+import "@erc725/smart-contracts/contracts/errors.sol";
 import {
     OPERATION_0_CALL,
     OPERATION_1_CREATE,
@@ -35,6 +34,7 @@ import {
     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
 } from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP9} from "./LSP9Constants.sol";
+import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 
 /**
  * @title Core Implementation of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
@@ -107,7 +107,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
 
     /**
      * @inheritdoc IERC725X
-     * @param operation The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3
+     * @param operationType The operation to execute: CALL = 0 CREATE = 1 CREATE2 = 2 STATICCALL = 3
      * @dev Executes any other smart contract.
      * SHOULD only be callable by the owner of the contract set via ERC173
      *
@@ -116,27 +116,15 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
      * Emits a {ValueReceived} event, when receives native token
      */
     function execute(
-        uint256 operation,
-        address to,
+        uint256 operationType,
+        address target,
         uint256 value,
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
         require(address(this).balance >= value, "ERC725X: insufficient balance");
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
-        // CALL
-        if (operation == OPERATION_0_CALL) return _executeCall(to, value, data);
-
-        // Deploy with CREATE
-        if (operation == OPERATION_1_CREATE) return _deployCreate(to, value, data);
-
-        // Deploy with CREATE2
-        if (operation == OPERATION_2_CREATE2) return _deployCreate2(to, value, data);
-
-        // STATICCALL
-        if (operation == OPERATION_3_STATICCALL) return _executeStaticCall(to, value, data);
-
-        revert("ERC725X: Unknown operation type");
+        return _execute(operationType, target, value, data);
     }
 
     /**
@@ -256,5 +244,40 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
             dataKey,
             dataValue.length <= 256 ? dataValue : BytesLib.slice(dataValue, 0, 256)
         );
+    }
+
+    /**
+     * @dev disable operation type DELEGATECALL
+     */
+    function _execute(
+        uint256 operationType,
+        address target,
+        uint256 value,
+        bytes memory data
+    ) internal virtual override returns (bytes memory) {
+        // CALL
+        if (operationType == OPERATION_0_CALL) {
+            return _executeCall(target, value, data);
+        }
+
+        // Deploy with CREATE
+        if (operationType == uint256(OPERATION_1_CREATE)) {
+            if (target != address(0)) revert ERC725X_CreateOperationsRequireEmptyRecipientAddress();
+            return _deployCreate(value, data);
+        }
+
+        // Deploy with CREATE2
+        if (operationType == uint256(OPERATION_2_CREATE2)) {
+            if (target != address(0)) revert ERC725X_CreateOperationsRequireEmptyRecipientAddress();
+            return _deployCreate2(value, data);
+        }
+
+        // STATICCALL
+        if (operationType == uint256(OPERATION_3_STATICCALL)) {
+            if (value != 0) revert ERC725X_MsgValueDisallowedInStaticCall();
+            return _executeStaticCall(target, data);
+        }
+
+        revert ERC725X_UnknownOperationType(operationType);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^3.2.0",
+        "@erc725/smart-contracts": "^4.0.0",
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
         "solidity-bytes-utils": "0.8.0"
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.2.0.tgz",
-      "integrity": "sha512-fkI82lFnHVMGGorp27Hr1/flK9Hhl+P07ZjEK6S0NWVadtZgJJzn97nimNrwybAta+tgPFFXNme1iWEjwni1hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.0.0.tgz",
+      "integrity": "sha512-0DlQPJb5/BrYM9/obahc64s/6OgXtaXeZj7HeDgH++h4vaYhF6oORm6WkcT3VrNvfQrWmlN/q8JLxqjx31JxLw==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
@@ -19900,9 +19900,9 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-3.2.0.tgz",
-      "integrity": "sha512-fkI82lFnHVMGGorp27Hr1/flK9Hhl+P07ZjEK6S0NWVadtZgJJzn97nimNrwybAta+tgPFFXNme1iWEjwni1hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.0.0.tgz",
+      "integrity": "sha512-0DlQPJb5/BrYM9/obahc64s/6OgXtaXeZj7HeDgH++h4vaYhF6oORm6WkcT3VrNvfQrWmlN/q8JLxqjx31JxLw==",
       "requires": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^3.2.0",
+    "@erc725/smart-contracts": "^4.0.0",
     "@openzeppelin/contracts": "^4.7.3",
     "@openzeppelin/contracts-upgradeable": "^4.7.3",
     "solidity-bytes-utils": "0.8.0"

--- a/tests/Helpers/AddressRegistry.test.ts
+++ b/tests/Helpers/AddressRegistry.test.ts
@@ -103,9 +103,15 @@ describe("Address Registry contracts", () => {
 
       await account
         .connect(owner)
-        .execute(0, addressRegistryRequireERC725.address, 0, abi, {
-          gasLimit: 3_000_000,
-        });
+        ["execute(uint256,address,uint256,bytes)"](
+          0,
+          addressRegistryRequireERC725.address,
+          0,
+          abi,
+          {
+            gasLimit: 3_000_000,
+          }
+        );
       expect(await addressRegistryRequireERC725.getAddress(0)).to.equal(
         account.address
       );
@@ -128,7 +134,12 @@ describe("Address Registry contracts", () => {
 
       await account
         .connect(owner)
-        .execute(0, addressRegistryRequireERC725.address, 0, abi);
+        ["execute(uint256,address,uint256,bytes)"](
+          0,
+          addressRegistryRequireERC725.address,
+          0,
+          abi
+        );
       expect(
         await addressRegistryRequireERC725.containsAddress(account.address)
       ).to.equal(false);

--- a/tests/Helpers/KeyManagerExecutionCosts.test.ts
+++ b/tests/Helpers/KeyManagerExecutionCosts.test.ts
@@ -103,12 +103,15 @@ describe("Key Manager gas cost interactions", () => {
           );
 
           let transferLyxPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              contractImplementsERC1271.address,
-              ethers.utils.parseEther("1"),
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                contractImplementsERC1271.address,
+                ethers.utils.parseEther("1"),
+                "0x",
+              ]
+            );
 
           let tx = await context.keyManager
             .connect(context.owner)
@@ -134,12 +137,15 @@ describe("Key Manager gas cost interactions", () => {
         );
 
         let transferLyxPayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            contractImplementsERC1271.address,
-            ethers.utils.parseEther("1"),
-            "0x",
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              contractImplementsERC1271.address,
+              ethers.utils.parseEther("1"),
+              "0x",
+            ]
+          );
 
         let tx = await context.keyManager
           .connect(restrictedToOneAddress)
@@ -164,12 +170,15 @@ describe("Key Manager gas cost interactions", () => {
         );
 
         let transferLyxPayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            contractImplementsERC1271.address,
-            ethers.utils.parseEther("1"),
-            "0x",
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              contractImplementsERC1271.address,
+              ethers.utils.parseEther("1"),
+              "0x",
+            ]
+          );
 
         let tx = await context.keyManager
           .connect(restrictedToOneAddressAndStandard)

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -117,7 +117,12 @@ export const shouldBehaveLikeLSP14 = (
 
         await context.contract
           .connect(context.deployParams.owner)
-          .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x");
+          ["execute(uint256,address,uint256,bytes)"](
+            OPERATION_TYPES.CALL,
+            recipient.address,
+            amount,
+            "0x"
+          );
 
         const recipientBalanceAfter = await provider.getBalance(
           recipient.address
@@ -253,7 +258,12 @@ export const shouldBehaveLikeLSP14 = (
           await expect(
             context.contract
               .connect(previousOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x")
+              ["execute(uint256,address,uint256,bytes)"](
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                "0x"
+              )
           ).to.be.revertedWith("Ownable: caller is not the owner");
         });
 
@@ -285,7 +295,12 @@ export const shouldBehaveLikeLSP14 = (
           await expect(() =>
             context.contract
               .connect(newOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x")
+              ["execute(uint256,address,uint256,bytes)"](
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                "0x"
+              )
           ).to.changeEtherBalances(
             [context.contract.address, recipient.address],
             [
@@ -396,7 +411,12 @@ export const shouldBehaveLikeLSP14 = (
           await expect(() =>
             context.contract
               .connect(context.deployParams.owner)
-              .execute(OPERATION_TYPES.CALL, recipient, amount, "0x")
+              ["execute(uint256,address,uint256,bytes)"](
+                OPERATION_TYPES.CALL,
+                recipient,
+                amount,
+                "0x"
+              )
           ).to.changeEtherBalances(
             [context.contract.address, recipient],
             [`-${amount}`, amount]
@@ -568,7 +588,12 @@ export const shouldBehaveLikeLSP14 = (
             await expect(
               context.contract
                 .connect(context.deployParams.owner)
-                .execute(OPERATION_TYPES.CALL, recipient, amount, "0x")
+                ["execute(uint256,address,uint256,bytes)"](
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  amount,
+                  "0x"
+                )
             ).to.be.revertedWith("Ownable: caller is not the owner");
           });
         });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1522,12 +1522,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             .transferOwnership(context.universalProfile1.address);
 
           let executePayload =
-            context.universalProfile1.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultA.address,
-              0,
-              lsp9VaultA.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile1.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultA.address,
+                0,
+                lsp9VaultA.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
@@ -1554,12 +1557,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             .transferOwnership(context.universalProfile1.address);
 
           let executePayload =
-            context.universalProfile1.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultB.address,
-              0,
-              lsp9VaultB.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile1.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultB.address,
+                0,
+                lsp9VaultB.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
@@ -1586,12 +1592,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             .transferOwnership(context.universalProfile1.address);
 
           let executePayload =
-            context.universalProfile1.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultC.address,
-              0,
-              lsp9VaultC.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile1.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultC.address,
+                0,
+                lsp9VaultC.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
@@ -1627,12 +1636,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             );
 
           let executePayload =
-            context.universalProfile2.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultA.address,
-              0,
-              lsp9VaultA.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile2.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultA.address,
+                0,
+                lsp9VaultA.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager2
             .connect(context.accounts.owner2)
@@ -1678,12 +1690,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             );
 
           let executePayload =
-            context.universalProfile2.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultB.address,
-              0,
-              lsp9VaultB.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile2.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultB.address,
+                0,
+                lsp9VaultB.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager2
             .connect(context.accounts.owner2)
@@ -1731,12 +1746,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             );
 
           let executePayload =
-            context.universalProfile2.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultC.address,
-              0,
-              lsp9VaultC.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile2.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultC.address,
+                0,
+                lsp9VaultC.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager2
             .connect(context.accounts.owner2)
@@ -1784,12 +1802,15 @@ export const shouldBehaveLikeLSP1Delegate = (
             );
 
           let executePayload =
-            context.universalProfile1.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              lsp9VaultB.address,
-              0,
-              lsp9VaultB.interface.getSighash("acceptOwnership"),
-            ]);
+            context.universalProfile1.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp9VaultB.address,
+                0,
+                lsp9VaultB.interface.getSighash("acceptOwnership"),
+              ]
+            );
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -182,7 +182,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -210,7 +210,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -238,7 +238,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -266,7 +266,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -295,7 +295,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -328,7 +328,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -371,7 +371,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -398,7 +398,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -475,7 +475,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -529,7 +529,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -568,7 +568,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -607,7 +607,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -652,7 +652,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -697,7 +697,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault2.address,
               0,
@@ -726,7 +726,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         await context.universalProfile
           .connect(context.accounts.owner1)
-          .execute(
+          ["execute(uint256,address,uint256,bytes)"](
             OPERATION_TYPES.CALL,
             context.lsp9Vault1.address,
             0,
@@ -741,7 +741,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         await context.universalProfile
           .connect(context.accounts.owner1)
-          .execute(
+          ["execute(uint256,address,uint256,bytes)"](
             OPERATION_TYPES.CALL,
             context.lsp9Vault2.address,
             0,
@@ -756,7 +756,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         await context.universalProfile
           .connect(context.accounts.owner1)
-          .execute(
+          ["execute(uint256,address,uint256,bytes)"](
             OPERATION_TYPES.CALL,
             context.lsp9Vault2.address,
             0,
@@ -771,7 +771,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         await context.universalProfile
           .connect(context.accounts.owner1)
-          .execute(
+          ["execute(uint256,address,uint256,bytes)"](
             OPERATION_TYPES.CALL,
             context.lsp9Vault2.address,
             0,
@@ -821,7 +821,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -851,7 +851,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -881,7 +881,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -911,7 +911,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -941,7 +941,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -973,7 +973,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1017,7 +1017,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1045,7 +1045,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1137,7 +1137,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1195,7 +1195,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1238,7 +1238,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1281,7 +1281,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1328,7 +1328,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault1.address,
               0,
@@ -1375,7 +1375,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
           await context.universalProfile
             .connect(context.accounts.owner1)
-            .execute(
+            ["execute(uint256,address,uint256,bytes)"](
               OPERATION_TYPES.CALL,
               context.lsp9Vault2.address,
               0,

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.test.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.test.ts
@@ -47,11 +47,21 @@ describe("LSP1UniversalReceiverDelegateVault", () => {
 
       await universalProfile
         .connect(accounts.owner1)
-        .execute(OPERATION_TYPES.CALL, lsp9Vault1.address, 0, abi);
+        ["execute(uint256,address,uint256,bytes)"](
+          OPERATION_TYPES.CALL,
+          lsp9Vault1.address,
+          0,
+          abi
+        );
 
       await universalProfile
         .connect(accounts.owner1)
-        .execute(OPERATION_TYPES.CALL, lsp9Vault2.address, 0, abi);
+        ["execute(uint256,address,uint256,bytes)"](
+          OPERATION_TYPES.CALL,
+          lsp9Vault2.address,
+          0,
+          abi
+        );
 
       return {
         accounts,

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -75,17 +75,19 @@ export const testAllowedCallsInternals = (
 
     describe("`getAllowedCallsFor(...)`", () => {
       it("should return the list of allowed calls", async () => {
-        let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
-          canCallOnlyTwoAddresses.address
-        );
+        let bytesResult =
+          await context.keyManagerInternalTester.getAllowedCallsFor(
+            canCallOnlyTwoAddresses.address
+          );
 
         expect(bytesResult).to.equal(encodedAllowedCalls);
       });
 
       it("should return no bytes when no allowed calls were set", async () => {
-        let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
-          context.owner.address
-        );
+        let bytesResult =
+          await context.keyManagerInternalTester.getAllowedCallsFor(
+            context.owner.address
+          );
         expect(bytesResult).to.equal("0x");
 
         let resultFromAccount = await context.universalProfile[
@@ -101,7 +103,7 @@ export const testAllowedCallsInternals = (
     describe("`verifyAllowedCall(...)`", () => {
       it("should not revert when payload = send 1 LYX to an address listed in allowed calls list", async () => {
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CALL,
             allowedEOA.address,
@@ -131,7 +133,7 @@ export const testAllowedCallsInternals = (
         );
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CALL,
             disallowedAddress,
@@ -161,7 +163,7 @@ export const testAllowedCallsInternals = (
         let randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CALL,
             randomAddress,
@@ -255,7 +257,7 @@ export const testAllowedCallsInternals = (
 
       beforeEach(async () => {
         payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CALL,
             randomAddress,
@@ -403,7 +405,7 @@ export const testAllowedCallsInternals = (
       context = await buildContext();
 
       payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CALL,
           randomAddress,

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -536,7 +536,7 @@ export const testAllowedCallsInternals = (
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
       const payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CALL,
           randomAddress,

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -104,10 +104,11 @@ export const shouldBehaveLikeAllowedAddresses = (
 
           let amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
+            );
 
           await context.keyManager
             .connect(context.owner)
@@ -134,10 +135,11 @@ export const shouldBehaveLikeAllowedAddresses = (
 
       let amount = ethers.utils.parseEther("1");
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, allowedEOA.address, amount, EMPTY_PAYLOAD]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, allowedEOA.address, amount, EMPTY_PAYLOAD]
+        );
 
       await context.keyManager
         .connect(canCallOnlyTwoAddresses)
@@ -155,13 +157,13 @@ export const shouldBehaveLikeAllowedAddresses = (
     it("should be allowed to interact with an allowed address (= contract)", async () => {
       const argument = "new name";
 
-      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData(
-        "setName",
-        [argument]
-      );
+      let targetContractPayload =
+        allowedTargetContract.interface.encodeFunctionData("setName", [
+          argument,
+        ]);
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CALL,
           allowedTargetContract.address,
@@ -186,15 +188,16 @@ export const shouldBehaveLikeAllowedAddresses = (
         notAllowedEOA.address
       );
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CALL,
-          notAllowedEOA.address,
-          ethers.utils.parseEther("1"),
-          EMPTY_PAYLOAD,
-        ]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            notAllowedEOA.address,
+            ethers.utils.parseEther("1"),
+            EMPTY_PAYLOAD,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -222,13 +225,13 @@ export const shouldBehaveLikeAllowedAddresses = (
     it("should revert when interacting with an non-allowed address (= contract)", async () => {
       const argument = "new name";
 
-      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData(
-        "setName",
-        [argument]
-      );
+      let targetContractPayload =
+        notAllowedTargetContract.interface.encodeFunctionData("setName", [
+          argument,
+        ]);
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CALL,
           notAllowedTargetContract.address,
@@ -262,10 +265,11 @@ export const shouldBehaveLikeAllowedAddresses = (
 
           let amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
+            );
 
           await context.keyManager
             .connect(invalidAbiEncodedAddresses)

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -135,12 +135,10 @@ export const shouldBehaveLikeAllowedAddresses = (
       let amount = ethers.utils.parseEther("1");
 
       let transferPayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          allowedEOA.address,
-          amount,
-          EMPTY_PAYLOAD,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, allowedEOA.address, amount, EMPTY_PAYLOAD]
+        );
 
       await context.keyManager
         .connect(canCallOnlyTwoAddresses)
@@ -190,12 +188,15 @@ export const shouldBehaveLikeAllowedAddresses = (
       );
 
       let transferPayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          notAllowedEOA.address,
-          ethers.utils.parseEther("1"),
-          EMPTY_PAYLOAD,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            notAllowedEOA.address,
+            ethers.utils.parseEther("1"),
+            EMPTY_PAYLOAD,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -264,15 +265,13 @@ export const shouldBehaveLikeAllowedAddresses = (
           let amount = ethers.utils.parseEther("1");
 
           let transferPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient,
-              amount,
-              EMPTY_PAYLOAD,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
+            );
 
           await context.keyManager
-            .connect(invalidAbiEncodedAddresses)
+            .connect(invalidEncodedAllowedCalls)
             .execute(transferPayload);
 
           let newBalanceUP = await provider.getBalance(

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -270,15 +270,6 @@ export const shouldBehaveLikeAllowedAddresses = (
               [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
             );
 
-          await context.keyManager
-            .connect(invalidEncodedAllowedCalls)
-            .execute(transferPayload);
-
-          let newBalanceUP = await provider.getBalance(
-            context.universalProfile.address
-          );
-          expect(newBalanceUP).to.be.lt(initialBalanceUP);
-
           await expect(
             context.keyManager
               .connect(invalidEncodedAllowedCalls)

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -77,20 +77,19 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialName = await targetContract.callStatic.getName();
           let newName = "Updated Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           await context.keyManager
             .connect(addressCanCallAnyFunctions)
@@ -105,19 +104,20 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialNumber = await targetContract.callStatic.getNumber();
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [newNumber]
-          );
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [
+              newNumber,
+            ]);
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           await context.keyManager
             .connect(addressCanCallAnyFunctions)
@@ -136,20 +136,19 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialName = await targetContract.callStatic.getName();
           let newName = "Updated Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           await context.keyManager
             .connect(addressCanCallOnlyOneFunction)
@@ -164,19 +163,20 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialNumber = await targetContract.callStatic.getNumber();
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [newNumber]
-          );
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [
+              newNumber,
+            ]);
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           await expect(
             context.keyManager
@@ -201,7 +201,7 @@ export const shouldBehaveLikeAllowedFunctions = (
           "0xbaadca110000000000000000000000000000000000000000000000000000000123456789";
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, targetContract.address, 0, randomPayload]
         );
 
@@ -228,24 +228,23 @@ export const shouldBehaveLikeAllowedFunctions = (
         it("`setName(...)` - should pass when the bytes4 selector of the function called is listed in its AllowedFunctions", async () => {
           let newName = "Dagobah";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCanCallOnlyOneFunction.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -286,20 +285,19 @@ export const shouldBehaveLikeAllowedFunctions = (
             addressCanCallOnlyOneFunction.address,
             channelId
           );
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [2354]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [2354]);
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -432,10 +430,11 @@ export const shouldBehaveLikeAllowedFunctions = (
           [context.universalProfile.address, recipient, tokenId, true, "0x"]
         );
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
+          );
 
         await context.keyManager
           .connect(addressCanCallOnlyTransferOnLSP8)
@@ -447,20 +446,22 @@ export const shouldBehaveLikeAllowedFunctions = (
       it("should revert when calling `authorizeOperator(...)` on LSP8 contract", async () => {
         const operator = context.accounts[8].address;
 
-        const authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-          "authorizeOperator",
-          [operator, tokenId]
-        );
+        const authorizeOperatorPayload =
+          lsp8Contract.interface.encodeFunctionData("authorizeOperator", [
+            operator,
+            tokenId,
+          ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            lsp8Contract.address,
-            0,
-            authorizeOperatorPayload,
-          ]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              lsp8Contract.address,
+              0,
+              authorizeOperatorPayload,
+            ]
+          );
 
         await expect(
           context.keyManager
@@ -489,10 +490,11 @@ export const shouldBehaveLikeAllowedFunctions = (
             "0x",
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp7Contract.address, 0, mintPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, lsp7Contract.address, 0, mintPayload]
+            );
 
           await context.keyManager
             .connect(
@@ -512,10 +514,11 @@ export const shouldBehaveLikeAllowedFunctions = (
             [context.universalProfile.address, recipient, amount, true, "0x"]
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp7Contract.address, 0, transferPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, lsp7Contract.address, 0, transferPayload]
+            );
 
           let tx = await context.keyManager
             .connect(
@@ -536,20 +539,22 @@ export const shouldBehaveLikeAllowedFunctions = (
           let operator = context.accounts[6].address;
           const amount = 10;
 
-          let authorizeOperatorPayload = lsp7Contract.interface.encodeFunctionData(
-            "authorizeOperator",
-            [operator, amount]
-          );
+          let authorizeOperatorPayload =
+            lsp7Contract.interface.encodeFunctionData("authorizeOperator", [
+              operator,
+              amount,
+            ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              lsp7Contract.address,
-              0,
-              authorizeOperatorPayload,
-            ]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp7Contract.address,
+                0,
+                authorizeOperatorPayload,
+              ]
+            );
 
           await context.keyManager
             .connect(
@@ -578,7 +583,7 @@ export const shouldBehaveLikeAllowedFunctions = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [OPERATION_TYPES.CALL, lsp7Contract.address, 0, setDataPayload]
           );
 
@@ -598,20 +603,22 @@ export const shouldBehaveLikeAllowedFunctions = (
         it("should pass when calling `authorizeOperator(...)`", async () => {
           let recipient = context.accounts[4].address;
 
-          let authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-            "authorizeOperator",
-            [recipient, tokenId]
-          );
+          let authorizeOperatorPayload =
+            lsp8Contract.interface.encodeFunctionData("authorizeOperator", [
+              recipient,
+              tokenId,
+            ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              lsp8Contract.address,
-              0,
-              authorizeOperatorPayload,
-            ]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                lsp8Contract.address,
+                0,
+                authorizeOperatorPayload,
+              ]
+            );
 
           await context.keyManager
             .connect(
@@ -631,10 +638,11 @@ export const shouldBehaveLikeAllowedFunctions = (
             [context.universalProfile.address, recipient, tokenId, true, "0x"]
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
+            );
 
           await expect(
             context.keyManager
@@ -660,10 +668,11 @@ export const shouldBehaveLikeAllowedFunctions = (
             "0x",
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp8Contract.address, 0, mintPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, lsp8Contract.address, 0, mintPayload]
+            );
 
           await expect(
             context.keyManager

--- a/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
@@ -111,7 +111,7 @@ export const shouldBehaveLikeAllowedStandards = (
       );
 
       let upPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
       );
 
@@ -134,7 +134,7 @@ export const shouldBehaveLikeAllowedStandards = (
         );
 
         let upPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload]
         );
 
@@ -149,10 +149,11 @@ export const shouldBehaveLikeAllowedStandards = (
         let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key"));
         let value = "0xcafecafecafecafe";
 
-        let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32,bytes)",
-          [key, value]
-        );
+        let setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
 
         await context.keyManager.connect(context.owner).execute(setDataPayload);
 
@@ -170,9 +171,8 @@ export const shouldBehaveLikeAllowedStandards = (
         let sampleHash = ethers.utils.keccak256(
           ethers.utils.toUtf8Bytes("Sample Message")
         );
-        let sampleSignature = await addressCanInteractOnlyWithERC1271.signMessage(
-          "Sample Message"
-        );
+        let sampleSignature =
+          await addressCanInteractOnlyWithERC1271.signMessage("Sample Message");
 
         let payload = signatureValidatorContract.interface.encodeFunctionData(
           "isValidSignature",
@@ -180,7 +180,7 @@ export const shouldBehaveLikeAllowedStandards = (
         );
 
         let upPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload]
         );
 
@@ -198,15 +198,16 @@ export const shouldBehaveLikeAllowedStandards = (
           otherUniversalProfile.address
         );
 
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            otherUniversalProfile.address,
-            ethers.utils.parseEther("1"),
-            "0x",
-          ]
-        );
+        let transferLyxPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              otherUniversalProfile.address,
+              ethers.utils.parseEther("1"),
+              "0x",
+            ]
+          );
 
         await context.keyManager
           .connect(addressCanInteractOnlyWithERC1271)
@@ -227,7 +228,7 @@ export const shouldBehaveLikeAllowedStandards = (
         );
 
         let upPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
         );
 
@@ -262,7 +263,7 @@ export const shouldBehaveLikeAllowedStandards = (
         );
 
         let upPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload]
         );
 
@@ -282,15 +283,16 @@ export const shouldBehaveLikeAllowedStandards = (
 
     describe("when interacting with an ERC725Account (LSP0)", () => {
       it("should fail when trying to transfer LYX", async () => {
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            otherUniversalProfile.address,
-            ethers.utils.parseEther("1"),
-            "0x",
-          ]
-        );
+        let transferLyxPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              otherUniversalProfile.address,
+              ethers.utils.parseEther("1"),
+              "0x",
+            ]
+          );
 
         await expect(
           context.keyManager
@@ -346,10 +348,11 @@ export const shouldBehaveLikeAllowedStandards = (
           [context.universalProfile.address, recipient, amount, true, "0x"]
         );
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, lsp7TokenA.address, 0, transferPayload]
-        );
+        const executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [OPERATION_TYPES.CALL, lsp7TokenA.address, 0, transferPayload]
+          );
 
         await context.keyManager
           .connect(addressCanInteractOnlyWithLSP7)
@@ -370,10 +373,11 @@ export const shouldBehaveLikeAllowedStandards = (
           [context.universalProfile.address, recipient, amount, true, "0x"]
         );
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, lsp7TokenB.address, 0, transferPayload]
-        );
+        const executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [OPERATION_TYPES.CALL, lsp7TokenB.address, 0, transferPayload]
+          );
 
         await context.keyManager
           .connect(addressCanInteractOnlyWithLSP7)
@@ -394,10 +398,11 @@ export const shouldBehaveLikeAllowedStandards = (
           [context.universalProfile.address, recipient, amount, true, "0x"]
         );
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, lsp7TokenC.address, 0, transferPayload]
-        );
+        const executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [OPERATION_TYPES.CALL, lsp7TokenC.address, 0, transferPayload]
+          );
 
         await context.keyManager
           .connect(addressCanInteractOnlyWithLSP7)

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -260,12 +260,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
           it("should fail if signer has nothing listed in its allowed calls", async () => {
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+              );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signerNoAllowedCalls.address,
@@ -480,7 +478,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let executeRelayCallPayload =
                 context.universalProfile.interface.encodeFunctionData(
-                  "execute",
+                  "execute(uint256,address,uint256,bytes)",
                   [
                     OPERATION_TYPES.CALL,
                     targetContract.address,

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -32,7 +32,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
     random: SignerWithAddress;
   let targetContract: TargetContract;
 
-  before(async () => {
+  beforeEach(async () => {
     context = await buildContext();
 
     signer = context.accounts[1];
@@ -119,6 +119,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
+
         describe("When sending 0 while msg.value signed > 0", () => {
           it("should revert by recovering a non permissioned address", async () => {
             let executeRelayCallPayload =
@@ -179,6 +180,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
+
         describe("When sending exact msg.value like the one that is signed", () => {
           it("should pass", async () => {
             let executeRelayCallPayload =
@@ -244,6 +246,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
+
         describe("When UP has 0 value and interacting with contract that require value", () => {
           describe("When relayer don't fund the UP so it's balance is less than the value param of execute(..)", () => {
             it("should revert", async () => {

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -64,12 +64,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
         describe("When sending more than the signed msg.value", () => {
           it("should revert by recovering a non permissioned address", async () => {
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+              );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -124,12 +122,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
         describe("When sending 0 while msg.value signed > 0", () => {
           it("should revert by recovering a non permissioned address", async () => {
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+              );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -186,12 +182,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
         describe("When sending exact msg.value like the one that is signed", () => {
           it("should pass", async () => {
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+              );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -250,8 +244,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
-        describe("When UP have 0 value and interacting with contract that require value", () => {
-          describe("When relayer don't fund the UP so it's balance is greater than the value param of execute(..)", () => {
+        describe("When UP has 0 value and interacting with contract that require value", () => {
+          describe("When relayer don't fund the UP so it's balance is less than the value param of execute(..)", () => {
             it("should revert", async () => {
               let nameToSet = "Alice";
               let targetContractPayload =
@@ -268,7 +262,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let executeRelayCallPayload =
                 context.universalProfile.interface.encodeFunctionData(
-                  "execute",
+                  "execute(uint256,address,uint256,bytes)",
                   [
                     OPERATION_TYPES.CALL,
                     targetContract.address,
@@ -316,7 +310,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                     executeRelayCallPayload,
                     { value: valueToSendFromRelayer }
                   )
-              ).to.be.revertedWith("ERC725X: insufficient balance");
+              )
+                .to.be.revertedWithCustomError(
+                  context.universalProfile,
+                  "ERC725X_InsufficientBalance"
+                )
+                .withArgs(0, requiredValueForExecution);
             });
           });
 
@@ -337,7 +336,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let executeRelayCallPayload =
                 context.universalProfile.interface.encodeFunctionData(
-                  "execute",
+                  "execute(uint256,address,uint256,bytes)",
                   [
                     OPERATION_TYPES.CALL,
                     targetContract.address,

--- a/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/tests/LSP6ControlledToken.test.ts
@@ -745,7 +745,7 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
         const payload =
           LSP0ERC725Account__factory.createInterface().encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [0, newTokenContract.address, 0, mintPayload]
           );
 

--- a/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/tests/MultiChannelNonce.test.ts
@@ -97,15 +97,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -168,15 +169,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -229,15 +231,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -295,15 +298,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -356,15 +360,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -422,15 +427,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -483,15 +489,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;
@@ -545,15 +552,16 @@ export const shouldBehaveLikeMultiChannelNonce = (
           "setName",
           [newName]
         );
-        let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executeRelayCallPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;

--- a/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
+++ b/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
@@ -75,7 +75,7 @@ export const otherTestScenarios = (
       const INVALID_OPERATION_TYPE = 8;
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [INVALID_OPERATION_TYPE, targetContract.address, 0, targetPayload]
       );
 
@@ -93,7 +93,7 @@ export const otherTestScenarios = (
       const INVALID_OPERATION_TYPE = 8;
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [INVALID_OPERATION_TYPE, targetContract.address, 0, targetPayload]
       );
 

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -70,7 +70,7 @@ export const shouldBehaveLikePermissionCall = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
         );
 
@@ -91,7 +91,7 @@ export const shouldBehaveLikePermissionCall = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
         );
 
@@ -112,7 +112,7 @@ export const shouldBehaveLikePermissionCall = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
         );
 
@@ -128,19 +128,19 @@ export const shouldBehaveLikePermissionCall = (
       it("should return the value to the Key Manager <- UP <- targetContract.getName()", async () => {
         let expectedName = await targetContract.callStatic.getName();
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "getName"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("getName");
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -153,19 +153,19 @@ export const shouldBehaveLikePermissionCall = (
       it("Should return the value to the Key Manager <- UP <- targetContract.getNumber()", async () => {
         let expectedNumber = await targetContract.callStatic.getNumber();
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "getNumber"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("getNumber");
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -178,12 +178,11 @@ export const shouldBehaveLikePermissionCall = (
 
     describe("when calling a function that reverts", () => {
       it("should revert", async () => {
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "revertCall"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("revertCall");
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CALL,
             targetContract.address,
@@ -208,24 +207,23 @@ export const shouldBehaveLikePermissionCall = (
         it("should execute successfully", async () => {
           let newName = "New Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             context.owner.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -243,13 +241,12 @@ export const shouldBehaveLikePermissionCall = (
 
           const eip191Signer = new EIP191Signer();
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT0
-          );
+          const { signature } =
+            await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT0
+            );
 
           await context.keyManager.executeRelayCall(
             signature,
@@ -267,24 +264,23 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionsSet` error", async () => {
           let newName = "New Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             context.owner.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -334,24 +330,23 @@ export const shouldBehaveLikePermissionCall = (
         it("should execute successfully", async () => {
           let newName = "Another name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCanMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -369,13 +364,12 @@ export const shouldBehaveLikePermissionCall = (
 
           const eip191Signer = new EIP191Signer();
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT1
-          );
+          const { signature } =
+            await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT1
+            );
 
           await context.keyManager.executeRelayCall(
             signature,
@@ -393,24 +387,23 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionsSet` error", async () => {
           let newName = "Another name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCanMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -459,24 +452,25 @@ export const shouldBehaveLikePermissionCall = (
         it("should revert with `NotAuthorised` and permission CALL error", async () => {
           const initialName = await targetContract.callStatic.getName();
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            ["Random name"]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [
+              "Random name",
+            ]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCannotMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -494,13 +488,12 @@ export const shouldBehaveLikePermissionCall = (
 
           const eip191Signer = new EIP191Signer();
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT2
-          );
+          const { signature } =
+            await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT2
+            );
 
           await expect(
             context.keyManager.executeRelayCall(
@@ -523,24 +516,25 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionSet`", async () => {
           const initialName = await targetContract.callStatic.getName();
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            ["Random name"]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [
+              "Random name",
+            ]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCannotMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -108,7 +108,7 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
           );
 
@@ -176,12 +176,15 @@ export const shouldBehaveLikePermissionCall = (
           targetContract.interface.encodeFunctionData("getName");
 
         let executePayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -198,12 +201,15 @@ export const shouldBehaveLikePermissionCall = (
           targetContract.interface.encodeFunctionData("getNumber");
 
         let executePayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            targetContract.address,
-            0,
-            targetContractPayload,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              targetContractPayload,
+            ]
+          );
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -253,12 +259,15 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -307,12 +316,15 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -366,17 +378,20 @@ export const shouldBehaveLikePermissionCall = (
             let targetContractPayload =
               targetContract.interface.encodeFunctionData("setName", [newName]);
             let nonce = await context.keyManager.callStatic.getNonce(
-              addressCanMakeCall.address,
+              addressCanMakeCallWithAllowedCalls.address,
               channelId
             );
 
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                targetContract.address,
-                0,
-                targetContractPayload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  targetContract.address,
+                  0,
+                  targetContractPayload,
+                ]
+              );
 
             const HARDHAT_CHAINID = 31337;
             let valueToSend = 0;
@@ -425,12 +440,15 @@ export const shouldBehaveLikePermissionCall = (
             );
 
             let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                targetContract.address,
-                0,
-                targetContractPayload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  targetContract.address,
+                  0,
+                  targetContractPayload,
+                ]
+              );
 
             const HARDHAT_CHAINID = 31337;
             let valueToSend = 0;
@@ -484,12 +502,15 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -550,12 +571,15 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -611,12 +635,15 @@ export const shouldBehaveLikePermissionCall = (
           );
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -377,6 +377,7 @@ export const shouldBehaveLikePermissionCall = (
 
             let targetContractPayload =
               targetContract.interface.encodeFunctionData("setName", [newName]);
+
             let nonce = await context.keyManager.callStatic.getNonce(
               addressCanMakeCallWithAllowedCalls.address,
               channelId
@@ -413,7 +414,7 @@ export const shouldBehaveLikePermissionCall = (
               await eip191Signer.signDataWithIntendedValidator(
                 context.keyManager.address,
                 encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
+                LOCAL_PRIVATE_KEYS.ACCOUNT2
               );
 
             await context.keyManager.executeRelayCall(
@@ -601,7 +602,7 @@ export const shouldBehaveLikePermissionCall = (
             await eip191Signer.signDataWithIntendedValidator(
               context.keyManager.address,
               encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT2
+              LOCAL_PRIVATE_KEYS.ACCOUNT3
             );
 
           await expect(

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -192,7 +192,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
           );
 
@@ -397,7 +397,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         let amount = ethers.utils.parseEther("3");
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
         );
 
@@ -436,7 +436,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         );
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
         );
 

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -74,20 +74,22 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
-        [key, value]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "updateStorage",
+          [key, value]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.DELEGATECALL,
-          erc725YDelegateCallContract.address,
-          0,
-          delegateCallPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.DELEGATECALL,
+            erc725YDelegateCallContract.address,
+            0,
+            delegateCallPayload,
+          ]
+        );
 
       await expect(
         context.keyManager.connect(context.owner).execute(executePayload)
@@ -110,20 +112,22 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
-        [key, value]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "updateStorage",
+          [key, value]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.DELEGATECALL,
-          erc725YDelegateCallContract.address,
-          0,
-          delegateCallPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.DELEGATECALL,
+            erc725YDelegateCallContract.address,
+            0,
+            delegateCallPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -148,20 +152,22 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "setData(bytes32[],bytes[])",
-        [[key], [value]]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "setData(bytes32[],bytes[])",
+          [[key], [value]]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.DELEGATECALL,
-          erc725YDelegateCallContract.address,
-          0,
-          delegateCallPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.DELEGATECALL,
+            erc725YDelegateCallContract.address,
+            0,
+            delegateCallPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -259,15 +265,16 @@ export const shouldBehaveLikePermissionDelegateCall = (
                 value,
               ]);
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
-                OPERATION_TYPES.DELEGATECALL,
-                randomContracts[ii].address,
-                0,
-                delegateCallPayload,
-              ]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.DELEGATECALL,
+                  randomContracts[ii].address,
+                  0,
+                  delegateCallPayload,
+                ]
+              );
 
             await expect(
               context.keyManager.connect(caller).execute(executePayload)
@@ -302,15 +309,16 @@ export const shouldBehaveLikePermissionDelegateCall = (
             value,
           ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            allowedDelegateCallContracts[0].address,
-            0,
-            delegateCallPayload,
-          ]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.DELEGATECALL,
+              allowedDelegateCallContracts[0].address,
+              0,
+              delegateCallPayload,
+            ]
+          );
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)
@@ -339,15 +347,16 @@ export const shouldBehaveLikePermissionDelegateCall = (
             value,
           ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            allowedDelegateCallContracts[1].address,
-            0,
-            delegateCallPayload,
-          ]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.DELEGATECALL,
+              allowedDelegateCallContracts[1].address,
+              0,
+              delegateCallPayload,
+            ]
+          );
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -119,12 +119,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
         );
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.DELEGATECALL,
-          erc725YDelegateCallContract.address,
-          0,
-          delegateCallPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.DELEGATECALL,
+            erc725YDelegateCallContract.address,
+            0,
+            delegateCallPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -156,12 +159,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
         );
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.DELEGATECALL,
-          erc725YDelegateCallContract.address,
-          0,
-          delegateCallPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.DELEGATECALL,
+            erc725YDelegateCallContract.address,
+            0,
+            delegateCallPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -260,12 +266,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
               ]);
 
             let executePayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.DELEGATECALL,
-                randomContracts[ii].address,
-                0,
-                delegateCallPayload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.DELEGATECALL,
+                  randomContracts[ii].address,
+                  0,
+                  delegateCallPayload,
+                ]
+              );
 
             await expect(
               context.keyManager.connect(caller).execute(executePayload)
@@ -301,12 +310,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
           ]);
 
         let executePayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.DELEGATECALL,
-            allowedDelegateCallContracts[0].address,
-            0,
-            delegateCallPayload,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.DELEGATECALL,
+              allowedDelegateCallContracts[0].address,
+              0,
+              delegateCallPayload,
+            ]
+          );
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)
@@ -336,12 +348,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
           ]);
 
         let executePayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.DELEGATECALL,
-            allowedDelegateCallContracts[1].address,
-            0,
-            delegateCallPayload,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.DELEGATECALL,
+              allowedDelegateCallContracts[1].address,
+              0,
+              delegateCallPayload,
+            ]
+          );
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -58,7 +58,7 @@ export const shouldBehaveLikePermissionDeploy = (
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CREATE, // operation type
           ethers.constants.AddressZero, // recipient
@@ -86,7 +86,7 @@ export const shouldBehaveLikePermissionDeploy = (
         "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CREATE2,
           ethers.constants.AddressZero,
@@ -116,7 +116,7 @@ export const shouldBehaveLikePermissionDeploy = (
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CREATE,
           ethers.constants.AddressZero,
@@ -144,7 +144,7 @@ export const shouldBehaveLikePermissionDeploy = (
         "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.CREATE2,
           ethers.constants.AddressZero,
@@ -177,7 +177,7 @@ export const shouldBehaveLikePermissionDeploy = (
         let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CREATE,
             ethers.constants.AddressZero,
@@ -199,7 +199,7 @@ export const shouldBehaveLikePermissionDeploy = (
           "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
 
         let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.CREATE2,
             ethers.constants.AddressZero,
@@ -228,7 +228,7 @@ export const shouldBehaveLikePermissionDeploy = (
             );
 
             let payload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              "execute(uint256,address,uint256,bytes)",
               [
                 OPERATION_TYPES.CREATE,
                 ethers.constants.AddressZero,
@@ -284,7 +284,7 @@ export const shouldBehaveLikePermissionDeploy = (
             );
 
             let payload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              "execute(uint256,address,uint256,bytes)",
               [
                 OPERATION_TYPES.CREATE,
                 ethers.constants.AddressZero,
@@ -338,7 +338,7 @@ export const shouldBehaveLikePermissionDeploy = (
             );
 
             let payload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              "execute(uint256,address,uint256,bytes)",
               [
                 OPERATION_TYPES.CREATE2,
                 ethers.constants.AddressZero,
@@ -395,7 +395,7 @@ export const shouldBehaveLikePermissionDeploy = (
             );
 
             let payload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              "execute(uint256,address,uint256,bytes)",
               [
                 OPERATION_TYPES.CREATE2,
                 ethers.constants.AddressZero,

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -831,12 +831,15 @@ export const shouldBehaveLikePermissionSetData = (
         ]);
 
       let aliceUniversalProfilePayload =
-        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          bobContext.keyManager.address,
-          0,
-          bobKeyManagerPayload,
-        ]);
+        aliceContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            bobContext.keyManager.address,
+            0,
+            bobKeyManagerPayload,
+          ]
+        );
 
       await expect(
         aliceContext.keyManager
@@ -879,12 +882,15 @@ export const shouldBehaveLikePermissionSetData = (
         ]);
 
       let aliceUniversalProfilePayload =
-        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          bobContext.keyManager.address,
-          0,
-          bobKeyManagerPayload,
-        ]);
+        aliceContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            bobContext.keyManager.address,
+            0,
+            bobKeyManagerPayload,
+          ]
+        );
 
       let tx = await aliceContext.keyManager
         .connect(alice)

--- a/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
@@ -184,12 +184,15 @@ export const shouldBehaveLikePermissionStaticCall = (
         targetContract.interface.encodeFunctionData("getName");
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.STATICCALL,
-          targetContract.address,
-          0,
-          targetContractPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.STATICCALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       await expect(
         context.keyManager

--- a/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
@@ -60,19 +60,19 @@ export const shouldBehaveLikePermissionStaticCall = (
     it("should pass and return data", async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.STATICCALL,
-          targetContract.address,
-          0,
-          targetContractPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.STATICCALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       let result = await context.keyManager
         .connect(context.owner)
@@ -87,19 +87,19 @@ export const shouldBehaveLikePermissionStaticCall = (
     it("should pass and return data", async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.STATICCALL,
-          targetContract.address,
-          0,
-          targetContractPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.STATICCALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       let result = await context.keyManager
         .connect(addressCanMakeStaticCall)
@@ -117,15 +117,16 @@ export const shouldBehaveLikePermissionStaticCall = (
         ["modified name"]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.STATICCALL,
-          targetContract.address,
-          0,
-          targetContractPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.STATICCALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -144,10 +145,16 @@ export const shouldBehaveLikePermissionStaticCall = (
         ["modified name"]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -161,19 +168,19 @@ export const shouldBehaveLikePermissionStaticCall = (
 
   describe("when caller does not have permission STATICCALL", () => {
     it("should revert", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.STATICCALL,
-          targetContract.address,
-          0,
-          targetContractPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.STATICCALL,
+            targetContract.address,
+            0,
+            targetContractPayload,
+          ]
+        );
 
       await expect(
         context.keyManager
@@ -227,7 +234,7 @@ export const shouldBehaveLikePermissionStaticCall = (
       ).deploy();
 
       const payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
@@ -252,7 +259,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         const name = await targetContract.getName();
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
@@ -275,7 +282,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         const number = await targetContract.getNumber();
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
@@ -301,7 +308,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         );
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.STATICCALL, targetContract.address, 0, targetPayload]
         );
 
@@ -319,7 +326,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         );
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.STATICCALL, targetContract.address, 0, targetPayload]
         );
 
@@ -336,7 +343,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         const name = await targetContract.getName();
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
@@ -359,7 +366,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         const number = await targetContract.getNumber();
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
@@ -385,7 +392,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         );
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.STATICCALL, targetContract.address, 0, targetPayload]
         );
 
@@ -403,7 +410,7 @@ export const shouldBehaveLikePermissionStaticCall = (
         );
 
         const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          "execute(uint256,address,uint256,bytes)",
           [OPERATION_TYPES.STATICCALL, targetContract.address, 0, targetPayload]
         );
 
@@ -460,7 +467,7 @@ export const shouldBehaveLikePermissionStaticCall = (
           const name = await targetContract.getName();
 
           const payload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [
               OPERATION_TYPES.STATICCALL,
               targetContract.address,

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -270,12 +270,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let transferPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await expect(
               context.keyManager
@@ -309,12 +312,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let transferPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await expect(
               context.keyManager
@@ -346,12 +352,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           const amount = ethers.utils.parseEther("3");
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient,
-              amount,
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -386,12 +390,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           const amount = ethers.utils.parseEther("3");
 
           let executeRelayCallPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient,
-              amount,
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -630,25 +632,32 @@ export const shouldBehaveLikePermissionTransferValue = (
       const amount = ethers.utils.parseEther("5");
 
       let finalTransferLyxPayload =
-        bobContext.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          aliceContext.universalProfile.address,
-          amount,
-          "0x",
-        ]);
+        bobContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            aliceContext.universalProfile.address,
+            amount,
+            "0x",
+          ]
+        );
 
       let bobKeyManagerPayload =
-        bobContext.keyManager.interface.encodeFunctionData("execute", [
-          finalTransferLyxPayload,
-        ]);
+        bobContext.keyManager.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [finalTransferLyxPayload]
+        );
 
       let aliceUniversalProfilePayload =
-        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          bobContext.keyManager.address,
-          0,
-          bobKeyManagerPayload,
-        ]);
+        aliceContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            bobContext.keyManager.address,
+            0,
+            bobKeyManagerPayload,
+          ]
+        );
 
       await expect(() =>
         aliceContext.keyManager
@@ -728,12 +737,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           const amount = ethers.utils.parseEther("1");
 
           let transferPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient,
-              amount,
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -755,12 +762,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           const amount = ethers.utils.parseEther("1");
 
           let transferPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient.address,
-              amount,
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -789,12 +794,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          newLSP7Token.address,
-          5,
-          lsp7TransferPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, newLSP7Token.address, 5, lsp7TransferPayload]
+        );
 
       await expect(context.keyManager.connect(caller).execute(executePayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -827,12 +830,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          lsp7Token.address,
-          0,
-          lsp7TransferPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, lsp7Token.address, 0, lsp7TransferPayload]
+        );
 
       await context.keyManager.connect(caller).execute(executePayload);
 
@@ -880,12 +881,15 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       let executePayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          targetContract.address,
-          lyxAmount,
-          targetContractPayload,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            targetContract.address,
+            lyxAmount,
+            targetContractPayload,
+          ]
+        );
 
       await expect(() =>
         context.keyManager.connect(caller).execute(executePayload)
@@ -944,12 +948,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       let initialBalanceRecipient = await provider.getBalance(recipient);
 
       let transferPayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          recipient,
-          amount,
-          "0x",
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+        );
 
       await expect(context.keyManager.connect(caller).execute(transferPayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -968,12 +970,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       const amount = ethers.utils.parseEther("1");
 
       let transferPayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          allowedAddress.address,
-          amount,
-          "0x",
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, allowedAddress.address, amount, "0x"]
+        );
 
       await expect(() =>
         context.keyManager.connect(caller).execute(transferPayload)
@@ -999,12 +999,10 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let executePayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                targetContract.address,
-                0,
-                payload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1053,12 +1051,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let executePayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                lsp7Token.address,
-                0,
-                tokenTransferPayload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  lsp7Token.address,
+                  0,
+                  tokenTransferPayload,
+                ]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1185,12 +1186,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           const amount = ethers.utils.parseEther("1");
 
           let transferPayload =
-            context.universalProfile.interface.encodeFunctionData("execute", [
-              OPERATION_TYPES.CALL,
-              recipient,
-              amount,
-              "0x",
-            ]);
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -1218,12 +1217,10 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let executePayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                targetContract.address,
-                0,
-                payload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1272,12 +1269,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
 
             let executePayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                lsp7Token.address,
-                0,
-                tokenTransferPayload,
-              ]);
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  lsp7Token.address,
+                  0,
+                  tokenTransferPayload,
+                ]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -92,10 +92,11 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has ALL PERMISSIONS", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, recipient, amount, data]
+              );
 
             /**
              * verify that balances have been updated
@@ -112,10 +113,11 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE only", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, recipient, amount, data]
+              );
 
             await expect(() =>
               context.keyManager
@@ -130,10 +132,11 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, recipient, amount, data]
+              );
 
             await expect(() =>
               context.keyManager
@@ -151,15 +154,16 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
             let initialBalanceRecipient = await provider.getBalance(recipient);
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await expect(
               context.keyManager
@@ -193,15 +197,16 @@ export const shouldBehaveLikePermissionTransferValue = (
 
             let initialBalanceRecipient = await provider.getBalance(recipient);
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await context.keyManager
               .connect(context.owner)
@@ -219,10 +224,11 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, recipient, amount, data]
+              );
 
             await expect(() =>
               context.keyManager
@@ -240,15 +246,16 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
             let initialBalanceRecipient = await provider.getBalance(recipient);
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await expect(
               context.keyManager
@@ -277,15 +284,16 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
             let initialBalanceRecipient = await provider.getBalance(recipient);
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
-                OPERATION_TYPES.CALL,
-                recipient,
-                ethers.utils.parseEther("3"),
-                data,
-              ]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  recipient,
+                  ethers.utils.parseEther("3"),
+                  data,
+                ]
+              );
 
             await expect(
               context.keyManager
@@ -314,10 +322,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         it("should revert if tx was signed with Eth Signed Message", async () => {
           const amount = ethers.utils.parseEther("3");
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -351,10 +360,11 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           const amount = ethers.utils.parseEther("3");
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -570,30 +580,32 @@ export const shouldBehaveLikePermissionTransferValue = (
     it("Alice should be able to send 5 LYX from Bob's UP to her UP", async () => {
       const amount = ethers.utils.parseEther("5");
 
-      let finalTransferLyxPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CALL,
-          aliceContext.universalProfile.address,
-          amount,
-          "0x",
-        ]
-      );
+      let finalTransferLyxPayload =
+        bobContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            aliceContext.universalProfile.address,
+            amount,
+            "0x",
+          ]
+        );
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
-        "execute",
-        [finalTransferLyxPayload]
-      );
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalTransferLyxPayload,
+        ]);
 
-      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CALL,
-          bobContext.keyManager.address,
-          0,
-          bobKeyManagerPayload,
-        ]
-      );
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            bobContext.keyManager.address,
+            0,
+            bobKeyManagerPayload,
+          ]
+        );
 
       await expect(() =>
         aliceContext.keyManager
@@ -672,10 +684,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         it(`should send LYX to EOA -> ${recipient}`, async () => {
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -696,10 +709,11 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -727,10 +741,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, newLSP7Token.address, 5, lsp7TransferPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, newLSP7Token.address, 5, lsp7TransferPayload]
+        );
 
       await expect(context.keyManager.connect(caller).execute(executePayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -762,10 +777,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, lsp7Token.address, 0, lsp7TransferPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, lsp7Token.address, 0, lsp7TransferPayload]
+        );
 
       await context.keyManager.connect(caller).execute(executePayload);
 
@@ -793,7 +809,7 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       let payload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
       );
 
@@ -812,15 +828,16 @@ export const shouldBehaveLikePermissionTransferValue = (
         [newValue]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
-          OPERATION_TYPES.CALL,
-          targetContract.address,
-          lyxAmount,
-          targetContractPayload,
-        ]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            targetContract.address,
+            lyxAmount,
+            targetContractPayload,
+          ]
+        );
 
       await expect(() =>
         context.keyManager.connect(caller).execute(executePayload)
@@ -878,10 +895,11 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       let initialBalanceRecipient = await provider.getBalance(recipient);
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+        );
 
       await expect(context.keyManager.connect(caller).execute(transferPayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -899,10 +917,11 @@ export const shouldBehaveLikePermissionTransferValue = (
     it("should be allowed to do a plain LYX transfer to an allowed address", async () => {
       const amount = ethers.utils.parseEther("1");
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, allowedAddress.address, amount, "0x"]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [OPERATION_TYPES.CALL, allowedAddress.address, amount, "0x"]
+        );
 
       await expect(() =>
         context.keyManager.connect(caller).execute(transferPayload)
@@ -927,10 +946,11 @@ export const shouldBehaveLikePermissionTransferValue = (
               [newValue]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -978,10 +998,16 @@ export const shouldBehaveLikePermissionTransferValue = (
               ]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, lsp7Token.address, 0, tokenTransferPayload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  lsp7Token.address,
+                  0,
+                  tokenTransferPayload,
+                ]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1025,7 +1051,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           );
 
           let payload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            "execute(uint256,address,uint256,bytes)",
             [
               OPERATION_TYPES.CALL,
               targetContract.address,
@@ -1107,10 +1133,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         it(`should send LYX to EOA -> ${recipient}`, async () => {
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "execute(uint256,address,uint256,bytes)",
+              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+            );
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -1137,10 +1164,11 @@ export const shouldBehaveLikePermissionTransferValue = (
               [newValue]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1188,10 +1216,16 @@ export const shouldBehaveLikePermissionTransferValue = (
               ]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, lsp7Token.address, 0, tokenTransferPayload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "execute(uint256,address,uint256,bytes)",
+                [
+                  OPERATION_TYPES.CALL,
+                  lsp7Token.address,
+                  0,
+                  tokenTransferPayload,
+                ]
+              );
 
             await context.keyManager.connect(caller).execute(executePayload);
 

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -108,7 +108,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             let transferPayload =
               context.universalProfile.interface.encodeFunctionData(
                 "execute(uint256,address,uint256,bytes)",
-                [OPERATION_TYPES.CALL, recipient, amount, data]
+                [OPERATION_TYPES.CALL, recipient.address, amount, data]
               );
 
             /**
@@ -129,7 +129,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             let transferPayload =
               context.universalProfile.interface.encodeFunctionData(
                 "execute(uint256,address,uint256,bytes)",
-                [OPERATION_TYPES.CALL, recipient, amount, data]
+                [OPERATION_TYPES.CALL, recipient.address, amount, data]
               );
 
             await expect(() =>
@@ -148,7 +148,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             let transferPayload =
               context.universalProfile.interface.encodeFunctionData(
                 "execute(uint256,address,uint256,bytes)",
-                [OPERATION_TYPES.CALL, recipient, amount, data]
+                [OPERATION_TYPES.CALL, recipient.address, amount, data]
               );
 
             await expect(() =>
@@ -174,7 +174,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 "execute(uint256,address,uint256,bytes)",
                 [
                   OPERATION_TYPES.CALL,
-                  recipient,
+                  recipient.address,
                   ethers.utils.parseEther("3"),
                   data,
                 ]
@@ -221,7 +221,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 "execute(uint256,address,uint256,bytes)",
                 [
                   OPERATION_TYPES.CALL,
-                  recipient,
+                  recipient.address,
                   ethers.utils.parseEther("3"),
                   data,
                 ]
@@ -248,7 +248,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             let transferPayload =
               context.universalProfile.interface.encodeFunctionData(
                 "execute(uint256,address,uint256,bytes)",
-                [OPERATION_TYPES.CALL, recipient, amount, data]
+                [OPERATION_TYPES.CALL, recipient.address, amount, data]
               );
 
             await expect(() =>
@@ -274,7 +274,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 "execute(uint256,address,uint256,bytes)",
                 [
                   OPERATION_TYPES.CALL,
-                  recipient,
+                  recipient.address,
                   ethers.utils.parseEther("3"),
                   data,
                 ]
@@ -316,7 +316,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 "execute(uint256,address,uint256,bytes)",
                 [
                   OPERATION_TYPES.CALL,
-                  recipient,
+                  recipient.address,
                   ethers.utils.parseEther("3"),
                   data,
                 ]
@@ -354,7 +354,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           let executeRelayCallPayload =
             context.universalProfile.interface.encodeFunctionData(
               "execute(uint256,address,uint256,bytes)",
-              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+              [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
             );
 
           const HARDHAT_CHAINID = 31337;
@@ -392,7 +392,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           let executeRelayCallPayload =
             context.universalProfile.interface.encodeFunctionData(
               "execute(uint256,address,uint256,bytes)",
-              [OPERATION_TYPES.CALL, recipient, amount, "0x"]
+              [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
             );
 
           const HARDHAT_CHAINID = 31337;
@@ -643,10 +643,9 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
 
       let bobKeyManagerPayload =
-        bobContext.keyManager.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [finalTransferLyxPayload]
-        );
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalTransferLyxPayload,
+        ]);
 
       let aliceUniversalProfilePayload =
         aliceContext.universalProfile.interface.encodeFunctionData(

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -89,7 +89,7 @@ export const testSecurityScenarios = (
     );
 
     let executePayload = context.universalProfile.interface.encodeFunctionData(
-      "execute",
+      "execute(uint256,address,uint256,bytes)",
       [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload]
     );
 
@@ -158,12 +158,15 @@ export const testSecurityScenarios = (
       // we assume the UP owner is not aware that some malicious code is present
       // in the fallback function of the target (= recipient) contract
       let transferPayload =
-        context.universalProfile.interface.encodeFunctionData("execute", [
-          OPERATION_TYPES.CALL,
-          maliciousContract.address,
-          ethers.utils.parseEther("1"),
-          EMPTY_PAYLOAD,
-        ]);
+        context.universalProfile.interface.encodeFunctionData(
+          "execute(uint256,address,uint256,bytes)",
+          [
+            OPERATION_TYPES.CALL,
+            maliciousContract.address,
+            ethers.utils.parseEther("1"),
+            EMPTY_PAYLOAD,
+          ]
+        );
 
       let executePayload = context.keyManager.interface.encodeFunctionData(
         "execute",
@@ -208,12 +211,15 @@ export const testSecurityScenarios = (
         );
 
         let executeRelayCallPayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            signer.address,
-            ethers.utils.parseEther("1"),
-            EMPTY_PAYLOAD,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              signer.address,
+              ethers.utils.parseEther("1"),
+              EMPTY_PAYLOAD,
+            ]
+          );
 
         const HARDHAT_CHAINID = 31337;
         let valueToSend = 0;

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.test.ts
@@ -76,9 +76,7 @@ describe("LSP7", () => {
             deployParams.symbol,
             deployParams.newOwner
           )
-        ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
-        );
+        ).to.be.revertedWith("Ownable: new owner is the zero address");
       });
 
       describe("once the contract was deployed", () => {
@@ -148,7 +146,7 @@ describe("LSP7", () => {
           accounts,
           deployParams,
         };
-      }
+      };
 
     const initializeProxy = async (context: LSP7TestContext) => {
       return context.lsp7["initialize(string,string,address,bool)"](
@@ -174,9 +172,7 @@ describe("LSP7", () => {
             ethers.constants.AddressZero,
             false
           )
-        ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
-        );
+        ).to.be.revertedWith("Ownable: new owner is the zero address");
       });
 
       describe("when initializing the contract", () => {
@@ -206,13 +202,13 @@ describe("LSP7", () => {
     describe("when testing deployed contract", () => {
       shouldBehaveLikeLSP4DigitalAssetMetadata(async () => {
         let lsp4Context = await buildLSP4DigitalAssetMetadataTestContext();
-        
+
         await lsp4Context.contract["initialize(string,string,address,bool)"](
           "LSP7 - deployed with proxy",
           "TKN",
           lsp4Context.deployParams.owner.address,
           false
-        )
+        );
 
         return lsp4Context;
       });

--- a/tests/LSP7DigitalAsset/extensions/LSP7Mintable.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7Mintable.behaviour.ts
@@ -142,7 +142,7 @@ export const shouldBehaveLikeLSP7Mintable = (
       );
 
       const executePayload = universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [OPERATION_TYPES.CALL, context.lsp7Mintable.address, 0, mintPayload]
       );
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.test.ts
@@ -71,9 +71,7 @@ describe("LSP8", () => {
             deployParams.symbol,
             ethers.constants.AddressZero
           )
-        ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
-        );
+        ).to.be.revertedWith("Ownable: new owner is the zero address");
       });
 
       describe("once the contract was deployed", () => {
@@ -138,7 +136,7 @@ describe("LSP8", () => {
           accounts,
           deployParams,
         };
-      }
+      };
 
     const initializeProxy = async (context: LSP8TestContext) => {
       return context.lsp8["initialize(string,string,address)"](
@@ -162,9 +160,7 @@ describe("LSP8", () => {
             context.deployParams.symbol,
             ethers.constants.AddressZero
           )
-        ).to.be.revertedWith(
-          "Ownable: contract owner cannot be the zero address"
-        );
+        ).to.be.revertedWith("Ownable: new owner is the zero address");
       });
 
       describe("when initializing the contract", () => {
@@ -194,12 +190,12 @@ describe("LSP8", () => {
     describe("when testing deployed contract", () => {
       shouldBehaveLikeLSP4DigitalAssetMetadata(async () => {
         let lsp4Context = await buildLSP4DigitalAssetMetadataTestContext();
-        
+
         await lsp4Context.contract["initialize(string,string,address)"](
           "LSP8 - deployed with proxy",
           "NFT",
           lsp4Context.deployParams.owner.address
-        )
+        );
 
         return lsp4Context;
       });

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.behaviour.ts
@@ -145,7 +145,7 @@ export const shouldBehaveLikeLSP8Mintable = (
       );
 
       const executePayload = universalProfile.interface.encodeFunctionData(
-        "execute",
+        "execute(uint256,address,uint256,bytes)",
         [OPERATION_TYPES.CALL, context.lsp8Mintable.address, 0, mintPayload]
       );
 

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -160,15 +160,20 @@ export const shouldBehaveLikeLSP9 = (
 
   describe("when testing setting execute", () => {
     describe("when executing operation (4) DELEGATECALL", () => {
-      it("should revert with unknow operation type string error", async () => {
+      it("should revert with unknow operation type custom error", async () => {
         await expect(
-          context.lsp9Vault.execute(
+          context.lsp9Vault["execute(uint256,address,uint256,bytes)"](
             OPERATION_TYPES.DELEGATECALL,
             context.accounts.random.address,
             0,
             "0x"
           )
-        ).to.be.revertedWith("ERC725X: Unknown operation type");
+        )
+          .to.be.revertedWithCustomError(
+            context.universalProfile,
+            "ERC725X_UnknownOperationType"
+          )
+          .withArgs(OPERATION_TYPES.DELEGATECALL);
       });
     });
   });
@@ -184,12 +189,15 @@ export const shouldBehaveLikeLSP9 = (
           context.universalProfile.interface.getSighash("acceptOwnership");
 
         let executePayload =
-          context.universalProfile.interface.encodeFunctionData("execute", [
-            OPERATION_TYPES.CALL,
-            context.lsp9Vault.address,
-            0,
-            acceptOwnershipSelector,
-          ]);
+          context.universalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [
+              OPERATION_TYPES.CALL,
+              context.lsp9Vault.address,
+              0,
+              acceptOwnershipSelector,
+            ]
+          );
 
         await context.lsp6KeyManager
           .connect(context.accounts.owner)

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -160,7 +160,10 @@ export async function setupProfileWithKeyManagerWithURD(
  * Returns the payload of Call operation with 0 value
  */
 export function callPayload(from: any, to: string, abi: string) {
-  let payload = from.interface.encodeFunctionData("execute", [0, to, 0, abi]);
+  let payload = from.interface.encodeFunctionData(
+    "execute(uint256,address,uint256,bytes)",
+    [0, to, 0, abi]
+  );
   return payload;
 }
 


### PR DESCRIPTION
# What does this PR introduce?

## 🏗️ Build

Upgrade dependency of `@erc725/smart-contracts` to version 4.0.0. 
This introduces the new batch `execute(...)` function from ERC725X in the smart contracts ABIs of LSP0ERC725Account and LSP9Vault

## ⚠️ BREAKING CHANGES

The following ERC165 interface IDs have changed:

- `LSP0ERC725Account`: `0xdca05671` -> `0xcf6e8efc`
- `LSP9Vault`: `0xca86ec0f` -> `0xd9483482`

