### PR TITLE
refactor: refactor LSP0 `isValidSignature(..)` to low level call 

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -162,11 +162,11 @@ abstract contract LSP0ERC725AccountCore is
         virtual
         returns (bytes4 magicValue)
     {
-        address owner_ = owner();
+        address _owner = owner();
 
         // If owner is a contract
-        if (owner_.code.length > 0) {
-            (bool success, bytes memory result) = owner_.staticcall(
+        if (_owner.code.length > 0) {
+            (bool success, bytes memory result) = _owner.staticcall(
                 abi.encodeWithSelector(IERC1271.isValidSignature.selector, dataHash, signature)
             );
 
@@ -179,7 +179,7 @@ abstract contract LSP0ERC725AccountCore is
         // If owner is an EOA
         else {
             return
-                owner_ == ECDSA.recover(dataHash, signature)
+                _owner == ECDSA.recover(dataHash, signature)
                     ? _ERC1271_MAGICVALUE
                     : _ERC1271_FAILVALUE;
         }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -26,6 +26,7 @@ import "@erc725/smart-contracts/contracts/errors.sol";
 import {
     _INTERFACEID_LSP0,
     _INTERFACEID_ERC1271,
+    _ERC1271_MAGICVALUE,
     _ERC1271_FAILVALUE,
     _TYPEID_LSP0_OwnershipTransferStarted,
     _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
@@ -171,15 +172,15 @@ abstract contract LSP0ERC725AccountCore is
 
             bool isValid = (success &&
                 result.length == 32 &&
-                abi.decode(result, (bytes32)) == bytes32(IERC1271.isValidSignature.selector));
+                abi.decode(result, (bytes32)) == bytes32(_ERC1271_MAGICVALUE));
 
-            return isValid ? IERC1271.isValidSignature.selector : _ERC1271_FAILVALUE;
+            return isValid ? _ERC1271_MAGICVALUE : _ERC1271_FAILVALUE;
         }
         // If owner is an EOA
         else {
             return
                 owner_ == ECDSA.recover(dataHash, signature)
-                    ? IERC1271.isValidSignature.selector
+                    ? _ERC1271_MAGICVALUE
                     : _ERC1271_FAILVALUE;
         }
     }

--- a/contracts/Mocks/GenericExecutor.sol
+++ b/contracts/Mocks/GenericExecutor.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract GenericExecutor {
     function call(
         address target,

--- a/contracts/Mocks/GenericExecutor.sol
+++ b/contracts/Mocks/GenericExecutor.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+contract GenericExecutor {
+    function call(
+        address target,
+        uint256 value,
+        bytes memory data
+    ) public returns (bytes memory result) {
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returnData) = target.call{value: value}(data);
+        result = _verifyCallResult(success, returnData, "Unknown Error");
+    }
+
+    function _verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            _revert(returndata, errorMessage);
+        }
+    }
+
+    function _revert(bytes memory returndata, string memory errorMessage) private pure {
+        // Look for revert reason and bubble it up if present
+        if (returndata.length > 0) {
+            // The easiest way to bubble the revert reason is using memory via assembly
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert(errorMessage);
+        }
+    }
+}

--- a/contracts/Mocks/MaliciousERC1271Wallet.sol
+++ b/contracts/Mocks/MaliciousERC1271Wallet.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.4;
 
 import {GenericExecutor} from "./GenericExecutor.sol";
 
+/**
+ * @dev This contract is used only for testing purposes
+ */
 contract ERC1271MaliciousMock is GenericExecutor {
     /**
      * @dev Returns a malicious 4-byte magic value.

--- a/contracts/Mocks/MaliciousERC1271Wallet.sol
+++ b/contracts/Mocks/MaliciousERC1271Wallet.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {GenericExecutor} from "./GenericExecutor.sol";
+
+contract ERC1271MaliciousMock is GenericExecutor {
+    /**
+     * @dev Returns a malicious 4-byte magic value.
+     * @return bytes4 The malicious 4-byte magic value.
+     */
+    function isValidSignature(bytes32, bytes memory) public pure returns (bytes4) {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            return(0, 32)
+        }
+    }
+}

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -101,7 +101,7 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
     });
 
-    it("should return failValue when the owner isValidSignature function that doesn't return bytes4", async () => {
+    it("should return failValue when the owner call isValidSignature function that doesn't return bytes4", async () => {
       const signer = context.accounts[1];
 
       const maliciousERC1271Wallet = await new ERC1271MaliciousMock__factory(

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -3,7 +3,11 @@ import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 // types
-import { UniversalProfile, TargetContract__factory } from "../types";
+import {
+  UniversalProfile,
+  GenericExecutor__factory,
+  ERC1271MaliciousMock__factory,
+} from "../types";
 
 // helpers
 import { getRandomAddresses } from "./utils/helpers";
@@ -33,6 +37,9 @@ export const shouldBehaveLikeLSP3 = (
   });
 
   describe("when using `isValidSignature()` from ERC1271", () => {
+    afterEach(async () => {
+      context = await buildContext(100);
+    });
     it("should verify signature from owner", async () => {
       const signer = context.deployParams.owner;
 
@@ -61,17 +68,60 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
     });
 
-    /** @todo update this test for acceptOwnership(...) */
-    it("should return failValue when the owner doesn't support ERC1271", async () => {
+    it("should return failValue when the owner doesn't have isValidSignature function", async () => {
       const signer = context.accounts[1];
 
-      const targetContract = await new TargetContract__factory(
+      const genericExecutor = await new GenericExecutor__factory(
         context.accounts[0]
       ).deploy();
 
       await context.universalProfile
         .connect(context.accounts[0])
-        .transferOwnership(targetContract.address);
+        .transferOwnership(genericExecutor.address);
+
+      const acceptOwnershipPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "acceptOwnership"
+        );
+
+      await genericExecutor.call(
+        context.universalProfile.address,
+        0,
+        acceptOwnershipPayload
+      );
+
+      const dataToSign = "0xcafecafe";
+      const messageHash = ethers.utils.hashMessage(dataToSign);
+      const signature = await signer.signMessage(dataToSign);
+
+      const result = await context.universalProfile.isValidSignature(
+        messageHash,
+        signature
+      );
+      expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
+    });
+
+    it("should return failValue when the owner isValidSignature function that doesn't return bytes4", async () => {
+      const signer = context.accounts[1];
+
+      const maliciousERC1271Wallet = await new ERC1271MaliciousMock__factory(
+        context.accounts[0]
+      ).deploy();
+
+      await context.universalProfile
+        .connect(context.accounts[0])
+        .transferOwnership(maliciousERC1271Wallet.address);
+
+      const acceptOwnershipPayload =
+        context.universalProfile.interface.encodeFunctionData(
+          "acceptOwnership"
+        );
+
+      await maliciousERC1271Wallet.call(
+        context.universalProfile.address,
+        0,
+        acceptOwnershipPayload
+      );
 
       const dataToSign = "0xcafecafe";
       const messageHash = ethers.utils.hashMessage(dataToSign);


### PR DESCRIPTION
## What does this PR introduce ?
- Remove the need to check for supportsInterface in `isValidSignature(..)` .
- Handle the call of `isValidSignature(..)` in a way that the check will not revert in case the function do not exist or the function return an unintended value. Instead just return failure value
- Unify the naming, use `isValidSignature.selector` instead of `InterfaceId`. 
- Use `code.length > 0` instead of `isContract(..)`
- Adjust the LSP0 tests to do the intended behavior of checking the signature (remove todo)
- Add tests for malicious behavior