### PR TITLE
refactor: Support Extension for `bytes4(0)` sig in LSP0-LSP9

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -41,6 +41,9 @@ import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 
 import {_LSP17_EXTENSION_PREFIX} from "../LSP17ContractExtension/LSP17Constants.sol";
 
+// errors
+import "../LSP17ContractExtension/LSP17Errors.sol";
+
 /**
  * @title Core Implementation of ERC725Account
  * @author Fabian Vogelsteller <fabian@lukso.network>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
@@ -68,10 +71,91 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executed when receiving native tokens with empty calldata.
+     * Executed when receiving a call with empty calldata.
      */
     receive() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+    }
+
+    // solhint-disable no-complex-fallback
+
+    /**
+     * @dev Emits an event when receiving native tokens
+     *
+     * Forwards the call to an extension contract (address). This address can be retrieved from
+     * the ERC725Y data key-value store using the data key below (function selector appended to the prefix):
+     *_LSP17_FALLBACK_EXTENSIONS_HANDLER_ + <function-selector>
+     * If there is no extension stored under the data key, return.
+     *
+     * The call to the extension is appended with bytes20 (msg.sender) and bytes32 (msg.value).
+     * Returns the return value on success and revert in case of failure.
+     *
+     * If the msg.data is shorter than 4 bytes do not check for an extension and return
+     *
+     * Executed when:
+     * - the first 4 bytes of the calldata do not match any publicly callable functions from the contract ABI.
+     * - receiving native tokens with some calldata.
+     */
+    fallback() external payable virtual {
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+        if (msg.data.length < 4) return;
+
+        _fallbackLSP17Extendable();
+    }
+
+    /**
+     * @dev Forwards the call to an extension mapped to a function selector. If no extension address
+     * is mapped to the function selector (address(0)), then revert.
+     *
+     * The bytes4(0) msg.sig is an exception, the function won't revert if there is no extension found
+     * mapped to bytes4(0), but will execute the call to the extension in case it existed.
+     *
+     * The call to the extension is appended with bytes20 (msg.sender) and bytes32 (msg.value).
+     * Returns the return value on success and revert in case of failure.
+     *
+     * As the function uses assembly {return()/revert()} to terminate the call, it cannot be
+     * called before other codes in fallback().
+     *
+     * Otherwise, the codes after _fallbackLSP17Extendable() may never be reached.
+     */
+    function _fallbackLSP17Extendable() internal virtual override {
+        // If there is a function selector
+        address extension = _getExtension(msg.sig);
+
+        // if no extension was found for bytes4(0) return don't revert
+        if (msg.sig == bytes4(0) && extension == address(0)) return;
+
+        // if no extension was found, revert
+        if (extension == address(0)) revert NoExtensionFoundForFunctionSelector(msg.sig);
+
+        // solhint-disable no-inline-assembly
+        // if the extension was found, call the extension with the msg.data
+        // appended with bytes20(address) and bytes32(msg.value)
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+
+            // The msg.sender address is shifted to the left by 12 bytes to remove the padding
+            // Then the address without padding is stored right after the calldata
+            mstore(calldatasize(), shl(96, caller()))
+
+            // The msg.value is stored right after the calldata + msg.sender
+            mstore(add(calldatasize(), 20), callvalue())
+
+            // Add 52 bytes for the msg.sender and msg.value appended at the end of the calldata
+            let success := call(gas(), extension, 0, 0, add(calldatasize(), 52), 0, 0)
+
+            // Copy the returned data
+            returndatacopy(0, 0, returndatasize())
+
+            switch success
+            // call returns 0 on failed calls
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
     }
 
     /**
@@ -96,33 +180,6 @@ abstract contract LSP0ERC725AccountCore is
         address extension = address(bytes20(_getData(mappedExtensionDataKey)));
 
         return extension;
-    }
-
-    // solhint-disable no-complex-fallback
-
-    /**
-     * @dev Emits an event when receiving native tokens
-     *
-     * Forwards the call to an extension contract (address). This address can be retrieved from
-     * the ERC725Y data key-value store using the data key below (function selector appended to the prefix):
-     *_LSP17_FALLBACK_EXTENSIONS_HANDLER_ + <function-selector>
-     * If there is no extension stored under the data key, return.
-     *
-     * The call to the extension is appended with bytes20 (msg.sender) and bytes32 (msg.value).
-     * Returns the return value on success and revert in case of failure.
-     *
-     * If the msg.data is shorter than 4 bytes or the first 4 bytes are 0s
-     * do not check for an extension and return
-     *
-     * Executed when:
-     * - the first 4 bytes of the calldata do not match any publicly callable functions from the contract ABI.
-     * - receiving native tokens with some calldata.
-     */
-    fallback() external payable virtual {
-        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        if (msg.data.length < 4 || msg.sig == bytes4(0)) return;
-
-        _fallbackLSP17Extendable();
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -71,7 +71,9 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executed when receiving a call with empty calldata.
+     * Executed:
+     *     - when receiving some native tokens without any additional data.
+     *     - on empty calls to the contract.
      */
     receive() external payable virtual {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
@@ -113,7 +115,7 @@ abstract contract LSP0ERC725AccountCore is
      * The call to the extension is appended with bytes20 (msg.sender) and bytes32 (msg.value).
      * Returns the return value on success and revert in case of failure.
      *
-     * As the function uses assembly {return()/revert()} to terminate the call, it cannot be
+     * Because the function uses assembly {return()/revert()} to terminate the call, it cannot be
      * called before other codes in fallback().
      *
      * Otherwise, the codes after _fallbackLSP17Extendable() may never be reached.

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -75,7 +75,9 @@ contract LSP9VaultCore is
     /**
      * @dev Emits an event when receiving native tokens
      *
-     * Executed when receiving a call with empty calldata.
+     * Executed:
+     *     - when receiving some native tokens without any additional data.
+     *     - on empty calls to the contract.
      */
     receive() external payable virtual {
         if (msg.value > 0) emit ValueReceived(msg.sender, msg.value);
@@ -117,7 +119,7 @@ contract LSP9VaultCore is
      * The call to the extension is appended with bytes20 (msg.sender) and bytes32 (msg.value).
      * Returns the return value on success and revert in case of failure.
      *
-     * As the function uses assembly {return()/revert()} to terminate the call, it cannot be
+     * Because the function uses assembly {return()/revert()} to terminate the call, it cannot be
      * called before other codes in fallback().
      *
      * Otherwise, the codes after _fallbackLSP17Extendable() may never be reached.


### PR DESCRIPTION
## What does this PR introduce ?

- Changing the logic of handling the `bytes4(0)` sig when called to LSP0 and LSP9.

### Behavior Before
Whenever the contract was called with any data that starts with `bytes4(0)` it would emit `ValueReceived` event if native token was received and then return (ending execution).


### Behavior After
Whenever the contract was called with any data that starts with `bytes4(0)` it would emit `ValueReceived` event if native token was received and check if there is extension set for `bytes4(0)`, if there is an extension set then forward the call to the extension, if not then return (ending execution).

The only difference between `bytes4(0)` and the other selectors is that in case the contract was called with a function selector that doesn't have an extension set it would usually revert, but when the contract is called with `bytes4(0)` the call will still succeed and return even if there is no extension set.