### PR TITLE
fix: add check for ValueReceived event in LSP0/LSP9

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -63,7 +63,7 @@ abstract contract LSP0ERC725AccountCore is
      * Executed when receiving native tokens with empty calldata.
      */
     receive() external payable virtual {
-        emit ValueReceived(msg.sender, msg.value);
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -74,7 +74,7 @@ contract LSP9VaultCore is ERC725XCore, ERC725YCore, LSP14Ownable2Step, ILSP1Univ
      * Executed when receiving native tokens with empty calldata.
      */
     receive() external payable virtual {
-        emit ValueReceived(msg.sender, msg.value);
+        if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
     }
 
     /**

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -1,4 +1,4 @@
-import { ethers, network } from "hardhat";
+import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import type { TransactionResponse } from "@ethersproject/abstract-provider";
 import { expect } from "chai";
@@ -140,6 +140,22 @@ export const shouldBehaveLikeLSP9 = (
 
         const result = await context.lsp9Vault["getData(bytes32)"](key);
         expect(result).to.equal(value);
+      });
+    });
+
+    describe.only("when calling the contract without any value or data", () => {
+      it("should pass and not emit the ValueReceived event", async () => {
+        const sender = context.accounts.anyone;
+        const amount = 0;
+
+        // prettier-ignore
+        await expect(
+          sender.sendTransaction({
+            to: context.lsp9Vault.address,
+            value: amount,
+          })
+        ).to.not.be.reverted
+         .to.not.emit(context.lsp9Vault, "ValueReceived");
       });
     });
 

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -143,7 +143,7 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe.only("when calling the contract without any value or data", () => {
+    describe("when calling the contract without any value or data", () => {
       it("should pass and not emit the ValueReceived event", async () => {
         const sender = context.accounts.anyone;
         const amount = 0;

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -249,6 +249,22 @@ export const shouldBehaveLikeLSP3 = (
     });
   });
 
+  describe.only("when calling the contract without any value or data", () => {
+    it("should pass and not emit the ValueReceived event", async () => {
+      const sender = context.accounts[0];
+      const amount = 0;
+
+      // prettier-ignore
+      await expect(
+          sender.sendTransaction({
+            to: context.universalProfile.address,
+            value: amount,
+          })
+        ).to.not.be.reverted
+         .to.not.emit(context.universalProfile, "ValueReceived");
+    });
+  });
+
   describe("when sending native tokens to the contract", () => {
     it("should emit the right ValueReceived event", async () => {
       const sender = context.accounts[0];

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -249,7 +249,7 @@ export const shouldBehaveLikeLSP3 = (
     });
   });
 
-  describe.only("when calling the contract without any value or data", () => {
+  describe("when calling the contract without any value or data", () => {
     it("should pass and not emit the ValueReceived event", async () => {
       const sender = context.accounts[0];
       const amount = 0;


### PR DESCRIPTION
## What does this PR introduce?
- An additional check made in the receive function to ensure that `msg.value` is greater than 0, then we emit the event.
If not the event will not be emitted and the call should go through.

In solidity, if both `receive` and `fallback` function are implemented, and the contract receive an empty call `{value: 0, data: "0x"}`, the call goes to the `receive` function. 

### Current Behavior

We emit `ValueReceived` in `receive` without checking that msg.value is greater than 0.

### Wanted Behavior

Emit  `ValueReceived` in `receive` only when `msg.value > 0`



