### PR TITLE
ci: do not run code coverage + gas benchmark CI on releases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,11 +3,19 @@
 name: 🆙 📊 Universal Profile Benchmark
 
 on:
+  # enable to run workflow manually
+  workflow_dispatch:
+
   pull_request:
     types: [opened]
+    branches-ignore:
+      - "main" # do not run on releases (merging to main)
 
 jobs:
   benchmark:
+    # Do not run when preparing a release and the branch name contains the term "prepare"
+    # (e.g: chore/prepare-release-x.x.x -> develop)
+    if: ${{ !contains(github.ref, "release") }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,8 +8,14 @@ on:
 
   pull_request:
     types: [opened]
+
+    # compare gas diff only when editing Solidity smart contract code
+    paths:
+      - "contracts/**/*.sol"
+
+    # do not run on releases (merging to main)
     branches-ignore:
-      - "main" # do not run on releases (merging to main)
+      - "main"
 
 jobs:
   benchmark:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - "develop"
-      - "main"
 
 jobs:
   coverage:


### PR DESCRIPTION
# What does this PR introduce?

Remove unecessary CI running when making releases. Including:

- merging `develop` -> `main`
- making PRs to `develop` that aim to bump the version in package.json + update the release CHANGELOG