### PR TITLE
fix: [WP-I6] add `onERC721Received` check for the `safeTransferFrom` functions of `LSP8CompatibleERC721` contracts

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -285,6 +285,7 @@ abstract contract LSP8CompatibleERC721 is
                 if (reason.length == 0) {
                     revert("LSP8CompatibleERC721: transfer to non ERC721Receiver implementer");
                 } else {
+                    // solhint-disable no-inline-assembly
                     /// @solidity memory-safe-assembly
                     assembly {
                         revert(add(32, reason), mload(reason))

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -3,10 +3,12 @@ pragma solidity ^0.8.12;
 
 // interfaces
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import {ILSP8CompatibleERC721} from "./ILSP8CompatibleERC721.sol";
 import {ILSP8IdentifiableDigitalAsset} from "../ILSP8IdentifiableDigitalAsset.sol";
 
 // libraries
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 
@@ -34,6 +36,7 @@ abstract contract LSP8CompatibleERC721 is
     LSP4Compatibility,
     LSP8IdentifiableDigitalAsset
 {
+    using Address for address;
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /**
@@ -152,12 +155,12 @@ abstract contract LSP8CompatibleERC721 is
         address to,
         uint256 tokenId
     ) public virtual {
-        return _transfer(from, to, bytes32(tokenId), true, "");
+        _transfer(from, to, bytes32(tokenId), true, "");
     }
 
     /**
      * @inheritdoc ILSP8CompatibleERC721
-     * @dev Compatible with ERC721 safeTransferFrom.
+     * @dev Compatible with ERC721 safeTransferFrom (without optional data).
      * Using allowNonLSP1Recipient=false so that no EOA and only contracts supporting LSP1 interface may receive the tokenId.
      */
     function safeTransferFrom(
@@ -165,11 +168,11 @@ abstract contract LSP8CompatibleERC721 is
         address to,
         uint256 tokenId
     ) public virtual {
-        return _transfer(from, to, bytes32(tokenId), false, "");
+        _safeTransfer(from, to, tokenId, "");
     }
 
     /*
-     * @dev Compatible with ERC721 safeTransferFrom.
+     * @dev Compatible with ERC721 safeTransferFrom (with optional data).
      * Using allowNonLSP1Recipient=false so that no EOA and only contracts supporting LSP1 interface may receive the tokenId.
      */
     function safeTransferFrom(
@@ -178,7 +181,7 @@ abstract contract LSP8CompatibleERC721 is
         uint256 tokenId,
         bytes memory data
     ) public virtual {
-        return _transfer(from, to, bytes32(tokenId), false, data);
+        _safeTransfer(from, to, tokenId, data);
     }
 
     // --- Overrides
@@ -208,8 +211,21 @@ abstract contract LSP8CompatibleERC721 is
             revert LSP8NotTokenOperator(tokenId, operator);
         }
 
-        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
         emit Transfer(from, to, uint256(tokenId));
+        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
+    }
+
+    function _safeTransfer(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) internal virtual {
+        _transfer(from, to, bytes32(tokenId), true, data);
+        require(
+            _checkOnERC721Received(from, to, tokenId, data),
+            "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer"
+        );
     }
 
     function _mint(
@@ -242,6 +258,42 @@ abstract contract LSP8CompatibleERC721 is
         require(tokensOwner != operator, "LSP8CompatibleERC721: approve to caller");
         _operatorApprovals[tokensOwner][operator] = approved;
         emit ApprovalForAll(tokensOwner, operator, approved);
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the token
+     * @param tokenId uint256 ID of the token to be transferred
+     * @param data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory data
+    ) private returns (bool) {
+        if (to.isContract()) {
+            try IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (
+                bytes4 retval
+            ) {
+                return retval == IERC721Receiver.onERC721Received.selector;
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert("LSP8CompatibleERC721: transfer to non ERC721Receiver implementer");
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        } else {
+            return true;
+        }
     }
 
     function _setData(bytes32 key, bytes memory value)

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -281,6 +281,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
                 if (reason.length == 0) {
                     revert("LSP8CompatibleERC721: transfer to non ERC721Receiver implementer");
                 } else {
+                    // solhint-disable no-inline-assembly
                     /// @solidity memory-safe-assembly
                     assembly {
                         revert(add(32, reason), mload(reason))

--- a/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
+++ b/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
@@ -15,12 +15,12 @@ import {_LSP4_METADATA_KEY} from "../../LSP4DigitalAssetMetadata/LSP4Constants.s
 
 contract LSP8CompatibleERC721Tester is LSP8CompatibleERC721 {
     constructor(
-        string memory name,
-        string memory symbol,
-        address newOwner,
-        bytes memory tokenURIValue
-    ) LSP8CompatibleERC721(name, symbol, newOwner) {
-        _setData(_LSP4_METADATA_KEY, tokenURIValue);
+        string memory name_,
+        string memory symbol_,
+        address newOwner_,
+        bytes memory tokenURIValue_
+    ) LSP8CompatibleERC721(name_, symbol_, newOwner_) {
+        _setData(_LSP4_METADATA_KEY, tokenURIValue_);
     }
 
     function mint(

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721Received.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721Received.sol
@@ -11,7 +11,7 @@ import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165S
 // constants
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
-contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
+contract TokenReceiverWithLSP1WithERC721Received is
     ERC165Storage,
     ILSP1UniversalReceiver,
     ERC721Holder
@@ -37,12 +37,5 @@ contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
         return "thanks for calling";
     }
 
-    function onERC721Received(
-        address, /* operator */
-        address, /* from */
-        uint256, /* tokenId */
-        bytes memory /* data */
-    ) public pure override returns (bytes4) {
-        revert("TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected");
-    }
+    // the onERC721Received function is inherited from ERC721Holder
 }

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedInvalid.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedInvalid.sol
@@ -11,7 +11,7 @@ import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165S
 // constants
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
-contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
+contract TokenReceiverWithLSP1WithERC721ReceivedInvalid is
     ERC165Storage,
     ILSP1UniversalReceiver,
     ERC721Holder
@@ -43,6 +43,6 @@ contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
         uint256, /* tokenId */
         bytes memory /* data */
     ) public pure override returns (bytes4) {
-        revert("TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected");
+        return 0xdeadbeef;
     }
 }

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedRevert.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedRevert.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import {ILSP1UniversalReceiver} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+
+// modules
+import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// constants
+import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
+    ERC165Storage,
+    ILSP1UniversalReceiver,
+    IERC721Receiver
+{
+    event UniversalReceiverCalled(bytes32 typeId, bytes data);
+
+    constructor() {
+        _registerInterface(_INTERFACEID_LSP1);
+    }
+
+    receive() external payable {}
+
+    fallback() external payable {}
+
+    function universalReceiver(bytes32 typeId, bytes memory data)
+        external
+        payable
+        override
+        returns (bytes memory returnValue)
+    {
+        emit UniversalReceiverCalled(typeId, data);
+
+        return "thanks for calling";
+    }
+
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
+    ) external pure returns (bytes4) {
+        revert("ERC721Receiver: transfer rejected");
+    }
+}

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721Received.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721Received.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+
+// constants
+import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+contract TokenReceiverWithoutLSP1WithERC721Received is ERC721Holder {
+    event UniversalReceiverCalled(bytes32 typeId, bytes data);
+
+    receive() external payable {}
+
+    fallback() external payable {}
+
+    // the onERC721Received function is inherited from ERC721Holder
+}

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedInvalid.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedInvalid.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+
+// constants
+import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+contract TokenReceiverWithoutLSP1WithERC721ReceivedInvalid is ERC721Holder {
+    event UniversalReceiverCalled(bytes32 typeId, bytes data);
+
+    receive() external payable {}
+
+    fallback() external payable {}
+
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes memory /* data */
+    ) public pure override returns (bytes4) {
+        return 0xdeadbeef;
+    }
+}

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedRevert.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedRevert.sol
@@ -3,39 +3,16 @@ pragma solidity ^0.8.4;
 
 // interfaces
 import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
