### PR TITLE
refactor: change `renounceOwnership(..)` delay to 200

### DIFF
--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -64,9 +64,12 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
     /**
      * @inheritdoc ILSP14Ownable2Step
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(OwnableUnset, ILSP14Ownable2Step) onlyOwner {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(OwnableUnset, ILSP14Ownable2Step)
+        onlyOwner
+    {
         _transferOwnership(newOwner);
 
         address currentOwner = owner();

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -37,12 +37,12 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
      * @dev The number of block that MUST pass before one is able to
      *  confirm renouncing ownership
      */
-    uint256 public constant RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY = 100;
+    uint256 public constant RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY = 200;
 
     /**
      * @dev The number of blocks during which one can renounce ownership
      */
-    uint256 public constant RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD = 100;
+    uint256 public constant RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD = 200;
 
     /**
      * @dev The block number saved when initiating the process of renouncing ownerhsip
@@ -64,12 +64,9 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
     /**
      * @inheritdoc ILSP14Ownable2Step
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(OwnableUnset, ILSP14Ownable2Step)
-        onlyOwner
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(OwnableUnset, ILSP14Ownable2Step) onlyOwner {
         _transferOwnership(newOwner);
 
         address currentOwner = owner();

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -411,7 +411,9 @@ export const shouldBehaveLikeLSP14 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0x62"]); // skip 98 blocks
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(98),
+        ]); // skip 98 blocks
 
         const renounceOwnershipSecond = context.contract
           .connect(context.deployParams.owner)
@@ -426,7 +428,6 @@ export const shouldBehaveLikeLSP14 = (
             (await renounceOwnershipOnce).blockNumber + 200,
             (await renounceOwnershipOnce).blockNumber + 400
           );
-
         expect(await context.contract.owner()).to.equal(
           context.deployParams.owner.address
         );
@@ -440,7 +441,9 @@ export const shouldBehaveLikeLSP14 = (
             .renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", ["0xC7"]); //
+          await network.provider.send("hardhat_mine", [
+            ethers.utils.hexValue(199),
+          ]);
         });
 
         it("should have emitted a OwnershipTransferred event", async () => {
@@ -546,7 +549,9 @@ export const shouldBehaveLikeLSP14 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0x190"]); // skip 400 blocks
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(400),
+        ]); // skip 400 blocks
 
         let tx = await context.contract
           .connect(context.deployParams.owner)

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -423,8 +423,8 @@ export const shouldBehaveLikeLSP14 = (
             "NotInRenounceOwnershipInterval"
           )
           .withArgs(
-            (await renounceOwnershipOnce).blockNumber + 100,
-            (await renounceOwnershipOnce).blockNumber + 200
+            (await renounceOwnershipOnce).blockNumber + 200,
+            (await renounceOwnershipOnce).blockNumber + 400
           );
 
         expect(await context.contract.owner()).to.equal(
@@ -433,13 +433,17 @@ export const shouldBehaveLikeLSP14 = (
       });
 
       describe("when called after the delay and before the confirmation period end", () => {
-        it("should have emitted a OwnershipTransferred event", async () => {
+        beforeEach(async () => {
+          // Call renounceOwnership for the first time
           await context.contract
             .connect(context.deployParams.owner)
             .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
+          // Skip 199 block to reach the time where renouncing ownership can happen
+          await network.provider.send("hardhat_mine", ["0xC7"]); //
+        });
 
+        it("should have emitted a OwnershipTransferred event", async () => {
           await expect(
             context.contract
               .connect(context.deployParams.owner)
@@ -457,12 +461,6 @@ export const shouldBehaveLikeLSP14 = (
         });
 
         it("should have emitted a OwnershipRenounced event", async () => {
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
           await expect(
             context.contract
               .connect(context.deployParams.owner)
@@ -479,24 +477,12 @@ export const shouldBehaveLikeLSP14 = (
             .connect(context.deployParams.owner)
             .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
           expect(await context.contract.owner()).to.equal(
             ethers.constants.AddressZero
           );
         });
 
         it("should have reset the `_renounceOwnershipStartedAt` state variable to zero", async () => {
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
           await context.contract
             .connect(context.deployParams.owner)
             .renounceOwnership();
@@ -513,12 +499,6 @@ export const shouldBehaveLikeLSP14 = (
 
         describe("currentOwner should not be able to interact with contract anymore after confirming", () => {
           it("`setData(...)`", async () => {
-            await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
-
-            await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
             await context.contract
               .connect(context.deployParams.owner)
               .renounceOwnership();
@@ -540,12 +520,6 @@ export const shouldBehaveLikeLSP14 = (
           });
 
           it("transfer LYX via `execute(...)`", async () => {
-            await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
-
-            await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
             await context.contract
               .connect(context.deployParams.owner)
               .renounceOwnership();
@@ -572,7 +546,7 @@ export const shouldBehaveLikeLSP14 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0xc8"]); // skip 200 blocks
+        await network.provider.send("hardhat_mine", ["0x190"]); // skip 400 blocks
 
         let tx = await context.contract
           .connect(context.deployParams.owner)
@@ -603,7 +577,7 @@ export const shouldBehaveLikeLSP14 = (
             .renounceOwnership();
 
           await network.provider.send("hardhat_mine", [
-            ethers.utils.hexValue(100),
+            ethers.utils.hexValue(200),
           ]);
 
           await context.contract
@@ -621,7 +595,7 @@ export const shouldBehaveLikeLSP14 = (
             .renounceOwnership();
 
           await network.provider.send("hardhat_mine", [
-            ethers.utils.hexValue(100),
+            ethers.utils.hexValue(200),
           ]);
 
           await context.contract

--- a/tests/LSP20CallVerification/LSP14CombinedWithLSP20.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP14CombinedWithLSP20.behaviour.ts
@@ -436,7 +436,9 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0x62"]); // skip 98 blocks
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(98),
+        ]); // skip 98 blocks
 
         const renounceOwnershipSecond = context.contract
           .connect(context.deployParams.owner)
@@ -465,7 +467,9 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
             .renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", ["0xC7"]); //
+          await network.provider.send("hardhat_mine", [
+            ethers.utils.hexValue(199),
+          ]);
         });
 
         it("should have emitted a OwnershipTransferred event", async () => {
@@ -579,7 +583,9 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0x190"]); // skip 400 blocks
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(400),
+        ]); // skip 400 blocks
 
         let tx = await context.contract
           .connect(context.deployParams.owner)

--- a/tests/LSP20CallVerification/LSP14CombinedWithLSP20.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP14CombinedWithLSP20.behaviour.ts
@@ -448,8 +448,8 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
             "NotInRenounceOwnershipInterval"
           )
           .withArgs(
-            (await renounceOwnershipOnce).blockNumber + 100,
-            (await renounceOwnershipOnce).blockNumber + 200
+            (await renounceOwnershipOnce).blockNumber + 200,
+            (await renounceOwnershipOnce).blockNumber + 400
           );
 
         expect(await context.contract.owner()).to.equal(
@@ -458,13 +458,17 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
       });
 
       describe("when called after the delay and before the confirmation period end", () => {
-        it("should have emitted a OwnershipTransferred event", async () => {
+        beforeEach(async () => {
+          // Call renounceOwnership for the first time
           await context.contract
             .connect(context.deployParams.owner)
             .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
+          // Skip 199 block to reach the time where renouncing ownership can happen
+          await network.provider.send("hardhat_mine", ["0xC7"]); //
+        });
 
+        it("should have emitted a OwnershipTransferred event", async () => {
           await expect(
             context.contract
               .connect(context.deployParams.owner)
@@ -482,12 +486,6 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
         });
 
         it("should have emitted a OwnershipRenounced event", async () => {
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
           await expect(
             context.contract
               .connect(context.deployParams.owner)
@@ -504,24 +502,12 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
             .connect(context.deployParams.owner)
             .renounceOwnership();
 
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
           expect(await context.contract.owner()).to.equal(
             ethers.constants.AddressZero
           );
         });
 
         it("should have reset the `_renounceOwnershipStartedAt` state variable to zero", async () => {
-          await context.contract
-            .connect(context.deployParams.owner)
-            .renounceOwnership();
-
-          await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
           await context.contract
             .connect(context.deployParams.owner)
             .renounceOwnership();
@@ -538,12 +524,6 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
 
         describe("currentOwner should not be able to interact with contract anymore after confirming", () => {
           it("`setData(...)`", async () => {
-            await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
-
-            await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
             await context.contract
               .connect(context.deployParams.owner)
               .renounceOwnership();
@@ -568,12 +548,6 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
           });
 
           it("transfer LYX via `execute(...)`", async () => {
-            await context.contract
-              .connect(context.deployParams.owner)
-              .renounceOwnership();
-
-            await network.provider.send("hardhat_mine", ["0x63"]); // skip 99 blocks
-
             await context.contract
               .connect(context.deployParams.owner)
               .renounceOwnership();
@@ -605,7 +579,7 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
           .connect(context.deployParams.owner)
           .renounceOwnership();
 
-        await network.provider.send("hardhat_mine", ["0xc8"]); // skip 200 blocks
+        await network.provider.send("hardhat_mine", ["0x190"]); // skip 400 blocks
 
         let tx = await context.contract
           .connect(context.deployParams.owner)
@@ -636,7 +610,7 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
             .renounceOwnership();
 
           await network.provider.send("hardhat_mine", [
-            ethers.utils.hexValue(100),
+            ethers.utils.hexValue(200),
           ]);
 
           await context.contract
@@ -654,7 +628,7 @@ export const shouldBehaveLikeLSP14CombinedWithLSP20 = (
             .renounceOwnership();
 
           await network.provider.send("hardhat_mine", [
-            ethers.utils.hexValue(100),
+            ethers.utils.hexValue(200),
           ]);
 
           await context.contract


### PR DESCRIPTION
## What does this PR introduce ?

- Change `renounceOwnership(..)` delay to 200
- Change tests to the new delay
- Refactor few tests to beforeEach block instead of duplicated code