### PR TITLE
fix: disallow calling LSP20 function on LSP6 through execute

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -152,3 +152,8 @@ error CallerIsNotTheTarget(address caller);
  * @dev reverts when sending value to the `setData(..)` functions
  */
 error CannotSendValueToSetData();
+
+/**
+ * @dev reverts when calling LSP20 functions on the KeyManager through execute(..)
+ */
+error CallingLSP20FunctionsOnLSP6NotAllowed();

--- a/tests/LSP20CallVerification/LSP6KeyManager/tests/BatchExecute.test.ts
+++ b/tests/LSP20CallVerification/LSP6KeyManager/tests/BatchExecute.test.ts
@@ -495,7 +495,7 @@ export const shouldBehaveLikeBatchExecute = (
           });
         });
 
-        describe.only("if specifying some value for each values[index]", () => {
+        describe("if specifying some value for each values[index]", () => {
           it("should revert with Key Manager error `CannotSendValueToSetData` when sending value while setting data", async () => {
             const amountToFund = ethers.utils.parseEther("2");
 
@@ -539,7 +539,7 @@ export const shouldBehaveLikeBatchExecute = (
         });
       });
 
-      describe.only("when sending 2x payloads, 1st for `setData`, 2nd for `execute`", () => {
+      describe("when sending 2x payloads, 1st for `setData`, 2nd for `execute`", () => {
         describe("when `msgValues[1]` is zero for `setData(...)`", () => {
           it("should pass", async () => {
             const recipient = context.accounts[5].address;

--- a/tests/LSP20CallVerification/LSP6KeyManager/tests/BatchExecute.test.ts
+++ b/tests/LSP20CallVerification/LSP6KeyManager/tests/BatchExecute.test.ts
@@ -495,8 +495,8 @@ export const shouldBehaveLikeBatchExecute = (
           });
         });
 
-        describe("if specifying some value for each values[index]", () => {
-          it("should revert LSP6 `_executePayload` error since `setData(...)` is not payable", async () => {
+        describe.only("if specifying some value for each values[index]", () => {
+          it("should revert with Key Manager error `CannotSendValueToSetData` when sending value while setting data", async () => {
             const amountToFund = ethers.utils.parseEther("2");
 
             const dataKeys = [
@@ -531,24 +531,15 @@ export const shouldBehaveLikeBatchExecute = (
                   [firstSetDataPayload, secondSetDataPayload],
                   { value: amountToFund }
                 )
-            ).to.be.revertedWith("LSP6: failed executing payload");
-
-            const keyManagerBalanceAfter = await ethers.provider.getBalance(
-              context.keyManager.address
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "CannotSendValueToSetData"
             );
-
-            expect(keyManagerBalanceAfter).to.equal(keyManagerBalanceBefore);
-
-            // the Key Manager must not hold any funds and must always forward any funds sent to it.
-            // it's balance must always be 0 after any execution
-            expect(
-              await provider.getBalance(context.keyManager.address)
-            ).to.equal(0);
           });
         });
       });
 
-      describe("when sending 2x payloads, 1st for `setData`, 2nd for `execute`", () => {
+      describe.only("when sending 2x payloads, 1st for `setData`, 2nd for `execute`", () => {
         describe("when `msgValues[1]` is zero for `setData(...)`", () => {
           it("should pass", async () => {
             const recipient = context.accounts[5].address;
@@ -633,7 +624,10 @@ export const shouldBehaveLikeBatchExecute = (
                 ["execute(uint256[],bytes[])"](msgValues, payloads, {
                   value: totalValues,
                 })
-            ).to.be.revertedWith("LSP6: failed executing payload");
+            ).to.be.revertedWithCustomError(
+              context.keyManager,
+              "CannotSendValueToSetData"
+            );
           });
         });
       });

--- a/tests/LSP20CallVerification/LSP6KeyManager/tests/Reentrancy/SingleExecuteRelayCallToSingleExecute.test.ts
+++ b/tests/LSP20CallVerification/LSP6KeyManager/tests/Reentrancy/SingleExecuteRelayCallToSingleExecute.test.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import { BigNumber, BytesLike } from "ethers";
 
 // constants
-import { ERC725YDataKeys } from "../../../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys } from "../../../../../constants";
 
 // setup
 import { LSP6TestContext } from "../../../../utils/context";
@@ -342,14 +342,12 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
 
       expect(
         await context.universalProfile["getData(bytes32)"](
           hardcodedPermissionKey
         )
-      ).to.equal(hardcodedPermissionValue);
+      ).to.equal(ALL_PERMISSIONS);
     });
   });
 

--- a/tests/LSP20CallVerification/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecute.test.ts
+++ b/tests/LSP20CallVerification/LSP6KeyManager/tests/Reentrancy/SingleExecuteToSingleExecute.test.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import { BigNumber, BytesLike } from "ethers";
 
 // constants
-import { ERC725YDataKeys } from "../../../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys } from "../../../../../constants";
 
 // setup
 import { LSP6TestContext } from "../../../../utils/context";
@@ -336,14 +336,12 @@ export const testSingleExecuteToSingleExecute = (
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
 
       expect(
         await context.universalProfile["getData(bytes32)"](
           hardcodedPermissionKey
         )
-      ).to.equal(hardcodedPermissionValue);
+      ).to.equal(ALL_PERMISSIONS);
     });
   });
 

--- a/tests/LSP20CallVerification/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP20CallVerification/LSP6KeyManager/tests/Security.test.ts
@@ -113,6 +113,53 @@ export const testSecurityScenarios = (
       .withArgs(addressWithNoPermissions.address);
   });
 
+  it("Should revert when caller calls the lsp20VerifyCall function on the KeyManager through execute", async () => {
+    let lsp20VerifyCallPayload =
+      context.keyManager.interface.encodeFunctionData(
+        "lsp20VerifyCall",
+        [context.accounts[2].address, 0, "0xaabbccdd"] // random arguments
+      );
+
+    await expect(
+      context.universalProfile
+        .connect(context.owner)
+        ["execute(uint256,address,uint256,bytes)"](
+          OPERATION_TYPES.CALL,
+          context.keyManager.address,
+          0,
+          lsp20VerifyCallPayload
+        )
+    ).to.be.revertedWithCustomError(
+      context.keyManager,
+      "CallingLSP20FunctionsOnLSP6NotAllowed"
+    );
+  });
+
+  it("Should revert when caller calls the lsp20VerifyCallResult function on the KeyManager through execute", async () => {
+    let lsp20VerifyCallResultPayload =
+      context.keyManager.interface.encodeFunctionData(
+        "lsp20VerifyCallResult",
+        [
+          "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+          "0xaabbccdd",
+        ] // random arguments
+      );
+
+    await expect(
+      context.universalProfile
+        .connect(context.owner)
+        ["execute(uint256,address,uint256,bytes)"](
+          OPERATION_TYPES.CALL,
+          context.keyManager.address,
+          0,
+          lsp20VerifyCallResultPayload
+        )
+    ).to.be.revertedWithCustomError(
+      context.keyManager,
+      "CallingLSP20FunctionsOnLSP6NotAllowed"
+    );
+  });
+
   describe("should revert when admin with ALL PERMISSIONS try to call `renounceOwnership(...)`", () => {
     it("via `execute(...)`", async () => {
       let payload =

--- a/tests/LSP6KeyManager/tests/Security.test.ts
+++ b/tests/LSP6KeyManager/tests/Security.test.ts
@@ -113,6 +113,63 @@ export const testSecurityScenarios = (
       .withArgs(addressWithNoPermissions.address);
   });
 
+  it("Should revert when caller calls the lsp20VerifyCall function on the KeyManager through execute", async () => {
+    let lsp20VerifyCallPayload =
+      context.keyManager.interface.encodeFunctionData(
+        "lsp20VerifyCall",
+        [context.accounts[2].address, 0, "0xaabbccdd"] // random arguments
+      );
+
+    let executePayload = context.universalProfile.interface.encodeFunctionData(
+      "execute(uint256,address,uint256,bytes)",
+      [
+        OPERATION_TYPES.CALL,
+        context.keyManager.address,
+        0,
+        lsp20VerifyCallPayload,
+      ]
+    );
+
+    await expect(
+      context.keyManager
+        .connect(context.owner)
+        ["execute(bytes)"](executePayload)
+    ).to.be.revertedWithCustomError(
+      context.keyManager,
+      "CallingLSP20FunctionsOnLSP6NotAllowed"
+    );
+  });
+
+  it("Should revert when caller calls the lsp20VerifyCallResult function on the KeyManager through execute", async () => {
+    let lsp20VerifyCallResultPayload =
+      context.keyManager.interface.encodeFunctionData(
+        "lsp20VerifyCallResult",
+        [
+          "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+          "0xaabbccdd",
+        ] // random arguments
+      );
+
+    let executePayload = context.universalProfile.interface.encodeFunctionData(
+      "execute(uint256,address,uint256,bytes)",
+      [
+        OPERATION_TYPES.CALL,
+        context.keyManager.address,
+        0,
+        lsp20VerifyCallResultPayload,
+      ]
+    );
+
+    await expect(
+      context.keyManager
+        .connect(context.owner)
+        ["execute(bytes)"](executePayload)
+    ).to.be.revertedWithCustomError(
+      context.keyManager,
+      "CallingLSP20FunctionsOnLSP6NotAllowed"
+    );
+  });
+
   describe("should revert when admin with ALL PERMISSIONS try to call `renounceOwnership(...)`", () => {
     it("via `execute(...)`", async () => {
       let payload =


### PR DESCRIPTION
## What does this PR introduce ?

- Disallowing calling lsp20 functions by erc725x execute in the KM.
- Add relevant tests
- Resolve failing tests from previous PR