### PR TITLE
test: fix the reentrancy tests to call the UP instead of KeyManager

### DIFF
--- a/contracts/Mocks/Reentrancy/ReentrantContract.sol
+++ b/contracts/Mocks/Reentrancy/ReentrantContract.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.4;
 
 // interfaces
 import {ILSP6KeyManager} from "../../LSP6KeyManager/ILSP6KeyManager.sol";
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
 
 // constants
 import "../../LSP1UniversalReceiver/LSP1Constants.sol";
@@ -10,27 +12,50 @@ import "../../LSP6KeyManager/LSP6Constants.sol";
 
 contract ReentrantContract {
     event ValueReceived(uint256);
-    mapping(string => bytes) private _payloads;
+    mapping(string => function() internal returns (bytes memory)) private functionCall;
 
-    constructor(
-        address newControllerAddress,
-        bytes32 newURDTypeId,
-        address newURDAddress
-    ) {
-        _payloads["TRANSFERVALUE"] = abi.encodeWithSignature(
-            "execute(uint256,address,uint256,bytes)",
-            0,
-            address(this),
-            1 ether,
-            ""
-        );
-        _payloads["SETDATA"] = abi.encodeWithSignature(
-            "setData(bytes32,bytes)",
+    address newControllerAddress;
+    bytes32 newURDTypeId;
+    address newURDAddress;
+
+    constructor(address newControllerAddress_, bytes32 newURDTypeId_, address newURDAddress_) {
+        newControllerAddress = newControllerAddress_;
+        newURDTypeId = newURDTypeId_;
+        newURDAddress = newURDAddress_;
+
+        functionCall["TRANSFERVALUE"] = transferValue;
+        functionCall["SETDATA"] = setData;
+        functionCall["ADDCONTROLLER"] = addController;
+        functionCall["EDITPERMISSIONS"] = editPermissions;
+        functionCall["ADDUNIVERSALRECEIVERDELEGATE"] = addUniversalReceiverDelegate;
+        functionCall["CHANGEUNIVERSALRECEIVERDELEGATE"] = changeUniversalReceiverDelegate;
+    }
+
+    receive() external payable {
+        emit ValueReceived(msg.value);
+    }
+
+    function callThatReenters(string memory payloadType) external returns (bytes memory) {
+        return functionCall[payloadType]();
+    }
+
+    // --- Internal Methods
+
+    function transferValue() internal returns (bytes memory) {
+        return IERC725X(msg.sender).execute(0, address(this), 1 ether, "");
+    }
+
+    function setData() internal returns (bytes memory) {
+        IERC725Y(msg.sender).setData(
             keccak256(bytes("SomeRandomTextUsed")),
             bytes("SomeRandomTextUsed")
         );
-        _payloads["ADDCONTROLLER"] = abi.encodeWithSignature(
-            "setData(bytes32,bytes)",
+
+        return "";
+    }
+
+    function addController() internal returns (bytes memory) {
+        IERC725Y(msg.sender).setData(
             bytes32(
                 bytes.concat(
                     _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
@@ -40,8 +65,12 @@ contract ReentrantContract {
             ),
             bytes.concat(bytes32(uint256(16)))
         );
-        _payloads["EDITPERMISSIONS"] = abi.encodeWithSignature(
-            "setData(bytes32,bytes)",
+
+        return "";
+    }
+
+    function editPermissions() internal returns (bytes memory) {
+        IERC725Y(msg.sender).setData(
             bytes32(
                 bytes.concat(
                     _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
@@ -51,8 +80,12 @@ contract ReentrantContract {
             ),
             ""
         );
-        _payloads["ADDUNIVERSALRECEIVERDELEGATE"] = abi.encodeWithSignature(
-            "setData(bytes32,bytes)",
+
+        return "";
+    }
+
+    function addUniversalReceiverDelegate() internal returns (bytes memory) {
+        IERC725Y(msg.sender).setData(
             bytes32(
                 bytes.concat(
                     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
@@ -62,8 +95,12 @@ contract ReentrantContract {
             ),
             bytes.concat(bytes20(newURDAddress))
         );
-        _payloads["CHANGEUNIVERSALRECEIVERDELEGATE"] = abi.encodeWithSignature(
-            "setData(bytes32,bytes)",
+
+        return "";
+    }
+
+    function changeUniversalReceiverDelegate() internal returns (bytes memory) {
+        IERC725Y(msg.sender).setData(
             bytes32(
                 bytes.concat(
                     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
@@ -73,16 +110,7 @@ contract ReentrantContract {
             ),
             ""
         );
-    }
 
-    receive() external payable {
-        emit ValueReceived(msg.value);
-    }
-
-    function callThatReenters(address keyManagerAddress, string memory payloadType)
-        external
-        returns (bytes memory)
-    {
-        return ILSP6KeyManager(keyManagerAddress).execute(_payloads[payloadType]);
+        return "";
     }
 }

--- a/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteRelayCallToSingleExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteRelayCallToSingleExecute.test.ts
@@ -23,9 +23,32 @@ import {
   changeUniversalReceiverDelegateTestCases,
   // Functions
   generateRelayCall,
-  generateExecutePayload,
   loadTestCase,
 } from "./reentrancyHelpers";
+import {
+  ReentrantContract__factory,
+  UniversalProfile__factory,
+} from "../../../../types";
+
+const generateExecutePayload = (
+  keyManagerAddress: string,
+  reentrantContractAddress: string,
+  payloadType: string
+) => {
+  const reentrantPayload =
+    new ReentrantContract__factory().interface.encodeFunctionData(
+      "callThatReenters",
+      [keyManagerAddress, payloadType]
+    );
+
+  const executePayload =
+    new UniversalProfile__factory().interface.encodeFunctionData(
+      "execute(uint256,address,uint256,bytes)",
+      [0, reentrantContractAddress, 0, reentrantPayload]
+    );
+
+  return executePayload;
+};
 
 export const testSingleExecuteRelayCallToSingleExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,

--- a/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToBatchExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToBatchExecute.test.ts
@@ -22,9 +22,12 @@ import {
   addUniversalReceiverDelegateTestCases,
   changeUniversalReceiverDelegateTestCases,
   // Functions
-  generateExecutePayload,
   loadTestCase,
 } from "./reentrancyHelpers";
+import {
+  ReentrantContract__factory,
+  UniversalProfile__factory,
+} from "../../../../types";
 
 export const testSingleExecuteToBatchExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -41,12 +44,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and transferring value", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "TRANSFERVALUE"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["TRANSFERVALUE"]
+          ),
+        ]
       );
     });
 
@@ -65,9 +75,9 @@ export const testSingleExecuteToBatchExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(uint256[],bytes[])"]([0], [executePayload])
+            .batchCalls([batchCall])
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -87,9 +97,9 @@ export const testSingleExecuteToBatchExecute = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(uint256[],bytes[])"]([0], [executePayload])
+          .batchCalls([batchCall])
       ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
     });
 
@@ -108,9 +118,9 @@ export const testSingleExecuteToBatchExecute = (
         )
       ).to.equal(ethers.utils.parseEther("10"));
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       expect(
         await context.universalProfile.provider.getBalance(
@@ -127,12 +137,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and setting data", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "SETDATA"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["SETDATA"]
+          ),
+        ]
       );
     });
 
@@ -151,9 +168,9 @@ export const testSingleExecuteToBatchExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(uint256[],bytes[])"]([0], [executePayload])
+            .batchCalls([batchCall])
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -173,9 +190,9 @@ export const testSingleExecuteToBatchExecute = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(uint256[],bytes[])"]([0], [executePayload])
+          .batchCalls([batchCall])
       ).to.be.revertedWithCustomError(
         context.keyManager,
         "NoERC725YDataKeysAllowed"
@@ -191,9 +208,9 @@ export const testSingleExecuteToBatchExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       const hardcodedKey = ethers.utils.keccak256(
         ethers.utils.toUtf8Bytes("SomeRandomTextUsed")
@@ -209,12 +226,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and adding permissions", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "ADDCONTROLLER"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["ADDCONTROLLER"]
+          ),
+        ]
       );
     });
 
