### PR TITLE
fix: error selector for `LSP7AmountExceedsBalance`

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -289,8 +289,8 @@ const Errors = {
 		},
 	},
 	LSP7: {
-		'0xc5e194ab': {
-			error: 'LSP7AmountExceedsBalance(address,address,uint256)',
+		'0x08d47949': {
+			error: 'LSP7AmountExceedsBalance(uint256,address,uint256)',
 			message: "LSP7: token amount exceeds sender's balance.",
 		},
 		'0xf3a6b691': {


### PR DESCRIPTION
In the `constants.js` file, one of the bytes4 selector for the custom error message is incorrect.

https://github.com/lukso-network/lsp-smart-contracts/blob/99a439f0176b53a0298d964f9d8ae6218ca5a686/constants.js#L292-L295

This is incorrect, as the error signature is defined as follow:

https://github.com/lukso-network/lsp-smart-contracts/blob/99a439f0176b53a0298d964f9d8ae6218ca5a686/contracts/LSP7DigitalAsset/LSP7Errors.sol#L6-L9

The first 4 bytes of the keccak256 hash of the error signature is incorrect.
- before ❌  --> `LSP7AmountExceedsBalance(address,address,uint256)`
- now ✅ --> `LSP7AmountExceedsBalance(uint256,address,uint256)`
