### PR TITLE
test: add more tests to custom ERC165CheckerCustom

### DIFF
--- a/contracts/Helpers/ERC165/NoSupportsInterfaceWithFallback.sol
+++ b/contracts/Helpers/ERC165/NoSupportsInterfaceWithFallback.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract NoSupportsInterfaceWithFallback {
-    // solhint-disable
+    // solhint-disable no-empty-blocks
     fallback() external payable {}
 }

--- a/contracts/Helpers/ERC165/NoSupportsInterfaceWithFallback.sol
+++ b/contracts/Helpers/ERC165/NoSupportsInterfaceWithFallback.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract NoSupportsInterfaceWithFallback {
+    // solhint-disable
+    fallback() external payable {}
+}

--- a/contracts/Helpers/ERC165/NoSupportsInterfaceWithoutFallback.sol
+++ b/contracts/Helpers/ERC165/NoSupportsInterfaceWithoutFallback.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract NoSupportsInterfaceWithoutFallback {
+    // solhint-disable
+    function hello() public {}
+}

--- a/contracts/Helpers/ERC165/NoSupportsInterfaceWithoutFallback.sol
+++ b/contracts/Helpers/ERC165/NoSupportsInterfaceWithoutFallback.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract NoSupportsInterfaceWithoutFallback {
-    // solhint-disable
+    // solhint-disable no-empty-blocks
     function hello() public {}
 }

--- a/contracts/Helpers/ERC165/SupportsInterfaceOnlyERC165.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceOnlyERC165.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract SupportsInterfaceOnlyERC165 {
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return interfaceId == 0x01ffc9a7;

--- a/contracts/Helpers/ERC165/SupportsInterfaceOnlyERC165.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceOnlyERC165.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract SupportsInterfaceOnlyERC165 {
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == 0x01ffc9a7;
+    }
+}

--- a/contracts/Helpers/ERC165/SupportsInterfaceOnlyLSP0.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceOnlyLSP0.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "../../LSP0ERC725Account/LSP0Constants.sol";
+
+contract SupportsInterfaceOnlyLSP0 {
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == _INTERFACEID_LSP0;
+    }
+}

--- a/contracts/Helpers/ERC165/SupportsInterfaceOnlyLSP0.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceOnlyLSP0.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.4;
 
 import "../../LSP0ERC725Account/LSP0Constants.sol";
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract SupportsInterfaceOnlyLSP0 {
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return interfaceId == _INTERFACEID_LSP0;

--- a/contracts/Helpers/ERC165/SupportsInterfaceRevert.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceRevert.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract SupportsInterfaceRevert {
+    function supportsInterface(
+        bytes4 /*interfaceId*/
+    ) public view virtual returns (bool) {
+        // solhint-disable
+        revert();
+    }
+}

--- a/contracts/Helpers/ERC165/SupportsInterfaceRevert.sol
+++ b/contracts/Helpers/ERC165/SupportsInterfaceRevert.sol
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract SupportsInterfaceRevert {
     function supportsInterface(
         bytes4 /*interfaceId*/
     ) public view virtual returns (bool) {
-        // solhint-disable
+        // solhint-disable-next-line reason-string
         revert();
     }
 }

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -222,4 +222,22 @@ describe("Test Custom implementation of ERC165Checker", () => {
       }
     }
   });
