### PR TITLE
refactor: [WP-D19] Change event `RenounceOwnershipInitiated` to `RenounceOwnershipStarted` in LSP14

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -612,7 +612,7 @@ const EventSignatures = {
 		 * signature = keccak256('RenounceOwnershipStarted()')
 		 */
 		RenounceOwnershipStarted:
-			'0x34adc479e345fc66ff75380de886d5353e8a315a2216b874cd957fbeeab20d9a',
+			'0x81b7f830f1f0084db6497c486cbe6974c86488dcc4e3738eab94ab6d6b1653e7',
 		/**
 		 * event OwnershipRenounced();
 		 *

--- a/constants.js
+++ b/constants.js
@@ -607,12 +607,12 @@ const EventSignatures = {
 		OwnershipTransferStarted:
 			'0x38d16b8cac22d99fc7c124b9cd0de2d3fa1faef420bfe791d8c362d765e22700',
 		/**
-		 * event RenounceOwnershipInitiated();
+		 * event RenounceOwnershipStarted();
 		 *
-		 * signature = keccak256('RenounceOwnershipInitiated()')
+		 * signature = keccak256('RenounceOwnershipStarted()')
 		 */
-		RenounceOwnershipInitiated:
-			'0X56272768d104766ae5e663c58927d0a9e47effb40b9a8f6644ac5dfbc9e56f84',
+		RenounceOwnershipStarted:
+			'0x34adc479e345fc66ff75380de886d5353e8a315a2216b874cd957fbeeab20d9a',
 		/**
 		 * event OwnershipRenounced();
 		 *

--- a/contracts/LSP14Ownable2Step/ILSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/ILSP14Ownable2Step.sol
@@ -19,7 +19,7 @@ interface ILSP14Ownable2Step {
     /**
      * @dev emitted when starting the `renounceOwnership(..)` 2-step process.
      */
-    event RenounceOwnershipInitiated();
+    event RenounceOwnershipStarted();
 
     /**
      * @dev emitted when the ownership of the contract has been renounced.

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -152,7 +152,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
 
         if (currentBlock > confirmationPeriodEnd) {
             _renounceOwnershipStartedAt = currentBlock;
-            emit RenounceOwnershipInitiated();
+            emit RenounceOwnershipStarted();
             return;
         }
 

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -336,10 +336,10 @@ export const shouldBehaveLikeLSP14 = (
         ).to.equal(renounceOwnershipTx.blockNumber);
       });
 
-      it("should have emitted a RenounceOwnershipInitiated event", async () => {
+      it("should have emitted a RenounceOwnershipStarted event", async () => {
         await expect(renounceOwnershipTx).to.emit(
           context.contract,
-          "RenounceOwnershipInitiated"
+          "RenounceOwnershipStarted"
         );
       });
 


### PR DESCRIPTION
## What does this PR introduce?

This PR updates the name of the event `RenounceOwnershipInitiated()` to `RenounceOwnershipStarted()` according to the specs of [LSP14](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-14-Ownable2Step.md#renounceownershipstarted)