### PR TITLE
refactor: replace > by >=

### DIFF
--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -287,7 +287,7 @@ library LSP2Utils {
          * Make sure that the last length describes exactly the last bytes value and you do not get out of bounds.
          */
         while (pointer < compactBytesArray.length) {
-            if (pointer + 1 >= compactBytesArray.length) return false;
+            if (pointer + 1 > compactBytesArray.length) return false;
             uint256 elementLength = uint16(
                 bytes2(abi.encodePacked(compactBytesArray[pointer], compactBytesArray[pointer + 1]))
             );

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -287,7 +287,7 @@ library LSP2Utils {
          * Make sure that the last length describes exactly the last bytes value and you do not get out of bounds.
          */
         while (pointer < compactBytesArray.length) {
-            if (pointer + 1 > compactBytesArray.length) return false;
+            if (pointer + 1 >= compactBytesArray.length) return false;
             uint256 elementLength = uint16(
                 bytes2(abi.encodePacked(compactBytesArray[pointer], compactBytesArray[pointer + 1]))
             );

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -92,7 +92,7 @@ library LSP6Utils {
         pure
         returns (bool)
     {
-        if(allowedCallsCompacted.length == 0) return false;
+        if (allowedCallsCompacted.length == 0) return false;
 
         uint256 pointer;
 

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -159,6 +159,7 @@ library LSP6Utils {
 
     /**
      * @dev combine multiple permissions into a single bytes32
+     * Make sure that the sum of the values of the input array is less than 2^256-1 to avoid overflow.
      * @param _permissions the array of permissions to combine
      * @return a bytes32 containing the combined permissions
      */

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -95,7 +95,7 @@ library LSP6Utils {
         uint256 pointer;
 
         while (pointer < allowedCallsCompacted.length) {
-            if (pointer + 1 > allowedCallsCompacted.length) return false;
+            if (pointer + 1 >= allowedCallsCompacted.length) return false;
             uint256 elementLength = uint16(
                 bytes2(
                     abi.encodePacked(
@@ -124,7 +124,7 @@ library LSP6Utils {
         uint256 pointer;
 
         while (pointer < allowedERC725YDataKeysCompacted.length) {
-            if (pointer + 1 > allowedERC725YDataKeysCompacted.length) return false;
+            if (pointer + 1 >= allowedERC725YDataKeysCompacted.length) return false;
             uint256 elementLength = uint16(
                 bytes2(
                     abi.encodePacked(

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -92,6 +92,8 @@ library LSP6Utils {
         pure
         returns (bool)
     {
+        if(allowedCallsCompacted.length == 0) return false;
+
         uint256 pointer;
 
         while (pointer < allowedCallsCompacted.length) {

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -92,8 +92,6 @@ library LSP6Utils {
         pure
         returns (bool)
     {
-        if (allowedCallsCompacted.length == 0) return false;
-
         uint256 pointer;
 
         while (pointer < allowedCallsCompacted.length) {
@@ -123,6 +121,7 @@ library LSP6Utils {
     function isCompactBytesArrayOfAllowedERC725YDataKeys(
         bytes memory allowedERC725YDataKeysCompacted
     ) internal pure returns (bool) {
+        if (allowedERC725YDataKeysCompacted.length == 0) return false;
         uint256 pointer;
 
         while (pointer < allowedERC725YDataKeysCompacted.length) {

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -121,7 +121,6 @@ library LSP6Utils {
     function isCompactBytesArrayOfAllowedERC725YDataKeys(
         bytes memory allowedERC725YDataKeysCompacted
     ) internal pure returns (bool) {
-        if (allowedERC725YDataKeysCompacted.length == 0) return false;
         uint256 pointer;
 
         while (pointer < allowedERC725YDataKeysCompacted.length) {

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,4 +7,4 @@ cache_path = 'forge-cache'
 test = 'tests/foundry'
 solc_version = "0.8.15"
 [fuzz]
-runs = 100_000
+runs = 10_000

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -262,6 +262,7 @@ describe("LSP2Utils", () => {
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });
+
       it("should return false for 0x000000", async () => {
         const data = "0x000000";
         const result = await lsp2Utils.isCompactBytesArray(data);

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -262,6 +262,11 @@ describe("LSP2Utils", () => {
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });
+      it("should return false for 0x000000", async () => {
+        const data = "0x000000";
+        const result = await lsp2Utils.isCompactBytesArray(data);
+        expect(result).to.be.false;
+      });
     });
   });
 });

--- a/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
+++ b/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
@@ -41,9 +41,8 @@ contract LSP2UtilsTests is Test {
         uint16 thirdBytesLength
     ) public view {
         // check if thirdBytesLength is not too big to speed up test
-        if (thirdBytesLength > 750) {
-            return;
-        }
+        if (thirdBytesLength > 750) return;
+
         // store firstBytes length
         bytes memory firstBytes = _generateRandomBytes(firstBytesLength);
         // store secondBytes length

--- a/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
+++ b/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
@@ -36,20 +36,29 @@ contract LSP2UtilsTests is Test {
     }
 
     function testIsCompactBytesArray(
-        bytes32 firstBytes,
-        bytes20 secondBytes,
-        bytes2 thirdBytes
-    ) public pure {
+        uint8 firstBytesLength,
+        uint8 secondBytesLength,
+        uint16 thirdBytesLength
+    ) public view {
+        // check if thirdBytesLength is not too big to speed up test
+        if (thirdBytesLength > 750) {
+            return;
+        }
         // store firstBytes length
-        uint16 firstBytesLength = firstBytes.length;
+        bytes memory firstBytes = _generateRandomBytes(firstBytesLength);
         // store secondBytes length
-        uint16 secondBytesLength = secondBytes.length;
+        bytes memory secondBytes = _generateRandomBytes(secondBytesLength);
+
+        bytes memory thirdBytes = _generateRandomBytes(thirdBytesLength);
+
+        uint16 firstBytesLength16 = uint16(firstBytesLength);
+        uint16 secondBytesLength16 = uint16(secondBytesLength);
+
         // store thirdBytes length
-        uint16 thirdBytesLength = thirdBytes.length;
         bytes memory data = abi.encodePacked(
-            firstBytesLength,
+            firstBytesLength16,
             firstBytes,
-            secondBytesLength,
+            secondBytesLength16,
             secondBytes,
             thirdBytesLength,
             thirdBytes
@@ -60,7 +69,7 @@ contract LSP2UtilsTests is Test {
     function testShouldNotRevertWithLowerLengthElement(
         bytes memory firstBytes,
         bytes memory secondBytes,
-        uint8 reducer
+        uint16 reducer
     ) public pure {
         // store firstBytes length
         uint16 firstBytesLength = uint16(firstBytes.length);
@@ -107,5 +116,13 @@ contract LSP2UtilsTests is Test {
         );
 
         LSP2Utils.isCompactBytesArray(data);
+    }
+
+    function _generateRandomBytes(uint256 length) private view returns (bytes memory) {
+        bytes memory b = new bytes(length);
+        for (uint256 i = 0; i < length; i++) {
+            b[i] = bytes1(uint8(uint256(keccak256(abi.encodePacked(block.timestamp, i)))));
+        }
+        return b;
     }
 }

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import "../../../contracts/LSP6KeyManager/LSP6Utils.sol";
+
+contract LSP6UtilsTests is Test {
+    function testIsCBAOfAllowedCallsWithValidAllowedCalls(uint8 numberOfAllowedCalls) public view {
+        bytes memory allowedCalls = _generateAllowedCalls(numberOfAllowedCalls % 50, 28);
+
+        assert(LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithSmallerAllowedCalls(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        bytes memory allowedCalls = _generateAllowedCalls(
+            numberOfAllowedCalls % 50,
+            numberOfAllowedCalls % 28
+        );
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithSmallerAllowedCallsAtTheBeginning(
+        uint8 numberOfAllowedCalls
+    ) public view {
+        bytes memory invalidAllowedCall = _generateAllowedCalls(1, numberOfAllowedCalls % 28);
+        bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(invalidAllowedCall, validAllowedCall);
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithSmallerAllowedCallsInTheMiddle(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        bytes memory validAllowedCallBefore = _generateAllowedCalls(1, 28);
+        bytes memory invalidAllowedCall = _generateAllowedCalls(1, numberOfAllowedCalls % 28);
+        bytes memory validAllowedCallAfter = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(
+            validAllowedCallBefore,
+            invalidAllowedCall,
+            validAllowedCallAfter
+        );
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithSmallerAllowedCallsAtTheEnd(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        bytes memory invalidAllowedCall = _generateAllowedCalls(1, numberOfAllowedCalls % 28);
+        bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(validAllowedCall, invalidAllowedCall);
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithBiggerAllowedCall(uint8 numberOfAllowedCalls) public view {
+        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+        bytes memory allowedCalls = _generateAllowedCalls(
+            numberOfAllowedCalls % 50,
+            numberOfAllowedCalls % allowedCallLength
+        );
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithBiggerAllowedCallAtTheBeginning(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+
+        bytes memory invalidAllowedCall = _generateAllowedCalls(
+            1,
+            numberOfAllowedCalls % allowedCallLength
+        );
+        bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(invalidAllowedCall, validAllowedCall);
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithBiggerAllowedCallInTheMiddle(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+
+        bytes memory validAllowedCallBefore = _generateAllowedCalls(1, 28);
+        bytes memory invalidAllowedCall = _generateAllowedCalls(
+            1,
+            numberOfAllowedCalls % allowedCallLength
+        );
+        bytes memory validAllowedCallAfter = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(
+            validAllowedCallBefore,
+            invalidAllowedCall,
+            validAllowedCallAfter
+        );
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function testIsCBAOfAllowedCallsWithBiggerAllowedCallAtTheEnd(uint8 numberOfAllowedCalls)
+        public
+        view
+    {
+        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+
+        bytes memory allowedCallsEnd = _generateAllowedCalls(
+            1,
+            numberOfAllowedCalls % allowedCallLength
+        );
+        bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
+        bytes memory allowedCalls = abi.encodePacked(validAllowedCall, allowedCallsEnd);
+
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
+    }
+
+    function _generateAllowedCalls(uint8 numberOfAllowedCalls, uint8 allowedCallLength)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes memory allowedCalls;
+        for (uint8 i = 0; i < numberOfAllowedCalls; i++) {
+            bytes memory allowedCall = _generateRandomBytes(allowedCallLength);
+            bytes memory allowedCallallowedCall = abi.encodePacked(
+                bytes2(uint16(allowedCallLength)),
+                allowedCall
+            );
+            allowedCalls = abi.encodePacked(allowedCalls, allowedCallallowedCall);
+        }
+        return allowedCalls;
+    }
+
+    function _generateRandomBytes(uint8 length) internal view returns (bytes memory) {
+        bytes memory bytesArray = new bytes(length);
+        for (uint8 i = 0; i < length; i++) {
+            bytesArray[i] = bytes1(
+                uint8(
+                    uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty))) %
+                        (i + 1)
+                )
+            );
+        }
+        return bytesArray;
+    }
+}

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -63,11 +63,12 @@ contract LSP6UtilsTests is Test {
     }
 
     function testIsCBAOfAllowedCallsWithBiggerAllowedCall(uint8 numberOfAllowedCalls) public view {
-        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
-        bytes memory allowedCalls = _generateAllowedCalls(
-            numberOfAllowedCalls % 50,
-            numberOfAllowedCalls % allowedCallLength
-        );
+        uint8 allowedCallLength = (numberOfAllowedCalls % (255 - 28)) + 29;
+        if (allowedCallLength == 28) {
+            allowedCallLength = allowedCallLength + 1;
+        }
+
+        bytes memory allowedCalls = _generateAllowedCalls(1, allowedCallLength);
 
         assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
     }
@@ -76,12 +77,12 @@ contract LSP6UtilsTests is Test {
         public
         view
     {
-        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+        uint8 allowedCallLength = (numberOfAllowedCalls % (255 - 28)) + 29;
+        if (allowedCallLength == 28) {
+            allowedCallLength = allowedCallLength + 1;
+        }
 
-        bytes memory invalidAllowedCall = _generateAllowedCalls(
-            1,
-            numberOfAllowedCalls % allowedCallLength
-        );
+        bytes memory invalidAllowedCall = _generateAllowedCalls(1, allowedCallLength);
         bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
         bytes memory allowedCalls = abi.encodePacked(invalidAllowedCall, validAllowedCall);
 
@@ -92,13 +93,13 @@ contract LSP6UtilsTests is Test {
         public
         view
     {
-        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+        uint8 allowedCallLength = (numberOfAllowedCalls % (255 - 28)) + 29;
+        if (allowedCallLength == 28) {
+            allowedCallLength = allowedCallLength + 1;
+        }
 
         bytes memory validAllowedCallBefore = _generateAllowedCalls(1, 28);
-        bytes memory invalidAllowedCall = _generateAllowedCalls(
-            1,
-            numberOfAllowedCalls % allowedCallLength
-        );
+        bytes memory invalidAllowedCall = _generateAllowedCalls(1, allowedCallLength);
         bytes memory validAllowedCallAfter = _generateAllowedCalls(1, 28);
         bytes memory allowedCalls = abi.encodePacked(
             validAllowedCallBefore,
@@ -113,12 +114,9 @@ contract LSP6UtilsTests is Test {
         public
         view
     {
-        uint8 allowedCallLength = (numberOfAllowedCalls % uint8(type(uint8).max)) + 29;
+        uint8 allowedCallLength = (numberOfAllowedCalls % (255 - 28)) + 29;
 
-        bytes memory allowedCallsEnd = _generateAllowedCalls(
-            1,
-            numberOfAllowedCalls % allowedCallLength
-        );
+        bytes memory allowedCallsEnd = _generateAllowedCalls(1, allowedCallLength);
         bytes memory validAllowedCall = _generateAllowedCalls(1, 28);
         bytes memory allowedCalls = abi.encodePacked(validAllowedCall, allowedCallsEnd);
 

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -7,7 +7,8 @@ import "../../../contracts/LSP6KeyManager/LSP6Utils.sol";
 
 contract LSP6UtilsTests is Test {
     function testIsCBAOfAllowedCallsWithValidAllowedCalls(uint8 numberOfAllowedCalls) public view {
-        bytes memory allowedCalls = _generateAllowedCalls(numberOfAllowedCalls % 50, 28);
+        // generate between 1 and 50 allowedCalls
+        bytes memory allowedCalls = _generateAllowedCalls((numberOfAllowedCalls % 50) + 1, 28);
 
         assert(LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
     }
@@ -17,7 +18,7 @@ contract LSP6UtilsTests is Test {
         view
     {
         bytes memory allowedCalls = _generateAllowedCalls(
-            numberOfAllowedCalls % 50,
+            (numberOfAllowedCalls % 50) + 1,
             numberOfAllowedCalls % 28
         );
 
@@ -124,6 +125,147 @@ contract LSP6UtilsTests is Test {
         assert(!LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls));
     }
 
+    function testIsCBAOfAllowedERC725YDataKeys(uint16 elementLength) public view {
+        uint8 numberBetween1and32 = uint8((elementLength % 31) + 1); // +1 to avoid having 0
+        bytes memory allowedKeys = _generateElementCBA(numberBetween1and32, numberBetween1and32);
+        assert(LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysForElementBiggerThan32ShouldReturnFalse(
+        uint16 elementLength
+    ) public view {
+        uint8 numberOver32 = uint8((elementLength % 31) + 33);
+        bytes memory allowedKeys = _generateElementCBA(numberOver32, numberOver32);
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidShorterCBAAtTheBeginning(
+        uint16 elementLength
+    ) public view {
+        uint8 numberBetween1and32 = uint8((elementLength % 32) + 1); // +1 to avoid having 0
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 - 1
+        );
+        bytes memory validAllowedKeys = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory allowedKeys = abi.encodePacked(invalidAllowedKey, validAllowedKeys);
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidShorterCBAInTheMiddle(uint16 elementLength)
+        public
+        view
+    {
+        uint8 numberBetween1and32 = uint8((elementLength % 32) + 1); // +1 to avoid having 0
+        bytes memory validAllowedKeysBefore = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 - 1
+        );
+        bytes memory validAllowedKeysAfter = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory allowedKeys = abi.encodePacked(
+            validAllowedKeysBefore,
+            invalidAllowedKey,
+            validAllowedKeysAfter
+        );
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidShorterCBAAtTheEnd(uint16 elementLength)
+        public
+        view
+    {
+        uint8 numberBetween1and32 = uint8((elementLength % 32) + 1); // +1 to avoid having 0
+        bytes memory validAllowedKeys = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 - 1
+        );
+        bytes memory allowedKeys = abi.encodePacked(validAllowedKeys, invalidAllowedKey);
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidBiggerCBAAtTheBeginning(
+        uint16 elementLength
+    ) public view {
+        uint8 numberBetween1and32 = uint8((elementLength % 31) + 1); // +1 to avoid having 0
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 + 1
+        );
+        bytes memory validAllowedKeys = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory allowedKeys = abi.encodePacked(invalidAllowedKey, validAllowedKeys);
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidBiggerCBAInTheMiddle(uint16 elementLength)
+        public
+        view
+    {
+        uint8 numberBetween1and32 = uint8((elementLength % 31) + 1); // +1 to avoid having 0
+        bytes memory validAllowedKeysBefore = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 + 1
+        );
+        bytes memory validAllowedKeysAfter = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory allowedKeys = abi.encodePacked(
+            validAllowedKeysBefore,
+            invalidAllowedKey,
+            validAllowedKeysAfter
+        );
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function testIsCBAOfAllowedERC725YDataKeysWithInvalidBiggerCBAAtTheEnd(uint16 elementLength)
+        public
+        view
+    {
+        uint8 numberBetween1and32 = uint8((elementLength % 31) + 1); // +1 to avoid having 0
+        bytes memory validAllowedKeys = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32
+        );
+        bytes memory invalidAllowedKey = _generateElementCBA(
+            numberBetween1and32,
+            numberBetween1and32 + 1
+        );
+        bytes memory allowedKeys = abi.encodePacked(validAllowedKeys, invalidAllowedKey);
+        assert(!LSP6Utils.isCompactBytesArrayOfAllowedERC725YDataKeys(allowedKeys));
+    }
+
+    function _generateElementCBA(uint16 elementLength, uint16 officialElementLength)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes memory elementBytes = _generateRandomBytes(elementLength);
+        bytes2 elementLengthToBytes2 = bytes2(uint16(officialElementLength));
+        bytes memory elementCBA = abi.encodePacked(elementLengthToBytes2, elementBytes);
+        return elementCBA;
+    }
+
     function _generateAllowedCalls(uint8 numberOfAllowedCalls, uint8 allowedCallLength)
         internal
         view
@@ -141,7 +283,7 @@ contract LSP6UtilsTests is Test {
         return allowedCalls;
     }
 
-    function _generateRandomBytes(uint8 length) internal view returns (bytes memory) {
+    function _generateRandomBytes(uint16 length) internal view returns (bytes memory) {
         bytes memory bytesArray = new bytes(length);
         for (uint8 i = 0; i < length; i++) {
             bytesArray[i] = bytes1(

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -264,6 +264,27 @@ contract LSP6UtilsTests is Test {
         return elementCBA;
     }
 
+    function testCombinePermissions(
+        uint64 firstPermission,
+        uint64 secondPermission,
+        uint64 thirdPermission,
+        uint64 foruthPermission
+    ) public pure {
+        uint256 totalPermissions = uint256(firstPermission) +
+            uint256(secondPermission) +
+            uint256(thirdPermission) +
+            uint256(foruthPermission);
+        bytes32 totalPermissionsBytes32 = bytes32(totalPermissions);
+
+        bytes32[] memory combinePermissions = new bytes32[](4);
+        combinePermissions[0] = bytes32(uint256(firstPermission));
+        combinePermissions[1] = bytes32(uint256(secondPermission));
+        combinePermissions[2] = bytes32(uint256(thirdPermission));
+        combinePermissions[3] = bytes32(uint256(foruthPermission));
+
+        assert(totalPermissionsBytes32 == LSP6Utils.combinePermissions(combinePermissions));
+    }
+
     function _generateAllowedCalls(uint8 numberOfAllowedCalls, uint8 allowedCallLength)
         internal
         view


### PR DESCRIPTION
# What does this PR introduce? 

- [x] Replace `>` by `>=` in `isCompactBytesArray(...)`.
- [x] Add several fuzzing test to `isCompactBytesArrayOfAllowedCalls`
- [x] Add several fuzzing test to `isCompactBytesArrayOfAllowedERC725YDataKeys`
- [x] Fuzz `combinePermissions`
- [x] Fuzz `hasPermission` 
