### PR TITLE
test: improve speed for running tests from LSP3 + LSP6 test suites.

### DIFF
--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -21,7 +21,7 @@ contract LSP9VaultInit is LSP9VaultInitAbstract {
      * @notice Sets the owner of the contract and sets the SupportedStandards:LSP9Vault key
      * @param newOwner the owner of the contract
      */
-    function initialize(address newOwner) external virtual initializer {
+    function initialize(address newOwner) external payable virtual initializer {
         LSP9VaultInitAbstract._initialize(newOwner);
     }
 }

--- a/tests/Helpers/ABIEncoder.test.ts
+++ b/tests/Helpers/ABIEncoder.test.ts
@@ -13,10 +13,7 @@ describe("ABI Encoder Contract", () => {
   });
 
   const verifyResult = async (txParameterA, txParameterB) => {
-    const [c, gasUsed] = await contract.callStatic.encode(
-      txParameterA,
-      txParameterB
-    );
+    const [c] = await contract.callStatic.encode(txParameterA, txParameterB);
     const [a, b] = await contract.callStatic.decode(c);
     expect(a).to.equal(txParameterA);
     expect(b).to.equal(txParameterB);
@@ -87,6 +84,7 @@ describe("ABI Encoder Contract", () => {
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
+
       it("Encoding small amount of bytes in both param", async () => {
         const txParams = {
           a: "0xaabbccdd",
@@ -114,6 +112,7 @@ describe("ABI Encoder Contract", () => {
         const result = await checkGasCost(txParams.a, txParams.b);
       });
     });
+
     describe("LSP1 Specific Cases", () => {
       it("Encoding URD response when typeId out of scope with empty bytes", async () => {
         const txParams = {

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -30,12 +30,12 @@ export const shouldBehaveLikeLSP1 = (
 ) => {
   let context: LSP1TestContext;
 
-  beforeEach(async () => {
-    context = await buildContext();
-  });
-
   describe("when calling the `universalReceiver(...)` function", () => {
     const valueSent = 0;
+
+    before(async () => {
+      context = await buildContext();
+    });
 
     describe("from an EOA", () => {
       it("should emit a UniversalReceiver(...) event with correct topics", async () => {
@@ -123,9 +123,12 @@ export const shouldBehaveLikeLSP1 = (
     });
 
     describe("to test typeId delegate feature", () => {
-      let revertableURD;
+      let revertableURD: UniversalReceiverDelegateRevert;
+
       describe("when setting a revertable typeId", () => {
-        beforeEach(async () => {
+        before(async () => {
+          context = await buildContext();
+
           revertableURD = await new UniversalReceiverDelegateRevert__factory(
             context.accounts[1]
           ).deploy();
@@ -155,6 +158,10 @@ export const shouldBehaveLikeLSP1 = (
 
   describe("when calling the `universalReceiver(...)` function while sending native tokens", () => {
     const valueSent = ethers.utils.parseEther("3");
+
+    before(async () => {
+      context = await buildContext();
+    });
 
     describe("from an EOA", () => {
       it("should emit a UniversalReceiver(...) event with correct topics", async () => {

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -4,7 +4,6 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 // types
 import {
-  ILSP1UniversalReceiver,
   UniversalProfile,
   UniversalReceiverTester,
   UniversalReceiverDelegateRevert__factory,
@@ -15,7 +14,7 @@ import {
 import { abiCoder, LSP1_HOOK_PLACEHOLDER } from "../utils/helpers";
 
 // constants
-import { ERC725YDataKeys, EventSignatures } from "../../constants";
+import { ERC725YDataKeys } from "../../constants";
 
 export type LSP1TestContext = {
   accounts: SignerWithAddress[];
@@ -186,10 +185,10 @@ export const shouldBehaveLikeLSP1 = (
     });
 
     describe("from a Contract", () => {
-      beforeEach(async () => {
+      before(async () => {
         await context.accounts[0].sendTransaction({
           to: context.lsp1Checker.address,
-          value: ethers.utils.parseEther("5"),
+          value: ethers.utils.parseEther("50"),
         });
       });
 

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1947,7 +1947,7 @@ export const shouldInitializeLikeLSP1Delegate = (
 ) => {
   let context: LSP1DelegateInitializeTestContext;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
   });
 

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.test.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.test.ts
@@ -46,7 +46,7 @@ describe("LSP1UniversalReceiverDelegateUP", () => {
     describe("when deploying the contract", () => {
       let context: LSP1DelegateTestContext;
 
-      beforeEach(async () => {
+      before(async () => {
         context = await buildLSP1DelegateTestContext();
       });
 

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -12,7 +12,7 @@ describe("LSP2Utils", () => {
   let accounts: SignerWithAddress[];
   let lsp2Utils: LSP2UtilsLibraryTester;
 
-  beforeEach(async () => {
+  before(async () => {
     accounts = await ethers.getSigners();
     lsp2Utils = await new LSP2UtilsLibraryTester__factory(accounts[0]).deploy();
   });

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -127,7 +127,7 @@ export const shouldInitializeLikeLSP6 = (
 ) => {
   let context: LSP6TestContext;
 
-  before(async () => {
+  beforeEach(async () => {
     context = await buildContext();
   });
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { BigNumber } from "ethers";
 import { LSP6TestContext, LSP6InternalsTestContext } from "../utils/context";
 
 import { INTERFACE_IDS } from "../../constants";
@@ -34,7 +35,7 @@ import {
 } from "./internals";
 
 export const shouldBehaveLikeLSP6 = (
-  buildContext: () => Promise<LSP6TestContext>
+  buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>
 ) => {
   describe("CHANGEOWNER", () => {
     shouldBehaveLikePermissionChangeOwner(buildContext);
@@ -72,7 +73,7 @@ export const shouldBehaveLikeLSP6 = (
     shouldBehaveLikePermissionDeploy(buildContext);
   });
 
-  describe("TRANSFERVALUE", () => {
+  describe.only("TRANSFERVALUE", () => {
     shouldBehaveLikePermissionTransferValue(buildContext);
   });
 
@@ -126,7 +127,7 @@ export const shouldInitializeLikeLSP6 = (
 ) => {
   let context: LSP6TestContext;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
   });
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -127,7 +127,7 @@ export const shouldInitializeLikeLSP6 = (
 ) => {
   let context: LSP6TestContext;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
   });
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -73,7 +73,7 @@ export const shouldBehaveLikeLSP6 = (
     shouldBehaveLikePermissionDeploy(buildContext);
   });
 
-  describe.only("TRANSFERVALUE", () => {
+  describe("TRANSFERVALUE", () => {
     shouldBehaveLikePermissionTransferValue(buildContext);
   });
 

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -39,22 +39,8 @@ describe("LSP6KeyManager", () => {
     };
 
     describe("when deploying the contract", () => {
-      let context: LSP6TestContext;
-
-      beforeEach(async () => {
-        context = await buildTestContext();
-      });
-
       describe("when initializing the contract", () => {
-        shouldInitializeLikeLSP6(async () => {
-          const { accounts, owner, universalProfile, keyManager } = context;
-          return {
-            accounts,
-            owner,
-            universalProfile,
-            keyManager,
-          };
-        });
+        shouldInitializeLikeLSP6(buildTestContext);
       });
     });
 
@@ -128,26 +114,17 @@ describe("LSP6KeyManager", () => {
     describe("when deploying the contract as proxy", () => {
       let context: LSP6TestContext;
 
-      beforeEach(async () => {
-        context = await buildTestContext();
-      });
-
       describe("when initializing the contract", () => {
         shouldInitializeLikeLSP6(async () => {
-          const { accounts, owner, universalProfile, keyManager } = context;
+          context = await buildTestContext();
           await initializeProxy(context);
-
-          return {
-            accounts,
-            owner,
-            universalProfile,
-            keyManager,
-          };
+          return context;
         });
       });
 
       describe("when calling `initialize(...) more than once`", () => {
         it("should revert", async () => {
+          context = await buildTestContext();
           await initializeProxy(context);
 
           await expect(initializeProxy(context)).to.be.revertedWith(

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -41,7 +41,7 @@ describe("LSP6KeyManager", () => {
     describe("when deploying the contract", () => {
       let context: LSP6TestContext;
 
-      beforeEach(async () => {
+      before(async () => {
         context = await buildTestContext();
       });
 
@@ -158,8 +158,8 @@ describe("LSP6KeyManager", () => {
     });
 
     describe("when testing deployed contract", () => {
-      shouldBehaveLikeLSP6(async () => {
-        let context = await buildTestContext(ethers.utils.parseEther("100"));
+      shouldBehaveLikeLSP6(async (initialFunding?: BigNumber) => {
+        let context = await buildTestContext(initialFunding);
         await initializeProxy(context);
         return context;
       });

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -41,7 +41,7 @@ describe("LSP6KeyManager", () => {
     describe("when deploying the contract", () => {
       let context: LSP6TestContext;
 
-      before(async () => {
+      beforeEach(async () => {
         context = await buildTestContext();
       });
 

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -2,7 +2,11 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
-import { TargetContract, TargetContract__factory } from "../../../types";
+import {
+  TargetContract,
+  TargetContract__factory,
+  UniversalProfile__factory,
+} from "../../../types";
 
 // constants
 import {
@@ -35,7 +39,7 @@ export const testAllowedCallsInternals = (
 
     let encodedAllowedCalls: string;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canCallOnlyTwoAddresses = context.accounts[1];
@@ -260,19 +264,18 @@ export const testAllowedCallsInternals = (
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
       const randomData = "0xaabbccdd";
 
-      let payload: string;
+      const universalProfileInterface =
+        UniversalProfile__factory.createInterface();
 
-      beforeEach(async () => {
-        payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.CALL,
-            randomAddress,
-            ethers.utils.parseEther("1"),
-            randomData,
-          ]
-        );
-      });
+      let payload: string = universalProfileInterface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          OPERATION_TYPES.CALL,
+          randomAddress,
+          ethers.utils.parseEther("1"),
+          randomData,
+        ]
+      );
 
       describe("should revert with `NoAllowedCall` error", () => {
         it(`noBytes -> ${zeroBytesValues[0]}`, async () => {

--- a/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
+++ b/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
@@ -25,7 +25,7 @@ export const testReadingPermissionsInternals = (
     let addressCanSetData: SignerWithAddress,
       addressCanSetDataAndCall: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       addressCanSetData = context.accounts[1];
@@ -84,7 +84,7 @@ export const testReadingPermissionsInternals = (
       ["0x0000000000000000000000000000000000000000000000000000000000000000"]
     );
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       moreThan32EmptyBytes = context.accounts[1];
@@ -175,7 +175,7 @@ export const testReadingPermissionsInternals = (
     let permissionArrayKeys: string[] = [];
     let permissionArrayValues: string[] = [];
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       firstBeneficiary = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -38,7 +38,7 @@ export const shouldBehaveLikeAllowedAddresses = (
     allowedTargetContract: TargetContract,
     notAllowedTargetContract: TargetContract;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     canCallOnlyTwoAddresses = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedFunctions.test.ts
@@ -38,7 +38,7 @@ export const shouldBehaveLikeAllowedFunctions = (
 
   let targetContract: TargetContract;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     addressWithNoAllowedFunctions = context.accounts[1];
@@ -519,14 +519,11 @@ export const shouldBehaveLikeAllowedFunctions = (
               [OPERATION_TYPES.CALL, lsp7Contract.address, 0, transferPayload]
             );
 
-          let tx = await context.keyManager
+          await context.keyManager
             .connect(
               addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8
             )
             ["execute(bytes)"](executePayload);
-
-          let receipt = await tx.wait();
-          console.log("gas used: ", receipt.gasUsed.toNumber());
 
           expect(await lsp7Contract.balanceOf(recipient)).to.equal(amount);
           expect(

--- a/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedStandards.test.ts
@@ -47,7 +47,7 @@ export const shouldBehaveLikeAllowedStandards = (
     signatureValidatorContract: SignatureValidator,
     otherUniversalProfile: UniversalProfile;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     addressCanInteractOnlyWithERC1271 = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/ExecuteRelayCall.test.ts
@@ -34,7 +34,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
   let targetContract: TargetContract;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     signer = context.accounts[1];
@@ -389,7 +389,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   context.universalProfile,
                   "ERC725X_InsufficientBalance"
                 )
-                .withArgs(0, requiredValueForExecution);
+                .withArgs(
+                  await provider.getBalance(context.universalProfile.address),
+                  requiredValueForExecution
+                );
             });
           });
 

--- a/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
+++ b/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
@@ -26,7 +26,7 @@ export const otherTestScenarios = (
   let addressCanMakeCall: SignerWithAddress;
   let targetContract: TargetContract;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     superAdmin = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -1124,7 +1124,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
     let invalidBytes: SignerWithAddress;
     let noBytes: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canOnlyAddPermissions = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeAddPermissions.test.ts
@@ -1228,7 +1228,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       zero32Bytes: SignerWithAddress,
       zero40Bytes: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canOnlyAddPermissions = context.accounts[1];
@@ -1689,7 +1689,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       zero32Bytes: SignerWithAddress,
       zero40Bytes: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canOnlyAddPermissions = context.accounts[1];
@@ -2150,7 +2150,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       zero32Bytes: SignerWithAddress,
       zero40Bytes: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canOnlyAddPermissions = context.accounts[1];
@@ -2653,7 +2653,7 @@ export const shouldBehaveLikePermissionChangeOrAddPermissions = (
       zero32Bytes: SignerWithAddress,
       zero40Bytes: SignerWithAddress;
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       canOnlyAddPermissions = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -73,23 +73,27 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
   describe("when upgrading to a new KeyManager via transferOwnership(...)", () => {
     let newKeyManager: LSP6KeyManager;
+    let transferOwnershipPayload: string;
+
+    before(async () => {
+      newKeyManager = await new LSP6KeyManager__factory(context.owner).deploy(
+        context.universalProfile.address
+      );
+
+      transferOwnershipPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "transferOwnership",
+          [newKeyManager.address]
+        );
+    });
 
     describe("when caller does not have have CHANGEOWNER permission", () => {
       beforeEach(async () => {
-        newKeyManager = await new LSP6KeyManager__factory(context.owner).deploy(
-          context.universalProfile.address
-        );
-
-        let transferOwnershipPayload =
-          context.universalProfile.interface.encodeFunctionData(
-            "transferOwnership",
-            [newKeyManager.address]
-          );
-
         await context.keyManager
           .connect(canChangeOwner)
           ["execute(bytes)"](transferOwnershipPayload);
       });
+
       it("should revert", async () => {
         let transferOwnershipPayload =
           context.universalProfile.interface.encodeFunctionData(
@@ -109,20 +113,11 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
     describe("when caller has ALL PERMISSIONS", () => {
       beforeEach(async () => {
-        newKeyManager = await new LSP6KeyManager__factory(context.owner).deploy(
-          context.universalProfile.address
-        );
-
-        let transferOwnershipPayload =
-          context.universalProfile.interface.encodeFunctionData(
-            "transferOwnership",
-            [newKeyManager.address]
-          );
-
         await context.keyManager
           .connect(context.owner)
           ["execute(bytes)"](transferOwnershipPayload);
       });
+
       it("should have set newKeyManager as pendingOwner", async () => {
         let pendingOwner = await context.universalProfile.pendingOwner();
         expect(pendingOwner).to.equal(newKeyManager.address);
@@ -284,24 +279,6 @@ export const shouldBehaveLikePermissionChangeOwner = (
   });
 
   describe("when calling acceptOwnership(...) from a KeyManager that is not the pendingOwner", () => {
-    let newKeyManager: LSP6KeyManager;
-
-    beforeEach(async () => {
-      newKeyManager = await new LSP6KeyManager__factory(context.owner).deploy(
-        context.universalProfile.address
-      );
-
-      let transferOwnershipPayload =
-        context.universalProfile.interface.encodeFunctionData(
-          "transferOwnership",
-          [newKeyManager.address]
-        );
-
-      await context.keyManager
-        .connect(context.owner)
-        ["execute(bytes)"](transferOwnershipPayload);
-    });
-
     it("should revert", async () => {
       let notPendingKeyManager = await new LSP6KeyManager__factory(
         context.accounts[5]

--- a/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionChangeOwner.test.ts
@@ -88,12 +88,6 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
 
     describe("when caller does not have have CHANGEOWNER permission", () => {
-      beforeEach(async () => {
-        await context.keyManager
-          .connect(canChangeOwner)
-          ["execute(bytes)"](transferOwnershipPayload);
-      });
-
       it("should revert", async () => {
         let transferOwnershipPayload =
           context.universalProfile.interface.encodeFunctionData(
@@ -219,10 +213,6 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
     describe("when caller has only CHANGE0OWNER permission", () => {
       beforeEach(async () => {
-        newKeyManager = await new LSP6KeyManager__factory(context.owner).deploy(
-          context.universalProfile.address
-        );
-
         let transferOwnershipPayload =
           context.universalProfile.interface.encodeFunctionData(
             "transferOwnership",

--- a/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDelegateCall.test.ts
@@ -26,40 +26,40 @@ export const shouldBehaveLikePermissionDelegateCall = (
 ) => {
   let context: LSP6TestContext;
 
-  let addressCanDelegateCall: SignerWithAddress,
-    addressCannotDelegateCall: SignerWithAddress;
-
-  let erc725YDelegateCallContract: ERC725YDelegateCall;
-
-  beforeEach(async () => {
-    context = await buildContext();
-
-    addressCanDelegateCall = context.accounts[1];
-    addressCannotDelegateCall = context.accounts[2];
-
-    erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(
-      context.owner
-    ).deploy(context.universalProfile.address);
-
-    const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
-        context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
-        addressCanDelegateCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
-        addressCannotDelegateCall.address.substring(2),
-    ];
-
-    const permissionsValues = [
-      ALL_PERMISSIONS,
-      PERMISSIONS.DELEGATECALL,
-      PERMISSIONS.CALL,
-    ];
-
-    await setupKeyManager(context, permissionKeys, permissionsValues);
-  });
-
   describe("when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed", () => {
+    let addressCanDelegateCall: SignerWithAddress,
+      addressCannotDelegateCall: SignerWithAddress;
+
+    let erc725YDelegateCallContract: ERC725YDelegateCall;
+
+    before(async () => {
+      context = await buildContext();
+
+      addressCanDelegateCall = context.accounts[1];
+      addressCannotDelegateCall = context.accounts[2];
+
+      erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(
+        context.owner
+      ).deploy(context.universalProfile.address);
+
+      const permissionKeys = [
+        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          addressCanDelegateCall.address.substring(2),
+        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          addressCannotDelegateCall.address.substring(2),
+      ];
+
+      const permissionsValues = [
+        ALL_PERMISSIONS,
+        PERMISSIONS.DELEGATECALL,
+        PERMISSIONS.CALL,
+      ];
+
+      await setupKeyManager(context, permissionKeys, permissionsValues);
+    });
+
     it("should revert even if caller has ALL PERMISSIONS", async () => {
       const key =
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -189,7 +189,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
       ERC725YDelegateCall
     ];
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       caller = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionStaticCall.test.ts
@@ -29,7 +29,7 @@ export const shouldBehaveLikePermissionStaticCall = (
 
   let targetContract: TargetContract;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     addressCanMakeStaticCall = context.accounts[1];
@@ -234,7 +234,7 @@ export const shouldBehaveLikePermissionStaticCall = (
     let caller: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       caller = context.accounts[1];
@@ -473,7 +473,7 @@ export const shouldBehaveLikePermissionStaticCall = (
     let caller: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
-    beforeEach(async () => {
+    before(async () => {
       context = await buildContext();
 
       caller = context.accounts[1];

--- a/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionTransferValue.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { EIP191Signer } from "@lukso/eip191-signer.js";
-
+import { BigNumber } from "ethers";
 import {
   Executor,
   Executor__factory,
@@ -36,7 +36,7 @@ import {
 } from "../../utils/helpers";
 
 export const shouldBehaveLikePermissionTransferValue = (
-  buildContext: () => Promise<LSP6TestContext>
+  buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>
 ) => {
   let context: LSP6TestContext;
 
@@ -47,8 +47,8 @@ export const shouldBehaveLikePermissionTransferValue = (
 
     let recipient;
 
-    beforeEach(async () => {
-      context = await buildContext();
+    before(async () => {
+      context = await buildContext(ethers.utils.parseEther("100"));
 
       canTransferValue = context.accounts[1];
       canTransferValueAndCall = context.accounts[2];
@@ -88,16 +88,9 @@ export const shouldBehaveLikePermissionTransferValue = (
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
-
-      await context.owner.sendTransaction({
-        to: context.universalProfile.address,
-        value: ethers.utils.parseEther("10"),
-      });
     });
 
     describe("when recipient = EOA", () => {
-      beforeEach(async () => {});
-
       describe("when transferring value via `execute(...)`", () => {
         describe("when transferring value without bytes `_data`", () => {
           const data = "0x";
@@ -456,8 +449,8 @@ export const shouldBehaveLikePermissionTransferValue = (
      */
     const GAS_PROVIDED = 200_000;
 
-    beforeEach(async () => {
-      context = await buildContext();
+    before(async () => {
+      context = await buildContext(ethers.utils.parseEther("100"));
 
       recipient = context.accounts[1].address;
 
@@ -485,11 +478,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
-
-      await context.owner.sendTransaction({
-        to: context.universalProfile.address,
-        value: ethers.utils.parseEther("1"),
-      });
     });
 
     describe("> Contract calls", () => {
@@ -562,10 +550,10 @@ export const shouldBehaveLikePermissionTransferValue = (
     let bobContext: LSP6TestContext;
 
     before(async () => {
-      aliceContext = await buildContext();
+      aliceContext = await buildContext(ethers.utils.parseEther("50"));
       alice = aliceContext.accounts[0];
 
-      bobContext = await buildContext();
+      bobContext = await buildContext(ethers.utils.parseEther("50"));
       bob = bobContext.accounts[1];
 
       const alicePermissionKeys = [
@@ -599,12 +587,6 @@ export const shouldBehaveLikePermissionTransferValue = (
         alicePermissionValues
       );
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
-
-      // fund Bob's Up with some LYX to be transfered
-      await bob.sendTransaction({
-        to: bobContext.universalProfile.address,
-        value: ethers.utils.parseEther("5"),
-      });
     });
 
     it("Alice should have ALL PERMISSIONS in her UP", async () => {
@@ -684,8 +666,8 @@ export const shouldBehaveLikePermissionTransferValue = (
     let lsp7Token: LSP7Mintable;
     let targetContract: TargetPayableContract;
 
-    beforeEach(async () => {
-      context = await buildContext();
+    before(async () => {
+      context = await buildContext(ethers.utils.parseEther("100"));
 
       caller = context.accounts[1];
 
@@ -722,11 +704,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
-
-      await context.owner.sendTransaction({
-        to: context.universalProfile.address,
-        value: ethers.utils.parseEther("10"),
-      });
     });
 
     describe("should be allowed to send LYX to any EOA", () => {
@@ -921,8 +898,8 @@ export const shouldBehaveLikePermissionTransferValue = (
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
-    beforeEach(async () => {
-      context = await buildContext();
+    before(async () => {
+      context = await buildContext(ethers.utils.parseEther("100"));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
@@ -944,11 +921,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
-
-      await context.owner.sendTransaction({
-        to: context.universalProfile.address,
-        value: ethers.utils.parseEther("10"),
-      });
     });
 
     it("should not be allowed to do a plain LYX transfer to a non-allowed address", async () => {
@@ -1161,8 +1133,8 @@ export const shouldBehaveLikePermissionTransferValue = (
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
-    beforeEach(async () => {
-      context = await buildContext();
+    before(async () => {
+      context = await buildContext(ethers.utils.parseEther("100"));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
@@ -1187,11 +1159,6 @@ export const shouldBehaveLikePermissionTransferValue = (
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
-
-      await context.owner.sendTransaction({
-        to: context.universalProfile.address,
-        value: ethers.utils.parseEther("10"),
-      });
     });
 
     describe("should be allowed to send LYX to any address", () => {

--- a/tests/LSP6KeyManager/tests/Reentrancy.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy.test.ts
@@ -208,6 +208,7 @@ export const testReentrancyScenarios = async (
   let owner: SignerWithAddress;
   let caller: SignerWithAddress;
   let signer: Wallet;
+
   before(async () => {
     context = await buildContext();
     owner = context.accounts[7];

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -48,7 +48,7 @@ export const testSecurityScenarios = (
 
   let targetContract: TargetContract, maliciousContract: Reentrancy;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
 
     signer = context.accounts[1];

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -33,6 +33,7 @@ import {
   OPERATION_TYPES,
   LSP1_TYPE_IDS,
 } from "../../constants";
+import { BigNumber } from "ethers";
 
 export type LSP9TestAccounts = {
   owner: SignerWithAddress;
@@ -48,7 +49,7 @@ export const getNamedAccounts = async (): Promise<LSP9TestAccounts> => {
 
 export type LSP9DeployParams = {
   newOwner: string;
-  initialFunding?: number;
+  initialFunding?: number | BigNumber;
 };
 
 export type LSP9TestContext = {
@@ -390,7 +391,7 @@ export const shouldBehaveLikeLSP9 = (
     });
 
     describe("when transferring ownership of the vault", () => {
-      beforeEach(async () => {
+      before(async () => {
         context = await buildContext();
       });
 

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -30,6 +30,7 @@ import {
   setupProfileWithKeyManagerWithURD,
 } from "../utils/fixtures";
 import { provider } from "../utils/helpers";
+import { BigNumber } from "ethers";
 
 describe("LSP9Vault", () => {
   describe("when using LSP9Vault contract with constructor", () => {
@@ -61,12 +62,15 @@ describe("LSP9Vault", () => {
       };
     };
 
-    const buildLSP14TestContext = async (): Promise<LSP14TestContext> => {
+    const buildLSP14TestContext = async (
+      initialFunding?: number | BigNumber
+    ): Promise<LSP14TestContext> => {
       const accounts = await ethers.getSigners();
-      const deployParams = { owner: accounts[0] };
+      const deployParams = { owner: accounts[0], initialFunding };
 
       const lsp9Vault = await new LSP9Vault__factory(accounts[0]).deploy(
-        deployParams.owner.address
+        deployParams.owner.address,
+        { value: initialFunding }
       );
 
       const onlyOwnerRevertString =
@@ -100,7 +104,7 @@ describe("LSP9Vault", () => {
       describe("when deploying the contract with or without value", () => {
         let context: LSP9TestContext;
 
-        beforeEach(async () => {
+        before(async () => {
           context = await buildTestContext(testCase.initialFunding);
         });
 
@@ -140,7 +144,7 @@ describe("LSP9Vault", () => {
 
   describe("when using LSP9Vault contract with proxy", () => {
     const buildTestContext = async (
-      initialFunding?: number
+      initialFunding?: number | BigNumber
     ): Promise<LSP9TestContext> => {
       const accounts = await getNamedAccounts();
       const deployParams = {
@@ -255,8 +259,8 @@ describe("LSP9Vault", () => {
         })
       );
 
-      shouldBehaveLikeLSP14(async () => {
-        let context = await buildTestContext();
+      shouldBehaveLikeLSP14(async (initialFunding?: number | BigNumber) => {
+        let context = await buildTestContext(initialFunding);
         let accounts = await ethers.getSigners();
         await initializeProxy(context);
 

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -28,7 +28,7 @@ export const shouldBehaveLikeLSP3 = (
 ) => {
   let context: LSP3TestContext;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext(100);
   });
 
@@ -92,6 +92,7 @@ export const shouldBehaveLikeLSP3 = (
       ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index +
         "00000000000000000000000000000001",
     ];
+
     let lsp12IssuedAssetsValues = [
       "0xd94353d9b005b3c0a9da169b768a31c57844e490",
       "0xdaea594e385fc724449e3118b2db7e86dfba1826",
@@ -362,7 +363,7 @@ export const shouldInitializeLikeLSP3 = (
 ) => {
   let context: LSP3TestContext;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
   });
 

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -129,10 +129,10 @@ describe("UniversalProfile", () => {
     });
 
     describe("when testing deployed contract", () => {
-      // shouldBehaveLikeLSP3(buildLSP3TestContext);
-      // shouldBehaveLikeLSP1(buildLSP1TestContext);
+      shouldBehaveLikeLSP3(buildLSP3TestContext);
+      shouldBehaveLikeLSP1(buildLSP1TestContext);
       shouldBehaveLikeLSP14(buildLSP14TestContext);
-      // shouldBehaveLikeLSP17(buildLSP17TestContext);
+      shouldBehaveLikeLSP17(buildLSP17TestContext);
     });
   });
 
@@ -298,19 +298,19 @@ describe("UniversalProfile", () => {
     });
 
     describe("when testing deployed contract", () => {
-      // shouldBehaveLikeLSP3(async (initialFunding?: number) => {
-      //   let context = await buildLSP3TestContext(initialFunding);
-      //   await initializeProxy(context);
-      //   return context;
-      // });
+      shouldBehaveLikeLSP3(async (initialFunding?: number) => {
+        let context = await buildLSP3TestContext(initialFunding);
+        await initializeProxy(context);
+        return context;
+      });
 
-      // shouldBehaveLikeLSP1(async () => {
-      //   let lsp3Context = await buildLSP3TestContext();
-      //   await initializeProxy(lsp3Context);
+      shouldBehaveLikeLSP1(async () => {
+        let lsp3Context = await buildLSP3TestContext();
+        await initializeProxy(lsp3Context);
 
-      //   let lsp1Context = await buildLSP1TestContext();
-      //   return lsp1Context;
-      // });
+        let lsp1Context = await buildLSP1TestContext();
+        return lsp1Context;
+      });
 
       shouldBehaveLikeLSP14(async (initialFunding?: number | BigNumber) => {
         let claimOwnershipContext = await buildLSP14TestContext(initialFunding);
@@ -324,18 +324,18 @@ describe("UniversalProfile", () => {
         return claimOwnershipContext;
       });
 
-      // shouldBehaveLikeLSP17(async () => {
-      //   let fallbackExtensionContext = await buildLSP17TestContext();
+      shouldBehaveLikeLSP17(async () => {
+        let fallbackExtensionContext = await buildLSP17TestContext();
 
-      //   await initializeProxy({
-      //     accounts: fallbackExtensionContext.accounts,
-      //     universalProfile:
-      //       fallbackExtensionContext.contract as LSP0ERC725Account,
-      //     deployParams: fallbackExtensionContext.deployParams,
-      //   });
+        await initializeProxy({
+          accounts: fallbackExtensionContext.accounts,
+          universalProfile:
+            fallbackExtensionContext.contract as LSP0ERC725Account,
+          deployParams: fallbackExtensionContext.deployParams,
+        });
 
-      //   return fallbackExtensionContext;
-      // });
+        return fallbackExtensionContext;
+      });
     });
   });
 });

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -1,7 +1,6 @@
 import { ethers } from "hardhat";
 import { expect } from "chai";
 import {
-  ILSP1UniversalReceiver,
   LSP0ERC725Account,
   UniversalProfileInit__factory,
   UniversalProfile__factory,
@@ -73,6 +72,7 @@ describe("UniversalProfile", () => {
         owner: accounts[0],
         initialFunding,
       };
+
       const contract = await new UniversalProfile__factory(accounts[0]).deploy(
         deployParams.owner.address,
         { value: initialFunding }

--- a/tests/utils/context.ts
+++ b/tests/utils/context.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber } from "ethers";
 import {
   KeyManagerInternalTester,
   LSP6KeyManager,
@@ -10,6 +11,7 @@ export type LSP6TestContext = {
   owner: SignerWithAddress;
   universalProfile: UniversalProfile;
   keyManager: LSP6KeyManager;
+  initialFunding?: BigNumber;
 };
 
 export type LSP6InternalsTestContext = {


### PR DESCRIPTION
# What does this PR introduce?

This PR concerns the following test suites:

- LSP3
- LSP6 (**mainly**)

These test suites take a lot of time to run in the CI, in particular LSP6. See screenshot below.

![image](https://user-images.githubusercontent.com/31145285/205102236-781cbb96-615b-472e-b43f-68022f3cbf04.png).

Improve the speed of these tests, using the following 2 techniques:
- replace `beforeEach` hooks by `before` hooks: avoid heavy setup on every single tests (deploying a UP, deploying a KeyManager, setting the permissions + link to a default LSP1UniversalReceiverDelegate, transferring ownership to the Key Manager, etc...)
- avoid sending separate transactions in the setup of the `before` hooks to fund the UP with LYX (for tests that require native LYX tokens transfers. Fund the UP immediately on deployment).