@@ -229,9 +253,9 @@ export const testSingleExecuteToBatchExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(uint256[],bytes[])"]([0], [executePayload])
+            .batchCalls([batchCall])
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -250,9 +274,9 @@ export const testSingleExecuteToBatchExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -269,12 +293,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and changing permissions", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "EDITPERMISSIONS"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["EDITPERMISSIONS"]
+          ),
+        ]
       );
     });
 
@@ -289,9 +320,9 @@ export const testSingleExecuteToBatchExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(uint256[],bytes[])"]([0], [executePayload])
+            .batchCalls([batchCall])
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -310,9 +341,9 @@ export const testSingleExecuteToBatchExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -328,12 +359,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and adding URD", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "ADDUNIVERSALRECEIVERDELEGATE"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["ADDUNIVERSALRECEIVERDELEGATE"]
+          ),
+        ]
       );
     });
 
@@ -348,9 +386,9 @@ export const testSingleExecuteToBatchExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(uint256[],bytes[])"]([0], [executePayload])
+            .batchCalls([batchCall])
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -369,9 +407,9 @@ export const testSingleExecuteToBatchExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
@@ -386,12 +424,19 @@ export const testSingleExecuteToBatchExecute = (
   });
 
   describe("when reentering and changing URD", () => {
-    let executePayload: BytesLike;
+    let batchCall: BytesLike;
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "CHANGEUNIVERSALRECEIVERDELEGATE"
+      batchCall = new UniversalProfile__factory().interface.encodeFunctionData(
+        "execute(uint256,address,uint256,bytes)",
+        [
+          0,
+          reentrancyContext.reentrantContract.address,
+          0,
+          new ReentrantContract__factory().interface.encodeFunctionData(
+            "callThatReenters",
+            ["CHANGEUNIVERSALRECEIVERDELEGATE"]
+          ),
+        ]
       );
     });
 