-import {ILSP1UniversalReceiver} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
-
-// modules
-import {ERC165Storage} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
 
 // constants
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
-contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
-    ERC165Storage,
-    ILSP1UniversalReceiver,
-    ERC721Holder
-{
+contract TokenReceiverWithoutLSP1WithERC721ReceivedRevert is ERC721Holder {
     event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
-    constructor() {
-        _registerInterface(_INTERFACEID_LSP1);
-    }
 
     receive() external payable {}
 
     fallback() external payable {}
-
-    function universalReceiver(bytes32 typeId, bytes memory data)
-        external
-        payable
-        override
-        returns (bytes memory returnValue)
-    {
-        emit UniversalReceiverCalled(typeId, data);
-
-        return "thanks for calling";
-    }
 
     function onERC721Received(
         address, /* operator */

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.behaviour.ts
@@ -8,7 +8,18 @@ import {
   TokenReceiverWithLSP1__factory,
   TokenReceiverWithoutLSP1__factory,
   TokenReceiverWithoutLSP1,
+  TokenReceiverWithLSP1WithERC721ReceivedRevert,
   TokenReceiverWithLSP1WithERC721ReceivedRevert__factory,
+  TokenReceiverWithLSP1WithERC721ReceivedInvalid,
+  TokenReceiverWithLSP1WithERC721ReceivedInvalid__factory,
+  TokenReceiverWithLSP1WithERC721Received,
+  TokenReceiverWithLSP1WithERC721Received__factory,
+  TokenReceiverWithoutLSP1WithERC721ReceivedRevert,
+  TokenReceiverWithoutLSP1WithERC721ReceivedRevert__factory,
+  TokenReceiverWithoutLSP1WithERC721ReceivedInvalid,
+  TokenReceiverWithoutLSP1WithERC721ReceivedInvalid__factory,
+  TokenReceiverWithoutLSP1WithERC721Received,
+  TokenReceiverWithoutLSP1WithERC721Received__factory,
 } from "../../../types";
 import { tokenIdAsBytes32 } from "../../utils/tokens";
 import {
@@ -624,18 +635,18 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe.only("transfers", () => {
+  describe("transfers", () => {
     type TestDeployedContracts = {
       tokenReceiverWithLSP1: TokenReceiverWithLSP1;
       tokenReceiverWithoutLSP1: TokenReceiverWithoutLSP1;
-      tokenReceiverWithLSP1WithoutERC721Receiver: Contract;
-      tokenReceiverWithLSP1WithERC721ReceiverRevert: Contract;
-      //   tokenReceiverWithLSP1WithERC721ReceiverInvalid: Contract;
-      //   tokenReceiverWithLSP1WithERC721Receiver: Contract;
-      tokenReceiverWithoutLSP1WithoutERC721Receiver: Contract;
-      //   tokenReceiverWithoutLSP1WithERC721ReceiverRevert: Contract;
-      //   tokenReceiverWithoutLSP1WithERC721ReceiverInvalid: Contract;
-      //   tokenReceiverWithoutLSP1WithERC721Receiver: Contract;
+      tokenReceiverWithLSP1WithoutERC721Receiver: TokenReceiverWithLSP1;
+      tokenReceiverWithLSP1WithERC721ReceivedRevert: TokenReceiverWithLSP1WithERC721ReceivedRevert;
+      tokenReceiverWithLSP1WithERC721ReceivedInvalid: TokenReceiverWithLSP1WithERC721ReceivedInvalid;
+      tokenReceiverWithLSP1WithERC721Received: TokenReceiverWithLSP1WithERC721Received;
+      tokenReceiverWithoutLSP1WithoutERC721Received: TokenReceiverWithoutLSP1;
+      tokenReceiverWithoutLSP1WithERC721ReceivedRevert: TokenReceiverWithoutLSP1WithERC721ReceivedRevert;
+      tokenReceiverWithoutLSP1WithERC721ReceivedInvalid: TokenReceiverWithoutLSP1WithERC721ReceivedInvalid;
+      tokenReceiverWithoutLSP1WithERC721Received: TokenReceiverWithoutLSP1WithERC721Received;
     };
     let deployedContracts: TestDeployedContracts;
 
@@ -653,19 +664,34 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           await new TokenReceiverWithLSP1__factory(
             context.accounts.owner
           ).deploy(),
-        tokenReceiverWithLSP1WithERC721ReceiverRevert:
+        tokenReceiverWithLSP1WithERC721ReceivedRevert:
           await new TokenReceiverWithLSP1WithERC721ReceivedRevert__factory(
             context.accounts.owner
           ).deploy(),
-        // tokenReceiverWithLSP1WithERC721ReceiverInvalid: ""
-        // tokenReceiverWithLSP1WithERC721Receiver: ""
-        tokenReceiverWithoutLSP1WithoutERC721Receiver:
+        tokenReceiverWithLSP1WithERC721ReceivedInvalid:
+          await new TokenReceiverWithLSP1WithERC721ReceivedInvalid__factory(
+            context.accounts.owner
+          ).deploy(),
+        tokenReceiverWithLSP1WithERC721Received:
+          await new TokenReceiverWithLSP1WithERC721Received__factory(
+            context.accounts.owner
+          ).deploy(),
+        tokenReceiverWithoutLSP1WithoutERC721Received:
           await new TokenReceiverWithoutLSP1__factory(
             context.accounts.owner
           ).deploy(),
-        // tokenReceiverWithoutLSP1WithERC721ReceiverRevert: ""
-        // tokenReceiverWithoutLSP1WithERC721ReceiverInvalid: ""
-        // tokenReceiverWithoutLSP1WithERC721Receiver: ""
+        tokenReceiverWithoutLSP1WithERC721ReceivedRevert:
+          await new TokenReceiverWithoutLSP1WithERC721ReceivedRevert__factory(
+            context.accounts.owner
+          ).deploy(),
+        tokenReceiverWithoutLSP1WithERC721ReceivedInvalid:
+          await new TokenReceiverWithoutLSP1WithERC721ReceivedInvalid__factory(
+            context.accounts.owner
+          ).deploy(),
+        tokenReceiverWithoutLSP1WithERC721Received:
+          await new TokenReceiverWithoutLSP1WithERC721Received__factory(
+            context.accounts.owner
+          ).deploy(),
       };
 
       // setup so we have a token to transfer
@@ -877,7 +903,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       });
     });
 
-    describe.only("safeTransferFrom(address,address,uint256)", () => {
+    describe("safeTransferFrom(address,address,uint256)", () => {
       const transferFn = "safeTransferFrom(address,address,uint256)";
 
       describe("when the from address is the tokenId owner", () => {
@@ -918,7 +944,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts
-                    .tokenReceiverWithLSP1WithERC721ReceiverRevert.address,
+                    .tokenReceiverWithLSP1WithERC721ReceivedRevert.address,
                   tokenId: mintedTokenId,
                 };
 
@@ -926,26 +952,107 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                   context.lsp8CompatibleERC721[
                     "safeTransferFrom(address,address,uint256)"
                   ](txParams.from, txParams.to, txParams.tokenId)
-                ).to.be.revertedWith("ERC721Receiver: transfer rejected");
+                ).to.be.revertedWith(
+                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected"
+                );
+              });
+
+              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithLSP1WithERC721ReceivedInvalid.address,
+                  tokenId: mintedTokenId,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer"
+                );
+              });
+
+              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts.tokenReceiverWithLSP1WithERC721Received
+                    .address,
+                  tokenId: mintedTokenId,
+                };
+
+                await transferSuccessScenario(txParams, transferFn, true, "0x");
               });
             });
           });
 
