### PR TITLE
refactor: Add a way to differentiate LSP0 from LSP9 inside the `universalReceiverDelegate(..)` of the LSP1

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -64,6 +64,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiverDelega
         (address keyManager, bool ownerIsKeyManager) = _validateCallerViaKeyManager();
         if (!ownerIsKeyManager) return "LSP1: account owner is not a LSP6KeyManager";
 
+        // if receiving ownership of an LSP0, do not register it as a received vault
         if (mapPrefix == _LSP10_VAULTS_MAP_KEY_PREFIX) {
             if (notifier.code.length != 0) {
                 if (!notifier.supportsERC165Interface(_INTERFACEID_LSP9))

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -23,6 +23,7 @@ import {LSP10Utils} from "../../LSP10ReceivedVaults/LSP10Utils.sol";
 import "../LSP1Constants.sol";
 import "../../LSP6KeyManager/LSP6Constants.sol";
 import "../../LSP9Vault/LSP9Constants.sol";
+import "../../LSP10ReceivedVaults/LSP10Constants.sol";
 import "../../LSP14Ownable2Step/LSP14Constants.sol";
 
 // errors
@@ -62,6 +63,13 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiverDelega
 
         (address keyManager, bool ownerIsKeyManager) = _validateCallerViaKeyManager();
         if (!ownerIsKeyManager) return "LSP1: account owner is not a LSP6KeyManager";
+
+        if (mapPrefix == _LSP10_VAULTS_MAP_KEY_PREFIX) {
+            if (notifier.code.length != 0) {
+                if (!notifier.supportsERC165Interface(_INTERFACEID_LSP9))
+                    return "LSP1: not an LSP9Vault ownership transfer";
+            }
+        }
 
         bytes32 notifierMapKey = LSP2Utils.generateMappingKey(mapPrefix, bytes20(notifier));
         bytes memory notifierMapValue = IERC725Y(msg.sender).getData(notifierMapKey);

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -64,7 +64,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiverDelega
         (address keyManager, bool ownerIsKeyManager) = _validateCallerViaKeyManager();
         if (!ownerIsKeyManager) return "LSP1: account owner is not a LSP6KeyManager";
 
-        // if receiving ownership of an LSP0, do not register it as a received vault
+        // if the contract being transferred doesn't support LSP9, do not register it as a received vault
         if (mapPrefix == _LSP10_VAULTS_MAP_KEY_PREFIX) {
             if (notifier.code.length != 0) {
                 if (!notifier.supportsERC165Interface(_INTERFACEID_LSP9))

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -13,6 +13,8 @@ import {
   LSP8Tester__factory,
   LSP9Vault,
   LSP9Vault__factory,
+  LSP0ERC725Account,
+  LSP0ERC725Account__factory,
 } from "../../types";
 
 // helpers
@@ -136,6 +138,51 @@ export const shouldBehaveLikeLSP1Delegate = (
         );
 
         expect(resultTypeID).to.equal("0x");
+      });
+    });
+  });
+
+  describe("when testing LSP0-ERC725Account", () => {
+    describe("when accepting ownership of an LSP0", () => {
+      let acceptingUniversalProfile: LSP0ERC725Account;
+      let sentUniversalProfile: LSP0ERC725Account;
+      before(async () => {
+        acceptingUniversalProfile = await new LSP0ERC725Account__factory(
+          context.accounts.owner1
+        ).deploy(context.accounts.owner1.address);
+        sentUniversalProfile = await new LSP0ERC725Account__factory(
+          context.accounts.owner1
+        ).deploy(context.accounts.owner1.address);
+      });
+
+      it("should not register universal profile as received vault", async () => {
+        await sentUniversalProfile
+          .connect(context.accounts.owner1)
+          .transferOwnership(acceptingUniversalProfile.address);
+        const acceptOwnershipPayload =
+          sentUniversalProfile.interface.encodeFunctionData("acceptOwnership");
+        await acceptingUniversalProfile
+          .connect(context.accounts.owner1)
+          ["execute(uint256,address,uint256,bytes)"](
+            0,
+            sentUniversalProfile.address,
+            0,
+            acceptOwnershipPayload
+          );
+
+        const receivedVaultsKeys = [
+          ERC725YKeys.LSP10["LSP10Vaults[]"].length,
+          ERC725YKeys.LSP10["LSP10Vaults[]"].index + "0".repeat(32),
+          ERC725YKeys.LSP10.LSP10VaultsMap +
+            sentUniversalProfile.address.substring(2),
+        ];
+        const receivedVaultsValues = ["0x", "0x", "0x"];
+
+        expect(
+          await acceptingUniversalProfile["getData(bytes32[])"](
+            receivedVaultsKeys
+          )
+        ).to.deep.equal(receivedVaultsValues);
       });
     });
   });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -142,33 +142,36 @@ export const shouldBehaveLikeLSP1Delegate = (
     });
   });
 
-  describe("when testing LSP0-ERC725Account", () => {
+  describe.only("when testing LSP0-ERC725Account", () => {
     describe("when accepting ownership of an LSP0", () => {
-      let acceptingUniversalProfile: LSP0ERC725Account;
       let sentUniversalProfile: LSP0ERC725Account;
       before(async () => {
-        acceptingUniversalProfile = await new LSP0ERC725Account__factory(
-          context.accounts.owner1
-        ).deploy(context.accounts.owner1.address);
         sentUniversalProfile = await new LSP0ERC725Account__factory(
           context.accounts.owner1
         ).deploy(context.accounts.owner1.address);
       });
 
-      it("should not register universal profile as received vault", async () => {
+      it.only("should not register universal profile as received vault", async () => {
+        const acceptingUniversalProfile: LSP0ERC725Account =
+          context.universalProfile1;
+        const acceptingUniversalProfileKM: LSP6KeyManager =
+          context.lsp6KeyManager1;
+
         await sentUniversalProfile
           .connect(context.accounts.owner1)
           .transferOwnership(acceptingUniversalProfile.address);
+
         const acceptOwnershipPayload =
           sentUniversalProfile.interface.encodeFunctionData("acceptOwnership");
-        await acceptingUniversalProfile
-          .connect(context.accounts.owner1)
-          ["execute(uint256,address,uint256,bytes)"](
-            0,
-            sentUniversalProfile.address,
-            0,
-            acceptOwnershipPayload
+        const payloadToExecute =
+          acceptingUniversalProfile.interface.encodeFunctionData(
+            "execute(uint256,address,uint256,bytes)",
+            [0, sentUniversalProfile.address, 0, acceptOwnershipPayload]
           );
+
+        await acceptingUniversalProfileKM
+          .connect(context.accounts.owner1)
+          .execute(payloadToExecute);
 
         const receivedVaultsKeys = [
           ERC725YKeys.LSP10["LSP10Vaults[]"].length,


### PR DESCRIPTION
## What does this PR introduce?

In this PR we introduce a check inside LSP1’s function, `universalReceiverDelegate(..)` that checks for the LSP9 interface id in order to differentiate between ownership transfers of an LSP9 and an LSP0