### PR TITLE
fix: all `solc` compiler warnings

### DIFF
--- a/contracts/Helpers/ABIEncoder.sol
+++ b/contracts/Helpers/ABIEncoder.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 contract ABIEncoder {
     function encode(bytes memory a, bytes memory b)
         public
+        view
         returns (bytes memory c, uint256 gasUsed)
     {
         uint256 gasUsed1 = gasleft();

--- a/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
+++ b/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
@@ -7,14 +7,11 @@ pragma solidity ^0.8.4;
 contract OnERC721ReceivedExtension {
     // solhint-disable
     function onERC721Received(
-        address operator,
-        address from,
-        uint256 tokenId,
-        bytes calldata data
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
     ) external pure returns (bytes4) {
-        // silent compiler warning (this does not push new items on the stack)
-        (operator, from, tokenId, data);
-
         return 0x150b7a02;
     }
 }

--- a/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
+++ b/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
@@ -12,6 +12,9 @@ contract OnERC721ReceivedExtension {
         uint256 tokenId,
         bytes calldata data
     ) external pure returns (bytes4) {
+        // silent compiler warning (this does not push new items on the stack)
+        (operator, from, tokenId, data);
+
         return 0x150b7a02;
     }
 }

--- a/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
+++ b/contracts/Helpers/FallbackExtensions/OnERC721ReceivedExtension.sol
@@ -11,7 +11,7 @@ contract OnERC721ReceivedExtension {
         address from,
         uint256 tokenId,
         bytes calldata data
-    ) external returns (bytes4) {
+    ) external pure returns (bytes4) {
         return 0x150b7a02;
     }
 }

