### PR TITLE
refactor: add length check in verifyAllowedERC725YSingleKey

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -141,4 +141,4 @@ error LSP6BatchExcessiveValueSent(uint256 totalValues, uint256 msgValue);
 /**
  * @dev reverts when CompatactBytesArray length element is not valid
  */
-error InvalidCompactByteArrayLengthElement(uint256 length);
+error InvalidCompactByteArrayLengthElement(uint256 invalidLength);

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -137,3 +137,8 @@ error LSP6BatchInsufficientValueSent(uint256 totalValues, uint256 msgValue);
  * forwarded on each payloads (`values[]` parameter from the batch functions above).
  */
 error LSP6BatchExcessiveValueSent(uint256 totalValues, uint256 msgValue);
+
+/**
+ * @dev reverts when CompatactBytesArray length element is not valid
+ */
+error InvalidCompactByteArrayLengthElement(uint256 length);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -631,6 +631,11 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
              */
             uint256 length = uint256(uint8(bytes1(allowedERC725YDataKeysCompacted[pointer])));
 
+            /**
+            * the length of the following key must be under 33 bytes
+            */
+            if (length > 32) revert InvalidCompactByteArrayLengthElement(length);
+
             /*
              * transform the allowed key situated from `pointer + 1` until `pointer + 1 + length` to a bytes32 value
              * E.g. 0xfff83a -> 0xfff83a0000000000000000000000000000000000000000000000000000000000

--- a/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 
 import { BytesLike } from "ethers";
 import { LSP6InternalsTestContext } from "../../utils/context";
+import { encodeCompactBytesArray } from "../../utils/helpers";
 
 export type DataKey = {
   length: BytesLike;
@@ -724,19 +725,17 @@ export const testAllowedERC725YDataKeysInternals = (
         });
       });
     });
+
     describe("_verifyAllowedERC725YSingleKey", () => {
       it("should revert if compactBytesArray length element is superior at 32", async () => {
         const length33InHex = "0x21";
         const dynamicKeyOfLength33 = ethers.utils.hexlify(
           ethers.utils.randomBytes(33)
         );
-        const compactBytesArray_with_0_length = ethers.utils.concat([
-          dataKeys.firstDynamicKey.length,
+        const compactBytesArray_with_0_length = encodeCompactBytesArray([
           dataKeys.firstDynamicKey.key,
-          dataKeys.secondDynamicKey.length,
-          dataKeys.secondDynamicKey.key,
-          length33InHex,
           dynamicKeyOfLength33,
+          dataKeys.thirdDynamicKey.key,
         ]);
 
         await expect(

--- a/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
@@ -724,5 +724,34 @@ export const testAllowedERC725YDataKeysInternals = (
         });
       });
     });
+    describe("_verifyAllowedERC725YSingleKey", () => {
+      it("should revert if compactBytesArray length element is superior at 32", async () => {
+        const length33InHex = "0x21";
+        const dynamicKeyOfLength33 = ethers.utils.hexlify(
+          ethers.utils.randomBytes(33)
+        );
+        const compactBytesArray_with_0_length = ethers.utils.concat([
+          dataKeys.firstDynamicKey.length,
+          dataKeys.firstDynamicKey.key,
+          dataKeys.secondDynamicKey.length,
+          dataKeys.secondDynamicKey.key,
+          length33InHex,
+          dynamicKeyOfLength33,
+        ]);
+
+        await expect(
+          context.keyManagerInternalTester.verifyAllowedERC725YSingleKey(
+            context.universalProfile.address,
+            dataKeys.firstFixedKey.key,
+            compactBytesArray_with_0_length
+          )
+        )
+          .to.be.revertedWithCustomError(
+            context.keyManagerInternalTester,
+            "InvalidCompactByteArrayLengthElement"
+          )
+          .withArgs(length33InHex);
+      });
+    });
   });
 };


### PR DESCRIPTION
## What does this PR introduce?

Added check that makes sure the length of a dynamic key is not superior to 32 in order to avoid overflow.