+
+  it.skip("Calling a pre-compiled contract addresses 0x0.02, 0x0.04 and 0x0.04", async () => {
+    const precompiledAddress = [
+      "0x0000000000000000000000000000000000000002",
+      "0x0000000000000000000000000000000000000003",
+      "0x0000000000000000000000000000000000000004",
+    ];
+
+    for (let i = 0; i < precompiledAddress.length; i++) {
+      for (let ii = 0; ii < 1000; ii++) {
+        const result = await contract.supportsERC165Interface(
+          precompiledAddress[i],
+          ethers.utils.hexlify(ethers.utils.randomBytes(4))
+        );
+        expect(result).to.be.true;
+      }
+    }
+  });
 });

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -4,12 +4,18 @@ import { expect } from "chai";
 import {
   ERC165CheckerCustomTest,
   ERC165CheckerCustomTest__factory,
-  TargetContract,
-  TargetContract__factory,
   ERC725,
   ERC725__factory,
-  TokenReceiverWithoutLSP1,
-  TokenReceiverWithoutLSP1__factory,
+  NoSupportsInterfaceWithoutFallback,
+  NoSupportsInterfaceWithoutFallback__factory,
+  NoSupportsInterfaceWithFallback,
+  NoSupportsInterfaceWithFallback__factory,
+  SupportsInterfaceOnlyERC165,
+  SupportsInterfaceOnlyERC165__factory,
+  SupportsInterfaceRevert,
+  SupportsInterfaceRevert__factory,
+  SupportsInterfaceOnlyLSP0,
+  SupportsInterfaceOnlyLSP0__factory,
 } from "../../types";
 
 // utils
