### PR TITLE
refactor: add `ContractCreated` event and refactor UniversalFactory contract

### DIFF
--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -34,6 +34,8 @@ error SendingValueNotAllowed();
  * More information: https://weka.medium.com/how-to-send-ether-to-11-440-people-187e332566b7
  */
 contract UniversalFactory {
+    using BytesLib for bytes;
+    
     /**
      * @dev Emitted whenever a contract is created
      * @param contractCreated The address of the contract created
@@ -47,8 +49,6 @@ contract UniversalFactory {
         bool indexed clone,
         bytes initialCalldata
     );
-
-    using BytesLib for bytes;
 
     // The bytecode hash of EIP-1167 Minimal Proxy
     bytes32 private constant _MINIMAL_PROXY_BYTECODE_HASH_PT1 =

--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -49,7 +49,6 @@ contract UniversalFactory {
     );
 
     using BytesLib for bytes;
-    using Address for bool;
 
     // The bytecode hash of EIP-1167 Minimal Proxy
     bytes32 private constant _MINIMAL_PROXY_BYTECODE_HASH_PT1 =
@@ -128,7 +127,11 @@ contract UniversalFactory {
             (bool success, bytes memory returnData) = contractCreated.call{value: msg.value}(
                 initializeCallData
             );
-            success.verifyCallResult(returnData, "UF: could not initialize the created contract");
+            Address.verifyCallResult(
+                success,
+                returnData,
+                "UF: could not initialize the created contract"
+            );
         }
     }
 
@@ -160,7 +163,11 @@ contract UniversalFactory {
             (bool success, bytes memory returnData) = proxy.call{value: msg.value}(
                 initializeCallData
             );
-            success.verifyCallResult(returnData, "UF: could not initialize the created contract");
+            Address.verifyCallResult(
+                success,
+                returnData,
+                "UF: could not initialize the created contract"
+            );
         }
     }
 

--- a/contracts/Factories/UniversalFactory.sol
+++ b/contracts/Factories/UniversalFactory.sol
@@ -7,6 +7,19 @@ import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
+// errors
+
+/**
+ * @dev reverts when the `byteCode` passed to the {deployCreate2} function is the EIP-1167 Minimal Proxy bytecode
+ */
+error MinimalProxiesDeploymentNotAllowed();
+
+/**
+ * @dev reverts when sending value to the {deployCreate2Proxy} function if the contract being created
+ * is an uninitializable clone.
+ */
+error SendingValueNotAllowed();
+
 /**
  * @dev UniversalFactory contract can be used to deploy CREATE2 contracts; normal contracts and minimal
  * proxies (EIP-1167) with the ability to deploy the same contract at the same address on different chains.
@@ -15,13 +28,28 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
  * the salt to ensure that the parameters of the contract should be the same on each chain.
  *
  * Security measures were taken to avoid deploying proxies from the `deployCreate2(..)` function
- * to prevent the problem mentioned above.
+ * to prevent tricking the security mechanism for the salt.
  *
  * This contract should be deployed using Nick's Method.
  * More information: https://weka.medium.com/how-to-send-ether-to-11-440-people-187e332566b7
  */
 contract UniversalFactory {
+    /**
+     * @dev Emitted whenever a contract is created
+     * @param contractCreated The address of the contract created
+     * @param providedSalt The bytes32 salt provided by the user
+     * @param clone The Boolean that specifies if the contract is a clone or not
+     * @param initialCalldata The bytes provided as initializeCalldata
+     */
+    event ContractCreated(
+        address indexed contractCreated,
+        bytes32 indexed providedSalt,
+        bool indexed clone,
+        bytes initialCalldata
+    );
+
     using BytesLib for bytes;
+    using Address for bool;
 
     // The bytecode hash of EIP-1167 Minimal Proxy
     bytes32 private constant _MINIMAL_PROXY_BYTECODE_HASH_PT1 =
@@ -39,7 +67,7 @@ contract UniversalFactory {
                 keccak256(byteCode.slice(0, 20)) == _MINIMAL_PROXY_BYTECODE_HASH_PT1 &&
                 keccak256(byteCode.slice(40, 15)) == _MINIMAL_PROXY_BYTECODE_HASH_PT2
             ) {
-                revert("Minimal Proxies deployment not allowed");
+                revert MinimalProxiesDeploymentNotAllowed();
             }
         }
         _;
@@ -51,10 +79,10 @@ contract UniversalFactory {
      */
     function calculateAddress(
         bytes32 byteCodeHash,
-        bytes32 salt,
-        bytes memory initializeCallData
+        bytes32 providedSalt,
+        bytes calldata initializeCallData
     ) public view returns (address) {
-        bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
+        bytes32 generatedSalt = _generateSalt(initializeCallData, providedSalt);
         return Create2.computeAddress(generatedSalt, byteCodeHash);
     }
 
@@ -64,17 +92,17 @@ contract UniversalFactory {
      */
     function calculateProxyAddress(
         address baseContract,
-        bytes32 salt,
-        bytes memory initializeCallData
+        bytes32 providedSalt,
+        bytes calldata initializeCallData
     ) public view returns (address) {
-        bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
+        bytes32 generatedSalt = _generateSalt(initializeCallData, providedSalt);
         return Clones.predictDeterministicAddress(baseContract, generatedSalt);
     }
 
     /**
      * @dev Deploys a contract using `CREATE2`. The address where the contract will be deployed
      * can be known in advance via {calculateAddress}. The salt is a combination between an initializable
-     * boolean, `salt` and the `initializeCallData` if the contract is initializable. This method allow users
+     * boolean, `providedSalt` and the `initializeCallData` if the contract is initializable. This method allow users
      * to have the same contracts at the same address across different chains with the same parameters.
      *
      * Using the same `byteCode` and salt multiple time will revert, since
@@ -84,20 +112,23 @@ contract UniversalFactory {
      */
     function deployCreate2(
         bytes memory byteCode,
-        bytes32 salt,
-        bytes memory initializeCallData
+        bytes32 providedSalt,
+        bytes calldata initializeCallData
     ) public payable notMinimalProxy(byteCode) returns (address contractCreated) {
-        bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
-        contractCreated = Create2.deploy(msg.value, generatedSalt, byteCode);
+        bytes32 generatedSalt = _generateSalt(initializeCallData, providedSalt);
 
-        if (initializeCallData.length != 0) {
+        if (initializeCallData.length == 0) {
+            contractCreated = Create2.deploy(msg.value, generatedSalt, byteCode);
+            emit ContractCreated(contractCreated, providedSalt, false, initializeCallData);
+        } else {
+            contractCreated = Create2.deploy(0, generatedSalt, byteCode);
+            emit ContractCreated(contractCreated, providedSalt, false, initializeCallData);
+
             // solhint-disable avoid-low-level-calls
-            (bool success, bytes memory returnData) = contractCreated.call(initializeCallData);
-            Address.verifyCallResult(
-                success,
-                returnData,
-                "UniversalFactory: could not initialize the created contract"
+            (bool success, bytes memory returnData) = contractCreated.call{value: msg.value}(
+                initializeCallData
             );
+            success.verifyCallResult(returnData, "UF: could not initialize the created contract");
         }
     }
 
@@ -106,7 +137,7 @@ contract UniversalFactory {
      * The address where the contract will be deployed can be known in advance via {calculateProxyAddress}.
      *
      * This function uses the CREATE2 opcode and a salt to deterministically deploy
-     * the clone. The salt is a combination between an initializable boolean, `salt`
+     * the clone. The salt is a combination between an initializable boolean, `providedSalt`
      * and the `initializeCallData` if the contract is initializable. This method allow users
      * to have the same contracts at the same address across different chains with the same parameters.
      *
@@ -115,45 +146,41 @@ contract UniversalFactory {
      */
     function deployCreate2Proxy(
         address baseContract,
-        bytes32 salt,
-        bytes memory initializeCallData
+        bytes32 providedSalt,
+        bytes calldata initializeCallData
     ) public payable returns (address proxy) {
-        bytes32 generatedSalt = _generateSalt(initializeCallData, salt);
+        bytes32 generatedSalt = _generateSalt(initializeCallData, providedSalt);
         proxy = Clones.cloneDeterministic(baseContract, generatedSalt);
+        emit ContractCreated(proxy, providedSalt, true, initializeCallData);
 
-        if (initializeCallData.length != 0) {
+        if (initializeCallData.length == 0) {
+            if (msg.value != 0) revert SendingValueNotAllowed();
+        } else {
             // solhint-disable avoid-low-level-calls
             (bool success, bytes memory returnData) = proxy.call{value: msg.value}(
                 initializeCallData
             );
-            Address.verifyCallResult(
-                success,
-                returnData,
-                "UniversalFactory: could not initialize the created contract"
-            );
-        } else {
-            require(
-                msg.value == 0,
-                "UniversalFactory: value cannot be sent to the factory if initializeCallData is empty"
-            );
+            success.verifyCallResult(returnData, "UF: could not initialize the created contract");
         }
     }
 
     /** internal functions */
 
     /**
-     * @dev Calculates the salt including the initializeCallData, or without but hashing it with a zero bytes padding.
+     * @dev Calculates the salt used to deploy the contract by hashing (Keccak256) the following parameters
+     * as packed encoded respectively: an initializable boolean, the initializeCallData if and only if
+     * the contract is initializable, and using the salt provided by the deployer.
      */
-    function _generateSalt(bytes memory initializeCallData, bytes32 salt)
+    function _generateSalt(bytes calldata initializeCallData, bytes32 providedSalt)
         internal
         pure
         returns (bytes32)
     {
         bool initializable = initializeCallData.length != 0;
         if (initializable) {
-            return keccak256(abi.encodePacked(initializable, initializeCallData, salt));
+            return keccak256(abi.encodePacked(initializable, initializeCallData, providedSalt));
         } else {
-            return keccak256(abi.encodePacked(initializable, salt));
+            return keccak256(abi.encodePacked(initializable, providedSalt));
         }
     }
 }


### PR DESCRIPTION
## What does this PR introduce?
- [x] Adding an event emitted whenever a contract is created
- [x] Refactoring the logic of the UniversalFactory to a more precise behavior 
( In case of {deployCreate2} if the contract is initializable the `msg.value` now goes to the external call, not the contract creation )  
- [x] Supporting Custom Errors
- [x] Improving the naming and the nastpec comments

### Old behavior

When deploying a normal contract using `deployCreate2(..)`, wether the contract is initializable or not, the `msg.value` passed was directly sent to the creation of the contract, which means to the constructor that needs to be payable.

And if the contract is initializable, there is no possibility to send value along calling the supposed `initialize(..)` function.
Most valid cases where the contract is initializable, the value needs to be send to the initialize function not the constructor. 

### New behavior

If the normal contract to deploy using `deployCreate2(..)`  is not initializable, we pass the `msg.value` to the contract creation (constructor), if it's intiializable we pass the `msg.value` to the external call that initialize the contract.


> NB: These changes are only valid for normal contract not Clones, as you cannot send `msg.value` to clones on deployment as they don't have a constructor. 
