### PR TITLE
refactor!: replace tuple value for LSP5/10 from `bytes8` -> `uint128`

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -326,11 +326,6 @@ export const Errors = {
       error: "InvalidLSP5ReceivedAssetsArrayLength(bytes,uint256)",
       message: "LSP5: Invalid value for `LSP5ReceivedAssets[]` (array length)",
     },
-    "0x1c458e39": {
-      error: "ReceivedAssetsIndexSuperiorToUint64(uint256)",
-      message:
-        "LSP5: The index of the received assets cannot be registered if superior to uint64",
-    },
     "0xe8a4fba": {
       error: "ReceivedAssetsIndexSuperiorToUint128(uint256)",
       message:

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -218,7 +218,7 @@ export async function getLSP5MapAndArrayKeysValue(account, token) {
   let mapKey =
     ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substr(2);
   const mapValue = await account["getData(bytes32)"](mapKey);
-  const indexInHex = "0x" + mapValue.substr(10, 16);
+  const indexInHex = "0x" + mapValue.substr(10, mapValue.length);
   const interfaceId = mapValue.substr(0, 10);
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
   const rawIndexInArray = ethers.utils.hexZeroPad(
@@ -247,15 +247,15 @@ export async function getLSP10MapAndArrayKeysValue(account, lsp9Vault) {
   let mapKey =
     ERC725YDataKeys.LSP10.LSP10VaultsMap + lsp9Vault.address.substr(2);
   const mapValue = await account["getData(bytes32)"](mapKey);
-  const indexInHex = "0x" + mapValue.substr(10, 16);
+  const indexInHex = "0x" + mapValue.substr(10, mapValue.length);
   const interfaceId = mapValue.substr(0, 10);
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
   const rawIndexInArray = ethers.utils.hexZeroPad(
     ethers.utils.hexValue(indexInNumber),
-    32
+    16
   );
   const elementInArrayKey =
-    ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + rawIndexInArray.substr(34);
+    ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + rawIndexInArray.substring(2);
   let arrayKey = ERC725YDataKeys.LSP10["LSP10Vaults[]"].length;
   let [arrayLength, elementAddress] = await account["getData(bytes32[])"]([
     arrayKey,


### PR DESCRIPTION
# What does this PR introduce?

## :warning: BREAKING CHANGE

- [x] Change the value stored under the LSP5/10 tuples from `bytes4,bytes8)` to --> `(bytes4,uint128)`

- [x] add checks to test when the value under the `LSP5ReceivedAssets[]` and `LSP10Vaults[]` array is the max possible index and introduce custom error to handle this case. 

This is to prevent a `Panic(uint256)` error type with error code `0x11` due to arithmetic overflow with `max(uint128) + 1`

This PR follows the changes introduced in the LSP5 and LSP10 specs. 
See this PR in the LIP repository for reference: https://github.com/lukso-network/LIPs/pull/173