-          describe("when receiving contract does not support LSP1", () => {
-            it("should fail and revert", async () => {
-              const txParams = {
-                operator: context.accounts.owner.address,
-                from: context.accounts.owner.address,
-                to: deployedContracts
-                  .tokenReceiverWithoutLSP1WithoutERC721Receiver.address,
-                tokenId: mintedTokenId,
-              };
+          describe("when the receiving contract does not support LSP1", () => {
+            describe("when the receiving contract does not implement `onERC721Received`", () => {
+              it("should fail and revert", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithoutERC721Received.address,
+                  tokenId: mintedTokenId,
+                };
 
-              await expect(
-                context.lsp8CompatibleERC721[
-                  "safeTransferFrom(address,address,uint256)"
-                ](txParams.from, txParams.to, txParams.tokenId)
-              ).to.be.reverted;
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.reverted;
+              });
+            });
+
+            describe("when the receiving contract implements `onERC721Received`", () => {
+              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721ReceivedRevert.address,
+                  tokenId: mintedTokenId,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected"
+                );
+              });
+
+              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721ReceivedInvalid.address,
+                  tokenId: mintedTokenId,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer"
+                );
+              });
+
+              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721Received.address,
+                  tokenId: mintedTokenId,
+                };
+
+                await transferSuccessScenario(txParams, transferFn, true, "0x");
+              });
             });
           });
         });
