### PR TITLE
refactor: [WP-G21] LSP-14: Unnecessary SLOAD

### DIFF
--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -124,7 +124,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
         require(msg.sender == pendingOwner(), "LSP14: caller is not the pendingOwner");
 
         address previousOwner = owner();
-        _setOwner(_pendingOwner);
+        _setOwner(msg.sender);
         delete _pendingOwner;
 
         _notifyUniversalReceiver(


### PR DESCRIPTION
## What does this PR introduce?

In this PR we remove an unnecessary SLOAD by changing `_setOwner(_pendingOwner);` to `_setOwner(msg.sender);`

```solidity
function _acceptOwnership() internal virtual {
        require(msg.sender == pendingOwner(), "LSP14: caller is not the pendingOwner");

        address previousOwner = owner();
        _setOwner(msg.sender);
        [...]
}
```