### PR TITLE
refactor!: switch the order of LSP6 `Executed` event + index both params

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -493,13 +493,13 @@ const EventSignatures = {
 	LSP6: {
 		/**
 		 * event Executed(
-		 *     uint256 indexed _value,
-		 *     bytes4 _data
+		 *     bytes4 indexed selector,
+		 *     uint256 indexed value
 		 * );
 		 *
-		 * signature = keccak256('Executed(uint256,bytes4)')
+		 * signature = keccak256('Executed(bytes4,uint256)')
 		 */
-		Executed: '0x6b9340454526f665e369d7ac17353d0b73774a4a80f746b959ece8130e0f1d72',
+		Executed: '0x4004d18dc05f04c061c306cbb394d4083af494786ab828142d6118ab2c43a492',
 	},
 	LSP7: {
 		/**

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -11,7 +11,7 @@ interface ILSP6KeyManager is
     IERC1271
     /* is ERC165 */
 {
-    event Executed(uint256 indexed value, bytes4 selector);
+    event Executed(bytes4 indexed selector, uint256 indexed value);
 
     /**
      * @notice returns the address of the account linked to this KeyManager

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -240,7 +240,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
       */
      function _executePayload(uint256 msgValue, bytes calldata payload) internal returns (bytes memory) {
 
-        emit Executed(msgValue, bytes4(payload));
+        emit Executed(bytes4(payload), msgValue);
 
         // solhint-disable avoid-low-level-calls
         (bool success, bytes memory returnData) = target.call{value: msgValue, gas: gasleft()}(


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

For LSP6KeyManager `Executed` event:
- change the order of the parameters emitted by the `Executed` event.
- mark both parameters as `indexed`.

- update the event signature under `constants.js`

**Before**

```
event Executed(uint256 indexed value, bytes4 selector);
```

**Now**

```
event Executed(bytes4 indexed selector, uint256 indexed value);
```