### PR TITLE
refactor: remove isCBACheck

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -932,6 +932,9 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bool isAllowedFunction;
 
         for (uint256 ii; ii < allowedCallsLength; ii += 30) {
+            if (ii + 28 > allowedCallsLength) {
+                revert InvalidEncodedAllowedCalls(allowedCalls);
+            }
             bytes memory chunk = BytesLib.slice(allowedCalls, ii + 2, 28);
 
             if (bytes28(chunk) == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff) {

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -932,7 +932,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bool isAllowedFunction;
 
         for (uint256 ii; ii < allowedCallsLength; ii += 30) {
-            if (ii + 28 > allowedCallsLength) {
+            if (ii + 30 >= allowedCallsLength) {
                 revert InvalidEncodedAllowedCalls(allowedCalls);
             }
             bytes memory chunk = BytesLib.slice(allowedCalls, ii + 2, 28);

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -923,7 +923,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bytes memory allowedCalls = ERC725Y(_target).getAllowedCallsFor(from);
         uint256 allowedCallsLength = allowedCalls.length;
 
-        if (allowedCallsLength == 0 || !LSP6Utils.isCompactBytesArrayOfAllowedCalls(allowedCalls)) {
+        if (allowedCallsLength == 0) {
             revert NoCallsAllowed(from);
         }
 

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -932,7 +932,7 @@ abstract contract LSP6KeyManagerCore is ERC165, ILSP6KeyManager {
         bool isAllowedFunction;
 
         for (uint256 ii; ii < allowedCallsLength; ii += 30) {
-            if (ii + 30 >= allowedCallsLength) {
+            if (ii + 30 > allowedCallsLength) {
                 revert InvalidEncodedAllowedCalls(allowedCalls);
             }
             bytes memory chunk = BytesLib.slice(allowedCalls, ii + 2, 28);

--- a/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/tests/AllowedAddresses.test.ts
@@ -37,6 +37,7 @@ export const shouldBehaveLikeAllowedAddresses = (
     notAllowedEOA: SignerWithAddress,
     allowedTargetContract: TargetContract,
     notAllowedTargetContract: TargetContract;
+  const invalidEncodedAllowedCallsValue = "0xbadbadbadbad";
 
   before(async () => {
     context = await buildContext();
@@ -79,7 +80,7 @@ export const shouldBehaveLikeAllowedAddresses = (
       combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
       encodedAllowedCalls,
       combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
-      "0xbadbadbadbad",
+      invalidEncodedAllowedCallsValue,
     ];
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
@@ -259,10 +260,8 @@ export const shouldBehaveLikeAllowedAddresses = (
 
       randomAddresses.forEach((recipient) => {
         it(`-> should revert when sending 1 LYX to EOA ${recipient}`, async () => {
-          let initialBalanceUP = await provider.getBalance(
-            context.universalProfile.address
-          );
-          let initialBalanceEOA = await provider.getBalance(recipient);
+          await provider.getBalance(context.universalProfile.address);
+          await provider.getBalance(recipient);
 
           let amount = ethers.utils.parseEther("1");
 
@@ -277,8 +276,11 @@ export const shouldBehaveLikeAllowedAddresses = (
               .connect(invalidEncodedAllowedCalls)
               ["execute(bytes)"](transferPayload)
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
-            .withArgs(invalidEncodedAllowedCalls.address);
+            .to.be.revertedWithCustomError(
+              context.keyManager,
+              "InvalidEncodedAllowedCalls"
+            )
+            .withArgs(invalidEncodedAllowedCallsValue);
         });
       });
     });


### PR DESCRIPTION
# What does this PR introduce

In `verifyAllowedCalls` we are looping over the allowedCalls array twice, once to make sure it is a valid allowedCalls and once to verify if the caller has the allowedCall permission.
Since we are checking the validity of the compact bytes array when setting the allowedCalls, in the vast majority of the case this will just be a waste of gas that can get expensive when the allowedCalls compact byte array get big. 

- [x] Remove `isCompactBytesArray` check
- [x] Update tests
- [x] Add new check within the loop to avoid `out_of_bonds` error  