### PR TITLE
test: add some missing test for locking base contracts on deployment

### DIFF
--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -103,6 +103,20 @@ describe("LSP6KeyManager", () => {
       return context;
     };
 
+    describe("when deploying the base contract implementation", () => {
+      it("should prevent any address from calling the `initialize(...)` function on the base contract", async () => {
+        let context = await buildTestContext();
+
+        const baseKM = await new LSP6KeyManagerInit__factory(
+          context.accounts[0]
+        ).deploy();
+
+        await expect(
+          baseKM.initialize(context.accounts[0].address)
+        ).to.be.revertedWith("Initializable: contract is already initialized");
+      });
+    });
+
     describe("when deploying the contract as proxy", () => {
       let context: LSP6TestContext;
 

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import {
   LSP7CompatibleERC20Tester__factory,
   LSP7CompatibleERC20InitTester__factory,
+  LSP7CompatibleERC20MintableInit__factory,
 } from "../../../types";
 
 import {
@@ -107,13 +108,12 @@ describe("LSP7CompatibleERC20", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+      it("LSP7CompatibleERC20Init: prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 
-        const lsp7CompatibilityForERC20TesterInit =
-          await new LSP7CompatibleERC20InitTester__factory(
-            accounts[0]
-          ).deploy();
+        const lsp7CompatibilityForERC20TesterInit = await new LSP7CompatibleERC20InitTester__factory(
+          accounts[0]
+        ).deploy();
 
         const randomCaller = accounts[1];
 
@@ -121,6 +121,24 @@ describe("LSP7CompatibleERC20", () => {
           lsp7CompatibilityForERC20TesterInit[
             "initialize(string,string,address)"
           ]("XXXXXXXXXXX", "XXX", randomCaller.address)
+        ).to.be.revertedWith("Initializable: contract is already initialized");
+      });
+
+      it("LSP7CompatibleERC20MintableInit: prevent any address from calling the initialize(...) function on the implementation", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp7CompatibleERC20MintableInit = await new LSP7CompatibleERC20MintableInit__factory(
+          accounts[0]
+        ).deploy();
+
+        const randomCaller = accounts[1];
+
+        await expect(
+          lsp7CompatibleERC20MintableInit["initialize(string,string,address)"](
+            "XXXXXXXXXXX",
+            "XXX",
+            randomCaller.address
+          )
         ).to.be.revertedWith("Initializable: contract is already initialized");
       });
     });

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
@@ -4,6 +4,7 @@ import { expect } from "chai";
 import {
   LSP8CompatibleERC721Tester__factory,
   LSP8CompatibleERC721InitTester__factory,
+  LSP8CompatibleERC721MintableInit__factory,
 } from "../../../types";
 
 import {
@@ -130,13 +131,12 @@ describe("LSP8CompatibleERC721", () => {
     };
 
     describe("when deploying the base implementation contract", () => {
-      it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+      it("LSP8CompatibleERC721Init: prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 
-        const lsp8CompatibilityForERC721TesterInit =
-          await new LSP8CompatibleERC721InitTester__factory(
-            accounts[0]
-          ).deploy();
+        const lsp8CompatibilityForERC721TesterInit = await new LSP8CompatibleERC721InitTester__factory(
+          accounts[0]
+        ).deploy();
 
         const randomCaller = accounts[1];
 
@@ -144,6 +144,24 @@ describe("LSP8CompatibleERC721", () => {
           lsp8CompatibilityForERC721TesterInit[
             "initialize(string,string,address,bytes)"
           ]("XXXXXXXXXXX", "XXX", randomCaller.address, "0x")
+        ).to.be.revertedWith("Initializable: contract is already initialized");
+      });
+
+      it("LSP8CompatibleERC721MintableInit: prevent any address from calling the initialize(...) function on the implementation", async () => {
+        const accounts = await ethers.getSigners();
+
+        const lsp8CompatibleERC721MintableInit = await new LSP8CompatibleERC721MintableInit__factory(
+          accounts[0]
+        ).deploy();
+
+        const randomCaller = accounts[1];
+
+        await expect(
+          lsp8CompatibleERC721MintableInit["initialize(string,string,address)"](
+            "XXXXXXXXXXX",
+            "XXX",
+            randomCaller.address
+          )
         ).to.be.revertedWith("Initializable: contract is already initialized");
       });
     });
@@ -188,6 +206,5 @@ describe("LSP8CompatibleERC721", () => {
         })
       );
     });
-
   });
 });


### PR DESCRIPTION
# What does this PR introduce?

Add some missing tests for the following contracts to ensure the base contracts (to be used behind proxies) are locked on deployment.

- `LSP6KeyManagerInit`
- `LSP7CompatibleERC20MintableInit`
- `LSP8CompatibleERC721MintableInit`

This was reported via code coverage.

https://coveralls.io/builds/54008815/source?filename=contracts%2FLSP7DigitalAsset%2Fpresets%2FLSP7CompatibleERC20MintableInit.sol

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/31145285/200577429-4d50ac44-ce9b-4245-be94-ae85ed663cc8.png">

https://coveralls.io/builds/54008815/source?filename=contracts%2FLSP8IdentifiableDigitalAsset%2Fpresets%2FLSP8CompatibleERC721MintableInit.sol

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/31145285/200577512-a81589f6-9245-4eb8-8ab2-6b6035b1d39e.png">