@@ -18,17 +24,36 @@ import { INTERFACE_IDS } from "../../constants";
 describe("Test Custom implementation of ERC165Checker", () => {
   let accounts: SignerWithAddress[];
   let contract: ERC165CheckerCustomTest;
-  let targetContract: TargetContract;
   let erc725: ERC725;
-  let contractWithFallback: TokenReceiverWithoutLSP1;
+  let noSupportsInterfaceWithFallback: NoSupportsInterfaceWithFallback;
+  let noSupportsInterfaceWithoutFallback: NoSupportsInterfaceWithoutFallback;
+  let supportsInterfaceOnlyERC165: SupportsInterfaceOnlyERC165;
+  let supportsInterfaceOnlyLSP0: SupportsInterfaceOnlyLSP0;
+  let supportsInterfaceRevert: SupportsInterfaceRevert;
 
   before(async () => {
     accounts = await ethers.getSigners();
     contract = await new ERC165CheckerCustomTest__factory(accounts[0]).deploy();
-    targetContract = await new TargetContract__factory(accounts[0]).deploy();
-    contractWithFallback = await new TokenReceiverWithoutLSP1__factory(
+
+    noSupportsInterfaceWithFallback =
+      await new NoSupportsInterfaceWithFallback__factory(accounts[0]).deploy();
+
+    noSupportsInterfaceWithoutFallback =
+      await new NoSupportsInterfaceWithoutFallback__factory(
+        accounts[0]
+      ).deploy();
+
+    supportsInterfaceOnlyERC165 =
+      await new SupportsInterfaceOnlyERC165__factory(accounts[0]).deploy();
+
+    supportsInterfaceOnlyLSP0 = await new SupportsInterfaceOnlyLSP0__factory(
       accounts[0]
     ).deploy();
+
+    supportsInterfaceRevert = await new SupportsInterfaceRevert__factory(
+      accounts[0]
+    ).deploy();
+
     erc725 = await new ERC725__factory(accounts[0]).deploy(accounts[0].address);
   });
 
@@ -45,39 +70,156 @@ describe("Test Custom implementation of ERC165Checker", () => {
     expect(result2).to.be.false;
   });
 
-  it("Calling a contract without a fallback function that doesn't support ERC165", async () => {
-    const result = await contract.supportsERC165Interface(
-      targetContract.address,
+  it("Calling a contract without a fallback function that doesn't include `supportsInterface(..)` function", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      noSupportsInterfaceWithoutFallback.address,
       INTERFACE_IDS.ERC165
     );
-    expect(result).to.be.false;
+    expect(result1).to.be.false;
+
+    const result2 = await contract.supportsERC165Interface(
+      noSupportsInterfaceWithoutFallback.address,
+      INTERFACE_IDS.LSP1UniversalReceiver
+    );
+    expect(result2).to.be.false;
   });
 
-  it("Calling a contract with a fallback function that doesn't support ERC165", async () => {
-    const result = await contract.supportsERC165Interface(
-      contractWithFallback.address,
+  it("Calling a contract with a fallback function that doesn't include `supportsInterface(..)` function", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      noSupportsInterfaceWithFallback.address,
       INTERFACE_IDS.ERC165
     );
-    expect(result).to.be.false;
+
+    expect(result1).to.be.false;
+
+    const result2 = await contract.supportsERC165Interface(
+      noSupportsInterfaceWithFallback.address,
+      INTERFACE_IDS.LSP1UniversalReceiver
+    );
+
+    expect(result2).to.be.false;
   });
 
-  it("Calling a contract that support ERC165 and ERC725X but doesn't support LSP1", async () => {
-    const ERC165result = await contract.supportsERC165Interface(
+  it("Calling a contract that include `supportsInterface(..)` function that reverts", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      supportsInterfaceRevert.address,
+      INTERFACE_IDS.ERC165
+    );
+
+    expect(result1).to.be.false;
+
+    const result2 = await contract.supportsERC165Interface(
+      supportsInterfaceRevert.address,
+      INTERFACE_IDS.LSP1UniversalReceiver
+    );
+
+    expect(result2).to.be.false;
+  });
+
+  it("Calling a contract that include `supportsInterface(..)` function that only supports ERC165", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      supportsInterfaceOnlyERC165.address,
+      INTERFACE_IDS.ERC165
+    );
+
+    expect(result1).to.be.true;
+
+    const result2 = await contract.supportsERC165Interface(
+      supportsInterfaceOnlyERC165.address,
+      INTERFACE_IDS.LSP1UniversalReceiver
+    );
+
+    expect(result2).to.be.false;
+  });
+
+  it("Calling a contract that include `supportsInterface(..)` function that only supports LSP0", async () => {
+    const result1 = await contract.supportsERC165Interface(
+      supportsInterfaceOnlyLSP0.address,
+      INTERFACE_IDS.ERC165
+    );
+
+    expect(result1).to.be.false;
+
+    const result2 = await contract.supportsERC165Interface(
+      supportsInterfaceOnlyLSP0.address,
+      INTERFACE_IDS.LSP0ERC725Account
+    );
+
+    expect(result2).to.be.true;
+  });
+
+  it("Calling a contract that include `supportsInterface(..)` function that supports ERC725 and ERC165", async () => {
+    const result1 = await contract.supportsERC165Interface(
       erc725.address,
       INTERFACE_IDS.ERC165
     );
-    expect(ERC165result).to.be.true;
 
-    const ERC725Xresult = await contract.supportsERC165Interface(
+    expect(result1).to.be.true;
+
+    const result2 = await contract.supportsERC165Interface(
       erc725.address,
       INTERFACE_IDS.ERC725X
     );
-    expect(ERC725Xresult).to.be.true;
 
-    const LSP1result = await contract.supportsERC165Interface(
+    expect(result2).to.be.true;
+
+    const result3 = await contract.supportsERC165Interface(
       erc725.address,
-      INTERFACE_IDS.LSP1UniversalReceiver
+      INTERFACE_IDS.ERC725Y
     );
-    expect(LSP1result).to.be.false;
+
+    expect(result3).to.be.true;
+  });
+
+  it("Calling a random/pre-compiled contract addresses", async () => {
+    const precompiledAddress = [
+      "0x0000000000000000000000000000000000000000",
+      "0x0000000000000000000000000000000000000001",
+      "0x0000000000000000000000000000000000000002",
+      "0x0000000000000000000000000000000000000003",
+      "0x0000000000000000000000000000000000000004",
+      "0x0000000000000000000000000000000000000005",
+      "0x0000000000000000000000000000000000000006",
+      "0x0000000000000000000000000000000000000007",
+      "0x0000000000000000000000000000000000000008",
+      "0x0000000000000000000000000000000000000009",
+      "0x0000000000000000000000000000000000000010",
+      "0x0000000000000000000000000000000000000011",
+      "0x0000000000000000000000000000000000000012",
+      "0x0000000000000000000000000000000000000013",
+      "0x0000000000000000000000000000000000000014",
+      "0x0000000000000000000000000000000000000015",
+      "0x0000000000000000000000000000000000000016",
+      "0x0000000000000000000000000000000000000017",
+      "0x0000000000000000000000000000000000000018",
+      "0x0000000000000000000000000000000000000019",
+      "0x0000000000000000000000000000000000000020",
+    ];
+
+    for (let i = 0; i < precompiledAddress.length; i++) {
+      const result1 = await contract.supportsERC165Interface(
+        precompiledAddress[i],
+        INTERFACE_IDS.ERC165
+      );
+
+      // The call on precomiled contracts: 0x0..02, 0x0..03, 0x0..04 will always return true
+      if (i > 1 && i < 5) {
+        expect(result1).to.be.true;
+      } else {
+        expect(result1).to.be.false;
+      }
+
+      const result2 = await contract.supportsERC165Interface(
+        precompiledAddress[i],
+        INTERFACE_IDS.LSP0ERC725Account
+      );
+
+      // The call on precomiled contracts: 0x0..02, 0x0..03, 0x0..04 will always return true
+      if (i > 1 && i < 5) {
+        expect(result2).to.be.true;
+      } else {
+        expect(result2).to.be.false;
+      }
+    }
   });
 });

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -57,173 +57,147 @@ describe("Test Custom implementation of ERC165Checker", () => {
     erc725 = await new ERC725__factory(accounts[0]).deploy(accounts[0].address);
   });
 
-  it("Calling an EOA", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      accounts[1].address,
-      INTERFACE_IDS.ERC165
-    );
-    const result2 = await contract.supportsERC165Interface(
-      accounts[1].address,
-      INTERFACE_IDS.LSP8IdentifiableDigitalAsset
-    );
-    expect(result1).to.be.false;
-    expect(result2).to.be.false;
+  it("should return false when calling supportsInterface on an EOA", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        accounts[1].address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.false;
+
+    expect(
+      await contract.supportsERC165Interface(
+        accounts[1].address,
+        INTERFACE_IDS.LSP8IdentifiableDigitalAsset
+      )
+    ).to.be.false;
   });
 
-  it("Calling a contract without a fallback function that doesn't include `supportsInterface(..)` function", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      noSupportsInterfaceWithoutFallback.address,
-      INTERFACE_IDS.ERC165
-    );
-    expect(result1).to.be.false;
+  it("should return false when calling supportsInterface on a contract without a fallback function that doesn't include `supportsInterface(..)` function", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        noSupportsInterfaceWithoutFallback.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.false;
 
-    const result2 = await contract.supportsERC165Interface(
-      noSupportsInterfaceWithoutFallback.address,
-      INTERFACE_IDS.LSP1UniversalReceiver
-    );
-    expect(result2).to.be.false;
+    expect(
+      await contract.supportsERC165Interface(
+        noSupportsInterfaceWithoutFallback.address,
+        INTERFACE_IDS.LSP1UniversalReceiver
+      )
+    ).to.be.false;
   });
 
-  it("Calling a contract with a fallback function that doesn't include `supportsInterface(..)` function", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      noSupportsInterfaceWithFallback.address,
-      INTERFACE_IDS.ERC165
-    );
+  it("should return false when calling supportsInterface on a contract with a fallback function that doesn't include `supportsInterface(..)` function", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        noSupportsInterfaceWithFallback.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.false;
 
-    expect(result1).to.be.false;
-
-    const result2 = await contract.supportsERC165Interface(
-      noSupportsInterfaceWithFallback.address,
-      INTERFACE_IDS.LSP1UniversalReceiver
-    );
-
-    expect(result2).to.be.false;
+    expect(
+      await contract.supportsERC165Interface(
+        noSupportsInterfaceWithFallback.address,
+        INTERFACE_IDS.LSP1UniversalReceiver
+      )
+    ).to.be.false;
   });
 
-  it("Calling a contract that include `supportsInterface(..)` function that reverts", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      supportsInterfaceRevert.address,
-      INTERFACE_IDS.ERC165
-    );
+  it("should return false when calling supportsInterface on a contract that include `supportsInterface(..)` function and reverts", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceRevert.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.false;
 
-    expect(result1).to.be.false;
-
-    const result2 = await contract.supportsERC165Interface(
-      supportsInterfaceRevert.address,
-      INTERFACE_IDS.LSP1UniversalReceiver
-    );
-
-    expect(result2).to.be.false;
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceRevert.address,
+        INTERFACE_IDS.LSP1UniversalReceiver
+      )
+    ).to.be.false;
   });
 