--- a/contracts/Helpers/FallbackExtensions/ReenterAccountExtension.sol
+++ b/contracts/Helpers/FallbackExtensions/ReenterAccountExtension.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 contract ReenterAccountExtension {
     function reenterAccount(bytes memory payload) public {
         // solhint-disable
-        (bool success, bytes memory result) = msg.sender.call(payload);
+        (bool success, ) = msg.sender.call(payload);
         require(success);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
@@ -13,6 +13,9 @@ contract ReentrancyWithAddPermission {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // bytes20(address(controller))
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
@@ -12,7 +12,7 @@ contract ReentrancyWithAddPermission {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // bytes20(address(controller))
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
@@ -29,5 +29,7 @@ contract ReentrancyWithAddPermission {
         );
 
         ILSP6KeyManager(keyManager).execute(addPermissionPayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
@@ -10,12 +10,9 @@ import "../../LSP6KeyManager/LSP6Constants.sol";
 
 contract ReentrancyWithAddPermission {
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
+        bytes32, /* typeId */
         bytes memory data // bytes20(address(controller))
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddPermission.sol
@@ -31,8 +31,6 @@ contract ReentrancyWithAddPermission {
             bytes.concat(bytes32(uint256(16)))
         );
 
-        ILSP6KeyManager(keyManager).execute(addPermissionPayload);
-
-        return "";
+        return ILSP6KeyManager(keyManager).execute(addPermissionPayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
@@ -12,7 +12,7 @@ contract ReentrancyWithAddURD {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
@@ -29,5 +29,7 @@ contract ReentrancyWithAddURD {
         );
 
         ILSP6KeyManager(keyManager).execute(addURDPayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
@@ -31,8 +31,6 @@ contract ReentrancyWithAddURD {
             data[32:]
         );
 
-        ILSP6KeyManager(keyManager).execute(addURDPayload);
-
-        return "";
+        return ILSP6KeyManager(keyManager).execute(addURDPayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
@@ -13,6 +13,9 @@ contract ReentrancyWithAddURD {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithAddURD.sol
@@ -10,12 +10,9 @@ import "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract ReentrancyWithAddURD {
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
+        bytes32, /* typeId */
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
@@ -31,8 +31,6 @@ contract ReentrancyWithChangePermission {
             ""
         );
 
-        ILSP6KeyManager(keyManager).execute(changePermissionPayload);
-
-        return "";
+        return ILSP6KeyManager(keyManager).execute(changePermissionPayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
@@ -10,12 +10,9 @@ import "../../LSP6KeyManager/LSP6Constants.sol";
 
 contract ReentrancyWithChangePermission {
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
+        bytes32, /* typeId */
         bytes memory data // bytes20(address(controller))
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
@@ -13,6 +13,9 @@ contract ReentrancyWithChangePermission {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // bytes20(address(controller))
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangePermission.sol
@@ -12,7 +12,7 @@ contract ReentrancyWithChangePermission {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // bytes20(address(controller))
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
@@ -29,5 +29,7 @@ contract ReentrancyWithChangePermission {
         );
 
         ILSP6KeyManager(keyManager).execute(changePermissionPayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
@@ -31,8 +31,6 @@ contract ReentrancyWithChangeURD {
             ""
         );
 
-        ILSP6KeyManager(keyManager).execute(addURDPayload);
-
-        return "";
+        return ILSP6KeyManager(keyManager).execute(addURDPayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
@@ -13,6 +13,9 @@ contract ReentrancyWithChangeURD {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
@@ -12,7 +12,7 @@ contract ReentrancyWithChangeURD {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
@@ -29,5 +29,7 @@ contract ReentrancyWithChangeURD {
         );
 
         ILSP6KeyManager(keyManager).execute(addURDPayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithChangeURD.sol
@@ -10,12 +10,9 @@ import "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract ReentrancyWithChangeURD {
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
+        bytes32, /* typeId */
         bytes calldata data // bytes32(TYPE_ID) + bytes20(address(URD))
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
@@ -10,6 +10,9 @@ contract ReentrancyWithSetData {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual returns (bytes memory) {
+        // silent compiler warnings (this does not push new items on the stack)
+        (typeId, data);
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory setDataPayload = abi.encodeWithSignature(

--- a/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
@@ -7,12 +7,9 @@ import {LSP14Ownable2Step} from "../../LSP14Ownable2Step/LSP14Ownable2Step.sol";
 
 contract ReentrancyWithSetData {
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
-        bytes memory data // solhint-disable no-unused-vars
+        bytes32, /* typeId */
+        bytes memory /* data */
     ) public virtual returns (bytes memory) {
-        // silent compiler warnings (this does not push new items on the stack)
-        (typeId, data);
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory setDataPayload = abi.encodeWithSignature(

--- a/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
@@ -9,7 +9,7 @@ contract ReentrancyWithSetData {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory setDataPayload = abi.encodeWithSignature(
@@ -18,5 +18,7 @@ contract ReentrancyWithSetData {
             bytes("SomeRandomTextUsed")
         );
         ILSP6KeyManager(keyManager).execute(setDataPayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithSetData.sol
@@ -20,8 +20,7 @@ contract ReentrancyWithSetData {
             keccak256(bytes("SomeRandomTextUsed")),
             bytes("SomeRandomTextUsed")
         );
-        ILSP6KeyManager(keyManager).execute(setDataPayload);
 
-        return "";
+        return ILSP6KeyManager(keyManager).execute(setDataPayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
@@ -12,7 +12,7 @@ contract ReentrancyWithValueTransfer {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory transferValuePayload = abi.encodeWithSignature(
@@ -23,5 +23,7 @@ contract ReentrancyWithValueTransfer {
             ""
         );
         ILSP6KeyManager(keyManager).execute(transferValuePayload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
@@ -13,6 +13,9 @@ contract ReentrancyWithValueTransfer {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        (typeId, data);
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory transferValuePayload = abi.encodeWithSignature(

--- a/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
@@ -25,8 +25,7 @@ contract ReentrancyWithValueTransfer {
             1 ether,
             ""
         );
-        ILSP6KeyManager(keyManager).execute(transferValuePayload);
 
-        return "";
+        return ILSP6KeyManager(keyManager).execute(transferValuePayload);
     }
 }

--- a/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
+++ b/contracts/Helpers/Reentrancy/ReentrancyWithValueTransfer.sol
@@ -10,12 +10,9 @@ contract ReentrancyWithValueTransfer {
     receive() external payable {}
 
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
-        bytes memory data // solhint-disable no-unused-vars
+        bytes32, /* typeId */
+        bytes memory /* data */
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        (typeId, data);
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
         bytes memory transferValuePayload = abi.encodeWithSignature(

--- a/contracts/Helpers/Reentrancy/RelayReentrancy.sol
+++ b/contracts/Helpers/Reentrancy/RelayReentrancy.sol
@@ -27,6 +27,9 @@ contract RelayReentrancy {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        (typeId, data);
+
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/RelayReentrancy.sol
+++ b/contracts/Helpers/Reentrancy/RelayReentrancy.sol
@@ -24,12 +24,9 @@ contract RelayReentrancy {
     receive() external payable {}
 
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
-        bytes memory data // solhint-disable no-unused-vars
+        bytes32, /* typeId */
+        bytes memory /* data */
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        (typeId, data);
-
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 

--- a/contracts/Helpers/Reentrancy/RelayReentrancy.sol
+++ b/contracts/Helpers/Reentrancy/RelayReentrancy.sol
@@ -26,10 +26,12 @@ contract RelayReentrancy {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
         ILSP6KeyManager(keyManager).executeRelayCall(_signature, _nonce, _payload);
+
+        return "";
     }
 }

--- a/contracts/Helpers/Reentrancy/RelayReentrancy.sol
+++ b/contracts/Helpers/Reentrancy/RelayReentrancy.sol
@@ -33,8 +33,6 @@ contract RelayReentrancy {
         // solhint-disable no-unused-vars
         address keyManager = LSP14Ownable2Step(msg.sender).owner();
 
-        ILSP6KeyManager(keyManager).executeRelayCall(_signature, _nonce, _payload);
-
-        return "";
+        return ILSP6KeyManager(keyManager).executeRelayCall(_signature, _nonce, _payload);
     }
 }

--- a/contracts/Helpers/Security/Reentrancy.sol
+++ b/contracts/Helpers/Security/Reentrancy.sol
@@ -18,11 +18,11 @@ contract Reentrancy {
         _payload = _dataPayload;
     }
 
-    fallback() external payable {
+    receive() external payable {
         if (!switchFallback) {
             switchFallback = true;
             (bool success, bytes memory returnData) = _target.call(_payload);
-            bytes memory result = Address.verifyCallResult(
+            Address.verifyCallResult(
                 success,
                 returnData,
                 "Reentrancy Helper Contract: failed to re-enter contract"

--- a/contracts/Helpers/SignatureValidatorContract.sol
+++ b/contracts/Helpers/SignatureValidatorContract.sol
@@ -22,12 +22,15 @@ contract SignatureValidator is IERC1271, ERC165Storage {
     /**
      * @notice Verifies that the signer is the owner of the signing contract.
      */
-    function isValidSignature(bytes32 _hash, bytes calldata _signature)
+    function isValidSignature(bytes32 messageHash, bytes calldata signature)
         external
         pure
         override
         returns (bytes4)
     {
+        // silent compiler warning (this does not push new items on the stack)
+        (messageHash, signature);
+
         // always return true (just for testing)
         return 0x1626ba7e;
     }

--- a/contracts/Helpers/UPWithInstantAcceptOwnership.sol
+++ b/contracts/Helpers/UPWithInstantAcceptOwnership.sol
@@ -31,8 +31,6 @@ contract UPWithInstantAcceptOwnership is LSP0ERC725AccountCore {
         if (typeId == _TYPEID_LSP14_OwnershipTransferStarted) {
             LSP14Ownable2Step(msg.sender).acceptOwnership();
         }
-        super.universalReceiver(typeId, receivedData);
-
-        return "";
+        return super.universalReceiver(typeId, receivedData);
     }
 }

--- a/contracts/Helpers/UPWithInstantAcceptOwnership.sol
+++ b/contracts/Helpers/UPWithInstantAcceptOwnership.sol
@@ -26,11 +26,13 @@ contract UPWithInstantAcceptOwnership is LSP0ERC725AccountCore {
         payable
         virtual
         override
-        returns (bytes memory returnedValue)
+        returns (bytes memory)
     {
         if (typeId == _TYPEID_LSP14_OwnershipTransferStarted) {
             LSP14Ownable2Step(msg.sender).acceptOwnership();
         }
         super.universalReceiver(typeId, receivedData);
+
+        return "";
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
@@ -24,11 +24,8 @@ contract UniversalReceiverDelegateDataUpdater is ERC165Storage {
 
     function universalReceiver(
         bytes32 typeId,
-        bytes memory data // solhint-disable no-unused-vars
+        bytes memory /* data */
     ) public virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        data;
-
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             address keyManager = LSP14Ownable2Step(msg.sender).owner();
             bytes memory setDataPayload = abi.encodeWithSignature(

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
@@ -25,7 +25,7 @@ contract UniversalReceiverDelegateDataUpdater is ERC165Storage {
     function universalReceiver(
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
-    ) public virtual returns (bytes memory result) {
+    ) public virtual returns (bytes memory) {
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             address keyManager = LSP14Ownable2Step(msg.sender).owner();
             bytes memory setDataPayload = abi.encodeWithSignature(
@@ -35,5 +35,6 @@ contract UniversalReceiverDelegateDataUpdater is ERC165Storage {
             );
             ILSP6KeyManager(keyManager).execute(setDataPayload);
         }
+        return "";
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
@@ -36,8 +36,9 @@ contract UniversalReceiverDelegateDataUpdater is ERC165Storage {
                 keccak256(bytes("some random data key")),
                 bytes("some random text for the data value")
             );
-            ILSP6KeyManager(keyManager).execute(setDataPayload);
+            return ILSP6KeyManager(keyManager).execute(setDataPayload);
         }
+
         return "";
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateDataUpdater.sol
@@ -26,6 +26,9 @@ contract UniversalReceiverDelegateDataUpdater is ERC165Storage {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        data;
+
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             address keyManager = LSP14Ownable2Step(msg.sender).owner();
             bytes memory setDataPayload = abi.encodeWithSignature(

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -18,7 +18,7 @@ contract UniversalReceiverDelegateRevert is ERC165, ILSP1UniversalReceiver {
     function universalReceiver(
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
-    ) public payable virtual returns (bytes memory result) {
+    ) public payable virtual returns (bytes memory) {
         revert("I Revert");
     }
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -16,12 +16,9 @@ contract UniversalReceiverDelegateRevert is ERC165, ILSP1UniversalReceiver {
      * @return result the return value of keyManager's execute function
      */
     function universalReceiver(
-        bytes32 typeId, // solhint-disable no-unused-vars
-        bytes memory data // solhint-disable no-unused-vars
+        bytes32, /* typeId */
+        bytes memory /* data */
     ) public payable virtual returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        (typeId, data);
-
         revert("I Revert");
     }
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -19,6 +19,9 @@ contract UniversalReceiverDelegateRevert is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId, // solhint-disable no-unused-vars
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        (typeId, data);
+
         revert("I Revert");
     }
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
@@ -27,5 +27,6 @@ contract UniversalReceiverDelegateVaultReentrantA is ERC165Storage {
         keys[0] = bytes32(data);
         values[0] = hex"aabbccdd";
         IERC725Y(msg.sender).setData(keys, values);
+        return "";
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
@@ -20,10 +20,10 @@ contract UniversalReceiverDelegateVaultReentrantA is ERC165Storage {
     }
 
     // solhint-disable no-unused-vars
-    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
+    function universalReceiver(
+        bytes32, /* typeId */
+        bytes memory data
+    ) external returns (bytes memory) {
         bytes32[] memory keys = new bytes32[](1);
         bytes[] memory values = new bytes[](1);
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
@@ -21,6 +21,9 @@ contract UniversalReceiverDelegateVaultReentrantA is ERC165Storage {
 
     // solhint-disable no-unused-vars
     function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         bytes32[] memory keys = new bytes32[](1);
         bytes[] memory values = new bytes[](1);
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
@@ -21,6 +21,9 @@ contract UniversalReceiverDelegateVaultReentrantB is ERC165Storage {
 
     // solhint-disable no-unused-vars
     function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        typeId;
+
         bytes32[] memory keys = new bytes32[](1);
         bytes[] memory values = new bytes[](1);
 

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
@@ -27,5 +27,6 @@ contract UniversalReceiverDelegateVaultReentrantB is ERC165Storage {
         keys[0] = bytes32(data);
         values[0] = hex"ddccbbaa";
         IERC725Y(msg.sender).setData(keys, values);
+        return "";
     }
 }

--- a/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
+++ b/contracts/Helpers/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
@@ -20,10 +20,10 @@ contract UniversalReceiverDelegateVaultReentrantB is ERC165Storage {
     }
 
     // solhint-disable no-unused-vars
-    function universalReceiver(bytes32 typeId, bytes memory data) external returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        typeId;
-
+    function universalReceiver(
+        bytes32, /* typeId */
+        bytes memory data
+    ) external returns (bytes memory) {
         bytes32[] memory keys = new bytes32[](1);
         bytes[] memory values = new bytes[](1);
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -49,11 +49,8 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
      */
     function universalReceiver(
         bytes32 typeId,
-        bytes memory data // solhint-disable no-unused-vars
+        bytes memory /* data */
     ) public payable virtual returns (bytes memory result) {
-        // silent compiler warning (this does not push new items on the stack)
-        data;
-
         if (msg.value != 0) revert NativeTokensNotAccepted();
 
         // This contract acts like a UniversalReceiverDelegate of a UP where we append the

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -51,6 +51,9 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
+        // silent compiler warning (this does not push new items on the stack)
+        data;
+
         if (msg.value != 0) revert NativeTokensNotAccepted();
 
         // This contract acts like a UniversalReceiverDelegate of a UP where we append the

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -37,11 +37,8 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
      */
     function universalReceiver(
         bytes32 typeId,
-        bytes memory data // solhint-disable no-unused-vars
+        bytes memory /* data */
     ) public payable virtual returns (bytes memory result) {
-        // silent compiler warning (this does not push new items on the stack)
-        data;
-
         if (msg.value != 0) revert NativeTokensNotAccepted();
         // This contract acts like a UniversalReceiverDelegate of a Vault where we append the
         // address and the value, sent to the universalReceiver function of the LSP9, to the msg.data

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -39,6 +39,9 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data // solhint-disable no-unused-vars
     ) public payable virtual returns (bytes memory result) {
+        // silent compiler warning (this does not push new items on the stack)
+        data;
+
         if (msg.value != 0) revert NativeTokensNotAccepted();
         // This contract acts like a UniversalReceiverDelegate of a Vault where we append the
         // address and the value, sent to the universalReceiver function of the LSP9, to the msg.data

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -295,6 +295,7 @@ library LSP2Utils {
             pointer += elementLength + 1;
         }
         if (pointer == compactBytesArray.length) return true;
+        return false;
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -388,6 +388,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
         address to,
         bytes32 tokenId // solhint-disable no-unused-vars
     ) internal virtual {
+        // silent compiler warning (this does not push new items on the stack)
+        tokenId;
+
         // token being minted
         if (from == address(0)) {
             _existingTokens += 1;

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -386,11 +386,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
     function _beforeTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId // solhint-disable no-unused-vars
+        bytes32 /* tokenId */
     ) internal virtual {
-        // silent compiler warning (this does not push new items on the stack)
-        tokenId;
-
         // token being minted
         if (from == address(0)) {
             _existingTokens += 1;

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -77,6 +77,9 @@ abstract contract LSP8CompatibleERC721 is
     function tokenURI(
         uint256 tokenId // solhint-disable no-unused-vars
     ) public view virtual returns (string memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        tokenId;
+
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -75,11 +75,8 @@ abstract contract LSP8CompatibleERC721 is
      * @inheritdoc ILSP8CompatibleERC721
      */
     function tokenURI(
-        uint256 tokenId // solhint-disable no-unused-vars
+        uint256 /* tokenId */
     ) public view virtual returns (string memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        tokenId;
-
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -73,6 +73,9 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     function tokenURI(
         uint256 tokenId // solhint-disable no-unused-vars
     ) public view virtual returns (string memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        tokenId;
+
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -71,11 +71,8 @@ abstract contract LSP8CompatibleERC721InitAbstract is
      * @inheritdoc ILSP8CompatibleERC721
      */
     function tokenURI(
-        uint256 tokenId // solhint-disable no-unused-vars
+        uint256 /* tokenId */
     ) public view virtual returns (string memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        tokenId;
-
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
         // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -38,6 +38,9 @@ contract UniversalReceiverAddressStore is ERC165Storage, AddressRegistry {
         bytes32 typeId,
         bytes memory
     ) external onlyAccount returns (bytes memory) {
+        // silent compiler warning (this does not push new items on the stack)
+        value;
+
         // require(typeId == _TOKENS_RECIPIENT_INTERFACE_HASH, 'UniversalReceiverDelegate: Type not supported');
 
         // store tokens only if received, DO NOT revert on _TOKENS_SENDER_INTERFACE_HASH

--- a/contracts/Legacy/UniversalReceiverAddressStore.sol
+++ b/contracts/Legacy/UniversalReceiverAddressStore.sol
@@ -34,13 +34,10 @@ contract UniversalReceiverAddressStore is ERC165Storage, AddressRegistry {
     // solhint-disable no-unused-vars
     function universalReceiverDelegate(
         address sender,
-        uint256 value,
+        uint256, /* value */
         bytes32 typeId,
         bytes memory
     ) external onlyAccount returns (bytes memory) {
-        // silent compiler warning (this does not push new items on the stack)
-        value;
-
         // require(typeId == _TOKENS_RECIPIENT_INTERFACE_HASH, 'UniversalReceiverDelegate: Type not supported');
 
         // store tokens only if received, DO NOT revert on _TOKENS_SENDER_INTERFACE_HASH

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -166,7 +166,7 @@ export const testSecurityScenarios = (
   });
 
   describe("when sending LYX to a contract", () => {
-    it("Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant fallback() function.", async () => {
+    it("Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant receive() function.", async () => {
       // the Universal Profile wants to send 1 x LYX from its UP to another smart contract
       // we assume the UP owner is not aware that some malicious code is present
       // in the fallback function of the target (= recipient) contract
@@ -185,7 +185,7 @@ export const testSecurityScenarios = (
         "execute(bytes)",
         [transferPayload]
       );
-      // load the malicious payload, that will be executed in the fallback function
+      // load the malicious payload, that will be executed in the receive function
       // every time the contract receives LYX
       await maliciousContract.loadPayload(executePayload);
 
@@ -197,7 +197,7 @@ export const testSecurityScenarios = (
       );
 
       // send LYX to malicious contract
-      // at this point, the malicious contract fallback function try to drain funds by re-entering the call
+      // at this point, the malicious contract receive function try to drain funds by re-entering the KeyManager
       // this should not be possible since it does not have the permission `REENTRANCY`
       await expect(
         context.keyManager
@@ -313,11 +313,11 @@ export const testSecurityScenarios = (
 
       await maliciousContract.loadPayload(executePayload);
 
-      const executeTransferPayload = context.keyManager
-        .connect(context.owner)
-        ["execute(bytes)"](transferPayload);
-
-      await expect(executeTransferPayload)
+      await expect(
+        context.keyManager
+          .connect(context.owner)
+          ["execute(bytes)"](transferPayload)
+      )
         .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
         .withArgs(maliciousContract.address, "REENTRANCY");
     });


### PR DESCRIPTION
# What does this PR introduce?

There is currently a lot of warnings generated by the solc compiler. These come from contracts in various places in the repository, including:
- many Helpers contracts
- `LSP1UniversalReceiverDelegateUP`.
- `LSP1UniversalReceiverDelegateUP`.
- the function `isCompactBytesArray` in `LSP2Utils.sol`.
- `LSP8IdentifiableDigitalAssetCore`

This PR introduces changes that fix all the compiler warnings.

## ℹ️ Note on the fixes for the LSP1 Delegate + `LSP8IdentifiableDigitalAssetCore`.

In some functions of these two contracts, some function parameters were not used. For instance.

- `data` in `LSP1UniversalReceiverDelegateUP`.
- `tokenId` in the `_beforeTokenTransfer` hook of LSP8.

See screenshot below for LSP1DelegateUP.

<img width="756" alt="image" src="https://user-images.githubusercontent.com/31145285/204750342-d815760b-6d1b-4627-bc86-765e192491d9.png">

<img width="941" alt="image" src="https://user-images.githubusercontent.com/31145285/204750425-23ef1e73-8940-4ff7-8ef7-0b4677b6e2bb.png">

**These warnings are made silent now using the following.**

<img width="735" alt="image" src="https://user-images.githubusercontent.com/31145285/204750643-127ff2fb-97bd-43b2-80aa-d36c3a635418.png">

After analysis, this syntax silent warning and is safe as it does not push any new item on the stack.

The opcodes before the change (between the variable `bytes memory result` and `address notifier`).

```
0212 PUSH1 60
0214 CALLVALUE
0215 ISZERO
0216 PUSH2 010d
0219 JUMPI
…
0269 JUMPDEST
0270 PUSH1 00
0272 DUP1
0273 CALLDATASIZE
0274 PUSH2 011c
0277 PUSH1 34
```

The opcodes after the change.

```

0212 PUSH1 60
0214 CALLVALUE
0215 ISZERO
0216 PUSH2 010d
0219 JUMPI
…
0269 JUMPDEST
0270 PUSH1 00
0272 DUP1
0273 CALLDATASIZE
0274 PUSH2 011c
0277 PUSH1 34
```