### PR TITLE
fix: Use @openzeppelin/contracts-upgradeable for Initializable imports

### DIFF
--- a/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInit.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInit.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {LSP11BasicSocialRecoveryInitAbstract} from "./LSP11BasicSocialRecoveryInitAbstract.sol";
 
 /**

--- a/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInitAbstract.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInitAbstract.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // modules
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 import {LSP11BasicSocialRecoveryCore} from "./LSP11BasicSocialRecoveryCore.sol";
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInitAbstract.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.5;
 
 // modules
 import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
 import {InvalidLSP6Target} from "./LSP6Errors.sol";
 

--- a/contracts/Mocks/ImplementationTester.sol
+++ b/contracts/Mocks/ImplementationTester.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 contract ImplementationTester is Initializable {
     address private _owner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@erc725/smart-contracts": "^4.1.0",
         "@openzeppelin/contracts": "^4.8.0",
-        "@openzeppelin/contracts-upgradeable": "^4.7.3",
+        "@openzeppelin/contracts-upgradeable": "^4.8.0",
         "solidity-bytes-utils": "0.8.0"
       },
       "devDependencies": {
@@ -1813,9 +1813,9 @@
       "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
-      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz",
+      "integrity": "sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw=="
     },
     "node_modules/@primitivefi/hardhat-dodoc": {
       "version": "0.1.3",
@@ -21324,9 +21324,9 @@
       "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
-      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.1.tgz",
+      "integrity": "sha512-1wTv+20lNiC0R07jyIAbHU7TNHKRwGiTGRfiNnA8jOWjKT98g5OgLpYWOi40Vgpk8SPLA9EvfJAbAeIyVn+7Bw=="
     },
     "@primitivefi/hardhat-dodoc": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@erc725/smart-contracts": "^4.1.0",
     "@openzeppelin/contracts": "^4.8.0",
-    "@openzeppelin/contracts-upgradeable": "^4.7.3",
+    "@openzeppelin/contracts-upgradeable": "^4.8.0",
     "solidity-bytes-utils": "0.8.0"
   },
   "devDependencies": {

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,6 @@
 @erc725/=node_modules/@erc725/
-@openzeppelin/=node_modules/@openzeppelin/
+@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 eth-gas-reporter/=node_modules/eth-gas-reporter/
 forge-std/=lib/forge-std/src/
 hardhat-deploy/=node_modules/hardhat-deploy/


### PR DESCRIPTION
Also bumped the @openzepplin versions for parity