### PR TITLE
[WP-M1] LSP-2: `LSP2Utils.isCompactBytesArray(bytes)` Empty array (`[]`) will return `false`

### DIFF
--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -267,7 +267,6 @@ library LSP2Utils {
      * @dev Verify the validity of the `compactBytesArray` according to LSP2
      */
     function isCompactBytesArray(bytes memory compactBytesArray) internal pure returns (bool) {
-        if (compactBytesArray.length == 0) return false;
         /**
          * Pointer will always land on these values:
          *

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -529,10 +529,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         view
         returns (bytes32)
     {
-        uint256 dataValueLength = uint256(bytes32(dataValue));
-        bool isEmptyArray = dataValueLength == 0;
-
-        if (!isEmptyArray && !LSP2Utils.isCompactBytesArray(dataValue)) {
+        if (!LSP2Utils.isCompactBytesArray(dataValue)) {
             if (bytes12(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDCALLS_PREFIX) {
                 revert InvalidEncodedAllowedCalls(dataValue);
             } else {
@@ -540,10 +537,13 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
             }
         }
 
-        bytes memory storedAllowedValues = ERC725Y(_target).getData(dataKey);
-
+        // if there is nothing stored under the data key, depending on the data key being set, we are trying to:
+        //  - either ADD a list of restricted calls (standards + address + function selector)
+        //  - or ADD a list of restricted ERC725Y Data Keys.
+        //
+        // if there are already some data set under one of these data keys, we are trying to CHANGE (= edit) these restrictions.
         return
-            storedAllowedValues.length == 0
+            ERC725Y(_target).getData(dataKey).length == 0
                 ? _PERMISSION_ADDPERMISSIONS
                 : _PERMISSION_CHANGEPERMISSIONS;
     }

--- a/contracts/Mocks/LSP2UtilsLibraryTester.sol
+++ b/contracts/Mocks/LSP2UtilsLibraryTester.sol
@@ -6,7 +6,11 @@ import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 contract LSP2UtilsLibraryTester {
     using LSP2Utils for *;
 
-    function isEncodedArray(bytes memory _data) public pure returns (bool) {
-        return _data.isEncodedArray();
+    function isEncodedArray(bytes memory data) public pure returns (bool) {
+        return data.isEncodedArray();
+    }
+
+    function isCompactBytesArray(bytes memory data) public pure returns (bool) {
+        return data.isCompactBytesArray();
     }
 }

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -183,4 +183,32 @@ describe("LSP2Utils", () => {
       });
     });
   });
+
+  describe("`isCompactBytesArray(...)`", () => {
+    it("should return true with `0x` (equivalent to `[]`)", async () => {
+      const data = "0x";
+      const result = await lsp2Utils.isCompactBytesArray(data);
+      expect(result).to.be.true;
+    });
+
+    it("should return false with `0x00`", async () => {
+      const data = "0x00";
+      const result = await lsp2Utils.isCompactBytesArray(data);
+      expect(result).to.be.false;
+    });
+
+    describe("when pass a CompactBytesArray with one element", () => {
+      it("should return true when the first length byte matches the following number of bytes", async () => {
+        const data = "0x05aabbccddee";
+        const result = await lsp2Utils.isCompactBytesArray(data);
+        expect(result).to.be.true;
+      });
+
+      it("should return false when the first length does not matches the following number of bytes", async () => {
+        const data = "0x04aabbccddee";
+        const result = await lsp2Utils.isCompactBytesArray(data);
+        expect(result).to.be.false;
+      });
+    });
+  });
 });

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -191,12 +191,6 @@ describe("LSP2Utils", () => {
       expect(result).to.be.true;
     });
 
-    it("should return false with `0x00`", async () => {
-      const data = "0x00";
-      const result = await lsp2Utils.isCompactBytesArray(data);
-      expect(result).to.be.false;
-    });
-
     describe("when pass a CompactBytesArray with one element", () => {
       it("should return true when the first length byte matches the following number of bytes", async () => {
         const data = "0x05aabbccddee";


### PR DESCRIPTION

<img width="705" alt="image" src="https://user-images.githubusercontent.com/31145285/211344303-79ee61b4-ecdd-4546-8eb3-e07c4771acab.png">


<img width="711" alt="image" src="https://user-images.githubusercontent.com/31145285/211344163-ff3880c4-e1de-4b0a-a901-01cb96cc7763.png">
