### PR TITLE
refactor: make LSP14 processes cancel each other.

### DIFF
--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -106,6 +106,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
         if (newOwner == address(this)) revert CannotTransferOwnershipToSelf();
 
         _pendingOwner = newOwner;
+        delete _renounceOwnershipStartedAt;
         address currentOwner = owner();
         emit OwnershipTransferStarted(currentOwner, newOwner);
 
@@ -152,6 +153,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
 
         if (currentBlock > confirmationPeriodEnd) {
             _renounceOwnershipStartedAt = currentBlock;
+            delete _pendingOwner;
             emit RenounceOwnershipStarted();
             return;
         }

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -347,7 +347,7 @@ export const shouldBehaveLikeLSP14 = (
         expect(await context.contract.owner()).to.equal(currentOwner.address);
       });
 
-      it("should not reset the pendingOwner", async () => {
+      it("should reset the pendingOwner", async () => {
         const anotherOwner = context.accounts[3].address;
 
         await context.contract
@@ -356,7 +356,9 @@ export const shouldBehaveLikeLSP14 = (
 
         await context.contract.connect(currentOwner).renounceOwnership();
 
-        expect(await context.contract.pendingOwner()).to.equal(anotherOwner);
+        expect(await context.contract.pendingOwner()).to.equal(
+          ethers.constants.AddressZero
+        );
       });
 
       describe("currentOwner should still be able to interact with contract before confirming", () => {


### PR DESCRIPTION
## What does this PR introduce?

In the PR the process of transferring ownership is canceled when the process of renouncing ownership is started and vice-versa.