### PR TITLE
fix: Narrower remapping of erc725 to support git modules downstream

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@erc725/=node_modules/@erc725/
+@erc725/smart-contracts/=node_modules/@erc725/smart-contracts/
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
 @openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/
 eth-gas-reporter/=node_modules/eth-gas-reporter/


### PR DESCRIPTION
One more tiny fix to remappings to support git modules in downstream projects