@@ -975,14 +1082,13 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
 
     describe("safeTransferFrom(address,address,uint256,bytes)", () => {
       const transferFn = "safeTransferFrom(address,address,uint256,bytes)";
-      const allowNonLSP1Recipient = false;
       const expectedData = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(`custom-data-${Date.now()}`)
       );
 
       describe("when the from address is the tokenId owner", () => {
         describe("when `to` is an EOA", () => {
-          it("should revert", async () => {
+          it("should pass", async () => {
             const txParams = {
               operator: context.accounts.owner.address,
               from: context.accounts.owner.address,
@@ -990,50 +1096,166 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               tokenId: mintedTokenId,
               data: expectedData,
             };
-            const expectedError = "LSP8NotifyTokenReceiverIsEOA";
 
-            await transferFailScenario(txParams, transferFn, {
-              error: expectedError,
-              args: [txParams.to],
-            });
+            await transferSuccessScenario(
+              txParams,
+              transferFn,
+              true,
+              expectedData
+            );
           });
         });
 
         describe("when `to` is a contract", () => {
-          describe("when receiving contract supports LSP1", () => {
-            it("should allow transfering the tokenId", async () => {
-              const txParams = {
-                operator: context.accounts.owner.address,
-                from: context.accounts.owner.address,
-                to: deployedContracts.tokenReceiverWithLSP1.address,
-                tokenId: mintedTokenId,
-                data: expectedData,
-              };
+          describe("when the receiving contract supports LSP1", () => {
+            describe("when the receiving contract does not implement `onERC721Received`", () => {
+              it("should fail and revert", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithLSP1WithoutERC721Receiver.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
 
-              await transferSuccessScenario(
-                txParams,
-                transferFn,
-                allowNonLSP1Recipient,
-                expectedData
-              );
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.reverted;
+              });
+            });
+
+            describe("when the receiving contract implements `onERC721Received`", () => {
+              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithLSP1WithERC721ReceivedRevert.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected"
+                );
+              });
+
+              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithLSP1WithERC721ReceivedInvalid.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer"
+                );
+              });
+
+              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts.tokenReceiverWithLSP1WithERC721Received
+                    .address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await transferSuccessScenario(
+                  txParams,
+                  transferFn,
+                  true,
+                  expectedData
+                );
+              });
             });
           });
 
-          describe("when receiving contract does not support LSP1", () => {
-            it("should revert", async () => {
-              const txParams = {
-                operator: context.accounts.owner.address,
-                from: context.accounts.owner.address,
-                to: deployedContracts.tokenReceiverWithoutLSP1.address,
-                tokenId: mintedTokenId,
-                data: expectedData,
-              };
-              const expectedError =
-                "LSP8NotifyTokenReceiverContractMissingLSP1Interface";
+          describe("when the receiving contract does not support LSP1", () => {
+            describe("when the receiving contract does not implement `onERC721Received`", () => {
+              it("should fail and revert", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithoutERC721Received.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
 
-              await transferFailScenario(txParams, transferFn, {
-                error: expectedError,
-                args: [txParams.to],
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.reverted;
+              });
+            });
+
+            describe("when the receiving contract implements `onERC721Received`", () => {
+              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721ReceivedRevert.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected"
+                );
+              });
+
+              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721ReceivedInvalid.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await expect(
+                  context.lsp8CompatibleERC721[
+                    "safeTransferFrom(address,address,uint256)"
+                  ](txParams.from, txParams.to, txParams.tokenId)
+                ).to.be.revertedWith(
+                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer"
+                );
+              });
+
+              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+                const txParams = {
+                  operator: context.accounts.owner.address,
+                  from: context.accounts.owner.address,
+                  to: deployedContracts
+                    .tokenReceiverWithoutLSP1WithERC721Received.address,
+                  tokenId: mintedTokenId,
+                  data: expectedData,
+                };
+
+                await transferSuccessScenario(
+                  txParams,
+                  transferFn,
+                  true,
+                  expectedData
+                );
               });
             });
           });

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
@@ -78,7 +78,7 @@ describe("LSP8CompatibleERC721", () => {
     });
   });
 
