### PR TITLE
refactor: [WP-D11] restrict UniversalReceiverDelegate to set LSP1/6/17 DataKeys

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -499,6 +499,12 @@ const Errors = {
 			message: 'LSP8CappedSupply: cannot mint over the max cap supply',
 		},
 	},
+	LSP9: {
+		'0x199611f': {
+			error: 'LSP1DelegateNotAllowedToSetDataKey(bytes32)',
+			message: 'The UniversalReceiverDelegate is not allowed to set this data key',
+		},
+	},
 	LSP11: {
 		'0x5560e16': {
 			error: 'CallerIsNotGuardian(address)',

--- a/constants.js
+++ b/constants.js
@@ -123,6 +123,8 @@ const ERC725YDataKeys = {
 			index: '0xdf30dba06db6a30e65354d9a64c60986',
 		},
 
+		AddressPermissionsPrefix: '0x4b80742de2bf',
+
 		// AddressPermissions:Permissions:<address>  + bytes2(0)
 		'AddressPermissions:Permissions': '0x4b80742de2bf82acb3630000',
 

--- a/contracts/LSP9Vault/LSP9Errors.sol
+++ b/contracts/LSP9Vault/LSP9Errors.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.4;
+
+/**
+ * @dev reverts when the UniversalReceiverDelegates of the Vault sets LSP1/6/17 Data Keys
+ * @param dataKey The data key that the UniversalReceiverDelegate is not allowed to set
+ */
+error LSP1DelegateNotAllowedToSetDataKey(bytes32 dataKey);

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultMalicious.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultMalicious.sol
@@ -21,6 +21,9 @@ import "../../LSP1UniversalReceiver/LSP1Constants.sol";
 import "../../LSP6KeyManager/LSP6Constants.sol";
 import "../../LSP17ContractExtension/LSP17Constants.sol";
 
+/**
+ * @dev This contract is used only for testing
+ */
 contract UniversalReceiverDelegateVaultMalicious is ERC165Storage {
     constructor() {
         _registerInterface(_INTERFACEID_LSP1);
@@ -86,6 +89,6 @@ contract UniversalReceiverDelegateVaultMalicious is ERC165Storage {
                 Address.verifyCallResult(success, result, "Call reverted");
             }
         }
-        return "";
+        return "Empty";
     }
 }

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultMalicious.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultMalicious.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {ILSP6KeyManager} from "../../LSP6KeyManager/ILSP6KeyManager.sol";
+import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {LSP14Ownable2Step} from "../../LSP14Ownable2Step/LSP14Ownable2Step.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
+// modules
+import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
+import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+
+// constants
+import {SETDATA_ARRAY_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
+import {_TYPEID_LSP7_TOKENSSENDER} from "../../LSP7DigitalAsset/LSP7Constants.sol";
+import "../../LSP1UniversalReceiver/LSP1Constants.sol";
+import "../../LSP6KeyManager/LSP6Constants.sol";
+import "../../LSP17ContractExtension/LSP17Constants.sol";
+
+contract UniversalReceiverDelegateVaultMalicious is ERC165Storage {
+    constructor() {
+        _registerInterface(_INTERFACEID_LSP1);
+    }
+
+    function universalReceiver(bytes32 typeId, bytes memory data)
+        public
+        virtual
+        returns (bytes memory)
+    {
+        if (typeId == keccak256(abi.encodePacked("setData"))) {
+            if (data[0] == 0x00) {
+                IERC725Y(msg.sender).setData(
+                    bytes32(abi.encodePacked(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX, bytes22(0))),
+                    bytes("some random text for the data value")
+                );
+            } else if (data[0] == 0x01) {
+                IERC725Y(msg.sender).setData(
+                    bytes32(abi.encodePacked(_LSP6KEY_ADDRESSPERMISSIONS_PREFIX, bytes26(0))),
+                    bytes("some random text for the data value")
+                );
+            } else if (data[0] == 0x02) {
+                IERC725Y(msg.sender).setData(
+                    bytes32(abi.encodePacked(_LSP17_EXTENSION_PREFIX, bytes22(0))),
+                    bytes("some random text for the data value")
+                );
+            }
+        } else if (typeId == keccak256(abi.encodePacked("setData[]"))) {
+            if (data[0] == 0x00) {
+                bytes32[] memory keys = new bytes32[](1);
+                bytes[] memory values = new bytes[](1);
+
+                keys[0] = bytes32(
+                    abi.encodePacked(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX, bytes22(0))
+                );
+
+                values[0] = bytes("some random text for the data value");
+                bytes memory payload = abi.encodeWithSelector(SETDATA_ARRAY_SELECTOR, keys, values);
+
+                (bool success, bytes memory result) = msg.sender.call(payload);
+                Address.verifyCallResult(success, result, "Call reverted");
+            } else if (data[0] == 0x01) {
+                bytes32[] memory keys = new bytes32[](1);
+                bytes[] memory values = new bytes[](1);
+
+                keys[0] = bytes32(abi.encodePacked(_LSP6KEY_ADDRESSPERMISSIONS_PREFIX, bytes26(0)));
+
+                values[0] = bytes("some random text for the data value");
+                bytes memory payload = abi.encodeWithSelector(SETDATA_ARRAY_SELECTOR, keys, values);
+
+                (bool success, bytes memory result) = msg.sender.call(payload);
+                Address.verifyCallResult(success, result, "Call reverted");
+            } else if (data[0] == 0x02) {
+                bytes32[] memory keys = new bytes32[](1);
+                bytes[] memory values = new bytes[](1);
+
+                keys[0] = bytes32(abi.encodePacked(_LSP17_EXTENSION_PREFIX, bytes22(0)));
+
+                values[0] = bytes("some random text for the data value");
+                bytes memory payload = abi.encodeWithSelector(SETDATA_ARRAY_SELECTOR, keys, values);
+
+                (bool success, bytes memory result) = msg.sender.call(payload);
+                Address.verifyCallResult(success, result, "Call reverted");
+            }
+        }
+        return "";
+    }
+}

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -11,6 +11,7 @@ import {
   UniversalReceiverDelegateVaultSetter__factory,
   UniversalReceiverDelegateVaultReentrantA__factory,
   UniversalReceiverDelegateVaultReentrantB__factory,
+  UniversalReceiverDelegateVaultMalicious__factory,
 } from "../../types";
 
 // helpers
@@ -188,6 +189,296 @@ export const shouldBehaveLikeLSP9 = (
         data.substring(0, 66)
       );
       expect(resultAfter).to.equal("0xddccbbaa");
+    });
+
+    describe("when setting LSP1, LSP6, LSP17 dataKeys", () => {
+      before(async () => {
+        // setting UniversalReceiverDelegate that setData
+        const lsp1UniversalReceiverDelegateVaultMalicious =
+          await new UniversalReceiverDelegateVaultMalicious__factory(
+            context.accounts.anyone
+          ).deploy();
+
+        await context.lsp9Vault
+          .connect(context.accounts.owner)
+          ["setData(bytes32,bytes)"](
+            ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
+            lsp1UniversalReceiverDelegateVaultMalicious.address
+          );
+      });
+      describe("when testing LSP1 Keys", () => {
+        describe("when the owner is setting data", () => {
+          describe("using setData", () => {
+            it("should pass", async () => {
+              const key =
+                ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value = "0xaabbccdd";
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32,bytes)"](key, value);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32)"
+              ](key);
+              expect(result).to.equal(value);
+            });
+          });
+
+          describe("using setData Array", () => {
+            it("should pass", async () => {
+              const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+              const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const key2 =
+                ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value2 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const keys = [key1, key2];
+              const values = [value1, value2];
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32[],bytes[])"](keys, values);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32[])"
+              ](keys);
+
+              expect(result).to.deep.equal(values);
+            });
+          });
+        });
+
+        describe("when the URD is setting data", () => {
+          describe("using setData", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData"]
+              );
+
+              const data = "0x00"; // To set MappedUniversalReceiverDelegate Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
+                    "00".repeat(20)
+                );
+            });
+          });
+          describe("using setData Array", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData[]"]
+              );
+
+              const data = "0x00"; // To set MappedUniversalReceiverDelegate Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
+                    "00".repeat(20)
+                );
+            });
+          });
+        });
+      });
+
+      describe("when testing LSP6 Keys", () => {
+        describe("when the owner is setting data", () => {
+          describe("using setData", () => {
+            it("should pass", async () => {
+              const key =
+                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value = "0xaabbccdd";
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32,bytes)"](key, value);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32)"
+              ](key);
+              expect(result).to.equal(value);
+            });
+          });
+
+          describe("using setData Array", () => {
+            it("should pass", async () => {
+              const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+              const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const key2 =
+                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value2 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const keys = [key1, key2];
+              const values = [value1, value2];
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32[],bytes[])"](keys, values);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32[])"
+              ](keys);
+
+              expect(result).to.deep.equal(values);
+            });
+          });
+        });
+
+        describe("when the URD is setting data", () => {
+          describe("using setData", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData"]
+              );
+
+              const data = "0x01"; // To set LSP6Permission Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP6.AddressPermissionsPrefix +
+                    "00".repeat(26)
+                );
+            });
+          });
+          describe("using setData Array", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData[]"]
+              );
+
+              const data = "0x01"; // To set LSP6Permission Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP6.AddressPermissionsPrefix +
+                    "00".repeat(26)
+                );
+            });
+          });
+        });
+      });
+
+      describe("when testing LSP17 Keys", () => {
+        describe("when the owner is setting data", () => {
+          describe("using setData", () => {
+            it("should pass", async () => {
+              const key =
+                ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value = "0xaabbccdd";
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32,bytes)"](key, value);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32)"
+              ](key);
+              expect(result).to.equal(value);
+            });
+          });
+
+          describe("using setData Array", () => {
+            it("should pass", async () => {
+              const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
+              const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const key2 =
+                ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+                ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+
+              const value2 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
+
+              const keys = [key1, key2];
+              const values = [value1, value2];
+
+              await context.lsp9Vault
+                .connect(context.accounts.owner)
+                ["setData(bytes32[],bytes[])"](keys, values);
+
+              const result = await context.lsp9Vault.callStatic[
+                "getData(bytes32[])"
+              ](keys);
+
+              expect(result).to.deep.equal(values);
+            });
+          });
+        });
+
+        describe("when the URD is setting data", () => {
+          describe("using setData", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData"]
+              );
+
+              const data = "0x02"; // To set LSP17Extension Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + "00".repeat(20)
+                );
+            });
+          });
+          describe("using setData Array", () => {
+            it("should revert", async () => {
+              const typeId = ethers.utils.solidityKeccak256(
+                ["string"],
+                ["setData[]"]
+              );
+
+              const data = "0x02"; // To set LSP17Extension Key
+
+              await expect(context.lsp9Vault.universalReceiver(typeId, data))
+                .to.be.revertedWithCustomError(
+                  context.lsp9Vault,
+                  "LSP1DelegateNotAllowedToSetDataKey"
+                )
+                .withArgs(
+                  ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + "00".repeat(20)
+                );
+            });
+          });
+        });
+      });
     });
 
     describe("when setting a data key with a value less than 256 bytes", () => {


### PR DESCRIPTION
## What does this PR introduce ?
- Refactoring the modifier to a internal function that allow the Owner and the reentrant UniversalReceiverDelegate to setData on the vault
- Add requirement in the setData functions when the URD is the one setting data, to not set LSP1/6/17 Data keys
- Add test suites to cover all scenarios possible  