### PR TITLE
fix!: [WP-M7] LSP-6: do not allow any interaction if `AllowedCalls` is empty for a caller/signer

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -90,3 +90,12 @@ error NoCallsAllowed(address from);
  * @param value the value to check for an CompactBytesArray
  */
 error InvalidEncodedAllowedERC725YKeys(bytes value);
+
+/**
+ * @dev a `from` address is not allowed to have 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ * in its list of AddressPermissions:AllowedCalls:<address>, as this allows any STANDARD:ADDRESS:FUNCTION.
+ * This is equivalent to granting the SUPER permission and should never be valid.
+ *
+ * @param from the address that has any allowed calls whitelisted.
+ */
+error InvalidWhitelistedCall(address from);

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -80,6 +80,12 @@ error AddressPermissionArrayIndexValueNotAnAddress(bytes32 dataKey, bytes invali
 error NoERC725YDataKeysAllowed(address from);
 
 /**
+ * @dev reverts if there are no allowed calls set for `from`
+ * @param from the address that has no AllowedCalls
+ */
+error NoCallsAllowed(address from);
+
+/**
  * @dev reverts when `value` is not encoded properly using the CompactBytesArray
  * @param value the value to check for an CompactBytesArray
  */

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -570,13 +570,12 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
     function _verifyAllowedCall(address from, bytes calldata payload) internal view {
         // CHECK for ALLOWED CALLS
         address to = address(bytes20(payload[48:68]));
-        bytes memory allowedCalls = ERC725Y(target).getAllowedCallsFor(from);
 
         bool containsFunctionCall = payload.length >= 168;
         bytes4 selector;
-
         if (containsFunctionCall) selector = bytes4(payload[164:168]);
 
+        bytes memory allowedCalls = ERC725Y(target).getAllowedCallsFor(from);
         uint256 allowedCallsLength = allowedCalls.length;
 
         // TODO: change behaviour to disallow if nothing is set

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -590,6 +590,8 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             bytes memory chunk = BytesLib.slice(allowedCalls, ii + 1, 28);
 
+            if (bytes28(chunk) == bytes28(type(uint224).max)) revert InvalidWhitelistedCall(from);
+
             bytes4 allowedStandard = bytes4(chunk);
             address allowedAddress = address(bytes20(bytes28(chunk) << 32));
             bytes4 allowedFunction = bytes4(bytes28(chunk) << 192);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -590,15 +590,17 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
 
             bytes memory chunk = BytesLib.slice(allowedCalls, ii + 1, 28);
 
-            if (bytes28(chunk) == bytes28(type(uint224).max)) revert InvalidWhitelistedCall(from);
+            if (bytes28(chunk) == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff) {
+                revert InvalidWhitelistedCall(from);
+            }
 
             bytes4 allowedStandard = bytes4(chunk);
             address allowedAddress = address(bytes20(bytes28(chunk) << 32));
             bytes4 allowedFunction = bytes4(bytes28(chunk) << 192);
 
-            isAllowedStandard = allowedStandard == bytes4(type(uint32).max) || to.supportsERC165Interface(allowedStandard);
-            isAllowedAddress = allowedAddress == address(bytes20(type(uint160).max)) || to == allowedAddress;
-            isAllowedFunction = allowedFunction == bytes4(type(uint32).max) || containsFunctionCall && (selector == allowedFunction);
+            isAllowedStandard = allowedStandard == 0xffffffff || to.supportsERC165Interface(allowedStandard);
+            isAllowedAddress = allowedAddress == 0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF || to == allowedAddress;
+            isAllowedFunction = allowedFunction == 0xffffffff || containsFunctionCall && (selector == allowedFunction);
 
             if (isAllowedStandard && isAllowedAddress && isAllowedFunction) return;
         }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -578,9 +578,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes memory allowedCalls = ERC725Y(target).getAllowedCallsFor(from);
         uint256 allowedCallsLength = allowedCalls.length;
 
-        // TODO: change behaviour to disallow if nothing is set
-        // if nothing set or not properly , whitelist everything
-        if (allowedCallsLength == 0 || !LSP2Utils.isCompactBytesArray(allowedCalls)) return;
+        if (allowedCallsLength == 0 || !LSP2Utils.isCompactBytesArray(allowedCalls)) {
+            revert NoCallsAllowed(from);
+        }
 
         bool isAllowedStandard;
         bool isAllowedAddress;

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -77,17 +77,19 @@ export const testAllowedCallsInternals = (
 
     describe("`getAllowedCallsFor(...)`", () => {
       it("should return the list of allowed calls", async () => {
-        let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
-          canCallOnlyTwoAddresses.address
-        );
+        let bytesResult =
+          await context.keyManagerInternalTester.getAllowedCallsFor(
+            canCallOnlyTwoAddresses.address
+          );
 
         expect(bytesResult).to.equal(encodedAllowedCalls);
       });
 
       it("should return no bytes when no allowed calls were set", async () => {
-        let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
-          context.owner.address
-        );
+        let bytesResult =
+          await context.keyManagerInternalTester.getAllowedCallsFor(
+            context.owner.address
+          );
         expect(bytesResult).to.equal("0x");
 
         let resultFromAccount = await context.universalProfile[
@@ -180,9 +182,9 @@ export const testAllowedCallsInternals = (
         )
           .to.be.revertedWithCustomError(
             context.keyManagerInternalTester,
-            "NotAllowedCall"
+            "NoCallsAllowed"
           )
-          .withArgs(canCallNoAllowedCalls.address, randomAddress, "0x00000000");
+          .withArgs(canCallNoAllowedCalls.address);
       });
     });
   });

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -103,10 +103,13 @@ export const shouldBehaveLikeAllowedAddresses = (
 
           let amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient,
+              amount,
+              EMPTY_PAYLOAD,
+            ]);
 
           await context.keyManager
             .connect(context.owner)
@@ -133,10 +136,13 @@ export const shouldBehaveLikeAllowedAddresses = (
 
       let amount = ethers.utils.parseEther("1");
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, allowedEOA.address, amount, EMPTY_PAYLOAD]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          allowedEOA.address,
+          amount,
+          EMPTY_PAYLOAD,
+        ]);
 
       await context.keyManager
         .connect(canCallOnlyTwoAddresses)
@@ -154,10 +160,10 @@ export const shouldBehaveLikeAllowedAddresses = (
     it("should be allowed to interact with an allowed address (= contract)", async () => {
       const argument = "new name";
 
-      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData(
-        "setName",
-        [argument]
-      );
+      let targetContractPayload =
+        allowedTargetContract.interface.encodeFunctionData("setName", [
+          argument,
+        ]);
 
       let payload = context.universalProfile.interface.encodeFunctionData(
         "execute",
@@ -185,15 +191,13 @@ export const shouldBehaveLikeAllowedAddresses = (
         notAllowedEOA.address
       );
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           notAllowedEOA.address,
           ethers.utils.parseEther("1"),
           EMPTY_PAYLOAD,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager
@@ -221,10 +225,10 @@ export const shouldBehaveLikeAllowedAddresses = (
     it("should revert when interacting with an non-allowed address (= contract)", async () => {
       const argument = "new name";
 
-      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData(
-        "setName",
-        [argument]
-      );
+      let targetContractPayload =
+        notAllowedTargetContract.interface.encodeFunctionData("setName", [
+          argument,
+        ]);
 
       let payload = context.universalProfile.interface.encodeFunctionData(
         "execute",
@@ -261,21 +265,21 @@ export const shouldBehaveLikeAllowedAddresses = (
 
           let amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient,
+              amount,
+              EMPTY_PAYLOAD,
+            ]);
 
           await expect(
             context.keyManager
               .connect(invalidEncodedAllowedCalls)
               .execute(transferPayload)
           )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "InvalidCompactBytes28Array"
-            )
-            .withArgs("0xbadbadbadbad");
+            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .withArgs(invalidEncodedAllowedCalls.address);
         });
       });
     });

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -77,62 +77,48 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialName = await targetContract.callStatic.getName();
           let newName = "Updated Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           await expect(
             context.keyManager
               .connect(addressWithNoAllowedFunctions)
               .execute(executePayload)
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-            .withArgs(
-              addressWithNoAllowedFunctions.address,
-              targetContract.address,
-              targetContract.interface.getSighash("setName")
-            );
+            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .withArgs(addressWithNoAllowedFunctions.address);
         });
 
         it("should revert when calling any function (eg: `setNumber(...)`)", async () => {
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [newNumber]
-          );
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [
+              newNumber,
+            ]);
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           await expect(
             context.keyManager
               .connect(addressWithNoAllowedFunctions)
               .execute(executePayload)
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-            .withArgs(
-              addressWithNoAllowedFunctions.address,
-              targetContract.address,
-              targetContract.interface.getSighash("setNumber")
-            );
+            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .withArgs(addressWithNoAllowedFunctions.address);
         });
       });
     });
@@ -143,20 +129,16 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialName = await targetContract.callStatic.getName();
           let newName = "Updated Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           await context.keyManager
             .connect(addressCanCallOnlyOneFunction)