-  describe.skip("when using LSP8 contract with proxy", () => {
+  describe("when using LSP8 contract with proxy", () => {
     const buildTestContext =
       async (): Promise<LSP8CompatibleERC721TestContext> => {
         const accounts = await getNamedAccounts();

--- a/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.test.ts
@@ -78,7 +78,7 @@ describe("LSP8CompatibleERC721", () => {
     });
   });
 
-  describe("when using LSP8 contract with proxy", () => {
+  describe.skip("when using LSP8 contract with proxy", () => {
     const buildTestContext =
       async (): Promise<LSP8CompatibleERC721TestContext> => {
         const accounts = await getNamedAccounts();


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

In `LSP8CompatibleERC721` and `LSP8CompatibleERC721Init`:

- [x] make the `allowNonLSP1Recipient` parameter set to `true` by default for all transfer functions (`transfer` from LSP8, `transferFrom` and `safeTransferFrom` from ERC721).

- [x] for the `safeTransferFrom` function, add an extra call to check that the token receiver MUST implement the `onERC721Received` function and return the magic value (`onERC721Received(address,address,uint256,bytes)` function selector).

## 🧪 Tests

- [x] add tests for the following scenarios below.

- when `to` is an EOA = ✅ pass  
- when `to`  is a contract that supports + implement LSP1 
    - but does not implement `onERC721Received` = ❌ fail and revert  
    - if it also implements `onERC721Received`, but the function `onERC721Received` reverts = ❌ fails and revert  
    - if it also implements `onERC721Received` , but the function `onERC721Received`  does not return the right bytes value = ❌ fails and revert  
    - if it also implements `onERC721Received` = ✅ pass  

- when `to` is a contract that does not supports LSP1
    - but does not implement `onERC721Received` = ❌ fail and revert  
    - if it also implements `onERC721Received` , but the function `onERC721Received` reverts = ❌ fails and revert  
    - if it also implements `onERC721Received` , but the function `onERC721Received` does not return the right bytes value = ❌ fails and revert  
    - if it also implements `onERC721Received` = ✅ pass  