### PR TITLE
refactor!: mark `initialize(...)` functions as `external`

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -21,7 +21,7 @@ contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
      * @notice Sets the owner of the contract
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public payable virtual initializer {
+    function initialize(address newOwner) external payable virtual initializer {
         LSP0ERC725AccountInitAbstract._initialize(newOwner);
     }
 }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -21,7 +21,7 @@ contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
      * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
      * @param target_ The address of the ER725Account to control
      */
-    function initialize(address target_) public virtual initializer {
+    function initialize(address target_) external virtual initializer {
         LSP6KeyManagerInitAbstract._initialize(target_);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
@@ -24,7 +24,7 @@ contract LSP7CompatibleERC20MintableInit is LSP7CompatibleERC20MintableInitAbstr
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) public virtual initializer {
+    ) external virtual initializer {
         LSP7CompatibleERC20MintableInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -28,7 +28,7 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
         string memory symbol_,
         address newOwner_,
         bool isNonDivisible_
-    ) public virtual initializer {
+    ) external virtual initializer {
         LSP7MintableInitAbstract._initialize(name_, symbol_, newOwner_, isNonDivisible_);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
@@ -13,7 +13,7 @@ contract LSP8CompatibleERC721MintableInit is LSP8CompatibleERC721MintableInitAbs
     constructor() {
         _disableInitializers();
     }
-    
+
     /**
      * @notice Sets the name, the symbol and the owner of the token
      * @param name_ The name of the token
@@ -24,7 +24,7 @@ contract LSP8CompatibleERC721MintableInit is LSP8CompatibleERC721MintableInitAbs
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) public virtual initializer {
+    ) external virtual initializer {
         LSP8CompatibleERC721MintableInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
@@ -26,7 +26,7 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
         string memory name_,
         string memory symbol_,
         address newOwner_
-    ) public virtual initializer {
+    ) external virtual initializer {
         LSP8MintableInitAbstract._initialize(name_, symbol_, newOwner_);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -21,7 +21,7 @@ contract LSP9VaultInit is LSP9VaultInitAbstract {
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public virtual initializer {
+    function initialize(address newOwner) external virtual initializer {
         LSP9VaultInitAbstract._initialize(newOwner);
     }
 }

--- a/contracts/UniversalProfileInit.sol
+++ b/contracts/UniversalProfileInit.sol
@@ -21,7 +21,7 @@ contract UniversalProfileInit is UniversalProfileInitAbstract {
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP3UniversalProfile key
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) public payable virtual initializer {
+    function initialize(address newOwner) external payable virtual initializer {
         UniversalProfileInitAbstract._initialize(newOwner);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGE

Change the visibility of the `initialize(...)` functions from `public` to `external` to make it behave more like a `constructor` (since constructor are only called externally on deployment).

This also prevent calling the `initialize(...)` internally by mistake when the `Init` contracts are used via inheritance.

Finally, this enables to **"open-up** the visibility/scope of the function via overriding, as it is not possible to "close-down/restrict" the visibility at the moment because of the current Solidity behaviour. See this issue on the OpenZeppelin repository for more details: https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3750