### PR TITLE
refactor: prevent calling universalReceiver(...) with value

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1Errors.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Errors.sol
@@ -17,6 +17,5 @@ error CallerNotLSP6LinkedTarget(address account, address target);
 
 /**
  * @dev reverts when `universalReceiver(...)` is called with a value different than 0
- * @param amount The amount of native tokens sent
  */
-error NativeTokensNotAccepted(uint256 amount);
+error NativeTokensNotAccepted();

--- a/contracts/LSP1UniversalReceiver/LSP1Errors.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Errors.sol
@@ -14,3 +14,9 @@ error CannotRegisterEOAsAsAssets(address caller);
  * @param target The address of the target linked to the KeyManager
  */
 error CallerNotLSP6LinkedTarget(address account, address target);
+
+/**
+ * @dev reverts when `universalReceiver(...)` is called with a value different than 0
+ * @param amount The amount of native tokens sent
+ */
+error NativeTokensNotAccepted(uint256 amount);

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -51,6 +51,8 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
+        if (msg.value != 0) revert NativeTokensNotAccepted(msg.value);
+
         // This contract acts like a UniversalReceiverDelegate of a UP where we append the
         // address and the value, sent to the universalReceiver function of the LSP0, to the msg.data
         // Check https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-0-ERC725Account.md#universalreceiver

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -51,7 +51,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
-        if (msg.value != 0) revert NativeTokensNotAccepted(msg.value);
+        if (msg.value != 0) revert NativeTokensNotAccepted();
 
         // This contract acts like a UniversalReceiverDelegate of a UP where we append the
         // address and the value, sent to the universalReceiver function of the LSP0, to the msg.data

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -39,6 +39,7 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
+        if (msg.value != 0) revert NativeTokensNotAccepted(msg.value);
         // This contract acts like a UniversalReceiverDelegate of a Vault where we append the
         // address and the value, sent to the universalReceiver function of the LSP9, to the msg.data
         // Check https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-9-Vault.md#universalreceiver

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -39,7 +39,7 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
-        if (msg.value != 0) revert NativeTokensNotAccepted(msg.value);
+        if (msg.value != 0) revert NativeTokensNotAccepted();
         // This contract acts like a UniversalReceiverDelegate of a Vault where we append the
         // address and the value, sent to the universalReceiver function of the LSP9, to the msg.data
         // Check https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-9-Vault.md#universalreceiver

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1977,12 +1977,10 @@ export const shouldInitializeLikeLSP1Delegate = (
             "0x",
             { value }
           )
-        )
-          .to.be.revertedWithCustomError(
-            context.lsp1universalReceiverDelegateUP,
-            "NativeTokensNotAccepted"
-          )
-          .withArgs(value);
+        ).to.be.revertedWithCustomError(
+          context.lsp1universalReceiverDelegateUP,
+          "NativeTokensNotAccepted"
+        );
       });
     });
   });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1966,4 +1966,24 @@ export const shouldInitializeLikeLSP1Delegate = (
       );
     });
   });
+  describe("edge cases", () => {
+    describe("when sending value to universalReceiver(...)", () => {
+      it("should revert with custom error", async () => {
+        // value of 1 ethers
+        const value = ethers.utils.parseEther("1");
+        await expect(
+          context.lsp1universalReceiverDelegateUP.universalReceiver(
+            LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
+            "0x",
+            { value }
+          )
+        )
+          .to.be.revertedWithCustomError(
+            context.lsp1universalReceiverDelegateUP,
+            "NativeTokensNotAccepted"
+          )
+          .withArgs(value);
+      });
+    });
+  });
 };


### PR DESCRIPTION
## What does this previous introduce 

Add a check that prevents calling `universalReceiver(...)` function with a value associated