### PR TITLE
build: update @erc725-smart-contracts package

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -435,11 +435,12 @@ const EventSignatures = {
 		 *     uint256 indexed _operation,
 		 *     address indexed _contractAddress,
 		 *     uint256 indexed _value
+		 * 	   bytes32 _salt
 		 * );
 		 *
-		 * signature = keccak256('ContractCreated(uint256,address,uint256)')
+		 * signature = keccak256('ContractCreated(uint256,address,uint256,bytes32)')
 		 */
-		ContractCreated: '0x01c42bd7e97a66166063b02fce6924e6656b6c2c61966630165095c4fb0b7b2f',
+		ContractCreated: '0xa1fb700aaee2ae4a2ff6f91ce7eba292f89c2f5488b8ec4c5c5c8150692595c3',
 		/**
 		 * event Executed(
 		 *      uint256 indexed _operation,

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -182,7 +182,7 @@ abstract contract LSP0ERC725AccountCore is
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        return super.execute(operationType, target, value, data);
+        return _execute(operationType, target, value, data);
     }
 
     /**
@@ -197,7 +197,7 @@ abstract contract LSP0ERC725AccountCore is
         bytes[] memory datas
     ) public payable virtual override onlyOwner returns (bytes[] memory) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        return super.execute(operationsType, targets, values, datas);
+        return _execute(operationsType, targets, values, datas);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -163,7 +163,7 @@ contract LSP9VaultCore is
         bytes memory data
     ) public payable virtual override onlyOwner returns (bytes memory) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        return super.execute(operationType, target, value, data);
+        return _execute(operationType, target, value, data);
     }
 
     /**
@@ -178,7 +178,7 @@ contract LSP9VaultCore is
         bytes[] memory datas
     ) public payable virtual override onlyOwner returns (bytes[] memory) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        return super.execute(operationsType, targets, values, datas);
+        return _execute(operationsType, targets, values, datas);
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^4.0.0",
+        "@erc725/smart-contracts": "^4.1.0",
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
         "solidity-bytes-utils": "0.8.0"
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.0.0.tgz",
-      "integrity": "sha512-0DlQPJb5/BrYM9/obahc64s/6OgXtaXeZj7HeDgH++h4vaYhF6oORm6WkcT3VrNvfQrWmlN/q8JLxqjx31JxLw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.1.0.tgz",
+      "integrity": "sha512-YGOjJt/6OyhvG+uObknwUeVRLKfnoo5/BcWT0+OMR2IFR7SEEJpNQxNmAWmFhhl1hlPbuMWhuUDJQjVKKoS7DA==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
@@ -19907,9 +19907,9 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.0.0.tgz",
-      "integrity": "sha512-0DlQPJb5/BrYM9/obahc64s/6OgXtaXeZj7HeDgH++h4vaYhF6oORm6WkcT3VrNvfQrWmlN/q8JLxqjx31JxLw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.1.0.tgz",
+      "integrity": "sha512-YGOjJt/6OyhvG+uObknwUeVRLKfnoo5/BcWT0+OMR2IFR7SEEJpNQxNmAWmFhhl1hlPbuMWhuUDJQjVKKoS7DA==",
       "requires": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^4.0.0",
+    "@erc725/smart-contracts": "^4.1.0",
     "@openzeppelin/contracts": "^4.7.3",
     "@openzeppelin/contracts-upgradeable": "^4.7.3",
     "solidity-bytes-utils": "0.8.0"

--- a/tests/LSP6KeyManager/tests/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/BatchExecute.test.ts
@@ -306,7 +306,8 @@ export const shouldBehaveLikeBatchExecute = (
           .withArgs(
             OPERATION_TYPES.CREATE,
             ethers.utils.getAddress(futureTokenAddress),
-            0
+            0,
+            ethers.utils.hexZeroPad("0x00", 32)
           );
 
         // CHECK initialize parameters have been set correctly
@@ -419,7 +420,8 @@ export const shouldBehaveLikeBatchExecute = (
           .withArgs(
             OPERATION_TYPES.CREATE,
             ethers.utils.getAddress(futureTokenAddress),
-            0
+            0,
+            ethers.utils.hexZeroPad("0x00", 32)
           );
 
         // CHECK for tokens balances of recipients

--- a/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionDeploy.test.ts
@@ -78,7 +78,8 @@ export const shouldBehaveLikePermissionDeploy = (
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
-          0
+          0,
+          ethers.utils.hexZeroPad("0x00", 32)
         );
     });
 
@@ -110,7 +111,8 @@ export const shouldBehaveLikePermissionDeploy = (
         .withArgs(
           OPERATION_TYPES.CREATE2,
           ethers.utils.getAddress(preComputedAddress),
-          0
+          0,
+          salt
         );
     });
   });
@@ -140,7 +142,8 @@ export const shouldBehaveLikePermissionDeploy = (
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
-          0
+          0,
+          ethers.utils.hexZeroPad("0x00", 32)
         );
     });
 
@@ -172,7 +175,8 @@ export const shouldBehaveLikePermissionDeploy = (
         .withArgs(
           OPERATION_TYPES.CREATE2,
           ethers.utils.getAddress(preComputedAddress),
-          0
+          0,
+          salt
         );
     });
   });


### PR DESCRIPTION
## What does this PR introduce?
[x] Update to erc725-smart-contratc to [**0.4.1**](https://github.com/ERC725Alliance/ERC725/releases/tag/v4.1.0) which include:
- Modification the `ContractCreated` event which now include an extra parameter (salt), Check this [PR](https://github.com/ERC725Alliance/ERC725/pull/183) 
- Refactor logic to internal functions, which make it possible to call internal functions instead of using `super` (to optimize).

[x] Update event signature
[x] Resolve the tests to support the new param of ContractCreated