### PR TITLE
refactor: add new utility methods in LSP5Utils and LSP10Utils

### DIFF
--- a/contracts/LSP10ReceivedVaults/LSP10Utils.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Utils.sol
@@ -54,7 +54,7 @@ library LSP10Utils {
         values = new bytes[](3);
 
         IERC725Y account = IERC725Y(receiver);
-        bytes memory encodedArrayLength = account.getData(_LSP10_VAULTS_ARRAY_KEY);
+        bytes memory encodedArrayLength = getLSP10ReceivedVaultsCount(account);
 
         // If it's the first vault to receive
         if (encodedArrayLength.length == 0) {
@@ -105,7 +105,7 @@ library LSP10Utils {
         IERC725Y account = IERC725Y(sender);
 
         // Updating the number of the received vaults
-        uint256 oldArrayLength = uint256(bytes32(account.getData(_LSP10_VAULTS_ARRAY_KEY)));
+        uint256 oldArrayLength = uint256(bytes32(getLSP10ReceivedVaultsCount(account)));
         uint256 newArrayLength = oldArrayLength - 1;
 
         uint64 index = extractIndexFromMap(vaultInterfaceIdAndIndex);
@@ -176,6 +176,10 @@ library LSP10Utils {
             keys[4] = lastVaultInArrayMapKey;
             values[4] = bytes.concat(_INTERFACEID_LSP9, bytes8(index));
         }
+    }
+
+    function getLSP10ReceivedVaultsCount(IERC725Y account) internal view returns (bytes memory) {
+        return account.getData(_LSP10_VAULTS_ARRAY_KEY);
     }
 
     /**

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -54,7 +54,7 @@ library LSP5Utils {
         values = new bytes[](3);
 
         IERC725Y account = IERC725Y(receiver);
-        bytes memory encodedArrayLength = account.getData(_LSP5_RECEIVED_ASSETS_ARRAY_KEY);
+        bytes memory encodedArrayLength = getLSP5ReceivedAssetsCount(account);
 
         // If it's the first asset to receive
         if (encodedArrayLength.length == 0) {
@@ -105,7 +105,7 @@ library LSP5Utils {
         IERC725Y account = IERC725Y(sender);
 
         // Updating the number of the received assets
-        uint256 oldArrayLength = uint256(bytes32(account.getData(_LSP5_RECEIVED_ASSETS_ARRAY_KEY)));
+        uint256 oldArrayLength = uint256(bytes32(getLSP5ReceivedAssetsCount(account)));
         uint256 newArrayLength = oldArrayLength - 1;
 
         uint64 index = extractIndexFromMap(assetInterfaceIdAndIndex);
@@ -179,6 +179,10 @@ library LSP5Utils {
             keys[4] = lastAssetInArrayMapKey;
             values[4] = bytes.concat(interfaceID, bytes8(index));
         }
+    }
+
+    function getLSP5ReceivedAssetsCount(IERC725Y account) internal view returns (bytes memory) {
+        return account.getData(_LSP5_RECEIVED_ASSETS_ARRAY_KEY);
     }
 
     /**


### PR DESCRIPTION
## What does this PR introduce?

In this PR a getter is introduced in both `LSP5Utils` and `LSP10Utils`:
- In `LSP5Utils` for getting the length of the array of `ReceivedAssets`
- In `LSP10Utils` for getting the length of the array of `ReceivedVaults`