### PR TITLE
refactor: optimise `_verifyAllowedERC725YKeys` and properly test bytes32(0) key

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -84,3 +84,9 @@ error NoERC725YDataKeysAllowed(address from);
  * @param value the value to check for an CompactBytesArray
  */
 error InvalidEncodedAllowedERC725YKeys(bytes value);
+
+/**
+ * @dev reverts when trying to set the following data key:
+ * "0x0000000000000000000000000000000000000000000000000000000000000000"
+ */
+error ZeroDataKeyNotAllowed();

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -424,6 +424,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
      * @dev Verify if the `inputKey` is present in `allowedERC725KeysCompacted` stored on the `from`'s ERC725Y contract
      */
     function _verifyAllowedERC725YSingleKey(address from, bytes32 inputKey, bytes memory allowedERC725YKeysCompacted) internal pure {
+        if (inputKey == bytes32(0)) revert NotAllowedERC725YKey(from, bytes32(0)); 
         if (allowedERC725YKeysCompacted.length == 0) revert NoERC725YDataKeysAllowed(from);
         if (!LSP2Utils.isCompactBytesArray(allowedERC725YKeysCompacted)) revert InvalidEncodedAllowedERC725YKeys(allowedERC725YKeysCompacted);
 
@@ -603,6 +604,13 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         for (uint256 i = 0; i < inputKeys.length; i++) {
             if (inputKeys[i] != bytes32(0)) revert NotAllowedERC725YKey(from, inputKeys[i]);
         }
+
+        /**
+         * If you got to this point, it means that `allowedKeysFound` is smaller than 
+         * the number of `inputKeys` and all of the `inputKeys` are bytes32(0).
+         * From that we can derive that one of the `inputKeys` was bytes32(0) from the start.
+         */
+        revert NotAllowedERC725YKey(from, bytes32(0));
     }
 
     /**

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -1783,16 +1783,33 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
               [key, value]
             );
 
-          await expect(
-            context.keyManager
-              .connect(controllerCanSetSomeKeys)
-              .execute(setDataPayload)
-          )
-            .to.be.revertedWithCustomError(
+          if (
+            key ==
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+          ) {
+            await expect(
+              context.keyManager
+                .connect(controllerCanSetSomeKeys)
+                .execute(setDataPayload)
+            ).to.be.revertedWithCustomError(
               context.keyManager,
-              "NotAllowedERC725YKey"
+              "ZeroDataKeyNotAllowed"
+            );
+          } else {
+            await expect(
+              context.keyManager
+                .connect(controllerCanSetSomeKeys)
+                .execute(setDataPayload)
             )
-            .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotAllowedERC725YKey"
+              )
+              .withArgs(
+                controllerCanSetSomeKeys.address,
+                testCase.datakeyToSet
+              );
+          }
         });
       });
 
@@ -1820,12 +1837,10 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           context.keyManager
             .connect(controllerCanSetSomeKeys)
             .execute(setDataPayload)
-        )
-          .to.be.revertedWithCustomError(
-            context.keyManager,
-            "NotAllowedERC725YKey"
-          )
-          .withArgs(controllerCanSetSomeKeys.address, zeroKey);
+        ).to.be.revertedWithCustomError(
+          context.keyManager,
+          "ZeroDataKeyNotAllowed"
+        );
       });
     });
 
@@ -1869,12 +1884,10 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           context.keyManager
             .connect(controllerCanSetSomeKeys)
             .execute(setDataPayload)
-        )
-          .to.be.revertedWithCustomError(
-            context.keyManager,
-            "NotAllowedERC725YKey"
-          )
-          .withArgs(controllerCanSetSomeKeys.address, zeroKey);
+        ).to.be.revertedWithCustomError(
+          context.keyManager,
+          "ZeroDataKeyNotAllowed"
+        );
       });
 
       it("should pass when trying to set an array of data keys including bytes32(0)", async () => {
@@ -1901,12 +1914,10 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           context.keyManager
             .connect(controllerCanSetSomeKeys)
             .execute(setDataPayload)
-        )
-          .to.revertedWithCustomError(
-            context.keyManager,
-            "NotAllowedERC725YKey"
-          )
-          .withArgs(controllerCanSetSomeKeys.address, zeroKey);
+        ).to.revertedWithCustomError(
+          context.keyManager,
+          "ZeroDataKeyNotAllowed"
+        );
       });
     });
   });

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -1679,12 +1679,21 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
     const customKey2 = ethers.utils.keccak256(
       ethers.utils.toUtf8Bytes("CustomKey2")
     );
-    const customKey3 = ethers.utils.keccak256(
-      ethers.utils.toUtf8Bytes("CustomKey3")
-    );
 
     const zeroKey =
       "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+    const bytes31DynamicKeyPrefix =
+      "0x00000000000000000000000000000000000000000000000000000000000000";
+
+    const bytes31DynamicKey =
+      "0x00000000000000000000000000000000000000000000000000000000000000ca";
+
+    const bytes20DynamicKeyPrefix =
+      "0x0000000000000000000000000000000000000000";
+
+    const bytes20DynamicKey =
+      "0x0000000000000000000000000000000000000000cafecafecafecafecafecafe";
 
     describe("When bytes32(0) key is part of the AllowedERC725YKeys", () => {
       before(async () => {
@@ -1762,14 +1771,6 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
             ethers.utils.toUtf8Bytes("Some random data key 5")
           ),
         },
-        {
-          datakeyToSet:
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-        },
-        {
-          datakeyToSet:
-            "0x00000000000000000000000000000000000000000000000000000000000000ca",
-        },
       ].forEach((testCase) => {
         it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
           const key = testCase.datakeyToSet;
@@ -1783,37 +1784,67 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
               [key, value]
             );
 
-          if (
-            key ==
-            "0x0000000000000000000000000000000000000000000000000000000000000000"
-          ) {
-            await expect(
-              context.keyManager
-                .connect(controllerCanSetSomeKeys)
-                .execute(setDataPayload)
-            ).to.be.revertedWithCustomError(
+          await expect(
+            context.keyManager
+              .connect(controllerCanSetSomeKeys)
+              .execute(setDataPayload)
+          )
+            .to.be.revertedWithCustomError(
               context.keyManager,
-              "ZeroDataKeyNotAllowed"
-            );
-          } else {
-            await expect(
-              context.keyManager
-                .connect(controllerCanSetSomeKeys)
-                .execute(setDataPayload)
+              "NotAllowedERC725YKey"
             )
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                "NotAllowedERC725YKey"
-              )
-              .withArgs(
-                controllerCanSetSomeKeys.address,
-                testCase.datakeyToSet
-              );
-          }
+            .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
         });
       });
 
-      it("should revert when trying to set an array of data keys including bytes32(0)", async () => {
+      it("should revert when trying to set bytes31(0) dynamic key, not in ALLowedERC725YKeys", async () => {
+        const key = bytes31DynamicKey;
+        const value = ethers.utils.hexlify(
+          ethers.utils.toUtf8Bytes("some value for " + key)
+        );
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NotAllowedERC725YKey"
+          )
+          .withArgs(controllerCanSetSomeKeys.address, key);
+      });
+
+      it("should revert when trying to set bytes32(0) data key, we do not allow changing the bytes32(0) data key", async () => {
+        const key =
+          "0x0000000000000000000000000000000000000000000000000000000000000000";
+        const value = ethers.utils.hexlify(
+          ethers.utils.toUtf8Bytes("some value for " + key)
+        );
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        ).to.be.revertedWithCustomError(
+          context.keyManager,
+          "ZeroDataKeyNotAllowed"
+        );
+      });
+
+      it("should revert when trying to set an array of data keys including bytes32(0), we do not allow changing the bytes32(0) data key", async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
           ethers.utils.hexlify(
@@ -1862,13 +1893,136 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         const permissionValues = [
           ALL_PERMISSIONS,
           PERMISSIONS.SETDATA,
-          encodeCompactBytesArray([customKey1, customKey2, customKey3]),
+          encodeCompactBytesArray([
+            customKey1,
+            customKey2,
+            bytes31DynamicKeyPrefix,
+            bytes20DynamicKeyPrefix,
+          ]),
         ];
 
         await setupKeyManager(context, permissionKeys, permissionValues);
       });
 
-      it("should revert when trying to set bytes32(0) key", async () => {
+      [{ allowedDataKey: customKey1 }, { allowedDataKey: customKey2 }].forEach(
+        (testCase) => {
+          it(`should pass when setting a data key listed in the allowed ERC725Y data keys: ${testCase.allowedDataKey}`, async () => {
+            const key = testCase.allowedDataKey;
+            const value = ethers.utils.hexlify(
+              ethers.utils.toUtf8Bytes("some value for " + key)
+            );
+
+            const setDataPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, value]
+              );
+
+            await context.keyManager
+              .connect(controllerCanSetSomeKeys)
+              .execute(setDataPayload);
+
+            const result = await context.universalProfile["getData(bytes32)"](
+              key
+            );
+            expect(result).to.equal(value);
+          });
+        }
+      );
+
+      [
+        {
+          datakeyToSet: ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("Some random data key 1")
+          ),
+        },
+        {
+          datakeyToSet: ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("Some random data key 2")
+          ),
+        },
+        {
+          datakeyToSet: ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("Some random data key 3")
+          ),
+        },
+        {
+          datakeyToSet: ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("Some random data key 4")
+          ),
+        },
+        {
+          datakeyToSet: ethers.utils.keccak256(
+            ethers.utils.toUtf8Bytes("Some random data key 5")
+          ),
+        },
+      ].forEach((testCase) => {
+        it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
+          const key = testCase.datakeyToSet;
+          const value = ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + key)
+          );
+
+          const setDataPayload =
+            context.universalProfile.interface.encodeFunctionData(
+              "setData(bytes32,bytes)",
+              [key, value]
+            );
+
+          await expect(
+            context.keyManager
+              .connect(controllerCanSetSomeKeys)
+              .execute(setDataPayload)
+          )
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "NotAllowedERC725YKey"
+            )
+            .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
+        });
+      });
+
+      it("should allow setting up a key with a prefix of 31 null bytes, as bytes31(0) is part of AllowedERC725YKeys", async () => {
+        const key = bytes31DynamicKey;
+        const value = ethers.utils.hexlify(
+          ethers.utils.toUtf8Bytes("some value for " + key)
+        );
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+        await context.keyManager
+          .connect(controllerCanSetSomeKeys)
+          .execute(setDataPayload);
+
+        const result = await context.universalProfile["getData(bytes32)"](key);
+        expect(result).to.equal(value);
+      });
+
+      it("should allow setting up a key with a prefix of 20 null bytes, as bytes20(0) is part of AllowedERC725YKeys", async () => {
+        const key = bytes20DynamicKey;
+        const value = ethers.utils.hexlify(
+          ethers.utils.toUtf8Bytes("some value for " + key)
+        );
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+        await context.keyManager
+          .connect(controllerCanSetSomeKeys)
+          .execute(setDataPayload);
+
+        const result = await context.universalProfile["getData(bytes32)"](key);
+        expect(result).to.equal(value);
+      });
+
+      it("should revert when trying to set bytes32(0) data key, we do not allow changing the bytes32(0) data key", async () => {
         const key = zeroKey;
         const value = ethers.utils.hexlify(
           ethers.utils.toUtf8Bytes("some value for " + key)
@@ -1890,7 +2044,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
         );
       });
 
-      it("should pass when trying to set an array of data keys including bytes32(0)", async () => {
+      it("should revert when trying to set an array of data keys including bytes32(0), we do not allow changing the bytes32(0) data key", async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
           ethers.utils.hexlify(

--- a/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedERC725YKeys.test.ts
@@ -1695,6 +1695,12 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
     const bytes20DynamicKey =
       "0x0000000000000000000000000000000000000000cafecafecafecafecafecafe";
 
+    const bytes24DynamicKey =
+      "0x000000000000000000000000000000000000000000000000cafecafecafecafe";
+
+    const bytes19DynamicKey =
+      "0x00000000000000000000000000000000000000cafecafecafecafecafecafeca";
+
     describe("When bytes32(0) key is part of the AllowedERC725YKeys", () => {
       before(async () => {
         context = await buildContext();
@@ -1873,6 +1879,70 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           "ZeroDataKeyNotAllowed"
         );
       });
+
+      it("should revert when trying to set an array of data keys including a dynamic bytes31(0) data key, not in AllowedERC725YKeys", async () => {
+        const keys = [customKey1, customKey2, bytes31DynamicKey];
+        const values = [
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[0])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[1])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[2])
+          ),
+        ];
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32[],bytes[])",
+            [keys, values]
+          );
+
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NotAllowedERC725YKey"
+          )
+          .withArgs(controllerCanSetSomeKeys.address, keys[2]);
+      });
+
+      it("should revert when trying to set an array of data keys including a dynamic bytes20(0) data key, not in AllowedERC725YKeys", async () => {
+        const keys = [customKey1, customKey2, bytes20DynamicKey];
+        const values = [
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[0])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[1])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[2])
+          ),
+        ];
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32[],bytes[])",
+            [keys, values]
+          );
+
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NotAllowedERC725YKey"
+          )
+          .withArgs(controllerCanSetSomeKeys.address, keys[2]);
+      });
     });
 
     describe("When bytes32(0) key is not part of the AllowedERC725YKeys", () => {
@@ -2014,7 +2084,7 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
             [key, value]
           );
 
-        await context.keyManager
+        const tx = await context.keyManager
           .connect(controllerCanSetSomeKeys)
           .execute(setDataPayload);
 
@@ -2072,6 +2142,67 @@ export const shouldBehaveLikeAllowedERC725YKeys = (
           context.keyManager,
           "ZeroDataKeyNotAllowed"
         );
+      });
+
+      it("should pass when trying to set an array of data keys including a dynamic bytes24(0) data key, because bytes20(0) dynamic data ke is in AllowedERC725YKeys", async () => {
+        const keys = [customKey1, customKey2, bytes24DynamicKey];
+        const values = [
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[0])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[1])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[2])
+          ),
+        ];
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32[],bytes[])",
+            [keys, values]
+          );
+
+        await context.keyManager
+          .connect(controllerCanSetSomeKeys)
+          .execute(setDataPayload);
+
+        expect(
+          await context.universalProfile["getData(bytes32[])"](keys)
+        ).to.deep.equal(values);
+      });
+
+      it("should revert when trying to set an array of data keys including a dynamic bytes19(0) data key, not in AllowedERC725YKeys", async () => {
+        const keys = [customKey1, customKey2, bytes19DynamicKey];
+        const values = [
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[0])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[1])
+          ),
+          ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("some value for " + keys[2])
+          ),
+        ];
+
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32[],bytes[])",
+            [keys, values]
+          );
+
+        await expect(
+          context.keyManager
+            .connect(controllerCanSetSomeKeys)
+            .execute(setDataPayload)
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManager,
+            "NotAllowedERC725YKey"
+          )
+          .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
     });
   });

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -207,10 +207,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             let randomValue = "0xcafecafecafecafecafe";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager.connect(context.owner).execute(setupPayload)
@@ -230,10 +231,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager.connect(context.owner).execute(setupPayload)
@@ -275,10 +277,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             let randomValue = "0xcafecafecafecafecafe";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager.connect(context.owner).execute(setupPayload)
@@ -298,10 +301,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager.connect(context.owner).execute(setupPayload)
@@ -476,10 +480,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             let randomValue = "0xcafecafecafecafecafe";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager
@@ -501,10 +506,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager
@@ -761,10 +767,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             let randomValue = "0xcafecafecafecafecafe";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager
@@ -786,10 +793,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
               "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData(bytes32,bytes)",
-              [key, randomValue]
-            );
+            let setupPayload =
+              context.universalProfile.interface.encodeFunctionData(
+                "setData(bytes32,bytes)",
+                [key, randomValue]
+              );
 
             await expect(
               context.keyManager
@@ -1120,10 +1128,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           beneficiary.address.substring(2);
         const dataValue = "0x";
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32,bytes)",
-          [dataKey, dataValue]
-        );
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [dataKey, dataValue]
+          );
 
         await expect(
           context.keyManager
@@ -1142,10 +1151,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           beneficiary.address.substring(2);
         const dataValue = "0x";
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setData(bytes32,bytes)",
-          [dataKey, dataValue]
-        );
+        const setDataPayload =
+          context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [dataKey, dataValue]
+          );
 
         await context.keyManager
           .connect(canOnlyChangePermissions)
@@ -2905,7 +2915,11 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
           context.owner.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           canSetDataAndAddPermissions.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
+          canSetDataAndAddPermissions.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
+          canSetDataAndChangePermissions.address.substring(2),
+        ERC725YKeys.LSP6["AddressPermissions:AllowedERC725YKeys"] +
           canSetDataAndChangePermissions.address.substring(2),
         ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
           canSetDataOnly.address.substring(2),
@@ -2919,7 +2933,15 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       const permissionValues = [
         ALL_PERMISSIONS,
         combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.ADDPERMISSIONS),
+        encodeCompactBytesArray([
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
+        ]),
         combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.CHANGEPERMISSIONS),
+        encodeCompactBytesArray([
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
+        ]),
         PERMISSIONS.SETDATA,
         // placeholder permission
         PERMISSIONS.TRANSFERVALUE,
@@ -3031,15 +3053,13 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission SETDATA + ADDPERMISSIONS", () => {
-        it("(should fail): 2 x keys + add 2 x new permissions + increment AddressPermissions[].length by +2", async () => {
+        it("(should pass): 2 x keys + add 2 x new permissions + increment AddressPermissions[].length by +2", async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(
-              ethers.utils.toUtf8Bytes("My SecondKey Key")
-            ),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
               newControllerKeyOne.address.substr(2),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
@@ -3060,16 +3080,13 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await expect(
-            context.keyManager
-              .connect(canSetDataAndAddPermissions)
-              .execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "NoERC725YDataKeysAllowed"
-            )
-            .withArgs(canSetDataAndAddPermissions.address);
+          await context.keyManager
+            .connect(canSetDataAndAddPermissions)
+            .execute(payload);
+
+          expect(
+            await context.universalProfile["getData(bytes32[])"](keys)
+          ).to.deep.equal(values);
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions + decrement AddressPermissions[].length by -1", async () => {
@@ -3180,12 +3197,10 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       });
 
       describe("when caller is an address with permission SETDATA + CHANGEPERMISSIONS + no Allowed ERC725Y Keys", () => {
-        it("(should fail): 2 x keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
+        it("(should pass): 2 x keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(
-              ethers.utils.toUtf8Bytes("My SecondKey Key")
-            ),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
               addressesToEditPermissions[0].address.substring(2),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
@@ -3206,24 +3221,19 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await expect(
-            context.keyManager
-              .connect(canSetDataAndChangePermissions)
-              .execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "NoERC725YDataKeysAllowed"
-            )
-            .withArgs(canSetDataAndChangePermissions.address);
+          await context.keyManager
+            .connect(canSetDataAndChangePermissions)
+            .execute(payload);
+
+          expect(
+            await context.universalProfile["getData(bytes32[])"](keys)
+          ).to.deep.equal(values);
         });
 
-        it("(should fail): 2 x keys + change 2 x existing permissions", async () => {
+        it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
           let keys = [
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(
-              ethers.utils.toUtf8Bytes("My SecondKey Key")
-            ),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
               addressesToEditPermissions[0].address.substring(2),
             ERC725YKeys.LSP6["AddressPermissions:Permissions"] +
@@ -3242,16 +3252,13 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
             [keys, values]
           );
 
-          await expect(
-            context.keyManager
-              .connect(canSetDataAndChangePermissions)
-              .execute(payload)
-          )
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              "NoERC725YDataKeysAllowed"
-            )
-            .withArgs(canSetDataAndChangePermissions.address);
+          await context.keyManager
+            .connect(canSetDataAndChangePermissions)
+            .execute(payload);
+
+          expect(
+            await context.universalProfile["getData(bytes32[])"](keys)
+          ).to.deep.equal(values);
         });
 
         it("(should fail): 2 x keys + add 2 x new permissions", async () => {


### PR DESCRIPTION
## What does this PR introduce?

- Optimising `_verifyAllowedERC725YKeys` so it is more gas efficient.
- Disallow `bytes32(0)` data key to be set a data value through the LSP6KeyManager, for security reasons.
- Properly test that one is not allowed to use `setData(bytes32,bytes)` & `setData(bytes32[],bytes[])` if one of the input data keys is equal to `bytes32(0)`.