### PR TITLE
chore: refactor `_validateCallerViaKeyManager` in LSP1DelegateUP

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -174,9 +174,11 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         if (accountOwner.supportsERC165InterfaceUnchecked(_INTERFACEID_LSP6))
             ownerIsKeyManager = true;
 
-        address target = ILSP6KeyManager(accountOwner).target();
-        // check if the caller is the same account controlled by the keyManager
-        if (target != msg.sender) revert CallerNotLSP6LinkedTarget(msg.sender, target);
+        if (ownerIsKeyManager) {
+            address target = ILSP6KeyManager(accountOwner).target();
+            // check if the caller is the same account controlled by the keyManager
+            if (target != msg.sender) revert CallerNotLSP6LinkedTarget(msg.sender, target);
+        }
     }
 
     // --- Overrides


### PR DESCRIPTION
## What does this PR introduce ? 
- refactor `_validateCallerViaKeyManager` in LSP1DelegateUP in a way that the call to check the `target` in LSP6 will only happen if the owner of the UP supports LSP6.