### PR TITLE
Fix Slither error for `transferBatch` in LSP7/8 + remove logic of `_beforeTokenTransfer` hooks

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -220,6 +220,9 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         _beforeTokenTransfer(address(0), to, amount);
 
+        // tokens being minted
+        _existingTokens += amount;
+
         _tokenOwnerBalances[to] += amount;
 
         emit Transfer(operator, address(0), to, amount, force, data);
@@ -263,6 +266,9 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         }
 
         _beforeTokenTransfer(from, address(0), amount);
+
+        // tokens being burned
+        _existingTokens -= amount;
 
         _tokenOwnerBalances[from] -= amount;
 
@@ -323,22 +329,13 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * transferred to `to`.
      * - When `from` is zero, `amount` tokens will be minted for `to`.
      * - When `to` is zero, ``from``'s `amount` tokens will be burned.
+     * - `from` and `to` are never both zero.
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256 amount
-    ) internal virtual {
-        // tokens being minted
-        if (from == address(0)) {
-            _existingTokens += amount;
-        }
-
-        // tokens being burned
-        if (to == address(0)) {
-            _existingTokens -= amount;
-        }
-    }
+    ) internal virtual {}
 
     /**
      * @dev An attempt is made to notify the token sender about the `amount` tokens changing owners using

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -335,7 +335,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         address from,
         address to,
         uint256 amount
-    ) internal virtual {}
+    ) internal virtual {} // solhint-disable no-empty-blocks
 
     /**
      * @dev An attempt is made to notify the token sender about the `amount` tokens changing owners using

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -394,7 +394,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         address from,
         address to,
         bytes32 tokenId // solhint-disable no-unused-vars
-    ) internal virtual {}
+    ) internal virtual {} // solhint-disable no-empty-blocks
 
     /**
      * @dev An attempt is made to notify the token sender about the `tokenId` changing owners using

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -293,6 +293,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
 
         _beforeTokenTransfer(address(0), to, tokenId);
 
+        // token being minted
+        _existingTokens += 1;
+
         _ownedTokens[to].add(tokenId);
         _tokenOwners[tokenId] = to;
 
@@ -315,6 +318,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         address operator = msg.sender;
 
         _beforeTokenTransfer(tokenOwner, address(0), tokenId);
+
+        // token being burned
+        _existingTokens -= 1;
 
         _clearOperators(tokenOwner, tokenId);
 
@@ -382,22 +388,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
      * transferred to `to`.
      * - When `from` is zero, `tokenId` will be minted for `to`.
      * - When `to` is zero, ``from``'s `tokenId` will be burned.
+     * - `from` and `to` are never both zero.
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         bytes32 tokenId // solhint-disable no-unused-vars
-    ) internal virtual {
-        // token being minted
-        if (from == address(0)) {
-            _existingTokens += 1;
-        }
-
-        // token being burned
-        if (to == address(0)) {
-            _existingTokens -= 1;
-        }
-    }
+    ) internal virtual {}
 
     /**
      * @dev An attempt is made to notify the token sender about the `tokenId` changing owners using


### PR DESCRIPTION
# What does this PR introduce?

## What is the current behaviour?

When running Slither against `LSP7DigitalAssetCore` or `LSP8IdentifiableDigitalAssetCore`, the following errors are reported ⬇️ .

<img width="1654" alt="Screenshot 2022-11-29 at 15 47 47" src="https://user-images.githubusercontent.com/31145285/204579632-9168d7b0-72f4-4544-b2d4-4966bb6c40e8.png">
<img width="1452" alt="Screenshot 2022-11-29 at 15 24 04" src="https://user-images.githubusercontent.com/31145285/204579645-1c475db7-4756-4555-85ac-686141caf8d5.png">

In brief, Slither spots some [potential costly operations inside a loop](https://github.com/crytic/slither/wiki/Detector-Documentation#costly-operations-inside-a-loop): the `for` loop of the `transferBatch` function.

This error is a false positive, as the **costly operations inside a loop** here refer to increasing/decreasing the total supply of `_existingTokens`, via the `_beforeTokenTransfer` hook. However, this will never happen as there will not be any token supply increase or decrease on any transferBatch, because neither `from` nor `to` can be `address(0)`. Only the functions `_mint(...)` and `_burn(...)` can increase/decrease the total supply.

## What is the new behaviour?

This Slither error is fixed by making the following changes.

- Inline the increase or decrease of the total supply (`_existingTokens`) inside the internal `_mint` and `_burn` functions.
- Remove any logic inside the `_beforeTokenTransfer` to leave it up to the developer to implement its own custom logic inside the hook.
This follow the same approach used by OpenZeppelin in their [ERC20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/8f8fd84f1e60426a5e785d6b5b2524938271bb05/contracts/token/ERC20/ERC20.sol#L364-L368)

See OpenZeppelin docs "Using Hooks" for more details ➡️ https://docs.openzeppelin.com/contracts/4.x/extending-contracts#using-hooks