-  it("Calling a contract that include `supportsInterface(..)` function that only supports ERC165", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      supportsInterfaceOnlyERC165.address,
-      INTERFACE_IDS.ERC165
-    );
+  it("should return true for ERC165InterfaceId and false for LSP1InterfaceId when calling supportsInterface on a contract that include `supportsInterface(..)` function and only supports ERC165", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceOnlyERC165.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.true;
 
-    expect(result1).to.be.true;
-
-    const result2 = await contract.supportsERC165Interface(
-      supportsInterfaceOnlyERC165.address,
-      INTERFACE_IDS.LSP1UniversalReceiver
-    );
-
-    expect(result2).to.be.false;
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceOnlyERC165.address,
+        INTERFACE_IDS.LSP1UniversalReceiver
+      )
+    ).to.be.false;
   });
 
-  it("Calling a contract that include `supportsInterface(..)` function that only supports LSP0", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      supportsInterfaceOnlyLSP0.address,
-      INTERFACE_IDS.ERC165
-    );
+  it("should return false for ERC165InterfaceId and true for LSP0InterfaceId when calling supportsInterface on a contract that include `supportsInterface(..)` function and only supports LSP0", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceOnlyLSP0.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.false;
 
-    expect(result1).to.be.false;
-
-    const result2 = await contract.supportsERC165Interface(
-      supportsInterfaceOnlyLSP0.address,
-      INTERFACE_IDS.LSP0ERC725Account
-    );
-
-    expect(result2).to.be.true;
+    expect(
+      await contract.supportsERC165Interface(
+        supportsInterfaceOnlyLSP0.address,
+        INTERFACE_IDS.LSP0ERC725Account
+      )
+    ).to.be.true;
   });
 
