### PR TITLE
fix: add `ValueReceived` event to batch ERC725X `execute(uint256[],address[],uint256[],bytes[])` functions in LSP0 and LSP9

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -187,6 +187,21 @@ abstract contract LSP0ERC725AccountCore is
     }
 
     /**
+     * @inheritdoc ERC725XCore
+     *
+     * @dev Emits a {ValueReceived} event when receiving native tokens.
+     */
+    function execute(
+        uint256[] memory operationsType,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas
+    ) public payable virtual override onlyOwner returns (bytes[] memory) {
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+        return super.execute(operationsType, targets, values, datas);
+    }
+
+    /**
      * @notice Triggers the UniversalReceiver event when this function gets executed successfully.
      * Forwards the call to the addresses stored in the ERC725Y storage under the LSP1UniversalReceiverDelegate
      * Key and the typeId Key (param) respectively. The call will be discarded if no addresses were set.

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -178,12 +178,8 @@ abstract contract LSP0ERC725AccountCore is
         uint256 value,
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
-        if (address(this).balance < value) {
-            revert ERC725X_InsufficientBalance(address(this).balance, value);
-        }
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-
-        return _execute(operationType, target, value, data);
+        return super.execute(operationType, target, value, data);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -169,6 +169,21 @@ contract LSP9VaultCore is
     }
 
     /**
+     * @inheritdoc ERC725XCore
+     *
+     * @dev Emits a {ValueReceived} event when receiving native tokens.
+     */
+    function execute(
+        uint256[] memory operationsType,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas
+    ) public payable virtual override onlyOwner returns (bytes[] memory) {
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+        return super.execute(operationsType, targets, values, datas);
+    }
+
+    /**
      * @inheritdoc IERC725Y
      * @dev Sets data as bytes in the vault storage for a single key.
      * SHOULD only be callable by the owner of the contract set via ERC173

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -160,12 +160,8 @@ contract LSP9VaultCore is
         uint256 value,
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
-        if (address(this).balance < value) {
-            revert ERC725X_InsufficientBalance(address(this).balance, value);
-        }
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-
-        return _execute(operationType, target, value, data);
+        return super.execute(operationType, target, value, data);
     }
 
     /**

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -293,8 +293,8 @@ describe("UniversalProfile", () => {
     });
 
     describe("when testing deployed contract", () => {
-      shouldBehaveLikeLSP3(async () => {
-        let context = await buildLSP3TestContext();
+      shouldBehaveLikeLSP3(async (initialFunding?: number) => {
+        let context = await buildLSP3TestContext(initialFunding);
         await initializeProxy(context);
         return context;
       });


### PR DESCRIPTION
# What does this PR introduce?

**In LSP0 and LSP9.**

Emit the `ValueReceived` event when caller send some value while calling the new batch `execute(uint256[],address[],uint256[],bytes[])` function from ERC725X.

This was missed in #355 