### PR TITLE
refactor: initialize memory vars before `if` checks in LSP1

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -108,19 +108,29 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 notifierMapKey,
         bytes4 interfaceID
     ) internal virtual returns (bytes memory) {
+        bytes32[] memory dataKeys;
+        bytes[] memory dataValues;
+
         // if it's a token transfer (LSP7/LSP8)
         if (typeId != _TYPEID_LSP9_OwnershipTransferred_RecipientNotification) {
             // if the amount sent is 0, then do not update the keys
             uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
             if (balance == 0) return "LSP1: balance not updated";
 
-            (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP5Utils
-                .generateReceivedAssetKeys(msg.sender, notifier, notifierMapKey, interfaceID);
+            (dataKeys, dataValues) = LSP5Utils.generateReceivedAssetKeys(
+                msg.sender,
+                notifier,
+                notifierMapKey,
+                interfaceID
+            );
 
             return LSP6Utils.setDataViaKeyManager(keyManager, dataKeys, dataValues);
         } else {
-            (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP10Utils
-                .generateReceivedVaultKeys(msg.sender, notifier, notifierMapKey);
+            (dataKeys, dataValues) = LSP10Utils.generateReceivedVaultKeys(
+                msg.sender,
+                notifier,
+                notifierMapKey
+            );
 
             return LSP6Utils.setDataViaKeyManager(keyManager, dataKeys, dataValues);
         }
@@ -138,19 +148,28 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 notifierMapKey,
         bytes memory notifierMapValue
     ) internal virtual returns (bytes memory) {
+        bytes32[] memory dataKeys;
+        bytes[] memory dataValues;
+
         // if it's a token transfer (LSP7/LSP8)
         if (typeId != _TYPEID_LSP9_OwnershipTransferred_SenderNotification) {
             // if the amount sent is not the full balance, then do not update the keys
             uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
             if (balance != 0) return "LSP1: full balance is not sent";
 
-            (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP5Utils
-                .generateSentAssetKeys(msg.sender, notifierMapKey, notifierMapValue);
+            (dataKeys, dataValues) = LSP5Utils.generateSentAssetKeys(
+                msg.sender,
+                notifierMapKey,
+                notifierMapValue
+            );
 
             return LSP6Utils.setDataViaKeyManager(keyManager, dataKeys, dataValues);
         } else {
-            (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP10Utils
-                .generateSentVaultKeys(msg.sender, notifierMapKey, notifierMapValue);
+            (dataKeys, dataValues) = LSP10Utils.generateSentVaultKeys(
+                msg.sender,
+                notifierMapKey,
+                notifierMapValue
+            );
 
             return LSP6Utils.setDataViaKeyManager(keyManager, dataKeys, dataValues);
         }

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -57,6 +57,9 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
         bytes32 notifierMapKey = LSP2Utils.generateMappingKey(mapPrefix, bytes20(notifier));
         bytes memory notifierMapValue = IERC725Y(msg.sender).getData(notifierMapKey);
 
+        bytes32[] memory dataKeys;
+        bytes[] memory dataValues;
+
         if (isReceiving) {
             // if the map value is already set, then do nothing
             if (bytes12(notifierMapValue) != bytes12(0))
@@ -66,10 +69,14 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
             uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
             if (balance == 0) return "LSP1: balance not updated";
 
-            (bytes32[] memory receiverDataKeys, bytes[] memory receiverDataValues) = LSP5Utils
-                .generateReceivedAssetKeys(msg.sender, notifier, notifierMapKey, interfaceID);
+            (dataKeys, dataValues) = LSP5Utils.generateReceivedAssetKeys(
+                msg.sender,
+                notifier,
+                notifierMapKey,
+                interfaceID
+            );
 
-            IERC725Y(msg.sender).setData(receiverDataKeys, receiverDataValues);
+            IERC725Y(msg.sender).setData(dataKeys, dataValues);
         } else {
             // if there is no map value for the asset to remove, then do nothing
             if (bytes12(notifierMapValue) == bytes12(0))
@@ -78,10 +85,13 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
             uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
             if (balance != 0) return "LSP1: full balance is not sent";
 
-            (bytes32[] memory senderDataKeys, bytes[] memory senderDataValues) = LSP5Utils
-                .generateSentAssetKeys(msg.sender, notifierMapKey, notifierMapValue);
+            (dataKeys, dataValues) = LSP5Utils.generateSentAssetKeys(
+                msg.sender,
+                notifierMapKey,
+                notifierMapValue
+            );
 
-            IERC725Y(msg.sender).setData(senderDataKeys, senderDataValues);
+            IERC725Y(msg.sender).setData(dataKeys, dataValues);
         }
     }
 


### PR DESCRIPTION
# What does this PR introduce?

Slither report the following when running against `LSP1UniversalReceiverDelegateUP`

![Screenshot 2023-03-14 at 13 53 09](https://user-images.githubusercontent.com/31145285/225048268-f01f211f-5ff4-46e6-9933-c83acb056738.png)

although this seems to be a false positive (as we are here dealing with `memory` variables, not `storage` ❌ ), refactor the code to allocate some memory for the array of `dataKeys[]` and `dataValues[]` first before to jump in the `if` checks.

This PR fixes the issue and remove the error reported by Slither.