-  it("Calling a contract that include `supportsInterface(..)` function that supports ERC725 and ERC165", async () => {
-    const result1 = await contract.supportsERC165Interface(
-      erc725.address,
-      INTERFACE_IDS.ERC165
-    );
+  it("should return true for when calling supportsInterface on a contract that include `supportsInterface(..)` function and supports ERC725 and ERC165", async () => {
+    expect(
+      await contract.supportsERC165Interface(
+        erc725.address,
+        INTERFACE_IDS.ERC165
+      )
+    ).to.be.true;
 
-    expect(result1).to.be.true;
+    expect(
+      await contract.supportsERC165Interface(
+        erc725.address,
+        INTERFACE_IDS.ERC725X
+      )
+    ).to.be.true;
 
-    const result2 = await contract.supportsERC165Interface(
-      erc725.address,
-      INTERFACE_IDS.ERC725X
-    );
-
-    expect(result2).to.be.true;
-
-    const result3 = await contract.supportsERC165Interface(
-      erc725.address,
-      INTERFACE_IDS.ERC725Y
-    );
-
-    expect(result3).to.be.true;
+    expect(
+      await contract.supportsERC165Interface(
+        erc725.address,
+        INTERFACE_IDS.ERC725Y
+      )
+    ).to.be.true;
   });
 
-  it("Calling a random/pre-compiled contract addresses", async () => {
+  it("should return false on pre-compiled contract addresses 0x0...01, and 0x0...05 till 0x0...09 with ANY bytes4 interface ID", async () => {
     const precompiledAddress = [
-      "0x0000000000000000000000000000000000000000",
       "0x0000000000000000000000000000000000000001",
-      "0x0000000000000000000000000000000000000002",
-      "0x0000000000000000000000000000000000000003",
-      "0x0000000000000000000000000000000000000004",
       "0x0000000000000000000000000000000000000005",
       "0x0000000000000000000000000000000000000006",
       "0x0000000000000000000000000000000000000007",
       "0x0000000000000000000000000000000000000008",
       "0x0000000000000000000000000000000000000009",
-      "0x0000000000000000000000000000000000000010",
-      "0x0000000000000000000000000000000000000011",
-      "0x0000000000000000000000000000000000000012",
-      "0x0000000000000000000000000000000000000013",
-      "0x0000000000000000000000000000000000000014",
-      "0x0000000000000000000000000000000000000015",
-      "0x0000000000000000000000000000000000000016",
-      "0x0000000000000000000000000000000000000017",
-      "0x0000000000000000000000000000000000000018",
-      "0x0000000000000000000000000000000000000019",
-      "0x0000000000000000000000000000000000000020",
     ];
 
     for (let i = 0; i < precompiledAddress.length; i++) {
-      const result1 = await contract.supportsERC165Interface(
-        precompiledAddress[i],
-        INTERFACE_IDS.ERC165
-      );
-
-      // The call on precomiled contracts: 0x0..02, 0x0..03, 0x0..04 will always return true
-      if (i > 1 && i < 5) {
-        expect(result1).to.be.true;
-      } else {
-        expect(result1).to.be.false;
-      }
-
-      const result2 = await contract.supportsERC165Interface(
-        precompiledAddress[i],
-        INTERFACE_IDS.LSP0ERC725Account
-      );
-
-      // The call on precomiled contracts: 0x0..02, 0x0..03, 0x0..04 will always return true
-      if (i > 1 && i < 5) {
-        expect(result2).to.be.true;
-      } else {
-        expect(result2).to.be.false;
+      for (let ii = 0; ii < 1000; ii++) {
+        const result = await contract.supportsERC165Interface(
+          precompiledAddress[i],
+          ethers.utils.hexlify(ethers.utils.randomBytes(4))
+        );
+        expect(result).to.be.false;
       }
     }
   });
 
-  it("Calling a pre-compiled contract addresses 0x0.02, 0x0.04 and 0x0.04", async () => {
+  it("should always return true on pre-compiled contract addresses 0x0...02, 0x0...03 and 0x0...04 with ANY bytes4 interface ID", async () => {
     const precompiledAddress = [
       "0x0000000000000000000000000000000000000002",
       "0x0000000000000000000000000000000000000003",

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -187,7 +187,7 @@ describe("Test Custom implementation of ERC165Checker", () => {
     ];
 
     for (let i = 0; i < precompiledAddress.length; i++) {
-      for (let ii = 0; ii < 1000; ii++) {
+      for (let ii = 0; ii < 100; ii++) {
         const result = await contract.supportsERC165Interface(
           precompiledAddress[i],
           ethers.utils.hexlify(ethers.utils.randomBytes(4))
@@ -205,7 +205,7 @@ describe("Test Custom implementation of ERC165Checker", () => {
     ];
 
     for (let i = 0; i < precompiledAddress.length; i++) {
-      for (let ii = 0; ii < 1000; ii++) {
+      for (let ii = 0; ii < 100; ii++) {
         const result = await contract.supportsERC165Interface(
           precompiledAddress[i],
           ethers.utils.hexlify(ethers.utils.randomBytes(4))

--- a/tests/Helpers/ERC165CheckerCustom.test.ts
+++ b/tests/Helpers/ERC165CheckerCustom.test.ts
@@ -223,7 +223,7 @@ describe("Test Custom implementation of ERC165Checker", () => {
     }
   });
 
-  it.skip("Calling a pre-compiled contract addresses 0x0.02, 0x0.04 and 0x0.04", async () => {
+  it("Calling a pre-compiled contract addresses 0x0.02, 0x0.04 and 0x0.04", async () => {
     const precompiledAddress = [
       "0x0000000000000000000000000000000000000002",
       "0x0000000000000000000000000000000000000003",


### PR DESCRIPTION
## What does this PR introduce?
- Adding more tests to ERC165CheckerCustom.
- Identify unexpected behavior pointed by Lucas from RV and confirm the case with tests.

### Unexpected Behavior

#### Normal cases
- When we call `supportsERC165Interface(address account, bytes4 interfaceId)` on an `account` that supports `interfaceId` via ERC165 it should return true. When the `account` doesn't support `interfaceId` it should return false.

#### Edge Cases
- When we call `supportsERC165Interface(address account, bytes4 interfaceId)` on the following precompiled adresses as `account`:  
                   - `0x0000000000000000000000000000000000000002`  
                   - `0x0000000000000000000000000000000000000003`
                   - `0x0000000000000000000000000000000000000004`    
                   it's always returning true regardless of the interfaceId (Checked 1000 interfaceIds). 