@@ -171,19 +153,17 @@ export const shouldBehaveLikeAllowedFunctions = (
           let initialNumber = await targetContract.callStatic.getNumber();
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [newNumber]
-          );
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [
+              newNumber,
+            ]);
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           await expect(
             context.keyManager
@@ -235,24 +215,20 @@ export const shouldBehaveLikeAllowedFunctions = (
         it("`setName(...)` - should pass when the bytes4 selector of the function called is listed in its AllowedFunctions", async () => {
           let newName = "Dagobah";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCanCallOnlyOneFunction.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -293,20 +269,16 @@ export const shouldBehaveLikeAllowedFunctions = (
             addressCanCallOnlyOneFunction.address,
             channelId
           );
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setNumber",
-            [2354]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setNumber", [2354]);
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -439,10 +411,13 @@ export const shouldBehaveLikeAllowedFunctions = (
           [context.universalProfile.address, recipient, tokenId, true, "0x"]
         );
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
-        );
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
+            OPERATION_TYPES.CALL,
+            lsp8Contract.address,
+            0,
+            transferPayload,
+          ]);
 
         await context.keyManager
           .connect(addressCanCallOnlyTransferOnLSP8)
@@ -454,20 +429,19 @@ export const shouldBehaveLikeAllowedFunctions = (
       it("should revert when calling `authorizeOperator(...)` on LSP8 contract", async () => {
         const operator = context.accounts[8].address;
 
-        const authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-          "authorizeOperator",
-          [operator, tokenId]
-        );
+        const authorizeOperatorPayload =
+          lsp8Contract.interface.encodeFunctionData("authorizeOperator", [
+            operator,
+            tokenId,
+          ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
             OPERATION_TYPES.CALL,
             lsp8Contract.address,
             0,
             authorizeOperatorPayload,
-          ]
-        );
+          ]);
 
         await expect(
           context.keyManager
@@ -496,10 +470,13 @@ export const shouldBehaveLikeAllowedFunctions = (
             "0x",
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp7Contract.address, 0, mintPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              lsp7Contract.address,
+              0,
+              mintPayload,
+            ]);
 
           await context.keyManager
             .connect(
@@ -519,10 +496,13 @@ export const shouldBehaveLikeAllowedFunctions = (
             [context.universalProfile.address, recipient, amount, true, "0x"]
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp7Contract.address, 0, transferPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              lsp7Contract.address,
+              0,
+              transferPayload,
+            ]);
 
           let tx = await context.keyManager
             .connect(
@@ -543,20 +523,19 @@ export const shouldBehaveLikeAllowedFunctions = (
           let operator = context.accounts[6].address;
           const amount = 10;
 
-          let authorizeOperatorPayload = lsp7Contract.interface.encodeFunctionData(
-            "authorizeOperator",
-            [operator, amount]
-          );
+          let authorizeOperatorPayload =
+            lsp7Contract.interface.encodeFunctionData("authorizeOperator", [
+              operator,
+              amount,
+            ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               lsp7Contract.address,
               0,
               authorizeOperatorPayload,
-            ]
-          );
+            ]);
 
           await context.keyManager
             .connect(
@@ -605,20 +584,19 @@ export const shouldBehaveLikeAllowedFunctions = (
         it("should pass when calling `authorizeOperator(...)`", async () => {
           let recipient = context.accounts[4].address;
 
-          let authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-            "authorizeOperator",
-            [recipient, tokenId]
-          );
+          let authorizeOperatorPayload =
+            lsp8Contract.interface.encodeFunctionData("authorizeOperator", [
+              recipient,
+              tokenId,
+            ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               lsp8Contract.address,
               0,
               authorizeOperatorPayload,
-            ]
-          );
+            ]);
 
           await context.keyManager
             .connect(
@@ -638,10 +616,13 @@ export const shouldBehaveLikeAllowedFunctions = (
             [context.universalProfile.address, recipient, tokenId, true, "0x"]
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              lsp8Contract.address,
+              0,
+              transferPayload,
+            ]);
 
           await expect(
             context.keyManager
@@ -667,10 +648,13 @@ export const shouldBehaveLikeAllowedFunctions = (
             "0x",
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, lsp8Contract.address, 0, mintPayload]
-          );
+          let executePayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              lsp8Contract.address,
+              0,
+              mintPayload,
+            ]);
 
           await expect(
             context.keyManager

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -33,7 +33,7 @@ export const shouldBehaveLikeAllowedFunctions = (
 ) => {
   let context: LSP6TestContext;
 
-  let addressCanCallAnyFunctions: SignerWithAddress,
+  let addressWithNoAllowedFunctions: SignerWithAddress,
     addressCanCallOnlyOneFunction: SignerWithAddress;
 
   let targetContract: TargetContract;
@@ -41,7 +41,7 @@ export const shouldBehaveLikeAllowedFunctions = (
   beforeEach(async () => {
     context = await buildContext();
 
-    addressCanCallAnyFunctions = context.accounts[1];
+    addressWithNoAllowedFunctions = context.accounts[1];
     addressCanCallOnlyOneFunction = context.accounts[2];
 
     targetContract = await new TargetContract__factory(
@@ -50,7 +50,7 @@ export const shouldBehaveLikeAllowedFunctions = (
 
     let permissionsKeys = [
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-        addressCanCallAnyFunctions.address.substring(2),
+        addressWithNoAllowedFunctions.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         addressCanCallOnlyOneFunction.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
@@ -71,9 +71,9 @@ export const shouldBehaveLikeAllowedFunctions = (
   });
 
   describe("when interacting via `execute(...)`", () => {
-    describe("when caller has nothing listed under when interacting via `execute(...)`", () => {
+    describe("when caller has nothing listed under allowedCalls", () => {
       describe("when calling a contract", () => {
-        it("should pass when calling any function (eg: `setName(...)`)", async () => {
+        it("should revert when calling any function (eg: `setName(...)`)", async () => {
           let initialName = await targetContract.callStatic.getName();
           let newName = "Updated Name";
 
@@ -92,17 +92,20 @@ export const shouldBehaveLikeAllowedFunctions = (
             ]
           );
 
-          await context.keyManager
-            .connect(addressCanCallAnyFunctions)
-            .execute(executePayload);
-
-          let result = await targetContract.callStatic.getName();
-          expect(result).to.not.equal(initialName);
-          expect(result).to.equal(newName);
+          await expect(
+            context.keyManager
+              .connect(addressWithNoAllowedFunctions)
+              .execute(executePayload)
+          )
+            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .withArgs(
+              addressWithNoAllowedFunctions.address,
+              targetContract.address,
+              targetContract.interface.getSighash("setName")
+            );
         });
 
-        it("should pass when calling any function (eg: `setNumber(...)`)", async () => {
-          let initialNumber = await targetContract.callStatic.getNumber();
+        it("should revert when calling any function (eg: `setNumber(...)`)", async () => {
           let newNumber = 18;
 
           let targetContractPayload = targetContract.interface.encodeFunctionData(
@@ -119,13 +122,17 @@ export const shouldBehaveLikeAllowedFunctions = (
             ]
           );
 
-          await context.keyManager
-            .connect(addressCanCallAnyFunctions)
-            .execute(executePayload);
-
-          let result = await targetContract.callStatic.getNumber();
-          expect(result).to.not.equal(initialNumber);
-          expect(result).to.equal(newNumber);
+          await expect(
+            context.keyManager
+              .connect(addressWithNoAllowedFunctions)
+              .execute(executePayload)
+          )
+            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .withArgs(
+              addressWithNoAllowedFunctions.address,
+              targetContract.address,
+              targetContract.interface.getSighash("setNumber")
+            );
         });
       });
     });

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../constants";
 
 // helpers
-import { combinePermissions } from "../../utils/helpers";
+import { combineAllowedCalls, combinePermissions } from "../../utils/helpers";
 
 // setup
 import { LSP6TestContext } from "../../utils/context";
@@ -29,7 +29,9 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
   let signer: SignerWithAddress,
     relayer: SignerWithAddress,
-    random: SignerWithAddress;
+    random: SignerWithAddress,
+    signerNoAllowedCalls: SignerWithAddress;
+
   let targetContract: TargetContract;
 
   before(async () => {
@@ -37,7 +39,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
     signer = context.accounts[1];
     relayer = context.accounts[2];
-    random = context.accounts[3];
+    signerNoAllowedCalls = context.accounts[3];
+    random = context.accounts[4];
 
     targetContract = await new TargetContract__factory(
       context.accounts[0]
@@ -48,10 +51,20 @@ export const shouldBehaveLikeExecuteRelayCall = (
         context.owner.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         signer.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        signer.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        signerNoAllowedCalls.address.substring(2),
     ];
 
     const permissionsValues = [
       ALL_PERMISSIONS,
+      combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
+      combineAllowedCalls(
+        ["0xffffffff", "0xffffffff"],
+        [random.address, targetContract.address],
+        ["0xffffffff", "0xffffffff"]
+      ),
       combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
     ];
 
@@ -63,13 +76,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
       describe("When testing msg.value", () => {
         describe("When sending more than the signed msg.value", () => {
           it("should revert by recovering a non permissioned address", async () => {
-            let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+            );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -101,12 +111,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let { signature } =
-              await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
-              );
+            let {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT1
+            );
 
             await expect(
               context.keyManager.executeRelayCall(
@@ -121,15 +132,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
+
         describe("When sending 0 while msg.value signed > 0", () => {
           it("should revert by recovering a non permissioned address", async () => {
-            let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+            );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -161,12 +170,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let { signature } =
-              await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
-              );
+            let {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT1
+            );
 
             await expect(
               context.keyManager
@@ -183,15 +193,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
             );
           });
         });
+
         describe("When sending exact msg.value like the one that is signed", () => {
-          it("should pass", async () => {
-            let executeRelayCallPayload =
-              context.universalProfile.interface.encodeFunctionData("execute", [
-                OPERATION_TYPES.CALL,
-                random.address,
-                0,
-                "0x",
-              ]);
+          it("should pass if signer has the `to` address in its allowed calls", async () => {
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+            );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -225,12 +233,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let { signature } =
-              await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
-              );
+            let {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT1
+            );
 
             await context.keyManager
               .connect(relayer)
@@ -245,19 +254,83 @@ export const shouldBehaveLikeExecuteRelayCall = (
               context.universalProfile.address
             );
 
-            expect(balanceOfUpBefore.add(valueToSendFromRelayer)).to.equal(
-              balanceOfUpAfter
+            expect(balanceOfUpAfter).to.equal(
+              balanceOfUpBefore.add(valueToSendFromRelayer)
             );
           });
+
+          it("should fail if signer has nothing listed in its allowed calls", async () => {
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
+            );
+
+            let latestNonce = await context.keyManager.callStatic.getNonce(
+              signerNoAllowedCalls.address,
+              0
+            );
+
+            let valueToSendFromRelayer = 10;
+
+            const signedMessageParams = {
+              lsp6Version: LSP6_VERSION,
+              chainId: 31337, // HARDHAT_CHAINID
+              nonce: latestNonce,
+              msgValue: valueToSendFromRelayer,
+              payload: executeRelayCallPayload,
+            };
+
+            let encodedMessage = ethers.utils.solidityPack(
+              ["uint256", "uint256", "uint256", "uint256", "bytes"],
+              [
+                signedMessageParams.lsp6Version,
+                signedMessageParams.chainId,
+                signedMessageParams.nonce,
+                signedMessageParams.msgValue,
+                signedMessageParams.payload,
+              ]
+            );
+
+            let eip191Signer = new EIP191Signer();
+
+            let {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT3
+            );
+
+            await expect(
+              context.keyManager
+                .connect(relayer)
+                .executeRelayCall(
+                  signature,
+                  signedMessageParams.nonce,
+                  signedMessageParams.payload,
+                  { value: valueToSendFromRelayer }
+                )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotAllowedCall"
+              )
+              .withArgs(
+                signerNoAllowedCalls.address,
+                random.address,
+                "0x00000000"
+              );
+          });
         });
+
         describe("When UP have 0 value and interacting with contract that require value", () => {
           describe("When relayer don't fund the UP so it's balance is greater than the value param of execute(..)", () => {
             it("should revert", async () => {
               let nameToSet = "Alice";
-              let targetContractPayload =
-                targetContract.interface.encodeFunctionData("setNamePayable", [
-                  nameToSet,
-                ]);
+              let targetContractPayload = targetContract.interface.encodeFunctionData(
+                "setNamePayable",
+                [nameToSet]
+              );
 
               let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
 
@@ -266,16 +339,15 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 0
               );
 
-              let executeRelayCallPayload =
-                context.universalProfile.interface.encodeFunctionData(
-                  "execute",
-                  [
-                    OPERATION_TYPES.CALL,
-                    targetContract.address,
-                    requiredValueForExecution,
-                    targetContractPayload,
-                  ]
-                );
+              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+                "execute",
+                [
+                  OPERATION_TYPES.CALL,
+                  targetContract.address,
+                  requiredValueForExecution,
+                  targetContractPayload,
+                ]
+              );
 
               let valueToSendFromRelayer = 0;
 
@@ -300,12 +372,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let eip191Signer = new EIP191Signer();
 
-              let { signature } =
-                await eip191Signer.signDataWithIntendedValidator(
-                  context.keyManager.address,
-                  encodedMessage,
-                  LOCAL_PRIVATE_KEYS.ACCOUNT1
-                );
+              let {
+                signature,
+              } = await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
               await expect(
                 context.keyManager
@@ -321,12 +394,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
 
           describe("When relayer fund the UP so it's balance is greater than the value param of execute(..)", () => {
-            it("should pass", async () => {
+            it("should pass if signer has the target contract address in its list of allowed calls", async () => {
               let nameToSet = "Alice";
-              let targetContractPayload =
-                targetContract.interface.encodeFunctionData("setNamePayable", [
-                  nameToSet,
-                ]);
+              let targetContractPayload = targetContract.interface.encodeFunctionData(
+                "setNamePayable",
+                [nameToSet]
+              );
 
               let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
 
@@ -335,16 +408,15 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 0
               );
 
-              let executeRelayCallPayload =
-                context.universalProfile.interface.encodeFunctionData(
-                  "execute",
-                  [
-                    OPERATION_TYPES.CALL,
-                    targetContract.address,
-                    requiredValueForExecution,
-                    targetContractPayload,
-                  ]
-                );
+              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+                "execute",
+                [
+                  OPERATION_TYPES.CALL,
+                  targetContract.address,
+                  requiredValueForExecution,
+                  targetContractPayload,
+                ]
+              );
 
               let valueToSendFromRelayer = 51;
 
@@ -369,12 +441,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let eip191Signer = new EIP191Signer();
 
-              let { signature } =
-                await eip191Signer.signDataWithIntendedValidator(
-                  context.keyManager.address,
-                  encodedMessage,
-                  LOCAL_PRIVATE_KEYS.ACCOUNT1
-                );
+              let {
+                signature,
+              } = await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
               await context.keyManager
                 .connect(relayer)
@@ -387,6 +460,82 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               const result = await targetContract.callStatic.getName();
               expect(result).to.equal(nameToSet);
+            });
+
+            it("should revert with 'NotAllowedCall' error if signer does not have any listed under its allowed calls", async () => {
+              let nameToSet = "Alice";
+              let targetContractPayload = targetContract.interface.encodeFunctionData(
+                "setNamePayable",
+                [nameToSet]
+              );
+
+              let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+
+              let latestNonce = await context.keyManager.callStatic.getNonce(
+                signerNoAllowedCalls.address,
+                0
+              );
+
+              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+                "execute",
+                [
+                  OPERATION_TYPES.CALL,
+                  targetContract.address,
+                  requiredValueForExecution,
+                  targetContractPayload,
+                ]
+              );
+
+              let valueToSendFromRelayer = 51;
+
+              const signedMessageParams = {
+                lsp6Version: LSP6_VERSION,
+                chainId: 31337, // HARDHAT_CHAINID
+                nonce: latestNonce,
+                msgValue: valueToSendFromRelayer,
+                payload: executeRelayCallPayload,
+              };
+
+              let encodedMessage = ethers.utils.solidityPack(
+                ["uint256", "uint256", "uint256", "uint256", "bytes"],
+                [
+                  signedMessageParams.lsp6Version,
+                  signedMessageParams.chainId,
+                  signedMessageParams.nonce,
+                  signedMessageParams.msgValue,
+                  signedMessageParams.payload,
+                ]
+              );
+
+              let eip191Signer = new EIP191Signer();
+
+              let {
+                signature,
+              } = await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT3
+              );
+
+              await expect(
+                context.keyManager
+                  .connect(relayer)
+                  .executeRelayCall(
+                    signature,
+                    latestNonce,
+                    executeRelayCallPayload,
+                    { value: valueToSendFromRelayer }
+                  )
+              )
+                .to.be.revertedWithCustomError(
+                  context.keyManager,
+                  "NotAllowedCall"
+                )
+                .withArgs(
+                  signerNoAllowedCalls.address,
+                  targetContract.address,
+                  targetContract.interface.getSighash("setNamePayable")
+                );
             });
           });
         });

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -76,10 +76,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
       describe("When testing msg.value", () => {
         describe("When sending more than the signed msg.value", () => {
           it("should revert by recovering a non permissioned address", async () => {
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
-            );
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -111,13 +114,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT1
-            );
+            let { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
             await expect(
               context.keyManager.executeRelayCall(
@@ -135,10 +137,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
         describe("When sending 0 while msg.value signed > 0", () => {
           it("should revert by recovering a non permissioned address", async () => {
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
-            );
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -170,13 +175,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT1
-            );
+            let { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
             await expect(
               context.keyManager
@@ -196,10 +200,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
         describe("When sending exact msg.value like the one that is signed", () => {
           it("should pass if signer has the `to` address in its allowed calls", async () => {
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
-            );
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signer.address,
@@ -233,13 +240,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT1
-            );
+            let { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
             await context.keyManager
               .connect(relayer)
@@ -260,10 +266,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
 
           it("should fail if signer has nothing listed in its allowed calls", async () => {
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"]
-            );
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                random.address,
+                0,
+                "0x",
+              ]);
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
               signerNoAllowedCalls.address,
@@ -293,13 +302,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             let eip191Signer = new EIP191Signer();
 
-            let {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT3
-            );
+            let { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT3
+              );
 
             await expect(
               context.keyManager
@@ -313,13 +321,9 @@ export const shouldBehaveLikeExecuteRelayCall = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "NotAllowedCall"
+                "NoCallsAllowed"
               )
-              .withArgs(
-                signerNoAllowedCalls.address,
-                random.address,
-                "0x00000000"
-              );
+              .withArgs(signerNoAllowedCalls.address);
           });
         });
 
@@ -327,10 +331,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
           describe("When relayer don't fund the UP so it's balance is greater than the value param of execute(..)", () => {
             it("should revert", async () => {
               let nameToSet = "Alice";
-              let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
-                [nameToSet]
-              );
+              let targetContractPayload =
+                targetContract.interface.encodeFunctionData("setNamePayable", [
+                  nameToSet,
+                ]);
 
               let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
 
@@ -339,15 +343,16 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 0
               );
 
-              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
-                [
-                  OPERATION_TYPES.CALL,
-                  targetContract.address,
-                  requiredValueForExecution,
-                  targetContractPayload,
-                ]
-              );
+              let executeRelayCallPayload =
+                context.universalProfile.interface.encodeFunctionData(
+                  "execute",
+                  [
+                    OPERATION_TYPES.CALL,
+                    targetContract.address,
+                    requiredValueForExecution,
+                    targetContractPayload,
+                  ]
+                );
 
               let valueToSendFromRelayer = 0;
 
@@ -372,13 +377,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let eip191Signer = new EIP191Signer();
 
-              let {
-                signature,
-              } = await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
-              );
+              let { signature } =
+                await eip191Signer.signDataWithIntendedValidator(
+                  context.keyManager.address,
+                  encodedMessage,
+                  LOCAL_PRIVATE_KEYS.ACCOUNT1
+                );
 
               await expect(
                 context.keyManager
@@ -396,10 +400,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
           describe("When relayer fund the UP so it's balance is greater than the value param of execute(..)", () => {
             it("should pass if signer has the target contract address in its list of allowed calls", async () => {
               let nameToSet = "Alice";
-              let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
-                [nameToSet]
-              );
+              let targetContractPayload =
+                targetContract.interface.encodeFunctionData("setNamePayable", [
+                  nameToSet,
+                ]);
 
               let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
 
@@ -408,15 +412,16 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 0
               );
 
-              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
-                [
-                  OPERATION_TYPES.CALL,
-                  targetContract.address,
-                  requiredValueForExecution,
-                  targetContractPayload,
-                ]
-              );
+              let executeRelayCallPayload =
+                context.universalProfile.interface.encodeFunctionData(
+                  "execute",
+                  [
+                    OPERATION_TYPES.CALL,
+                    targetContract.address,
+                    requiredValueForExecution,
+                    targetContractPayload,
+                  ]
+                );
 
               let valueToSendFromRelayer = 51;
 
@@ -441,13 +446,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let eip191Signer = new EIP191Signer();
 
-              let {
-                signature,
-              } = await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT1
-              );
+              let { signature } =
+                await eip191Signer.signDataWithIntendedValidator(
+                  context.keyManager.address,
+                  encodedMessage,
+                  LOCAL_PRIVATE_KEYS.ACCOUNT1
+                );
 
               await context.keyManager
                 .connect(relayer)
@@ -464,10 +468,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
             it("should revert with 'NotAllowedCall' error if signer does not have any listed under its allowed calls", async () => {
               let nameToSet = "Alice";
-              let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
-                [nameToSet]
-              );
+              let targetContractPayload =
+                targetContract.interface.encodeFunctionData("setNamePayable", [
+                  nameToSet,
+                ]);
 
               let requiredValueForExecution = 51; // specified in `setNamePayable(..)`
 
@@ -476,15 +480,16 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 0
               );
 
-              let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
-                [
-                  OPERATION_TYPES.CALL,
-                  targetContract.address,
-                  requiredValueForExecution,
-                  targetContractPayload,
-                ]
-              );
+              let executeRelayCallPayload =
+                context.universalProfile.interface.encodeFunctionData(
+                  "execute",
+                  [
+                    OPERATION_TYPES.CALL,
+                    targetContract.address,
+                    requiredValueForExecution,
+                    targetContractPayload,
+                  ]
+                );
 
               let valueToSendFromRelayer = 51;
 
@@ -509,13 +514,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
               let eip191Signer = new EIP191Signer();
 
-              let {
-                signature,
-              } = await eip191Signer.signDataWithIntendedValidator(
-                context.keyManager.address,
-                encodedMessage,
-                LOCAL_PRIVATE_KEYS.ACCOUNT3
-              );
+              let { signature } =
+                await eip191Signer.signDataWithIntendedValidator(
+                  context.keyManager.address,
+                  encodedMessage,
+                  LOCAL_PRIVATE_KEYS.ACCOUNT3
+                );
 
               await expect(
                 context.keyManager
@@ -529,13 +533,9 @@ export const shouldBehaveLikeExecuteRelayCall = (
               )
                 .to.be.revertedWithCustomError(
                   context.keyManager,
-                  "NotAllowedCall"
+                  "NoCallsAllowed"
                 )
-                .withArgs(
-                  signerNoAllowedCalls.address,
-                  targetContract.address,
-                  targetContract.interface.getSighash("setNamePayable")
-                );
+                .withArgs(signerNoAllowedCalls.address);
             });
           });
         });

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -117,12 +117,8 @@ export const shouldBehaveLikePermissionCall = (
               .connect(addressCanMakeCallNoAllowedCalls)
               .execute(payload)
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-            .withArgs(
-              addressCanMakeCallNoAllowedCalls.address,
-              targetContract.address,
-              targetContract.interface.getSighash("setName")
-            );
+            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .withArgs(addressCanMakeCallNoAllowedCalls.address);
         });
       });
 
@@ -176,19 +172,16 @@ export const shouldBehaveLikePermissionCall = (
       it("should return the value to the Key Manager <- UP <- targetContract.getName()", async () => {
         let expectedName = await targetContract.callStatic.getName();
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "getName"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("getName");
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
             targetContractPayload,
-          ]
-        );
+          ]);
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -201,19 +194,16 @@ export const shouldBehaveLikePermissionCall = (
       it("Should return the value to the Key Manager <- UP <- targetContract.getNumber()", async () => {
         let expectedNumber = await targetContract.callStatic.getNumber();
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "getNumber"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("getNumber");
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
             targetContractPayload,
-          ]
-        );
+          ]);
 
         let result = await context.keyManager
           .connect(context.owner)
@@ -226,9 +216,8 @@ export const shouldBehaveLikePermissionCall = (
 
     describe("when calling a function that reverts", () => {
       it("should revert", async () => {
-        let targetContractPayload = targetContract.interface.encodeFunctionData(
-          "revertCall"
-        );
+        let targetContractPayload =
+          targetContract.interface.encodeFunctionData("revertCall");
 
         let payload = context.universalProfile.interface.encodeFunctionData(
           "execute",
@@ -256,24 +245,20 @@ export const shouldBehaveLikePermissionCall = (
         it("should execute successfully", async () => {
           let newName = "New Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             context.owner.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -291,13 +276,12 @@ export const shouldBehaveLikePermissionCall = (
 
           const eip191Signer = new EIP191Signer();
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT0
-          );
+          const { signature } =
+            await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT0
+            );
 
           await context.keyManager.executeRelayCall(
             signature,
@@ -315,24 +299,20 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionsSet` error", async () => {
           let newName = "New Name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             context.owner.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -383,24 +363,20 @@ export const shouldBehaveLikePermissionCall = (
           it("should execute successfully", async () => {
             let newName = "Another name";
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData(
-              "setName",
-              [newName]
-            );
+            let targetContractPayload =
+              targetContract.interface.encodeFunctionData("setName", [newName]);
             let nonce = await context.keyManager.callStatic.getNonce(
               addressCanMakeCallWithAllowedCalls.address,
               channelId
             );
 
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
                 targetContractPayload,
-              ]
-            );
+              ]);
 
             const HARDHAT_CHAINID = 31337;
             let valueToSend = 0;
@@ -418,13 +394,12 @@ export const shouldBehaveLikePermissionCall = (
 
             const eip191Signer = new EIP191Signer();
 
-            const {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT2
-            );
+            const { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT2
+              );
 
             await context.keyManager.executeRelayCall(
               signature,
@@ -442,24 +417,20 @@ export const shouldBehaveLikePermissionCall = (
           it("should revert with `NotAllowedCall(...)` error", async () => {
             let newName = "Another name";
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData(
-              "setName",
-              [newName]
-            );
+            let targetContractPayload =
+              targetContract.interface.encodeFunctionData("setName", [newName]);
             let nonce = await context.keyManager.callStatic.getNonce(
               addressCanMakeCallNoAllowedCalls.address,
               channelId
             );
 
-            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let executeRelayCallPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
                 targetContractPayload,
-              ]
-            );
+              ]);
 
             const HARDHAT_CHAINID = 31337;
             let valueToSend = 0;
@@ -477,13 +448,12 @@ export const shouldBehaveLikePermissionCall = (
 
             const eip191Signer = new EIP191Signer();
 
-            const {
-              signature,
-            } = await eip191Signer.signDataWithIntendedValidator(
-              context.keyManager.address,
-              encodedMessage,
-              LOCAL_PRIVATE_KEYS.ACCOUNT1
-            );
+            const { signature } =
+              await eip191Signer.signDataWithIntendedValidator(
+                context.keyManager.address,
+                encodedMessage,
+                LOCAL_PRIVATE_KEYS.ACCOUNT1
+              );
 
             await expect(
               context.keyManager.executeRelayCall(
@@ -495,13 +465,9 @@ export const shouldBehaveLikePermissionCall = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "NotAllowedCall"
+                "NoCallsAllowed"
               )
-              .withArgs(
-                addressCanMakeCallNoAllowedCalls.address,
-                targetContract.address,
-                targetContract.interface.getSighash("setName")
-              );
+              .withArgs(addressCanMakeCallNoAllowedCalls.address);
           });
         });
       });
@@ -510,24 +476,20 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionsSet` error", async () => {
           let newName = "Another name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [newName]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCanMakeCallWithAllowedCalls.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -578,24 +540,22 @@ export const shouldBehaveLikePermissionCall = (
         it("should revert with `NotAuthorised` and permission CALL error", async () => {
           const initialName = await targetContract.callStatic.getName();
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            ["Random name"]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [
+              "Random name",
+            ]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCannotMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -613,13 +573,12 @@ export const shouldBehaveLikePermissionCall = (
 
           const eip191Signer = new EIP191Signer();
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT3
-          );
+          const { signature } =
+            await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT3
+            );
 
           await expect(
             context.keyManager.executeRelayCall(
@@ -642,24 +601,22 @@ export const shouldBehaveLikePermissionCall = (
         it("should retrieve the incorrect signer address and revert with `NoPermissionSet`", async () => {
           const initialName = await targetContract.callStatic.getName();
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            ["Random name"]
-          );
+          let targetContractPayload =
+            targetContract.interface.encodeFunctionData("setName", [
+              "Random name",
+            ]);
           let nonce = await context.keyManager.callStatic.getNonce(
             addressCannotMakeCall.address,
             channelId
           );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
               targetContractPayload,
-            ]
-          );
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -19,14 +19,19 @@ import { LSP6TestContext } from "../../utils/context";
 import { setupKeyManager } from "../../utils/fixtures";
 
 // helpers
-import { abiCoder, LOCAL_PRIVATE_KEYS } from "../../utils/helpers";
+import {
+  abiCoder,
+  combineAllowedCalls,
+  LOCAL_PRIVATE_KEYS,
+} from "../../utils/helpers";
 
 export const shouldBehaveLikePermissionCall = (
   buildContext: () => Promise<LSP6TestContext>
 ) => {
   let context: LSP6TestContext;
 
-  let addressCanMakeCall: SignerWithAddress,
+  let addressCanMakeCallNoAllowedCalls: SignerWithAddress,
+    addressCanMakeCallWithAllowedCalls: SignerWithAddress,
     addressCannotMakeCall: SignerWithAddress;
 
   let targetContract: TargetContract;
@@ -34,8 +39,9 @@ export const shouldBehaveLikePermissionCall = (
   beforeEach(async () => {
     context = await buildContext();
 
-    addressCanMakeCall = context.accounts[1];
-    addressCannotMakeCall = context.accounts[2];
+    addressCanMakeCallNoAllowedCalls = context.accounts[1];
+    addressCanMakeCallWithAllowedCalls = context.accounts[2];
+    addressCannotMakeCall = context.accounts[3];
 
     targetContract = await new TargetContract__factory(
       context.accounts[0]
@@ -45,15 +51,25 @@ export const shouldBehaveLikePermissionCall = (
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         context.owner.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-        addressCanMakeCall.address.substring(2),
+        addressCanMakeCallNoAllowedCalls.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        addressCanMakeCallWithAllowedCalls.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         addressCannotMakeCall.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        addressCanMakeCallWithAllowedCalls.address.substring(2),
     ];
 
     const permissionsValues = [
       ALL_PERMISSIONS,
       PERMISSIONS.CALL,
+      PERMISSIONS.CALL,
       PERMISSIONS.SETDATA,
+      combineAllowedCalls(
+        ["0xffffffff"],
+        [targetContract.address],
+        ["0xffffffff"]
+      ),
     ];
 
     await setupKeyManager(context, permissionKeys, permissionsValues);
@@ -82,23 +98,55 @@ export const shouldBehaveLikePermissionCall = (
     });
 
     describe("when caller has permission CALL", () => {
-      it("should pass and change state at the target contract", async () => {
-        let argument = "another name";
+      describe("when caller has no allowed calls set", () => {
+        it("should revert with `NotAllowedCall(...)` error", async () => {
+          let argument = "another name";
 
-        let targetPayload = targetContract.interface.encodeFunctionData(
-          "setName",
-          [argument]
-        );
+          let targetPayload = targetContract.interface.encodeFunctionData(
+            "setName",
+            [argument]
+          );
 
-        let payload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
-        );
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "execute",
+            [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
+          );
 
-        await context.keyManager.connect(addressCanMakeCall).execute(payload);
+          await expect(
+            context.keyManager
+              .connect(addressCanMakeCallNoAllowedCalls)
+              .execute(payload)
+          )
+            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .withArgs(
+              addressCanMakeCallNoAllowedCalls.address,
+              targetContract.address,
+              targetContract.interface.getSighash("setName")
+            );
+        });
+      });
 
-        const result = await targetContract.callStatic.getName();
-        expect(result).to.equal(argument);
+      describe("when caller has some allowed calls set", () => {
+        it("should pass and change state at the target contract", async () => {
+          let argument = "another name";
+
+          let targetPayload = targetContract.interface.encodeFunctionData(
+            "setName",
+            [argument]
+          );
+
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "execute",
+            [OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload]
+          );
+
+          await context.keyManager
+            .connect(addressCanMakeCallWithAllowedCalls)
+            .execute(payload);
+
+          const result = await targetContract.callStatic.getName();
+          expect(result).to.equal(argument);
+        });
       });
     });
 
@@ -331,61 +379,130 @@ export const shouldBehaveLikePermissionCall = (
 
     describe("when signer has permission CALL", () => {
       describe("when signing tx with EIP191Signer `\\x19\\x00` prefix", () => {
-        it("should execute successfully", async () => {
-          let newName = "Another name";
+        describe("when caller has some allowed calls set", () => {
+          it("should execute successfully", async () => {
+            let newName = "Another name";
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData(
-            "setName",
-            [newName]
-          );
-          let nonce = await context.keyManager.callStatic.getNonce(
-            addressCanMakeCall.address,
-            channelId
-          );
+            let targetContractPayload = targetContract.interface.encodeFunctionData(
+              "setName",
+              [newName]
+            );
+            let nonce = await context.keyManager.callStatic.getNonce(
+              addressCanMakeCallWithAllowedCalls.address,
+              channelId
+            );
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [
-              OPERATION_TYPES.CALL,
-              targetContract.address,
-              0,
-              targetContractPayload,
-            ]
-          );
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
 
-          const HARDHAT_CHAINID = 31337;
-          let valueToSend = 0;
+            const HARDHAT_CHAINID = 31337;
+            let valueToSend = 0;
 
-          let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "bytes"],
-            [
-              LSP6_VERSION,
-              HARDHAT_CHAINID,
+            let encodedMessage = ethers.utils.solidityPack(
+              ["uint256", "uint256", "uint256", "uint256", "bytes"],
+              [
+                LSP6_VERSION,
+                HARDHAT_CHAINID,
+                nonce,
+                valueToSend,
+                executeRelayCallPayload,
+              ]
+            );
+
+            const eip191Signer = new EIP191Signer();
+
+            const {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT2
+            );
+
+            await context.keyManager.executeRelayCall(
+              signature,
               nonce,
-              valueToSend,
               executeRelayCallPayload,
-            ]
-          );
+              { value: valueToSend }
+            );
 
-          const eip191Signer = new EIP191Signer();
+            const result = await targetContract.callStatic.getName();
+            expect(result).to.equal(newName);
+          });
+        });
 
-          const {
-            signature,
-          } = await eip191Signer.signDataWithIntendedValidator(
-            context.keyManager.address,
-            encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT1
-          );
+        describe("when caller has no allowed calls set", () => {
+          it("should revert with `NotAllowedCall(...)` error", async () => {
+            let newName = "Another name";
 
-          await context.keyManager.executeRelayCall(
-            signature,
-            nonce,
-            executeRelayCallPayload,
-            { value: valueToSend }
-          );
+            let targetContractPayload = targetContract.interface.encodeFunctionData(
+              "setName",
+              [newName]
+            );
+            let nonce = await context.keyManager.callStatic.getNonce(
+              addressCanMakeCallNoAllowedCalls.address,
+              channelId
+            );
 
-          const result = await targetContract.callStatic.getName();
-          expect(result).to.equal(newName);
+            let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
+              "execute",
+              [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContractPayload,
+              ]
+            );
+
+            const HARDHAT_CHAINID = 31337;
+            let valueToSend = 0;
+
+            let encodedMessage = ethers.utils.solidityPack(
+              ["uint256", "uint256", "uint256", "uint256", "bytes"],
+              [
+                LSP6_VERSION,
+                HARDHAT_CHAINID,
+                nonce,
+                valueToSend,
+                executeRelayCallPayload,
+              ]
+            );
+
+            const eip191Signer = new EIP191Signer();
+
+            const {
+              signature,
+            } = await eip191Signer.signDataWithIntendedValidator(
+              context.keyManager.address,
+              encodedMessage,
+              LOCAL_PRIVATE_KEYS.ACCOUNT1
+            );
+
+            await expect(
+              context.keyManager.executeRelayCall(
+                signature,
+                nonce,
+                executeRelayCallPayload,
+                { value: valueToSend }
+              )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotAllowedCall"
+              )
+              .withArgs(
+                addressCanMakeCallNoAllowedCalls.address,
+                targetContract.address,
+                targetContract.interface.getSighash("setName")
+              );
+          });
         });
       });
 
@@ -398,7 +515,7 @@ export const shouldBehaveLikePermissionCall = (
             [newName]
           );
           let nonce = await context.keyManager.callStatic.getNonce(
-            addressCanMakeCall.address,
+            addressCanMakeCallWithAllowedCalls.address,
             channelId
           );
 
@@ -426,7 +543,9 @@ export const shouldBehaveLikePermissionCall = (
             ]
           );
 
-          let signature = await addressCanMakeCall.signMessage(encodedMessage);
+          let signature = await addressCanMakeCallWithAllowedCalls.signMessage(
+            encodedMessage
+          );
 
           const eip191Signer = new EIP191Signer();
           const incorrectSignerAddress = eip191Signer.recover(
@@ -499,7 +618,7 @@ export const shouldBehaveLikePermissionCall = (
           } = await eip191Signer.signDataWithIntendedValidator(
             context.keyManager.address,
             encodedMessage,
-            LOCAL_PRIVATE_KEYS.ACCOUNT2
+            LOCAL_PRIVATE_KEYS.ACCOUNT3
           );
 
           await expect(

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -8,6 +8,7 @@ import {
   ALL_PERMISSIONS,
   PERMISSIONS,
   INTERFACE_IDS,
+  OPERATION_TYPES,
 } from "../../../constants";
 
 // setup
@@ -20,6 +21,7 @@ import {
   combineAllowedCalls,
   encodeCompactBytesArray,
 } from "../../utils/helpers";
+import { TargetContract__factory } from "../../../types";
 
 export const shouldBehaveLikePermissionChangeOrAddPermissions = (
   buildContext: () => Promise<LSP6TestContext>
@@ -1061,6 +1063,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       canOnlyChangePermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress;
+    let invalidBytes: SignerWithAddress;
+    let noBytes: SignerWithAddress;
 
     beforeEach(async () => {
       context = await buildContext();
@@ -1069,19 +1073,31 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       canOnlyChangePermissions = context.accounts[2];
 
       beneficiary = context.accounts[3];
+      invalidBytes = context.accounts[4];
+      noBytes = context.accounts[5];
 
       let permissionKeys = [
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           canOnlyAddPermissions.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           canOnlyChangePermissions.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          invalidBytes.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          noBytes.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
           beneficiary.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          invalidBytes.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          noBytes.address.substring(2),
       ];
 
       let permissionValues = [
         PERMISSIONS.ADDPERMISSIONS,
         PERMISSIONS.CHANGEPERMISSIONS,
+        PERMISSIONS.CALL,
+        PERMISSIONS.CALL,
         combineAllowedCalls(
           ["0xffffffff", "0xffffffff"],
           [
@@ -1090,6 +1106,8 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           ],
           ["0xffffffff", "0xffffffff"]
         ),
+        "0xbadbadbadbad",
+        "0x",
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -74,20 +74,19 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
-        [key, value]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "updateStorage",
+          [key, value]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.DELEGATECALL,
           erc725YDelegateCallContract.address,
           0,
           delegateCallPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager.connect(context.owner).execute(executePayload)
@@ -110,20 +109,19 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
-        [key, value]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "updateStorage",
+          [key, value]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.DELEGATECALL,
           erc725YDelegateCallContract.address,
           0,
           delegateCallPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager
@@ -148,20 +146,19 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
-      let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "setData(bytes32[],bytes[])",
-        [[key], [value]]
-      );
+      let delegateCallPayload =
+        erc725YDelegateCallContract.interface.encodeFunctionData(
+          "setData(bytes32[],bytes[])",
+          [[key], [value]]
+        );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.DELEGATECALL,
           erc725YDelegateCallContract.address,
           0,
           delegateCallPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager
@@ -259,15 +256,13 @@ export const shouldBehaveLikePermissionDelegateCall = (
                 value,
               ]);
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.DELEGATECALL,
                 randomContracts[ii].address,
                 0,
                 delegateCallPayload,
-              ]
-            );
+              ]);
 
             await expect(
               context.keyManager.connect(caller).execute(executePayload)
@@ -302,15 +297,13 @@ export const shouldBehaveLikePermissionDelegateCall = (
             value,
           ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
             OPERATION_TYPES.DELEGATECALL,
             allowedDelegateCallContracts[0].address,
             0,
             delegateCallPayload,
-          ]
-        );
+          ]);
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)
@@ -339,15 +332,13 @@ export const shouldBehaveLikePermissionDelegateCall = (
             value,
           ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [
+        let executePayload =
+          context.universalProfile.interface.encodeFunctionData("execute", [
             OPERATION_TYPES.DELEGATECALL,
             allowedDelegateCallContracts[1].address,
             0,
             delegateCallPayload,
-          ]
-        );
+          ]);
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload)

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -237,8 +237,7 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash:
-                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -340,8 +339,7 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash:
-                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -445,8 +443,7 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash:
-                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -542,8 +539,7 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash:
-                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -823,25 +819,24 @@ export const shouldBehaveLikePermissionSetData = (
         ethers.utils.toUtf8Bytes("Alice's Value")
       );
 
-      let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "setData(bytes32,bytes)",
-        [key, value]
-      );
+      let finalSetDataPayload =
+        bobContext.universalProfile.interface.encodeFunctionData(
+          "setData(bytes32,bytes)",
+          [key, value]
+        );
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
-        "execute",
-        [finalSetDataPayload]
-      );
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalSetDataPayload,
+        ]);
 
-      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           bobContext.keyManager.address,
           0,
           bobKeyManagerPayload,
-        ]
-      );
+        ]);
 
       await expect(
         aliceContext.keyManager
@@ -861,25 +856,35 @@ export const shouldBehaveLikePermissionSetData = (
         ethers.utils.toUtf8Bytes("Alice's Value")
       );
 
-      let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
+      // Adding `key` to AllowedERC725YDataKeys for Alice
+      const payload = bobContext.universalProfile.interface.encodeFunctionData(
         "setData(bytes32,bytes)",
-        [key, value]
-      );
-
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
-        "execute",
-        [finalSetDataPayload]
-      );
-
-      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
         [
+          ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+            aliceContext.universalProfile.address.substring(2),
+          encodeCompactBytesArray([key]),
+        ]
+      );
+      await bobContext.keyManager.connect(bob).execute(payload);
+
+      let finalSetDataPayload =
+        bobContext.universalProfile.interface.encodeFunctionData(
+          "setData(bytes32,bytes)",
+          [key, value]
+        );
+
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalSetDataPayload,
+        ]);
+
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           bobContext.keyManager.address,
           0,
           bobKeyManagerPayload,
-        ]
-      );
+        ]);
 
       await aliceContext.keyManager
         .connect(alice)

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -237,7 +237,8 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash:
+                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -339,7 +340,8 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash:
+                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -443,7 +445,8 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash:
+                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -539,7 +542,8 @@ export const shouldBehaveLikePermissionSetData = (
           const basicUPSetup = {
             LSP3Profile: {
               hashFunction: "keccak256(utf8)",
-              hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
+              hash:
+                "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
               url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
             },
             "LSP12IssuedAssets[]": [
@@ -819,24 +823,25 @@ export const shouldBehaveLikePermissionSetData = (
         ethers.utils.toUtf8Bytes("Alice's Value")
       );
 
-      let finalSetDataPayload =
-        bobContext.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32,bytes)",
-          [key, value]
-        );
+      let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
+        "setData(bytes32,bytes)",
+        [key, value]
+      );
 
-      let bobKeyManagerPayload =
-        bobContext.keyManager.interface.encodeFunctionData("execute", [
-          finalSetDataPayload,
-        ]);
+      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
+        "execute",
+        [finalSetDataPayload]
+      );
 
-      let aliceUniversalProfilePayload =
-        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
+      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
+        "execute",
+        [
           OPERATION_TYPES.CALL,
           bobContext.keyManager.address,
           0,
           bobKeyManagerPayload,
-        ]);
+        ]
+      );
 
       await expect(
         aliceContext.keyManager
@@ -856,41 +861,29 @@ export const shouldBehaveLikePermissionSetData = (
         ethers.utils.toUtf8Bytes("Alice's Value")
       );
 
-      // Adding `key` to AllowedERC725YDataKeys for Alice
-      const payload = bobContext.universalProfile.interface.encodeFunctionData(
+      let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
         "setData(bytes32,bytes)",
-        [
-          ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
-            aliceContext.universalProfile.address.substring(2),
-          encodeCompactBytesArray([key]),
-        ]
+        [key, value]
       );
-      await bobContext.keyManager.connect(bob).execute(payload);
 
-      let finalSetDataPayload =
-        bobContext.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32,bytes)",
-          [key, value]
-        );
+      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
+        "execute",
+        [finalSetDataPayload]
+      );
 
-      let bobKeyManagerPayload =
-        bobContext.keyManager.interface.encodeFunctionData("execute", [
-          finalSetDataPayload,
-        ]);
-
-      let aliceUniversalProfilePayload =
-        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
+      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
+        "execute",
+        [
           OPERATION_TYPES.CALL,
           bobContext.keyManager.address,
           0,
           bobKeyManagerPayload,
-        ]);
+        ]
+      );
 
-      let tx = await aliceContext.keyManager
+      await aliceContext.keyManager
         .connect(alice)
         .execute(aliceUniversalProfilePayload);
-      let receipt = await tx.wait();
-      console.log("gas used: ", receipt.gasUsed.toNumber());
 
       const result = await bobContext.universalProfile["getData(bytes32)"](key);
       expect(result).to.equal(value);

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -677,7 +677,7 @@ export const shouldBehaveLikePermissionSetData = (
     });
 
     describe("> Low-level calls", () => {
-      it("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
+      it.only("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
         // check that nothing is set at store[key]
         const initialStorage = await context.universalProfile.callStatic[
           "getData(bytes32)"
@@ -694,7 +694,7 @@ export const shouldBehaveLikePermissionSetData = (
 
         // make the executor call
         await contractCanSetData.setHardcodedKeyRawCall({
-          gasLimit: GAS_PROVIDED,
+          //   gasLimit: GAS_PROVIDED,
         });
 
         // check that store[key] is now set to value

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -677,7 +677,7 @@ export const shouldBehaveLikePermissionSetData = (
     });
 
     describe("> Low-level calls", () => {
-      it.only("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
+      it("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
         // check that nothing is set at store[key]
         const initialStorage = await context.universalProfile.callStatic[
           "getData(bytes32)"

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -694,7 +694,7 @@ export const shouldBehaveLikePermissionSetData = (
 
         // make the executor call
         await contractCanSetData.setHardcodedKeyRawCall({
-          //   gasLimit: GAS_PROVIDED,
+          gasLimit: GAS_PROVIDED,
         });
 
         // check that store[key] is now set to value

--- a/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
@@ -72,19 +72,16 @@ export const shouldBehaveLikePermissionStaticCall = (
     it("should pass and return data", async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       let result = await context.keyManager
         .connect(context.owner)
@@ -99,19 +96,16 @@ export const shouldBehaveLikePermissionStaticCall = (
     it("should pass and return data", async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       let result = await context.keyManager
         .connect(addressCanMakeStaticCall)
@@ -129,15 +123,13 @@ export const shouldBehaveLikePermissionStaticCall = (
         ["modified name"]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager
@@ -156,10 +148,13 @@ export const shouldBehaveLikePermissionStaticCall = (
         ["modified name"]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          targetContract.address,
+          0,
+          targetContractPayload,
+        ]);
 
       await expect(
         context.keyManager
@@ -173,49 +168,39 @@ export const shouldBehaveLikePermissionStaticCall = (
 
   describe("when caller has permission STATICCALL + no allowed calls", () => {
     it("should revert with `NotAllowedCall` error", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager
           .connect(addressCanMakeStaticCallNoAllowedCalls)
           .callStatic.execute(executePayload)
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-        .withArgs(
-          addressCanMakeStaticCallNoAllowedCalls.address,
-          targetContract.address,
-          targetContract.interface.getSighash("getName")
-        );
+        .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+        .withArgs(addressCanMakeStaticCallNoAllowedCalls.address);
     });
   });
 
   describe("when caller does not have permission STATICCALL", () => {
     it("should revert", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData(
-        "getName"
-      );
+      let targetContractPayload =
+        targetContract.interface.encodeFunctionData("getName");
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       await expect(
         context.keyManager

--- a/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
@@ -24,7 +24,8 @@ export const shouldBehaveLikePermissionStaticCall = (
   let context: LSP6TestContext;
 
   let addressCanMakeStaticCall: SignerWithAddress,
-    addressCannotMakeStaticCall: SignerWithAddress;
+    addressCannotMakeStaticCall: SignerWithAddress,
+    addressCanMakeStaticCallNoAllowedCalls: SignerWithAddress;
 
   let targetContract: TargetContract;
 
@@ -33,6 +34,7 @@ export const shouldBehaveLikePermissionStaticCall = (
 
     addressCanMakeStaticCall = context.accounts[1];
     addressCannotMakeStaticCall = context.accounts[2];
+    addressCanMakeStaticCallNoAllowedCalls = context.accounts[3];
 
     targetContract = await new TargetContract__factory(
       context.accounts[0]
@@ -43,14 +45,24 @@ export const shouldBehaveLikePermissionStaticCall = (
         context.owner.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         addressCanMakeStaticCall.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        addressCanMakeStaticCall.address.substring(2),
       ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
         addressCannotMakeStaticCall.address.substring(2),
+      ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+        addressCanMakeStaticCallNoAllowedCalls.address.substring(2),
     ];
 
     const permissionsValues = [
       ALL_PERMISSIONS,
       PERMISSIONS.STATICCALL,
+      combineAllowedCalls(
+        ["0xffffffff"],
+        [targetContract.address],
+        ["0xffffffff"]
+      ),
       PERMISSIONS.SETDATA,
+      PERMISSIONS.STATICCALL,
     ];
 
     await setupKeyManager(context, permissionKeys, permissionsValues);
@@ -83,7 +95,7 @@ export const shouldBehaveLikePermissionStaticCall = (
     });
   });
 
-  describe("when caller has permission STATICCALL", () => {
+  describe("when caller has permission STATICCALL + some allowed calls", () => {
     it("should pass and return data", async () => {
       let expectedName = await targetContract.callStatic.getName();
 
@@ -156,6 +168,36 @@ export const shouldBehaveLikePermissionStaticCall = (
       )
         .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
         .withArgs(addressCanMakeStaticCall.address, "CALL");
+    });
+  });
+
+  describe("when caller has permission STATICCALL + no allowed calls", () => {
+    it("should revert with `NotAllowedCall` error", async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData(
+        "getName"
+      );
+
+      let executePayload = context.universalProfile.interface.encodeFunctionData(
+        "execute",
+        [
+          OPERATION_TYPES.STATICCALL,
+          targetContract.address,
+          0,
+          targetContractPayload,
+        ]
+      );
+
+      await expect(
+        context.keyManager
+          .connect(addressCanMakeStaticCallNoAllowedCalls)
+          .callStatic.execute(executePayload)
+      )
+        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+        .withArgs(
+          addressCanMakeStaticCallNoAllowedCalls.address,
+          targetContract.address,
+          targetContract.interface.getSighash("getName")
+        );
     });
   });
 

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -45,19 +45,26 @@ export const shouldBehaveLikePermissionTransferValue = (
       canTransferValueAndCall: SignerWithAddress,
       cannotTransferValue: SignerWithAddress;
 
+    let recipient;
+
     beforeEach(async () => {
       context = await buildContext();
 
       canTransferValue = context.accounts[1];
       canTransferValueAndCall = context.accounts[2];
       cannotTransferValue = context.accounts[3];
+      recipient = context.accounts[4];
 
       const permissionsKeys = [
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           context.owner.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           canTransferValue.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          canTransferValue.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          canTransferValueAndCall.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
           canTransferValueAndCall.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           cannotTransferValue.address.substring(2),
@@ -66,7 +73,17 @@ export const shouldBehaveLikePermissionTransferValue = (
       const permissionsValues = [
         ALL_PERMISSIONS,
         PERMISSIONS.TRANSFERVALUE,
+        combineAllowedCalls(
+          ["0xffffffff"],
+          [recipient.address],
+          ["0xffffffff"]
+        ),
         combinePermissions(PERMISSIONS.TRANSFERVALUE, PERMISSIONS.CALL),
+        combineAllowedCalls(
+          ["0xffffffff"],
+          [recipient.address],
+          ["0xffffffff"]
+        ),
         PERMISSIONS.CALL,
       ];
 
@@ -79,11 +96,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
 
     describe("when recipient = EOA", () => {
-      let recipient;
-
-      beforeEach(async () => {
-        recipient = context.accounts[3].address;
-      });
+      beforeEach(async () => {});
 
       describe("when transferring value via `execute(...)`", () => {
         describe("when transferring value without bytes `_data`", () => {
@@ -104,7 +117,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             await expect(() =>
               context.keyManager.connect(context.owner).execute(transferPayload)
             ).to.changeEtherBalances(
-              [context.universalProfile.address, recipient],
+              [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount]
             );
           });
@@ -122,7 +135,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .connect(canTransferValue)
                 .execute(transferPayload)
             ).to.changeEtherBalances(
-              [context.universalProfile.address, recipient],
+              [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount]
             );
           });
@@ -140,7 +153,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .connect(canTransferValueAndCall)
                 .execute(transferPayload)
             ).to.changeEtherBalances(
-              [context.universalProfile.address, recipient],
+              [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount]
             );
           });
@@ -149,13 +162,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             let initialBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let initialBalanceRecipient = await provider.getBalance(recipient);
+            let initialBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             let transferPayload = context.universalProfile.interface.encodeFunctionData(
               "execute",
               [
                 OPERATION_TYPES.CALL,
-                recipient,
+                recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
               ]
@@ -175,7 +190,9 @@ export const shouldBehaveLikePermissionTransferValue = (
             let newBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let newBalanceRecipient = await provider.getBalance(recipient);
+            let newBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             // verify that native token balances have not changed
             expect(newBalanceUP).to.equal(initialBalanceUP);
@@ -191,13 +208,15 @@ export const shouldBehaveLikePermissionTransferValue = (
               context.universalProfile.address
             );
 
-            let initialBalanceRecipient = await provider.getBalance(recipient);
+            let initialBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             let transferPayload = context.universalProfile.interface.encodeFunctionData(
               "execute",
               [
                 OPERATION_TYPES.CALL,
-                recipient,
+                recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
               ]
@@ -212,7 +231,9 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
             expect(newBalanceUP).to.be.lt(initialBalanceUP);
 
-            let newBalanceRecipient = await provider.getBalance(recipient);
+            let newBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
             expect(newBalanceRecipient).to.be.gt(initialBalanceRecipient);
           });
 
@@ -229,7 +250,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .connect(canTransferValueAndCall)
                 .execute(transferPayload)
             ).to.changeEtherBalances(
-              [context.universalProfile.address, recipient],
+              [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount]
             );
           });
@@ -238,13 +259,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             let initialBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let initialBalanceRecipient = await provider.getBalance(recipient);
+            let initialBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             let transferPayload = context.universalProfile.interface.encodeFunctionData(
               "execute",
               [
                 OPERATION_TYPES.CALL,
-                recipient,
+                recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
               ]
@@ -264,7 +287,9 @@ export const shouldBehaveLikePermissionTransferValue = (
             let newBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let newBalanceRecipient = await provider.getBalance(recipient);
+            let newBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             // verify that native token balances have not changed
             expect(newBalanceUP).to.equal(initialBalanceUP);
@@ -275,13 +300,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             let initialBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let initialBalanceRecipient = await provider.getBalance(recipient);
+            let initialBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             let transferPayload = context.universalProfile.interface.encodeFunctionData(
               "execute",
               [
                 OPERATION_TYPES.CALL,
-                recipient,
+                recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
               ]
@@ -301,7 +328,9 @@ export const shouldBehaveLikePermissionTransferValue = (
             let newBalanceUP = await provider.getBalance(
               context.universalProfile.address
             );
-            let newBalanceRecipient = await provider.getBalance(recipient);
+            let newBalanceRecipient = await provider.getBalance(
+              recipient.address
+            );
 
             // verify that native token balances have not changed
             expect(newBalanceUP).to.equal(initialBalanceUP);
@@ -383,7 +412,7 @@ export const shouldBehaveLikePermissionTransferValue = (
                 value: valueToSend,
               })
           ).to.changeEtherBalances(
-            [context.universalProfile.address, recipient],
+            [context.universalProfile.address, recipient.address],
             [`-${amount}`, amount]
           );
         });
@@ -398,6 +427,8 @@ export const shouldBehaveLikePermissionTransferValue = (
   describe("when caller = contract", () => {
     let contractCanTransferValue: Executor;
 
+    let recipient: string;
+
     const hardcodedRecipient: string =
       "0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe";
 
@@ -411,6 +442,8 @@ export const shouldBehaveLikePermissionTransferValue = (
     beforeEach(async () => {
       context = await buildContext();
 
+      recipient = context.accounts[1].address;
+
       contractCanTransferValue = await new Executor__factory(
         context.accounts[0]
       ).deploy(context.universalProfile.address, context.keyManager.address);
@@ -420,9 +453,19 @@ export const shouldBehaveLikePermissionTransferValue = (
           context.owner.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           contractCanTransferValue.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          contractCanTransferValue.address.substring(2),
       ];
 
-      const permissionValues = [ALL_PERMISSIONS, PERMISSIONS.TRANSFERVALUE];
+      const permissionValues = [
+        ALL_PERMISSIONS,
+        PERMISSIONS.TRANSFERVALUE,
+        combineAllowedCalls(
+          ["0xffffffff", "0xffffffff"],
+          [hardcodedRecipient, recipient],
+          ["0xffffffff", "0xffffffff"]
+        ),
+      ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
 
@@ -450,7 +493,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
 
       it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)", async () => {
-        const recipient = context.accounts[1].address;
         const amount = ethers.utils.parseEther("1");
 
         await expect(() =>
@@ -479,7 +521,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
 
       it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)", async () => {
-        const recipient = context.accounts[1].address;
         const amount = ethers.utils.parseEther("1");
 
         await expect(() =>
@@ -521,9 +562,19 @@ export const shouldBehaveLikePermissionTransferValue = (
           bob.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           aliceContext.universalProfile.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          aliceContext.universalProfile.address.substring(2),
       ];
 
-      const bobPermissionValues = [ALL_PERMISSIONS, PERMISSIONS.TRANSFERVALUE];
+      const bobPermissionValues = [
+        ALL_PERMISSIONS,
+        PERMISSIONS.TRANSFERVALUE,
+        combineAllowedCalls(
+          ["0xffffffff"],
+          [aliceContext.universalProfile.address],
+          ["0xffffffff"]
+        ),
+      ];
 
       await setupKeyManager(
         aliceContext,

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -105,10 +105,13 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has ALL PERMISSIONS", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                data,
+              ]);
 
             /**
              * verify that balances have been updated
@@ -125,10 +128,13 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE only", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                data,
+              ]);
 
             await expect(() =>
               context.keyManager
@@ -143,10 +149,13 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                data,
+              ]);
 
             await expect(() =>
               context.keyManager
@@ -166,15 +175,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               recipient.address
             );
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
-              ]
-            );
+              ]);
 
             await expect(
               context.keyManager
@@ -212,15 +219,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               recipient.address
             );
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
-              ]
-            );
+              ]);
 
             await context.keyManager
               .connect(context.owner)
@@ -240,10 +245,13 @@ export const shouldBehaveLikePermissionTransferValue = (
           it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
             const amount = ethers.utils.parseEther("3");
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, recipient, amount, data]
-            );
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                recipient.address,
+                amount,
+                data,
+              ]);
 
             await expect(() =>
               context.keyManager
@@ -263,15 +271,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               recipient.address
             );
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
-              ]
-            );
+              ]);
 
             await expect(
               context.keyManager
@@ -304,15 +310,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               recipient.address
             );
 
-            let transferPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [
+            let transferPayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
                 OPERATION_TYPES.CALL,
                 recipient.address,
                 ethers.utils.parseEther("3"),
                 data,
-              ]
-            );
+              ]);
 
             await expect(
               context.keyManager
@@ -343,10 +347,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         it("should revert if tx was signed with Eth Signed Message", async () => {
           const amount = ethers.utils.parseEther("3");
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient.address,
+              amount,
+              "0x",
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -380,10 +387,13 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           const amount = ethers.utils.parseEther("3");
 
-          let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let executeRelayCallPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient.address,
+              amount,
+              "0x",
+            ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
@@ -621,30 +631,26 @@ export const shouldBehaveLikePermissionTransferValue = (
     it("Alice should be able to send 5 LYX from Bob's UP to her UP", async () => {
       const amount = ethers.utils.parseEther("5");
 
-      let finalTransferLyxPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let finalTransferLyxPayload =
+        bobContext.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           aliceContext.universalProfile.address,
           amount,
           "0x",
-        ]
-      );
+        ]);
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData(
-        "execute",
-        [finalTransferLyxPayload]
-      );
+      let bobKeyManagerPayload =
+        bobContext.keyManager.interface.encodeFunctionData("execute", [
+          finalTransferLyxPayload,
+        ]);
 
-      let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let aliceUniversalProfilePayload =
+        aliceContext.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           bobContext.keyManager.address,
           0,
           bobKeyManagerPayload,
-        ]
-      );
+        ]);
 
       await expect(() =>
         aliceContext.keyManager
@@ -723,10 +729,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         it(`should send LYX to EOA -> ${recipient}`, async () => {
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient,
+              amount,
+              "0x",
+            ]);
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -747,10 +756,13 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient.address, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient.address,
+              amount,
+              "0x",
+            ]);
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -778,10 +790,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, newLSP7Token.address, 5, lsp7TransferPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          newLSP7Token.address,
+          5,
+          lsp7TransferPayload,
+        ]);
 
       await expect(context.keyManager.connect(caller).execute(executePayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -813,10 +828,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, lsp7Token.address, 0, lsp7TransferPayload]
-      );
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          lsp7Token.address,
+          0,
+          lsp7TransferPayload,
+        ]);
 
       await context.keyManager.connect(caller).execute(executePayload);
 
@@ -863,15 +881,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         [newValue]
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [
+      let executePayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
           OPERATION_TYPES.CALL,
           targetContract.address,
           lyxAmount,
           targetContractPayload,
-        ]
-      );
+        ]);
 
       await expect(() =>
         context.keyManager.connect(caller).execute(executePayload)
@@ -929,10 +945,13 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       let initialBalanceRecipient = await provider.getBalance(recipient);
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          recipient,
+          amount,
+          "0x",
+        ]);
 
       await expect(context.keyManager.connect(caller).execute(transferPayload))
         .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
@@ -950,10 +969,13 @@ export const shouldBehaveLikePermissionTransferValue = (
     it("should be allowed to do a plain LYX transfer to an allowed address", async () => {
       const amount = ethers.utils.parseEther("1");
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, allowedAddress.address, amount, "0x"]
-      );
+      let transferPayload =
+        context.universalProfile.interface.encodeFunctionData("execute", [
+          OPERATION_TYPES.CALL,
+          allowedAddress.address,
+          amount,
+          "0x",
+        ]);
 
       await expect(() =>
         context.keyManager.connect(caller).execute(transferPayload)
@@ -978,10 +1000,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               [newValue]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                payload,
+              ]);
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1029,10 +1054,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               ]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, lsp7Token.address, 0, tokenTransferPayload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                lsp7Token.address,
+                0,
+                tokenTransferPayload,
+              ]);
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1158,10 +1186,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         it(`should send LYX to EOA -> ${recipient}`, async () => {
           const amount = ethers.utils.parseEther("1");
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, recipient, amount, "0x"]
-          );
+          let transferPayload =
+            context.universalProfile.interface.encodeFunctionData("execute", [
+              OPERATION_TYPES.CALL,
+              recipient,
+              amount,
+              "0x",
+            ]);
 
           await expect(() =>
             context.keyManager.connect(caller).execute(transferPayload)
@@ -1188,10 +1219,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               [newValue]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, targetContract.address, 0, payload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                payload,
+              ]);
 
             await context.keyManager.connect(caller).execute(executePayload);
 
@@ -1239,10 +1273,13 @@ export const shouldBehaveLikePermissionTransferValue = (
               ]
             );
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, lsp7Token.address, 0, tokenTransferPayload]
-            );
+            let executePayload =
+              context.universalProfile.interface.encodeFunctionData("execute", [
+                OPERATION_TYPES.CALL,
+                lsp7Token.address,
+                0,
+                tokenTransferPayload,
+              ]);
 
             await context.keyManager.connect(caller).execute(executePayload);
 

--- a/tests/LSP7DigitalAsset/extensions/LSP7Mintable.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7Mintable.behaviour.ts
@@ -11,6 +11,7 @@ import {
 import { setupProfileWithKeyManagerWithURD } from "../../utils/fixtures";
 
 import { PERMISSIONS, ERC725YKeys, OPERATION_TYPES } from "../../../constants";
+import { combineAllowedCalls } from "../../utils/helpers";
 
 export type LSP7MintableTestAccounts = {
   owner: SignerWithAddress;
@@ -113,10 +114,20 @@ export const shouldBehaveLikeLSP7Mintable = (
         [
           [
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-              URDTokenReentrant.address.substr(2),
+              URDTokenReentrant.address.substring(2),
+            ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+              URDTokenReentrant.address.substring(2),
             ERC725YKeys.LSP1.LSP1UniversalReceiverDelegate,
           ],
-          [PERMISSIONS.CALL, URDTokenReentrant.address],
+          [
+            PERMISSIONS.CALL,
+            combineAllowedCalls(
+              ["0xffffffff"],
+              [context.lsp7Mintable.address],
+              ["0xffffffff"]
+            ),
+            URDTokenReentrant.address,
+          ],
         ]
       );
 
@@ -124,6 +135,7 @@ export const shouldBehaveLikeLSP7Mintable = (
         .connect(context.accounts.profileOwner)
         .execute(setDataPayload);
     });
+
     it("should pass", async () => {
       const firstAmount = 50;
       const secondAmount = 150;

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8Mintable.behaviour.ts
@@ -11,6 +11,7 @@ import {
 import { setupProfileWithKeyManagerWithURD } from "../../utils/fixtures";
 
 import { PERMISSIONS, ERC725YKeys, OPERATION_TYPES } from "../../../constants";
+import { combineAllowedCalls } from "../../utils/helpers";
 
 export type LSP8MintableTestAccounts = {
   owner: SignerWithAddress;
@@ -116,10 +117,20 @@ export const shouldBehaveLikeLSP8Mintable = (
         [
           [
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
-              URDTokenReentrant.address.substr(2),
+              URDTokenReentrant.address.substring(2),
+            ERC725YKeys.LSP6["AddressPermissions:AllowedCalls"] +
+              URDTokenReentrant.address.substring(2),
             ERC725YKeys.LSP1.LSP1UniversalReceiverDelegate,
           ],
-          [PERMISSIONS.CALL, URDTokenReentrant.address],
+          [
+            PERMISSIONS.CALL,
+            combineAllowedCalls(
+              ["0xffffffff"],
+              [context.lsp8Mintable.address],
+              ["0xffffffff"]
+            ),
+            URDTokenReentrant.address,
+          ],
         ]
       );
 


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGE

Change the behaviour of the permissions `TRANSFER_VALUE`, `CALL` and `STATICCALL` to not allow any interaction if nothing is set under `AllowedCall`.

![image](https://user-images.githubusercontent.com/31145285/200310644-d5876782-735b-4ee2-8e72-cb1716a0ab42.png)

![image](https://user-images.githubusercontent.com/31145285/200310770-0af36c28-dcc5-43b1-8aac-38dfb3d78a7e.png)

![image](https://user-images.githubusercontent.com/31145285/200310954-0469bc68-a321-49da-a3f9-12b72a712467.png)
