### PR TITLE
chore: prepare patch release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.8.2](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.8.1...v0.8.2) (2023-03-30)
+
+### Bug Fixes
+
+- Fix artifacts exports for 0.8.1 (PR #487) (also PR #541)
+- Fix package.json (PR #543)
+
 ### [0.8.1](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.8.0...v0.8.1) (2023-02-21)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "The reference implementation for universal profiles smart contracts",
   "directories": {
     "test": "test"


### PR DESCRIPTION
# What does this PR introduce?

> This is to fix the artifacts import from 0.8.1, shipped in 0.9.0, but 0.9.0 includes too many breaking changes.

Fix package.json version and changelog to be able to manually publish the npm.


