### PR TITLE
chore: adjust CI and prettier settings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,9 +19,6 @@ on:
 
 jobs:
   benchmark:
-    # Do not run when preparing a release and the branch name contains the term "prepare"
-    # (e.g: chore/prepare-release-x.x.x -> develop)
-    if: ${{ !contains(github.ref, "release") }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/solc-version.yml
+++ b/.github/workflows/solc-version.yml
@@ -2,7 +2,13 @@
 # with different Solidity 0.8.x versions
 name: Solidity Compiler Versions
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
+
+    # compare gas diff only when editing Solidity smart contract code
+    paths:
+      - "contracts/**/*.sol"
 
 jobs:
   solc_version:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 contracts/LSP6KeyManager/LSP6Constants.sol
+artifacts
+cache
+types

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "merkletreejs": "0.2.24",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.4.1",
-        "prettier-plugin-solidity": "^1.1.3",
+        "prettier-plugin-solidity": "^1.0.0-beta.19",
         "solhint": "^3.3.6",
         "standard-version": "^9.3.1",
         "ts-node": "^10.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "merkletreejs": "0.2.24",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.4.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.19",
+        "prettier-plugin-solidity": "^1.1.3",
         "solhint": "^3.3.6",
         "standard-version": "^9.3.1",
         "ts-node": "^10.2.0",
@@ -6200,12 +6200,6 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
-      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
-      "dev": true
     },
     "node_modules/encode-utf8": {
       "version": "1.0.3",
@@ -14627,35 +14621,29 @@
       }
     },
     "node_modules/prettier-plugin-solidity": {
-      "version": "1.0.0-beta.24",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz",
-      "integrity": "sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz",
+      "integrity": "sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==",
       "dev": true,
       "dependencies": {
-        "@solidity-parser/parser": "^0.14.3",
-        "emoji-regex": "^10.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "semver": "^7.3.7",
-        "solidity-comments-extractor": "^0.0.7",
-        "string-width": "^4.2.3"
+        "@solidity-parser/parser": "^0.16.0",
+        "semver": "^7.3.8",
+        "solidity-comments-extractor": "^0.0.7"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "prettier": "^2.3.0"
+        "prettier": ">=2.3.0 || >=3.0.0-alpha.0"
       }
     },
-    "node_modules/prettier-plugin-solidity/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+    "node_modules/prettier-plugin-solidity/node_modules/@solidity-parser/parser": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.0.tgz",
+      "integrity": "sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==",
       "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
       }
     },
     "node_modules/process": {
@@ -15664,9 +15652,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -24905,12 +24893,6 @@
         }
       }
     },
-    "emoji-regex": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
-      "integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
-      "dev": true
-    },
     "encode-utf8": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
@@ -31678,24 +31660,24 @@
       "dev": true
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-beta.24",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.24.tgz",
-      "integrity": "sha512-6JlV5BBTWzmDSq4kZ9PTXc3eLOX7DF5HpbqmmaF+kloyUwOZbJ12hIYsUaZh2fVgZdV2t0vWcvY6qhILhlzgqg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.3.tgz",
+      "integrity": "sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.14.3",
-        "emoji-regex": "^10.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "semver": "^7.3.7",
-        "solidity-comments-extractor": "^0.0.7",
-        "string-width": "^4.2.3"
+        "@solidity-parser/parser": "^0.16.0",
+        "semver": "^7.3.8",
+        "solidity-comments-extractor": "^0.0.7"
       },
       "dependencies": {
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
+        "@solidity-parser/parser": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.16.0.tgz",
+          "integrity": "sha512-ESipEcHyRHg4Np4SqBCfcXwyxxna1DgFVz69bgpLV8vzl/NP1DtcKsJ4dJZXWQhY/Z4J2LeKBiOkOVZn9ct33Q==",
+          "dev": true,
+          "requires": {
+            "antlr4ts": "^0.5.0-alpha.4"
+          }
         }
       }
     },
@@ -32470,9 +32452,9 @@
       "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "merkletreejs": "0.2.24",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
-    "prettier-plugin-solidity": "^1.1.3",
+    "prettier-plugin-solidity": "^1.0.0-beta.19",
     "solhint": "^3.3.6",
     "standard-version": "^9.3.1",
     "ts-node": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "merkletreejs": "0.2.24",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
-    "prettier-plugin-solidity": "^1.0.0-beta.19",
+    "prettier-plugin-solidity": "^1.1.3",
     "solhint": "^3.3.6",
     "standard-version": "^9.3.1",
     "ts-node": "^10.2.0",


### PR DESCRIPTION
## What does this PR introduce ?
- Add artifacts cache types to `.prettierignore`
- Make solc ci run only on solidity changes
- Remove not working settings in benchmark ci