### PR TITLE
chore: rename function parameters to mixedCase

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -11,7 +11,7 @@ import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725AccountInitAbstract.sol
  */
 contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
     /**
-     * @dev @dev initialize (= lock) base implementation contract on deployment
+     * @dev initialize (= lock) base implementation contract on deployment
      */
     constructor() {
         _disableInitializers();

--- a/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
@@ -191,12 +191,11 @@ abstract contract LSP11BasicSocialRecoveryCore is OwnableUnset, ERC165, ILSP11Ba
         address keyManager = ERC725(target_).owner();
 
         // Setting permissions for `recoverer`
-        (bytes32[] memory keys, bytes[] memory values) = LSP6Utils
-            .generatePermissionsKeysForNewController(
-                ERC725(target_),
-                recoverer,
-                ALL_REGULAR_PERMISSIONS
-            );
+        (bytes32[] memory keys, bytes[] memory values) = LSP6Utils.generateNewPermissionsKeys(
+            ERC725(target_),
+            recoverer,
+            ALL_REGULAR_PERMISSIONS
+        );
 
         LSP6Utils.setDataViaKeyManager(keyManager, keys, values);
 

--- a/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
@@ -192,7 +192,7 @@ abstract contract LSP11BasicSocialRecoveryCore is OwnableUnset, ERC165, ILSP11Ba
 
         // Setting permissions for `recoverer`
         (bytes32[] memory keys, bytes[] memory values) = LSP6Utils
-            .generatePermissionsKeysForController(
+            .generatePermissionsKeysForNewController(
                 ERC725(target_),
                 recoverer,
                 ALL_REGULAR_PERMISSIONS

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -188,7 +188,7 @@ library LSP6Utils {
      *  - values[1] = the address of the controller
      *  - values[2] = the `permissions` passed as param
      */
-    function generatePermissionsKeysForNewController(
+    function generateNewPermissionsKeys(
         IERC725Y account,
         address controller,
         bytes32 permissions

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -162,26 +162,41 @@ library LSP6Utils {
     /**
      * @dev combine multiple permissions into a single bytes32
      * Make sure that the sum of the values of the input array is less than 2^256-1 to avoid overflow.
-     * @param _permissions the array of permissions to combine
+     * @param permissions the array of permissions to combine
      * @return a bytes32 containing the combined permissions
      */
-    function combinePermissions(bytes32[] memory _permissions) internal pure returns (bytes32) {
+    function combinePermissions(bytes32[] memory permissions) internal pure returns (bytes32) {
         uint256 result = 0;
-        for (uint256 i = 0; i < _permissions.length; i++) {
-            result += uint256(_permissions[i]);
+        for (uint256 i = 0; i < permissions.length; i++) {
+            result += uint256(permissions[i]);
         }
         return bytes32(result);
     }
 
-    function generatePermissionsKeysForController(
-        IERC725Y _account,
-        address _address,
+    /**
+     * @dev Generate a new set of 3 x LSP6 permission data keys to add a new `controller` on `account`
+     * @param account the ERC725Y contract to add the controller into (used to fetch the `LSP6Permissions[]` length)
+     * @param controller the address of the controller to grant permissions to
+     * @param permissions the BitArray of permissions to grant to the controller
+     * @return keys an array of 3 x data keys containing:
+     *  - keys[0] = `AddressPermissions[]` (array length)
+     *  - keys[1] = `AddressPermissions[index]` (where to store the controller address)
+     *  - keys[2] = `AddressPermissions:Permissions:<controller>`
+     *
+     * @return values : an array of 3 x data values containing:
+     *  - values[0] = the new array length of `AddressPermissions[]`
+     *  - values[1] = the address of the controller
+     *  - values[2] = the `permissions` passed as param
+     */
+    function generatePermissionsKeysForNewController(
+        IERC725Y account,
+        address controller,
         bytes32 permissions
     ) internal view returns (bytes32[] memory keys, bytes[] memory values) {
         keys = new bytes32[](3);
         values = new bytes[](3);
 
-        uint128 arrayLength = uint128(bytes16(_account.getData(_LSP6KEY_ADDRESSPERMISSIONS_ARRAY)));
+        uint128 arrayLength = uint128(bytes16(account.getData(_LSP6KEY_ADDRESSPERMISSIONS_ARRAY)));
         uint128 newArrayLength = arrayLength + 1;
 
         keys[0] = _LSP6KEY_ADDRESSPERMISSIONS_ARRAY;
@@ -191,11 +206,11 @@ library LSP6Utils {
             _LSP6KEY_ADDRESSPERMISSIONS_ARRAY,
             arrayLength
         );
-        values[1] = abi.encodePacked(_address);
+        values[1] = abi.encodePacked(controller);
 
         keys[2] = LSP2Utils.generateMappingWithGroupingKey(
             _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
-            bytes20(_address)
+            bytes20(controller)
         );
         values[2] = abi.encodePacked(permissions);
     }


### PR DESCRIPTION
# What does this PR introduce?

- Rename some function parameters starting with underscore `_` as spotted by Slither.
- rename LSP6Utils library function `generatePermissionsKeysForController` to --> `generatePermissionsKeysForNewController` for better readability + add Natspec comment above function.