### PR TITLE
refactor: remove internal functions and add first check for contract creation permission

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -67,8 +67,17 @@ abstract contract LSP6ExecuteModule {
 
         uint256 value = uint256(bytes32(payload[68:100]));
 
-        // prettier-ignore
-        bool isContractCreation = operationType == OPERATION_1_CREATE || operationType == OPERATION_2_CREATE2;
+        bool hasSuperTransferValue = controllerPermissions.hasPermission(
+            _PERMISSION_SUPER_TRANSFERVALUE
+        );
+
+        if (value != 0 && !hasSuperTransferValue) {
+            _requirePermissions(
+                controllerAddress,
+                controllerPermissions,
+                _PERMISSION_TRANSFERVALUE
+            );
+        }
 
         // CHECK the offset of `data` is not pointing to the previous parameters
         if (
@@ -77,6 +86,18 @@ abstract contract LSP6ExecuteModule {
         ) {
             revert InvalidPayload(payload);
         }
+
+        // if it is a contract creation
+        if (operationType == OPERATION_1_CREATE || operationType == OPERATION_2_CREATE2) {
+            _requirePermissions(controllerAddress, controllerPermissions, _PERMISSION_DEPLOY);
+            return;
+        }
+
+        // if it is a message call
+        (bytes32 executePermission, bytes32 superOperationPermission) = operationType ==
+            OPERATION_0_CALL
+            ? (_PERMISSION_CALL, _PERMISSION_SUPER_CALL)
+            : (_PERMISSION_STATICCALL, _PERMISSION_SUPER_STATICCALL);
 
         // NB: all the parameters are abi-encoded (padded to 32 bytes words)
         //
@@ -90,45 +111,17 @@ abstract contract LSP6ExecuteModule {
         // = 164 bytes in total
         bool isCallDataPresent = payload.length > 164;
 
-        // SUPER operation only applies to contract call, not contract creation
-        bool hasSuperOperation = isContractCreation
-            ? false
-            : controllerPermissions.hasPermission(
-                _extractSuperPermissionFromOperation(operationType)
-            );
+        bool hasSuperOperation = controllerPermissions.hasPermission(superOperationPermission);
 
         // CHECK if we are doing an empty call, as the receive() or fallback() function
         // of the controlledContract could run some code.
         if (!hasSuperOperation && !isCallDataPresent && value == 0) {
-            _requirePermissions(
-                controllerAddress,
-                controllerPermissions,
-                _extractPermissionFromOperation(operationType)
-            );
+            _requirePermissions(controllerAddress, controllerPermissions, executePermission);
         }
 
         if (isCallDataPresent && !hasSuperOperation) {
-            _requirePermissions(
-                controllerAddress,
-                controllerPermissions,
-                _extractPermissionFromOperation(operationType)
-            );
+            _requirePermissions(controllerAddress, controllerPermissions, executePermission);
         }
-
-        bool hasSuperTransferValue = controllerPermissions.hasPermission(
-            _PERMISSION_SUPER_TRANSFERVALUE
-        );
-
-        if (value != 0 && !hasSuperTransferValue) {
-            _requirePermissions(
-                controllerAddress,
-                controllerPermissions,
-                _PERMISSION_TRANSFERVALUE
-            );
-        }
-
-        // Skip on contract creation (CREATE or CREATE2)
-        if (isContractCreation) return;
 
         // Skip if caller has SUPER permissions for external calls, with or without calldata (empty calls)
         if (hasSuperOperation && value == 0) return;
@@ -195,39 +188,6 @@ abstract contract LSP6ExecuteModule {
         }
 
         revert NotAllowedCall(controllerAddress, to, selector);
-    }
-
-    /**
-     * @dev extract the required permission + a descriptive string, based on the `_operationType`
-     * being run via ERC725Account.execute(...)
-     * @param operationType 0 = CALL, 1 = CREATE, 2 = CREATE2, etc... See ERC725X docs for more infos.
-     * @return permissionsRequired (bytes32) the permission associated with the `_operationType`
-     */
-    function _extractPermissionFromOperation(uint256 operationType)
-        internal
-        pure
-        virtual
-        returns (bytes32 permissionsRequired)
-    {
-        if (operationType == OPERATION_0_CALL) return _PERMISSION_CALL;
-        else if (operationType == OPERATION_1_CREATE) return _PERMISSION_DEPLOY;
-        else if (operationType == OPERATION_2_CREATE2) return _PERMISSION_DEPLOY;
-        else if (operationType == OPERATION_3_STATICCALL) return _PERMISSION_STATICCALL;
-        else if (operationType == OPERATION_4_DELEGATECALL) return _PERMISSION_DELEGATECALL;
-    }
-
-    /**
-     * @dev returns the `superPermission` needed for a specific `operationType` of the `execute(..)`
-     */
-    function _extractSuperPermissionFromOperation(uint256 operationType)
-        internal
-        pure
-        virtual
-        returns (bytes32 superPermission)
-    {
-        if (operationType == OPERATION_0_CALL) return _PERMISSION_SUPER_CALL;
-        else if (operationType == OPERATION_3_STATICCALL) return _PERMISSION_SUPER_STATICCALL;
-        else if (operationType == OPERATION_4_DELEGATECALL) return _PERMISSION_SUPER_DELEGATECALL;
     }
 
     /**

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -94,10 +94,18 @@ abstract contract LSP6ExecuteModule {
         }
 
         // if it is a message call
-        (bytes32 executePermission, bytes32 superOperationPermission) = operationType ==
-            OPERATION_0_CALL
-            ? (_PERMISSION_CALL, _PERMISSION_SUPER_CALL)
-            : (_PERMISSION_STATICCALL, _PERMISSION_SUPER_STATICCALL);
+        bytes32 executePermission;
+        bytes32 superOperationPermission;
+
+        if (operationType == OPERATION_0_CALL) {
+            // prettier-ignore
+            (executePermission, superOperationPermission) = (_PERMISSION_CALL, _PERMISSION_SUPER_CALL);
+        }
+
+        if (operationType == OPERATION_3_STATICCALL) {
+            // prettier-ignore
+            (executePermission, superOperationPermission) = (_PERMISSION_STATICCALL, _PERMISSION_SUPER_STATICCALL);
+        }
 
         // NB: all the parameters are abi-encoded (padded to 32 bytes words)
         //


### PR DESCRIPTION
# What does this PR introduce?

in the Key Manager, remove the internal function that extract the permission depending on the operation type.

Simply inline the first check for contract creation and simplify the logic for checking for the permission `CALL` or `STATICCALL`