### PR TITLE
refactor: add check for the payload length in `LSP6KeyManagerCore`

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -392,6 +392,10 @@ const Errors = {
 			error: 'DelegateCallDisallowedViaKeyManager()',
 			message: 'LSP6: DelegateCall is disallowed via the Key Manager',
 		},
+		'0x3621bbcc': {
+			error: 'InvalidPayload(bytes)',
+			message: 'LSP6: Invalid Payload',
+		},
 	},
 	LSP7: {
 		'0x08d47949': {

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -136,3 +136,8 @@ error LSP6BatchExcessiveValueSent(uint256 totalValues, uint256 msgValue);
  * @dev ERC725X operation type 4 (DELEGATECALL) is disallowed by default
  */
 error DelegateCallDisallowedViaKeyManager();
+
+/**
+ * @dev reverts when the payload is invalid.
+ */
+error InvalidPayload(bytes payload);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -200,7 +200,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         returns (bytes memory)
     {
         if (payload.length < 4) {
-            revert LSP6InvalidPayload(payload);
+            revert InvalidPayload(payload);
         }
 
         _nonReentrantBefore(msg.sender);
@@ -217,7 +217,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes calldata payload
     ) internal virtual returns (bytes memory) {
         if (payload.length < 4) {
-            revert LSP6InvalidPayload(payload);
+            revert InvalidPayload(payload);
         }
 
         bytes memory encodedMessage = abi.encodePacked(

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -199,6 +199,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         virtual
         returns (bytes memory)
     {
+        if (payload.length < 4) {
+            revert LSP6InvalidPayload(payload);
+        }
+
         _nonReentrantBefore(msg.sender);
         _verifyPermissions(msg.sender, payload);
         bytes memory result = _executePayload(msgValue, payload);
@@ -212,6 +216,10 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         uint256 msgValue,
         bytes calldata payload
     ) internal virtual returns (bytes memory) {
+        if (payload.length < 4) {
+            revert LSP6InvalidPayload(payload);
+        }
+
         bytes memory encodedMessage = abi.encodePacked(
             LSP6_VERSION,
             block.chainid,

--- a/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
+++ b/tests/LSP6KeyManager/tests/OtherScenarios.test.ts
@@ -52,8 +52,30 @@ export const otherTestScenarios = (
   });
 
   describe("payload", () => {
-    it.skip("should fail when sending an empty payload to `keyManager.execute('0x')`", async () => {
-      await context.keyManager.connect(context.owner)["execute(bytes)"]("0x");
+    describe("when the payload is smaller than 4 bytes", () => {
+      it("should revert when using `execute(..)` with a payload smaller than 4 bytes", async () => {
+        await expect(context.keyManager["execute(bytes)"]("0xaabbcc"))
+          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .withArgs("0xaabbcc");
+      });
+
+      it("should revert when using `executeRelayCall(..)` with a payload smaller than 4 bytes", async () => {
+        await expect(
+          context.keyManager["executeRelayCall(bytes,uint256,bytes)"](
+            "0x",
+            0,
+            "0xaabbcc"
+          )
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .withArgs("0xaabbcc");
+      });
+    });
+
+    it("should fail when sending an empty payload to `keyManager.execute('0x')`", async () => {
+      await expect(context.keyManager["execute(bytes)"]("0x"))
+        .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+        .withArgs("0x");
     });
 
     it("Should revert because calling an unexisting function in ERC725", async () => {

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -76,26 +76,6 @@ export const shouldBehaveLikePermissionCall = (
   });
 
   describe("when interacting via `execute(...)`", () => {
-    describe("when the payload is smaller than 4 bytes", () => {
-      it("should revert when using `execute(..)` with a payload smaller than 4 bytes", async () => {
-        await expect(context.keyManager["execute(bytes)"]("0xaabbcc"))
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
-          .withArgs("0xaabbcc");
-      });
-
-      it("should revert when using `executeRelayCall(..)` with a payload smaller than 4 bytes", async () => {
-        await expect(
-          context.keyManager["executeRelayCall(bytes,uint256,bytes)"](
-            "0x",
-            0,
-            "0xaabbcc"
-          )
-        )
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
-          .withArgs("0xaabbcc");
-      });
-    });
-
     describe("when caller has ALL PERMISSIONS", () => {
       it("should pass and change state at the target contract", async () => {
         let argument = "new name";

--- a/tests/LSP6KeyManager/tests/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionCall.test.ts
@@ -76,6 +76,26 @@ export const shouldBehaveLikePermissionCall = (
   });
 
   describe("when interacting via `execute(...)`", () => {
+    describe("when the payload is smaller than 4 bytes", () => {
+      it("should revert when using `execute(..)` with a payload smaller than 4 bytes", async () => {
+        await expect(context.keyManager["execute(bytes)"]("0xaabbcc"))
+          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .withArgs("0xaabbcc");
+      });
+
+      it("should revert when using `executeRelayCall(..)` with a payload smaller than 4 bytes", async () => {
+        await expect(
+          context.keyManager["executeRelayCall(bytes,uint256,bytes)"](
+            "0x",
+            0,
+            "0xaabbcc"
+          )
+        )
+          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .withArgs("0xaabbcc");
+      });
+    });
+
     describe("when caller has ALL PERMISSIONS", () => {
       it("should pass and change state at the target contract", async () => {
         let argument = "new name";


### PR DESCRIPTION
### What does this PR introduce?

In this PR the following changes are made:
- A new error added, 'InvalidPayload(bytes)'.
- A check added in both internal function, `` and `` in order to verify that the payload is not smaller than 4 bytes.