### PR TITLE
feat!: Mark setData functions as payable

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -231,10 +231,12 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(
-        bytes32[] memory dataKeys,
-        bytes[] memory dataValues
-    ) public payable virtual override {
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+        public
+        payable
+        virtual
+        override
+    {
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
@@ -269,10 +271,12 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(
-        bytes32 typeId,
-        bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        returns (bytes memory returnedValues)
+    {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -328,9 +332,11 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - When notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP0OwnershipTransferStarted')
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(LSP14Ownable2Step, OwnableUnset)
+    {
         address currentOwner = owner();
 
         if (msg.sender == currentOwner) {
@@ -409,9 +415,13 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore, LSP17Extendable)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -428,10 +438,12 @@ abstract contract LSP0ERC725AccountCore is
      * @param dataHash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
      * @param signature owner's signature(s) of the data
      */
-    function isValidSignature(
-        bytes32 dataHash,
-        bytes memory signature
-    ) public view virtual returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 dataHash, bytes memory signature)
+        public
+        view
+        virtual
+        returns (bytes4 magicValue)
+    {
         address _owner = owner();
 
         // If owner is a contract
@@ -520,9 +532,13 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(
-        bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    function _getExtension(bytes4 functionSelector)
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -232,10 +232,12 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(
-        bytes32[] memory dataKeys,
-        bytes[] memory dataValues
-    ) public payable virtual override {
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+        public
+        payable
+        virtual
+        override
+    {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
         if (dataKeys.length != dataValues.length) {
@@ -272,10 +274,12 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(
-        bytes32 typeId,
-        bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        returns (bytes memory returnedValues)
+    {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -331,9 +335,11 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - When notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP0OwnershipTransferStarted')
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(LSP14Ownable2Step, OwnableUnset)
+    {
         address currentOwner = owner();
 
         if (msg.sender == currentOwner) {
@@ -412,9 +418,13 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore, LSP17Extendable)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -431,10 +441,12 @@ abstract contract LSP0ERC725AccountCore is
      * @param dataHash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
      * @param signature owner's signature(s) of the data
      */
-    function isValidSignature(
-        bytes32 dataHash,
-        bytes memory signature
-    ) public view virtual returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 dataHash, bytes memory signature)
+        public
+        view
+        virtual
+        returns (bytes4 magicValue)
+    {
         address _owner = owner();
 
         // If owner is a contract
@@ -523,9 +535,13 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(
-        bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    function _getExtension(bytes4 functionSelector)
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -208,7 +208,7 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 dataKey, bytes memory dataValue) public virtual override {
+    function setData(bytes32 dataKey, bytes memory dataValue) public payable virtual override {
         address _owner = owner();
 
         if (msg.sender == _owner) return _setData(dataKey, dataValue);
@@ -231,7 +231,10 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public virtual override {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override {
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
@@ -266,12 +269,10 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
-        public
-        payable
-        virtual
-        returns (bytes memory returnedValues)
-    {
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -327,11 +328,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - When notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP0OwnershipTransferStarted')
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(LSP14Ownable2Step, OwnableUnset)
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
         address currentOwner = owner();
 
         if (msg.sender == currentOwner) {
@@ -410,13 +409,9 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore, LSP17Extendable)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -433,12 +428,10 @@ abstract contract LSP0ERC725AccountCore is
      * @param dataHash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
      * @param signature owner's signature(s) of the data
      */
-    function isValidSignature(bytes32 dataHash, bytes memory signature)
-        public
-        view
-        virtual
-        returns (bytes4 magicValue)
-    {
+    function isValidSignature(
+        bytes32 dataHash,
+        bytes memory signature
+    ) public view virtual returns (bytes4 magicValue) {
         address _owner = owner();
 
         // If owner is a contract
@@ -527,13 +520,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(bytes4 functionSelector)
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view virtual override returns (address) {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -232,12 +232,10 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
-        public
-        payable
-        virtual
-        override
-    {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
 
         if (dataKeys.length != dataValues.length) {
@@ -274,12 +272,10 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
-        public
-        payable
-        virtual
-        returns (bytes memory returnedValues)
-    {
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -335,11 +331,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - When notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP0OwnershipTransferStarted')
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(LSP14Ownable2Step, OwnableUnset)
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
         address currentOwner = owner();
 
         if (msg.sender == currentOwner) {
@@ -418,13 +412,9 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore, LSP17Extendable)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -441,12 +431,10 @@ abstract contract LSP0ERC725AccountCore is
      * @param dataHash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
      * @param signature owner's signature(s) of the data
      */
-    function isValidSignature(bytes32 dataHash, bytes memory signature)
-        public
-        view
-        virtual
-        returns (bytes4 magicValue)
-    {
+    function isValidSignature(
+        bytes32 dataHash,
+        bytes memory signature
+    ) public view virtual returns (bytes4 magicValue) {
         address _owner = owner();
 
         // If owner is a contract
@@ -535,13 +523,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(bytes4 functionSelector)
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view virtual override returns (address) {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -209,6 +209,7 @@ abstract contract LSP0ERC725AccountCore is
      * Emits a {DataChanged} event.
      */
     function setData(bytes32 dataKey, bytes memory dataValue) public payable virtual override {
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         address _owner = owner();
 
         if (msg.sender == _owner) return _setData(dataKey, dataValue);
@@ -231,12 +232,12 @@ abstract contract LSP0ERC725AccountCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
-        public
-        payable
-        virtual
-        override
-    {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override {
+        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
@@ -271,12 +272,10 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
-        public
-        payable
-        virtual
-        returns (bytes memory returnedValues)
-    {
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -332,11 +331,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - When notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP0OwnershipTransferStarted')
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(LSP14Ownable2Step, OwnableUnset)
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
         address currentOwner = owner();
 
         if (msg.sender == currentOwner) {
@@ -415,13 +412,9 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore, LSP17Extendable)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -438,12 +431,10 @@ abstract contract LSP0ERC725AccountCore is
      * @param dataHash hash of the data signed//Arbitrary length data signed on the behalf of address(this)
      * @param signature owner's signature(s) of the data
      */
-    function isValidSignature(bytes32 dataHash, bytes memory signature)
-        public
-        view
-        virtual
-        returns (bytes4 magicValue)
-    {
+    function isValidSignature(
+        bytes32 dataHash,
+        bytes memory signature
+    ) public view virtual returns (bytes4 magicValue) {
         address _owner = owner();
 
         // If owner is a contract
@@ -532,13 +523,9 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(bytes4 functionSelector)
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view virtual override returns (address) {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -147,3 +147,8 @@ error InvalidPayload(bytes payload);
  * @param caller The address calling lsp20 related functions
  */
 error CallerIsNotTheTarget(address caller);
+
+/**
+ * @dev reverts when sending value to the `setData(..)` functions
+ */
+error CannotSendValueToSetData();

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -108,7 +108,7 @@ abstract contract LSP6KeyManagerCore is
      * @inheritdoc ILSP20
      */
     function lsp20VerifyCallResult(
-        bytes32 /*callHash*/,
+        bytes32, /*callHash*/
         bytes memory /*result*/
     ) external returns (bytes4) {
         if (msg.sender != _target) revert CallerIsNotTheTarget(msg.sender);
@@ -137,10 +137,11 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc IERC1271
      */
-    function isValidSignature(
-        bytes32 dataHash,
-        bytes memory signature
-    ) public view returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 dataHash, bytes memory signature)
+        public
+        view
+        returns (bytes4 magicValue)
+    {
         address recoveredAddress = dataHash.recover(signature);
 
         return (
@@ -160,10 +161,12 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc ILSP6KeyManager
      */
-    function execute(
-        uint256[] calldata values,
-        bytes[] calldata payloads
-    ) public payable virtual returns (bytes[] memory) {
+    function execute(uint256[] calldata values, bytes[] calldata payloads)
+        public
+        payable
+        virtual
+        returns (bytes[] memory)
+    {
         if (values.length != payloads.length) {
             revert BatchExecuteParamsLengthMismatch();
         }
@@ -232,10 +235,11 @@ abstract contract LSP6KeyManagerCore is
         return results;
     }
 
-    function _execute(
-        uint256 msgValue,
-        bytes calldata payload
-    ) internal virtual returns (bytes memory) {
+    function _execute(uint256 msgValue, bytes calldata payload)
+        internal
+        virtual
+        returns (bytes memory)
+    {
         if (payload.length < 4) {
             revert InvalidPayload(payload);
         }
@@ -296,10 +300,11 @@ abstract contract LSP6KeyManagerCore is
      * @param payload the abi-encoded function call to execute on the target.
      * @return bytes the result from calling the target with `payload`
      */
-    function _executePayload(
-        uint256 msgValue,
-        bytes calldata payload
-    ) internal virtual returns (bytes memory) {
+    function _executePayload(uint256 msgValue, bytes calldata payload)
+        internal
+        virtual
+        returns (bytes memory)
+    {
         (bool success, bytes memory returnData) = _target.call{value: msgValue, gas: gasleft()}(
             payload
         );

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -170,9 +170,13 @@ contract LSP9VaultCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(
-        bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    function _getExtension(bytes4 functionSelector)
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector
@@ -192,9 +196,13 @@ contract LSP9VaultCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore, LSP17Extendable)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
@@ -297,10 +305,12 @@ contract LSP9VaultCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(
-        bytes32[] memory dataKeys,
-        bytes[] memory dataValues
-    ) public payable virtual override {
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+        public
+        payable
+        virtual
+        override
+    {
         bool isURD = _validateAndIdentifyCaller();
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
@@ -345,10 +355,12 @@ contract LSP9VaultCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(
-        bytes32 typeId,
-        bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        returns (bytes memory returnedValues)
+    {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -404,9 +416,12 @@ contract LSP9VaultCore is
      * Requirements:
      *  - when notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP9OwnershipTransferStarted')
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(LSP14Ownable2Step, OwnableUnset) onlyOwner {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(LSP14Ownable2Step, OwnableUnset)
+        onlyOwner
+    {
         LSP14Ownable2Step._transferOwnership(newOwner);
 
         address currentOwner = owner();

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -170,13 +170,9 @@ contract LSP9VaultCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(bytes4 functionSelector)
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view virtual override returns (address) {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector
@@ -196,13 +192,9 @@ contract LSP9VaultCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore, LSP17Extendable)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
@@ -281,7 +273,9 @@ contract LSP9VaultCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32 dataKey, bytes memory dataValue) public virtual override {
+    function setData(bytes32 dataKey, bytes memory dataValue) public payable virtual override {
+        if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
+
         bool isURD = _validateAndIdentifyCaller();
         if (isURD) {
             if (
@@ -303,11 +297,16 @@ contract LSP9VaultCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public virtual override {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override {
         bool isURD = _validateAndIdentifyCaller();
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
         }
+
+        if (msg.value != 0) revert ERC725Y_MsgValueDisallowed();
 
         for (uint256 i = 0; i < dataKeys.length; i = GasLib.uncheckedIncrement(i)) {
             if (isURD) {
@@ -346,12 +345,10 @@ contract LSP9VaultCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
-        public
-        payable
-        virtual
-        returns (bytes memory returnedValues)
-    {
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -407,12 +404,9 @@ contract LSP9VaultCore is
      * Requirements:
      *  - when notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP9OwnershipTransferStarted')
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(LSP14Ownable2Step, OwnableUnset)
-        onlyOwner
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(LSP14Ownable2Step, OwnableUnset) onlyOwner {
         LSP14Ownable2Step._transferOwnership(newOwner);
 
         address currentOwner = owner();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^4.1.1",
+        "@erc725/smart-contracts": "^4.2.0",
         "@openzeppelin/contracts": "^4.8.0",
         "@openzeppelin/contracts-upgradeable": "^4.8.0",
         "solidity-bytes-utils": "0.8.0"
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.1.1.tgz",
-      "integrity": "sha512-ZYnI1jaVGkReAsfxgv1QgXA3cgKkIjIADSxtUpPYFov5sC/IXb68QQzCh1Suz4RUxxs8Gyqzano83WAMigtpPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.2.0.tgz",
+      "integrity": "sha512-aEZSdH8Ak/LyLsOAyKpUpa8Tcarrv/mKWTu7Q3vtIGzkkFgjRJBoklRy+cd9Fa5qAYkYIb5hFmbtpvjdpHPuKQ==",
       "dependencies": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
@@ -20380,9 +20380,9 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.1.1.tgz",
-      "integrity": "sha512-ZYnI1jaVGkReAsfxgv1QgXA3cgKkIjIADSxtUpPYFov5sC/IXb68QQzCh1Suz4RUxxs8Gyqzano83WAMigtpPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-4.2.0.tgz",
+      "integrity": "sha512-aEZSdH8Ak/LyLsOAyKpUpa8Tcarrv/mKWTu7Q3vtIGzkkFgjRJBoklRy+cd9Fa5qAYkYIb5hFmbtpvjdpHPuKQ==",
       "requires": {
         "@openzeppelin/contracts": "^4.7.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^4.1.1",
+    "@erc725/smart-contracts": "^4.2.0",
     "@openzeppelin/contracts": "^4.8.0",
     "@openzeppelin/contracts-upgradeable": "^4.8.0",
     "solidity-bytes-utils": "0.8.0"

--- a/tests/LSP6KeyManager/tests/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/BatchExecute.test.ts
@@ -496,7 +496,7 @@ export const shouldBehaveLikeBatchExecute = (
         });
 
         describe("if specifying some value for each values[index]", () => {
-          it("should revert LSP6 `_executePayload` error since `setData(...)` is not payable", async () => {
+          it("should revert with Key Manager error `CannotSendValueToSetData` when sending value while setting data", async () => {
             const amountToFund = ethers.utils.parseEther("2");
 
             const dataKeys = [

--- a/tests/LSP6KeyManager/tests/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/tests/BatchExecute.test.ts
@@ -531,7 +531,10 @@ export const shouldBehaveLikeBatchExecute = (
                   [firstSetDataPayload, secondSetDataPayload],
                   { value: amountToFund }
                 )
-            ).to.be.revertedWith("LSP6: failed executing payload");
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "CannotSendValueToSetData"
+            );
 
             const keyManagerBalanceAfter = await ethers.provider.getBalance(
               context.keyManager.address
@@ -633,7 +636,10 @@ export const shouldBehaveLikeBatchExecute = (
                 ["execute(uint256[],bytes[])"](msgValues, payloads, {
                   value: totalValues,
                 })
-            ).to.be.revertedWith("LSP6: failed executing payload");
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "CannotSendValueToSetData"
+            );
           });
         });
       });

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -203,7 +203,7 @@ export const shouldBehaveLikePermissionSetData = (
       });
 
       describe("when sending value while setting data", async () => {
-        it("should revert", async () => {
+        it("should revert with Key Manager error `CannotSendValueToSetData`", async () => {
           let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
           let value = ethers.utils.hexlify(
             ethers.utils.toUtf8Bytes("Hello Lukso!!!")
@@ -626,7 +626,7 @@ export const shouldBehaveLikePermissionSetData = (
       });
 
       describe("when sending value while setting data", async () => {
-        it("should revert", async () => {
+        it("should revert with Key Manager error `CannotSendValueToSetData`", async () => {
           let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
           let elements = {
             MyFirstKey: "aaaaaaaaaa",

--- a/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/tests/PermissionSetData.test.ts
@@ -201,6 +201,29 @@ export const shouldBehaveLikePermissionSetData = (
             .withArgs(cannotSetData.address, "SETDATA");
         });
       });
+
+      describe("when sending value while setting data", async () => {
+        it("should revert", async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+          let value = ethers.utils.hexlify(
+            ethers.utils.toUtf8Bytes("Hello Lukso!!!")
+          );
+
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32,bytes)",
+            [key, value]
+          );
+
+          await expect(
+            context.keyManager
+              .connect(canSetDataWithAllowedERC725YDataKeys)
+              ["execute(bytes)"](payload, { value: 12 })
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "CannotSendValueToSetData"
+          );
+        });
+      });
     });
 
     describe("when setting multiple keys", () => {
@@ -599,6 +622,35 @@ export const shouldBehaveLikePermissionSetData = (
           )
             .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
             .withArgs(cannotSetData.address, "SETDATA");
+        });
+      });
+
+      describe("when sending value while setting data", async () => {
+        it("should revert", async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+          let elements = {
+            MyFirstKey: "aaaaaaaaaa",
+            MySecondKey: "bbbbbbbbbb",
+            MyThirdKey: "cccccccccc",
+            MyFourthKey: "dddddddddd",
+            MyFifthKey: "eeeeeeeeee",
+          };
+
+          let [keys, values] = generateKeysAndValues(elements);
+
+          let payload = context.universalProfile.interface.encodeFunctionData(
+            "setData(bytes32[],bytes[])",
+            [keys, values]
+          );
+
+          await expect(
+            context.keyManager
+              .connect(context.owner)
+              ["execute(bytes)"](payload, { value: 12 })
+          ).to.be.revertedWithCustomError(
+            context.keyManager,
+            "CannotSendValueToSetData"
+          );
         });
       });
     });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -541,7 +541,7 @@ export const shouldBehaveLikeLSP9 = (
 
     describe("When sending value to setData", () => {
       it("should revert when sending value to setData(..)", async () => {
-        let value = 100;
+        let value = ethers.utils.parseEther("2");
         const txParams = {
           dataKey: ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
           dataValue: "0xaabbccdd",
@@ -560,7 +560,7 @@ export const shouldBehaveLikeLSP9 = (
       });
 
       it("should revert when sending value to setData(..) Array", async () => {
-        let value = 100;
+        let value = ethers.utils.parseEther("2");
         const txParams = {
           dataKey: [
             ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -538,6 +538,52 @@ export const shouldBehaveLikeLSP9 = (
         expect(result).to.equal(value);
       });
     });
+
+    describe("When sending value to setData", () => {
+      it("should revert when sending value to setData(..)", async () => {
+        let value = 100;
+        const txParams = {
+          dataKey: ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
+          dataValue: "0xaabbccdd",
+        };
+
+        await expect(
+          context.lsp9Vault
+            .connect(context.accounts.owner)
+            ["setData(bytes32,bytes)"](txParams.dataKey, txParams.dataValue, {
+              value: value,
+            })
+        ).to.be.revertedWithCustomError(
+          context.lsp9Vault,
+          "ERC725Y_MsgValueDisallowed"
+        );
+      });
+
+      it("should revert when sending value to setData(..) Array", async () => {
+        let value = 100;
+        const txParams = {
+          dataKey: [
+            ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
+          ],
+          dataValue: ["0xaabbccdd"],
+        };
+
+        await expect(
+          context.lsp9Vault
+            .connect(context.accounts.owner)
+            ["setData(bytes32[],bytes[])"](
+              txParams.dataKey,
+              txParams.dataValue,
+              {
+                value: value,
+              }
+            )
+        ).to.be.revertedWithCustomError(
+          context.lsp9Vault,
+          "ERC725Y_MsgValueDisallowed"
+        );
+      });
+    });
   });
 
   describe("when testing execute(...)", () => {

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -299,6 +299,52 @@ export const shouldBehaveLikeLSP3 = (
         expect(result).to.equal(value);
       });
     });
+
+    describe("when sending value while setting data", () => {
+      describe("when calling setData(..)", () => {
+        it("should pass and emit the ValueReceived event", async () => {
+          let msgValue = ethers.utils.parseEther("2");
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+          let value = ethers.utils.hexlify(ethers.utils.randomBytes(256));
+
+          await expect(
+            context.universalProfile
+              .connect(context.accounts[0])
+              ["setData(bytes32,bytes)"](key, value, { value: msgValue })
+          )
+            .to.emit(context.universalProfile, "ValueReceived")
+            .withArgs(context.accounts[0].address, msgValue);
+
+          const result = await context.universalProfile["getData(bytes32)"](
+            key
+          );
+          expect(result).to.equal(value);
+        });
+      });
+
+      describe("when calling setData(..) Array", () => {
+        it("should pass and emit the ValueReceived event", async () => {
+          let msgValue = ethers.utils.parseEther("2");
+          let key = [
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key")),
+          ];
+          let value = [ethers.utils.hexlify(ethers.utils.randomBytes(256))];
+
+          await expect(
+            context.universalProfile
+              .connect(context.accounts[0])
+              ["setData(bytes32[],bytes[])"](key, value, { value: msgValue })
+          )
+            .to.emit(context.universalProfile, "ValueReceived")
+            .withArgs(context.accounts[0].address, msgValue);
+
+          const result = await context.universalProfile["getData(bytes32[])"](
+            key
+          );
+          expect(result).to.deep.equal(value);
+        });
+      });
+    });
   });
 
   describe("when calling the contract without any value or data", () => {


### PR DESCRIPTION
## What does this PR introduce ?

- Marking setData functions in LSP0 and LSP9 as payable
- Disallowing sending value to setData of LSP9
- Disallowing sending value to setData of LSP0 while having KM as owner. (In the KeyManager)
- Add needed tests