@@ -407,9 +452,9 @@ export const testSingleExecuteToBatchExecute = (
           );
 
           await expect(
-            context.keyManager
+            context.universalProfile
               .connect(reentrancyContext.caller)
-              ["execute(uint256[],bytes[])"]([0], [executePayload])
+              .batchCalls([batchCall])
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(
@@ -429,9 +474,9 @@ export const testSingleExecuteToBatchExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(uint256[],bytes[])"]([0], [executePayload]);
+        .batchCalls([batchCall]);
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +

--- a/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToBatchExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToBatchExecuteRelayCall.test.ts
@@ -3,10 +3,7 @@ import { ethers } from "hardhat";
 
 //types
 import { BigNumber, BytesLike } from "ethers";
-import {
-  SingleReentrancyRelayer__factory,
-  UniversalProfile__factory,
-} from "../../../../types";
+import { SingleReentrancyRelayer__factory } from "../../../../types";
 
 // constants
 import { ERC725YDataKeys } from "../../../../constants";
@@ -38,27 +35,29 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
 ) => {
   let context: LSP6TestContext;
   let reentrancyContext: ReentrancyContext;
-  let executePayload: BytesLike;
+  let executeCalldata: {
+    operationType: number;
+    to: string;
+    value: number;
+    data: BytesLike;
+  };
 
   before(async () => {
     context = await buildContext(ethers.utils.parseEther("10"));
     reentrancyContext = await buildReentrancyContext(context);
 
-    const reentrantCallPayload =
+    const reentrantCall =
       new SingleReentrancyRelayer__factory().interface.encodeFunctionData(
         "relayCallThatReenters",
         [context.keyManager.address]
       );
-    executePayload =
-      new UniversalProfile__factory().interface.encodeFunctionData(
-        "execute(uint256,address,uint256,bytes)",
-        [
-          0,
-          reentrancyContext.batchReentarncyRelayer.address,
-          0,
-          reentrantCallPayload,
-        ]
-      );
+
+    executeCalldata = {
+      operationType: 0,
+      to: reentrancyContext.batchReentarncyRelayer.address,
+      value: 0,
+      data: reentrantCall,
+    };
   });
 
   describe("when reentering and transferring value", () => {
@@ -89,9 +88,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -111,9 +115,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
     });
 
@@ -132,9 +141,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         )
       ).to.equal(ethers.utils.parseEther("10"));
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       expect(
         await context.universalProfile.provider.getBalance(
@@ -178,9 +192,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -200,9 +219,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(
         context.keyManager,
         "NoERC725YDataKeysAllowed"
@@ -218,9 +242,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         reentrancyContext.batchReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedKey = ethers.utils.keccak256(
         ethers.utils.toUtf8Bytes("SomeRandomTextUsed")
@@ -259,9 +288,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -280,9 +314,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         reentrancyContext.batchReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -322,9 +361,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -343,9 +387,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         reentrancyContext.batchReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -384,9 +433,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -405,9 +459,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         reentrancyContext.batchReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
@@ -446,9 +505,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
           );
 
           await expect(
-            context.keyManager
+            context.universalProfile
               .connect(reentrancyContext.caller)
-              ["execute(bytes)"](executePayload)
+              ["execute(uint256,address,uint256,bytes)"](
+                executeCalldata.operationType,
+                executeCalldata.to,
+                executeCalldata.value,
+                executeCalldata.data
+              )
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(
@@ -468,9 +532,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         reentrancyContext.batchReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +

--- a/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecute.test.ts
@@ -22,9 +22,9 @@ import {
   addUniversalReceiverDelegateTestCases,
   changeUniversalReceiverDelegateTestCases,
   // Functions
-  generateExecutePayload,
   loadTestCase,
 } from "./reentrancyHelpers";
+import { ReentrantContract__factory } from "../../../../types";
 
 export const testSingleExecuteToSingleExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -41,13 +41,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and transferring value", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "TRANSFERVALUE"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["TRANSFERVALUE"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     transferValueTestCases.NotAuthorised.forEach((testCase) => {
@@ -65,9 +77,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -87,9 +104,14 @@ export const testSingleExecuteToSingleExecute = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
     });
 
@@ -108,9 +130,14 @@ export const testSingleExecuteToSingleExecute = (
         )
       ).to.equal(ethers.utils.parseEther("10"));
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       expect(
         await context.universalProfile.provider.getBalance(
@@ -127,13 +154,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and setting data", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "SETDATA"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["SETDATA"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     setDataTestCases.NotAuthorised.forEach((testCase) => {
@@ -151,9 +190,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -173,9 +217,14 @@ export const testSingleExecuteToSingleExecute = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(
         context.keyManager,
         "NoERC725YDataKeysAllowed"
@@ -191,9 +240,14 @@ export const testSingleExecuteToSingleExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedKey = ethers.utils.keccak256(
         ethers.utils.toUtf8Bytes("SomeRandomTextUsed")
@@ -209,13 +263,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and adding permissions", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "ADDCONTROLLER"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["ADDCONTROLLER"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
@@ -229,9 +295,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -250,9 +321,14 @@ export const testSingleExecuteToSingleExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -269,13 +345,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and changing permissions", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "EDITPERMISSIONS"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["EDITPERMISSIONS"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
@@ -289,9 +377,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -310,9 +403,14 @@ export const testSingleExecuteToSingleExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -328,13 +426,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and adding URD", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "ADDUNIVERSALRECEIVERDELEGATE"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["ADDUNIVERSALRECEIVERDELEGATE"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
@@ -348,9 +458,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -369,9 +484,14 @@ export const testSingleExecuteToSingleExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
@@ -386,13 +506,25 @@ export const testSingleExecuteToSingleExecute = (
   });
 
   describe("when reentering and changing URD", () => {
-    let executePayload: BytesLike;
+    let executeCalldata: {
+      operationType: number;
+      to: string;
+      value: number;
+      data: BytesLike;
+    };
     before(async () => {
-      executePayload = generateExecutePayload(
-        context.keyManager.address,
-        reentrancyContext.reentrantContract.address,
-        "CHANGEUNIVERSALRECEIVERDELEGATE"
-      );
+      const reentrantCall =
+        new ReentrantContract__factory().interface.encodeFunctionData(
+          "callThatReenters",
+          ["CHANGEUNIVERSALRECEIVERDELEGATE"]
+        );
+
+      executeCalldata = {
+        operationType: 0,
+        to: reentrancyContext.reentrantContract.address,
+        value: 0,
+        data: reentrantCall,
+      };
     });
 
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach(
@@ -407,9 +539,14 @@ export const testSingleExecuteToSingleExecute = (
           );
 
           await expect(
-            context.keyManager
+            context.universalProfile
               .connect(reentrancyContext.caller)
-              ["execute(bytes)"](executePayload)
+              ["execute(uint256,address,uint256,bytes)"](
+                executeCalldata.operationType,
+                executeCalldata.to,
+                executeCalldata.value,
+                executeCalldata.data
+              )
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(
@@ -429,9 +566,14 @@ export const testSingleExecuteToSingleExecute = (
         reentrancyContext.reentrantContract.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +

--- a/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecuteRelayCall.test.ts
@@ -3,10 +3,7 @@ import { ethers } from "hardhat";
 
 //types
 import { BigNumber, BytesLike } from "ethers";
-import {
-  SingleReentrancyRelayer__factory,
-  UniversalProfile__factory,
-} from "../../../../types";
+import { SingleReentrancyRelayer__factory } from "../../../../types";
 
 // constants
 import { ERC725YDataKeys } from "../../../../constants";
@@ -38,27 +35,29 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
 ) => {
   let context: LSP6TestContext;
   let reentrancyContext: ReentrancyContext;
-  let executePayload: BytesLike;
+  let executeCalldata: {
+    operationType: number;
+    to: string;
+    value: number;
+    data: BytesLike;
+  };
 
   before(async () => {
     context = await buildContext(ethers.utils.parseEther("10"));
     reentrancyContext = await buildReentrancyContext(context);
 
-    const reentrantCallPayload =
+    const reentrantCall =
       new SingleReentrancyRelayer__factory().interface.encodeFunctionData(
         "relayCallThatReenters",
         [context.keyManager.address]
       );
-    executePayload =
-      new UniversalProfile__factory().interface.encodeFunctionData(
-        "execute(uint256,address,uint256,bytes)",
-        [
-          0,
-          reentrancyContext.singleReentarncyRelayer.address,
-          0,
-          reentrantCallPayload,
-        ]
-      );
+
+    executeCalldata = {
+      operationType: 0,
+      to: reentrancyContext.singleReentarncyRelayer.address,
+      value: 0,
+      data: reentrantCall,
+    };
   });
 
   describe("when reentering and transferring value", () => {
@@ -89,9 +88,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -111,9 +115,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
     });
 
@@ -132,9 +141,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         )
       ).to.equal(ethers.utils.parseEther("10"));
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       expect(
         await context.universalProfile.provider.getBalance(
@@ -178,9 +192,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -200,9 +219,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       );
 
       await expect(
-        context.keyManager
+        context.universalProfile
           .connect(reentrancyContext.caller)
-          ["execute(bytes)"](executePayload)
+          ["execute(uint256,address,uint256,bytes)"](
+            executeCalldata.operationType,
+            executeCalldata.to,
+            executeCalldata.value,
+            executeCalldata.data
+          )
       ).to.be.revertedWithCustomError(
         context.keyManager,
         "NoERC725YDataKeysAllowed"
@@ -218,9 +242,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         reentrancyContext.singleReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedKey = ethers.utils.keccak256(
         ethers.utils.toUtf8Bytes("SomeRandomTextUsed")
@@ -259,9 +288,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -280,9 +314,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         reentrancyContext.singleReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -322,9 +361,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -343,9 +387,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         reentrancyContext.singleReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
@@ -384,9 +433,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(
-          context.keyManager
+          context.universalProfile
             .connect(reentrancyContext.caller)
-            ["execute(bytes)"](executePayload)
+            ["execute(uint256,address,uint256,bytes)"](
+              executeCalldata.operationType,
+              executeCalldata.to,
+              executeCalldata.value,
+              executeCalldata.data
+            )
         )
           .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
           .withArgs(
@@ -405,9 +459,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         reentrancyContext.singleReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
@@ -446,9 +505,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
           );
 
           await expect(
-            context.keyManager
+            context.universalProfile
               .connect(reentrancyContext.caller)
-              ["execute(bytes)"](executePayload)
+              ["execute(uint256,address,uint256,bytes)"](
+                executeCalldata.operationType,
+                executeCalldata.to,
+                executeCalldata.value,
+                executeCalldata.data
+              )
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(
@@ -468,9 +532,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         reentrancyContext.singleReentarncyRelayer.address
       );
 
-      await context.keyManager
+      await context.universalProfile
         .connect(reentrancyContext.caller)
-        ["execute(bytes)"](executePayload);
+        ["execute(uint256,address,uint256,bytes)"](
+          executeCalldata.operationType,
+          executeCalldata.to,
+          executeCalldata.value,
+          executeCalldata.data
+        );
 
       const hardcodedLSP1Key =
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +

--- a/tests/LSP6KeyManager/tests/Reentrancy/reentrancyHelpers.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/reentrancyHelpers.ts
@@ -694,12 +694,7 @@ export const loadTestCase = async (
     }
   }
 
-  const permissionsPayload =
-    new UniversalProfile__factory().interface.encodeFunctionData(
-      "setData(bytes32[],bytes[])",
-      [permissionKeys, permissionValues]
-    );
-  await context.keyManager
+  await context.universalProfile
     .connect(context.owner)
-    ["execute(bytes)"](permissionsPayload);
+    ["setData(bytes32[],bytes[])"](permissionKeys, permissionValues);
 };

--- a/tests/LSP6KeyManager/tests/Reentrancy/reentrancyHelpers.ts
+++ b/tests/LSP6KeyManager/tests/Reentrancy/reentrancyHelpers.ts
@@ -613,26 +613,6 @@ export const generateBatchRelayPayload = async (
   );
 };
 
-export const generateExecutePayload = (
-  keyManagerAddress: string,
-  reentrantContractAddress: string,
-  payloadType: string
-) => {
-  const reentrantPayload =
-    new ReentrantContract__factory().interface.encodeFunctionData(
-      "callThatReenters",
-      [keyManagerAddress, payloadType]
-    );
-
-  const executePayload =
-    new UniversalProfile__factory().interface.encodeFunctionData(
-      "execute(uint256,address,uint256,bytes)",
-      [0, reentrantContractAddress, 0, reentrantPayload]
-    );
-
-  return executePayload;
-};
-
 export const loadTestCase = async (
   payloadType: string,
   testCase: TransferValueTestCase | SetDataTestCase | SimplePermissionTestCase,


### PR DESCRIPTION
### What does this PR introduce?

In this PR we refactor the tests so that the `execute(..)` and `setData(..)` calls are made directly to the UP.