### PR TITLE
fix: Add appropriate overrides of supportsInterface in LSP7 and LSP8

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ILSP7CompatibleERC20} from "./ILSP7CompatibleERC20.sol";
 import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
 
@@ -26,6 +27,19 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
         string memory symbol_,
         address newOwner_
     ) LSP7DigitalAsset(name_, symbol_, newOwner_, false) {}
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC725YCore, LSP7DigitalAsset)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
 
     /**
      * @inheritdoc ILSP7CompatibleERC20

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ILSP7CompatibleERC20} from "./ILSP7CompatibleERC20.sol";
 import {ILSP7DigitalAsset} from "../ILSP7DigitalAsset.sol";
 
@@ -35,6 +36,19 @@ abstract contract LSP7CompatibleERC20InitAbstract is
         address newOwner_
     ) internal virtual override onlyInitializing {
         LSP7DigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_, false);
+    }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, ERC725YCore, LSP7DigitalAssetInitAbstract)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -62,7 +62,7 @@ abstract contract LSP8CompatibleERC721 is
         public
         view
         virtual
-        override(IERC165, LSP8IdentifiableDigitalAsset)
+        override(IERC165, ERC725YCore, LSP8IdentifiableDigitalAsset)
         returns (bool)
     {
         return

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -58,7 +58,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
         public
         view
         virtual
-        override(IERC165, LSP8IdentifiableDigitalAssetInitAbstract)
+        override(IERC165, ERC725YCore, LSP8IdentifiableDigitalAssetInitAbstract)
         returns (bool)
     {
         return

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -94,7 +94,7 @@ const config: HardhatUserConfig = {
     showMethodSig: true,
   },
   solidity: {
-    version: "0.8.10",
+    version: "0.8.13",
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
When compiling with Solidity version 0.8.13, the compiler produces the following errors:

```
TypeError: Derived contract must override function "supportsInterface". Two or more base classes define function with same name and parameter types.
  --> contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol:16:1:
   |
16 | abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility, LSP7DigitalAsset {
   | ^ (Relevant source part starts here and spans across multiple lines).
Note: Definition in "ERC725YCore": 
   --> @erc725/smart-contracts/contracts/ERC725YCore.sol:101:5:
    |
101 |     function supportsInterface(bytes4 interfaceId)
    |     ^ (Relevant source part starts here and spans across multiple lines).
Note: Definition in "LSP7DigitalAsset": 
  --> contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol:44:5:
   |
44 |     function supportsInterface(bytes4 interfaceId)
   |     ^ (Relevant source part starts here and spans across multiple lines).

...

TypeError: Function needs to specify overridden contract "ERC725YCore".
  --> contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol:65:9:
   |
65 |         override(IERC165, LSP8IdentifiableDigitalAsset)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: This contract: 
  --> @erc725/smart-contracts/contracts/ERC725YCore.sol:24:1:
   |
24 | abstract contract ERC725YCore is OwnableUnset, ERC165, IERC725Y {
   | ^ (Relevant source part starts here and spans across multiple lines).
```
The same errors are also flagged in `LSP7CompatibleERC20InitAbstract` and `LSP8CompatibleERC721InitAbstract`, respectively.

This happens because the `supportsInterface` function from `ERC725YCore` (inherited via `LSP4Compatibility`) is not being properly overriden. To fix this, we do the following:
* Add an override for the `supportsInterface` function to `LSP7CompatibleERC20` and `LSP7CompatibleERC20InitAbstract`.
* Add `ERC725YCore` to the `overrides` clause of `supportsInterface` in `LSP8CompatibleERC721` and `LSP8CompatibleERC721InitAbstract`.