### PR TITLE
 feat!: adjust supportsInterface in LSP0/9 to support Interfaces of ERC165Extension

### DIFF
--- a/contracts/Helpers/FallbackExtensions/ERC165Extension.sol
+++ b/contracts/Helpers/FallbackExtensions/ERC165Extension.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @dev This contract is used only for testing purposes
+ */
+contract ERC165Extension is IERC165 {
+    bytes4 private constant _RANDOM_INTERFACE_ID = 0xaabbccdd;
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == _RANDOM_INTERFACE_ID;
+    }
+}

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -69,8 +69,6 @@ abstract contract LSP0ERC725AccountCore is
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
     }
 
-    // solhint-disable
-
     /**
      * @dev Returns the extension stored under the `_LSP17_EXTENSION_PREFIX` data key
      * mapped to the functionSelector provided.
@@ -88,6 +86,8 @@ abstract contract LSP0ERC725AccountCore is
 
         return extension;
     }
+
+    // solhint-disable no-complex-fallback
 
     /**
      * @dev Emits an event when receiving native tokens
@@ -111,10 +111,13 @@ abstract contract LSP0ERC725AccountCore is
         _fallbackLSP17Extendable();
     }
 
-    // solhint-enable
-
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`.
+     *
+     * If the contract doesn't support the `interfaceId`, it forwards the call to the
+     * `supportsInterface` extension according to LSP17, and checks if the extension
+     * implements the interface defined by `interfaceId`.
      */
     function supportsInterface(bytes4 interfaceId)
         public

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -131,8 +131,8 @@ abstract contract LSP0ERC725AccountCore is
             interfaceId == _INTERFACEID_LSP0 ||
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_LSP14 ||
-            _supportsInterfaceInERC165Extension(interfaceId) ||
-            super.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId) ||
+            _supportsInterfaceInERC165Extension(interfaceId);
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 // interfaces
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 
@@ -128,6 +129,7 @@ abstract contract LSP0ERC725AccountCore is
             interfaceId == _INTERFACEID_LSP0 ||
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_LSP14 ||
+            _supportsInterfaceInERC165Extension(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/LSP17ContractExtension/LSP17Extendable.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extendable.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {ERC165Checker} from "../Custom/ERC165Checker.sol";
 
 // constants
 import {_INTERFACEID_LSP17_EXTENDABLE} from "./LSP17Constants.sol";
@@ -19,6 +20,26 @@ abstract contract LSP17Extendable is ERC165 {
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
         return interfaceId == _INTERFACEID_LSP17_EXTENDABLE || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @dev Returns whether the interfaceId being checked is supported in the extension of the
+     * {supportsInterface} selector.
+     */
+    function _supportsInterfaceInERC165Extension(bytes4 interfaceId)
+        internal
+        view
+        virtual
+        returns (bool)
+    {
+        address erc165Extension = _getExtension(ERC165.supportsInterface.selector);
+        if (erc165Extension == address(0)) return false;
+
+        if (ERC165Checker.supportsERC165Interface(erc165Extension, interfaceId)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/contracts/LSP17ContractExtension/LSP17Extendable.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extendable.sol
@@ -35,11 +35,7 @@ abstract contract LSP17Extendable is ERC165 {
         address erc165Extension = _getExtension(ERC165.supportsInterface.selector);
         if (erc165Extension == address(0)) return false;
 
-        if (ERC165Checker.supportsERC165Interface(erc165Extension, interfaceId)) {
-            return true;
-        } else {
-            return false;
-        }
+        return ERC165Checker.supportsERC165Interface(erc165Extension, interfaceId);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 // interfaces
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 
 // libraries
@@ -139,6 +140,7 @@ contract LSP9VaultCore is
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_LSP14 ||
+            _supportsInterfaceInERC165Extension(interfaceId) ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -83,8 +83,6 @@ contract LSP9VaultCore is
         if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
     }
 
-    // solhint-disable
-
     /**
      * @dev Returns the extension stored under the `_LSP17_EXTENSION_PREFIX` data key
      * mapped to the functionSelector provided.
@@ -102,6 +100,8 @@ contract LSP9VaultCore is
 
         return extension;
     }
+
+    // solhint-disable no-complex-fallback
 
     /**
      * @dev Emits an event when receiving native tokens
@@ -123,10 +123,13 @@ contract LSP9VaultCore is
         _fallbackLSP17Extendable();
     }
 
-    // solhint-enable
-
     /**
-     * @dev See {IERC165-supportsInterface}.
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`.
+     *
+     * If the contract doesn't support the `interfaceId`, it forwards the call to the
+     * `supportsInterface` extension according to LSP17, and checks if the extension
+     * implements the interface defined by `interfaceId`.
      */
     function supportsInterface(bytes4 interfaceId)
         public

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 // interfaces
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
 
 // libraries

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -142,8 +142,8 @@ contract LSP9VaultCore is
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_LSP14 ||
-            _supportsInterfaceInERC165Extension(interfaceId) ||
-            super.supportsInterface(interfaceId);
+            super.supportsInterface(interfaceId) ||
+            _supportsInterfaceInERC165Extension(interfaceId);
     }
 
     /**

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -673,16 +673,14 @@ export const shouldBehaveLikeLSP17 = (
         describe("when calling the supportsInterface of the extendable contract with `0xaabbccdd` value", () => {
           describe("when the ERC165 extension was not set", () => {
             it("should return false", async () => {
-              let result = await context.contract.supportsInterface(
-                "0xaabbccdd"
-              );
-              expect(result).to.be.false;
+              expect(await context.contract.supportsInterface("0xaabbccdd")).to
+                .be.false;
             });
           });
 
           describe("when the ERC165 extension was set", () => {
             let erc165Extension: ERC165Extension;
-            beforeEach(async () => {
+            before(async () => {
               erc165Extension = await new ERC165Extension__factory(
                 context.accounts[0]
               ).deploy();
@@ -696,10 +694,8 @@ export const shouldBehaveLikeLSP17 = (
             });
 
             it("should return true", async () => {
-              let result = await context.contract.supportsInterface(
-                "0xaabbccdd"
-              );
-              expect(result).to.be.true;
+              expect(await context.contract.supportsInterface("0xaabbccdd")).to
+                .be.true;
             });
           });
         });

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -8,6 +8,8 @@ import {
   CheckerExtension__factory,
   CheckerExtension,
   RevertStringExtension,
+  ERC165Extension,
+  ERC165Extension__factory,
   RevertStringExtension__factory,
   RevertCustomExtension,
   RevertCustomExtension__factory,
@@ -54,7 +56,8 @@ export const shouldBehaveLikeLSP17 = (
     reenterAccountFunctionSelector,
     revertStringFunctionSelector,
     revertCustomFunctionSelector,
-    emitEventFunctionSelector;
+    emitEventFunctionSelector,
+    supportsInterfaceFunctionSelector;
 
   let checkMsgVariableFunctionExtensionHandlerKey,
     nameFunctionExtensionHandlerKey,
@@ -65,7 +68,8 @@ export const shouldBehaveLikeLSP17 = (
     revertStringFunctionExtensionHandlerKey,
     revertCustomFunctionExtensionHandlerKey,
     emitEventFunctionExtensionHandlerKey,
-    onERC721ReceivedFunctionExtensionHandlerKey;
+    onERC721ReceivedFunctionExtensionHandlerKey,
+    supportsInterfaceFunctionExtensionHandlerKey;
 
   beforeEach(async () => {
     context = await buildContext();
@@ -100,6 +104,9 @@ export const shouldBehaveLikeLSP17 = (
 
     // onERC721Received(address,address,uint256,bytes)
     onERC721ReceivedFunctionSelector = "0x150b7a02";
+
+    // supportsInterface(bytes4)
+    supportsInterfaceFunctionSelector = "0x01ffc9a7";
 
     checkMsgVariableFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
@@ -144,6 +151,11 @@ export const shouldBehaveLikeLSP17 = (
     onERC721ReceivedFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       onERC721ReceivedFunctionSelector.substring(2) +
+      "00000000000000000000000000000000"; // zero padded
+
+    supportsInterfaceFunctionExtensionHandlerKey =
+      ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+      supportsInterfaceFunctionSelector.substring(2) +
       "00000000000000000000000000000000"; // zero padded
   });
 
@@ -654,6 +666,40 @@ export const shouldBehaveLikeLSP17 = (
                   })
                 ).to.emit(emitEventExtension, "EventEmittedInExtension");
               });
+            });
+          });
+        });
+
+        describe("when calling the supportsInterface of the extendable contract with `0xaabbccdd` value", () => {
+          describe("when the ERC165 extension was not set", () => {
+            it("should return false", async () => {
+              let result = await context.contract.supportsInterface(
+                "0xaabbccdd"
+              );
+              expect(result).to.be.false;
+            });
+          });
+
+          describe("when the ERC165 extension was set", () => {
+            let erc165Extension: ERC165Extension;
+            beforeEach(async () => {
+              erc165Extension = await new ERC165Extension__factory(
+                context.accounts[0]
+              ).deploy();
+
+              await context.contract
+                .connect(context.deployParams.owner)
+                ["setData(bytes32,bytes)"](
+                  supportsInterfaceFunctionExtensionHandlerKey,
+                  erc165Extension.address
+                );
+            });
+
+            it("should return true", async () => {
+              let result = await context.contract.supportsInterface(
+                "0xaabbccdd"
+              );
+              expect(result).to.be.true;
             });
           });
         });

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -71,7 +71,7 @@ export const shouldBehaveLikeLSP17 = (
     onERC721ReceivedFunctionExtensionHandlerKey,
     supportsInterfaceFunctionExtensionHandlerKey;
 
-  beforeEach(async () => {
+  before(async () => {
     context = await buildContext();
     newOwner = context.accounts[1];
 


### PR DESCRIPTION
## What does this PR introduce?
- Adding to LSP0/9 the possibility of supporting an interface through the ERC165Extension.

### Why this changes are introduced?
- Since we implemented Fallback extensions in LSP0, now we can call functions on the LSP0 that are not existing as part of the core code but as extensions, but adding functions as extensions is not enough since some application check InterfaceId before calling. (For example in our `universalReceiver(..)` function we check LSP1 interfaceId before calling the function)

To avoid situations where we implement a new function as extension but we miss supporting the interfaceId, we decided to check if there is more interfaceIds supported in the ERC165Extension whenever someone calls the `supportsInterface(..)` function of the LSP0/LSP9

### Old Behavior

The `supportsInterface(..)` on LSP0 will return true if only called with the interfaceId of `LSP0`, `LSP14`, `LSP17`, `ERC725X`, `ERC725Y` and `ERC1271`.

### New Behavior

If no ERC165Extension is set, the `supportsInterface(..)` on LSP0 will return true if only called with the following interfaceIds: `LSP0`, `LSP14`, `LSP17`, `ERC725X`, `ERC725Y` and `ERC1271`.

If the ERC165Extension is set, the `supportsInterface(..)` on LSP0 will return true if called with the following interfaceIds: `LSP0`, `LSP14`, `LSP17`, `ERC725X`, `ERC725Y` and `ERC1271` **and** if the interfaceId being checked matches the interfaceIds existing in the `supportsInterface(..)` of the ERC165Extension.

If the function doesn't exist on the extension or the function reverts, the call will return false. 