### PR TITLE
fix: [WP-L11] LSP-7: LSP7CompatibleERC20 is not fully compatible with the conventional implementation of ERC20 on the emission of `Approval` events

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -58,15 +58,6 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
 
     // --- Overrides
 
-    function authorizeOperator(address operator, uint256 amount)
-        public
-        virtual
-        override(ILSP7DigitalAsset, LSP7DigitalAssetCore)
-    {
-        super.authorizeOperator(operator, amount);
-        emit Approval(msg.sender, operator, amount);
-    }
-
     /**
      * @inheritdoc ILSP7CompatibleERC20
      * @dev Compatible with ERC20 transfer.
@@ -75,6 +66,19 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
     function transfer(address to, uint256 amount) public virtual override returns (bool) {
         transfer(msg.sender, to, amount, true, "");
         return true;
+    }
+
+    /**
+     * @dev same behaviour as LSP7DigitalAssetCore
+     * with the addition of emitting ERC20 Approval event.
+     */
+    function _updateOperator(
+        address tokenOwner,
+        address operator,
+        uint256 amount
+    ) internal virtual override {
+        super._updateOperator(tokenOwner, operator, amount);
+        emit Approval(tokenOwner, operator, amount);
     }
 
     function _transfer(

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -69,18 +69,6 @@ abstract contract LSP7CompatibleERC20InitAbstract is
     // --- Overrides
 
     /**
-     * @inheritdoc ILSP7DigitalAsset
-     */
-    function authorizeOperator(address operator, uint256 amount)
-        public
-        virtual
-        override(ILSP7DigitalAsset, LSP7DigitalAssetCore)
-    {
-        super.authorizeOperator(operator, amount);
-        emit Approval(msg.sender, operator, amount);
-    }
-
-    /**
      * @inheritdoc ILSP7CompatibleERC20
      * @dev Compatible with ERC20 transfer.
      * Using force=true so that EOA and any contract may receive the tokens.
@@ -88,6 +76,19 @@ abstract contract LSP7CompatibleERC20InitAbstract is
     function transfer(address to, uint256 amount) public virtual override returns (bool) {
         transfer(msg.sender, to, amount, true, "");
         return true;
+    }
+
+    /**
+     * @dev same behaviour as LSP7DigitalAssetCore
+     * with the addition of emitting ERC20 Approval event.
+     */
+    function _updateOperator(
+        address tokenOwner,
+        address operator,
+        uint256 amount
+    ) internal virtual override {
+        super._updateOperator(tokenOwner, operator, amount);
+        emit Approval(tokenOwner, operator, amount);
     }
 
     function _transfer(

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.behaviour.ts
@@ -452,7 +452,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       describe(transferFn, () => {
         describe("when sender has enough balance", () => {
           describe("when `to` is an EOA", () => {
-            it("should allow transfering the tokenId", async () => {
+            it("should allow transfering the tokens", async () => {
               const txParams = {
                 operator: context.accounts.owner.address,
                 from: context.accounts.owner.address,
@@ -470,7 +470,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
           describe("when `to` is a contract", () => {
             describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+              it("should allow transfering the tokens", async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -487,7 +487,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             });
 
             describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+              it("should allow transfering the tokens", async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,

--- a/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
+++ b/tests/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.test.ts
@@ -21,7 +21,7 @@ describe("LSP7CompatibleERC20", () => {
     const buildTestContext =
       async (): Promise<LSP7CompatibleERC20TestContext> => {
         const accounts = await getNamedAccounts();
-        const initialSupply = ethers.BigNumber.from("3");
+        const initialSupply = ethers.BigNumber.from("1000");
         const deployParams = {
           name: "Compat for ERC20",
           symbol: "NFT",
@@ -72,7 +72,7 @@ describe("LSP7CompatibleERC20", () => {
     const buildTestContext =
       async (): Promise<LSP7CompatibleERC20TestContext> => {
         const accounts = await getNamedAccounts();
-        const initialSupply = ethers.BigNumber.from("3");
+        const initialSupply = ethers.BigNumber.from("1000");
         const deployParams = {
           name: "LSP7 - deployed with constructor",
           symbol: "NFT",
@@ -111,9 +111,10 @@ describe("LSP7CompatibleERC20", () => {
       it("LSP7CompatibleERC20Init: prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 
-        const lsp7CompatibilityForERC20TesterInit = await new LSP7CompatibleERC20InitTester__factory(
-          accounts[0]
-        ).deploy();
+        const lsp7CompatibilityForERC20TesterInit =
+          await new LSP7CompatibleERC20InitTester__factory(
+            accounts[0]
+          ).deploy();
 
         const randomCaller = accounts[1];
 
@@ -127,9 +128,10 @@ describe("LSP7CompatibleERC20", () => {
       it("LSP7CompatibleERC20MintableInit: prevent any address from calling the initialize(...) function on the implementation", async () => {
         const accounts = await ethers.getSigners();
 
-        const lsp7CompatibleERC20MintableInit = await new LSP7CompatibleERC20MintableInit__factory(
-          accounts[0]
-        ).deploy();
+        const lsp7CompatibleERC20MintableInit =
+          await new LSP7CompatibleERC20MintableInit__factory(
+            accounts[0]
+          ).deploy();
 
         const randomCaller = accounts[1];
 


### PR DESCRIPTION
# What does this PR introduce?

This PR fixes the following issue ⬇️ 

![image](https://user-images.githubusercontent.com/31145285/203327194-dbd1d3e6-3891-419a-b96e-bfd84cd8fab0.png)
![image](https://user-images.githubusercontent.com/31145285/203327402-e71c2e2c-6892-434c-b20d-a3b5d97562f7.png)


## ♻️ Refactor

Update the current behaviour of the LSP7CompatibleERC20 and LSP7CompatibleERC20Init to reflect this behaviour.

emit `Approval` event in the following circumstances:
- [x] with the `approve(...)` function from ERC20. **Was already implemented ✅ **
- [x] with the `transferFrom(address,address,uint256)` function from ERC20.
- [x] with the `transfer(address,address,uint256,bool,bytes)` function from LSP7.

This was implemented by overriding the behaviour of `_updateOperator` from LSP7DigitalAssetCore, as mentioned in the suggestions.

## 🧪 Tests

- [x] add tests for `Approval` event on `approve(...)` function from ERC20. **Was already implemented**
- [x] add tests for `Approval` event on `transferFrom(address,address,uint256)` function from ERC20.
- [x] add tests for `Approval` event on `transfer(address,address,uint256,bool,bytes)` function from LSP7.

> ### ℹ️ **Notice**

> The screenshot above suggests to implement the `Approval` event in the internal `_burn` function. This was not implemented for the following reason.
>
> In the OpenZeppelin implementation, the `Approval` event is implemented on the public [`burnFrom`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/afb20119b33072da041c97ea717d3ce4417b5e01/contracts/token/ERC20/extensions/ERC20Burnable.sol#L36) function, not on the internal `_burn` function.
>
> The `burnFrom` function internally calls [`_spendAllowance`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/99589794db43c8b285f5b3464d2e0864caab8199/contracts/token/ERC20/ERC20.sol#L336-L348) which in turn calls [`_approve`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/99589794db43c8b285f5b3464d2e0864caab8199/contracts/token/ERC20/ERC20.sol#L316-L326), where the `Approval` event is emitted.
> 
> ![image](https://user-images.githubusercontent.com/31145285/203329756-2e6c8002-2609-44b2-870e-79ab5cf75b0b.png)
