### PR TITLE
fix: export artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
       "import": "./module/constants.js",
       "require": "./common/constant.js",
       "types": "./common/constants.d.ts"
-    }
+    },
+    "./artifacts/*": "./artifacts/*"
   },
   "scripts": {
     "test": "hardhat test",


### PR DESCRIPTION
Without this export, we get that error when importing:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './artifacts/LSP0ERC725Account.json' is not defined by "exports" in /myPath.../service-multichain-universalprofiles-contracts/node_modules/@lukso/lsp-smart-contracts/package.json.
```