### PR TITLE
feat: Allow calling `ERC725X.execute(uint256[],address[],uint256[],bytes[])` through the LSP6

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -158,3 +158,9 @@ error CannotSendValueToSetData();
  * @dev reverts when calling the KeyManager through execute(..)
  */
 error CallingKeyManagerNotAllowed();
+
+/**
+ * @dev reverts when the parameters of `ERC725X.execute(uint256[],address[],uint256[],bytes[])`
+ * have diferent lengths
+ */
+error ERC725XBatchExecuteArrayParamsLengthMissmatch();

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -158,9 +158,3 @@ error CannotSendValueToSetData();
  * @dev reverts when calling the KeyManager through execute(..)
  */
 error CallingKeyManagerNotAllowed();
-
-/**
- * @dev reverts when the parameters of `ERC725X.execute(uint256[],address[],uint256[],bytes[])`
- * have diferent lengths
- */
-error ERC725XBatchExecuteArrayParamsLengthMissmatch();

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -43,7 +43,8 @@ import {
 import {
     SETDATA_SELECTOR,
     SETDATA_ARRAY_SELECTOR,
-    EXECUTE_SELECTOR
+    EXECUTE_SELECTOR,
+    EXECUTE_ARRAY_SELECTOR
 } from "@erc725/smart-contracts/contracts/constants.sol";
 import {
     _INTERFACEID_ERC1271,
@@ -394,6 +395,10 @@ abstract contract LSP6KeyManagerCore is
             // ERC725X.execute(uint256,address,uint256,bytes)
         } else if (erc725Function == EXECUTE_SELECTOR) {
             LSP6ExecuteModule._verifyCanExecute(_target, from, permissions, payload);
+
+            // ERC725X.execute(uint256,address,uint256,bytes)
+        } else if (erc725Function == EXECUTE_ARRAY_SELECTOR) {
+            LSP6ExecuteModule._verifyCanBatchExecute(_target, from, permissions, payload);
         } else if (
             erc725Function == ILSP14Ownable2Step.transferOwnership.selector ||
             erc725Function == ILSP14Ownable2Step.acceptOwnership.selector

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -36,9 +36,9 @@ import {
     InvalidERC725Function,
     NotAuthorised,
     CallerIsNotTheTarget,
-    CannotSendValueToSetData,
-    ERC725XBatchExecuteArrayParamsLengthMissmatch
+    CannotSendValueToSetData
 } from "./LSP6Errors.sol";
+import "@erc725/smart-contracts/contracts/errors.sol";
 
 // constants
 import {
@@ -391,6 +391,9 @@ abstract contract LSP6KeyManagerCore is
                 (bytes32[], bytes[])
             );
 
+            if (inputKeys.length != inputValues.length)
+                revert ERC725Y_DataKeysValuesLengthMismatch(inputKeys.length, inputValues.length);
+
             LSP6SetDataModule._verifyCanSetData(_target, from, permissions, inputKeys, inputValues);
 
             // ERC725X.execute(uint256,address,uint256,bytes)
@@ -403,7 +406,7 @@ abstract contract LSP6KeyManagerCore is
                 revert InvalidPayload(payload);
             }
 
-            (uint256 operationType, address callee, uint256 value, bytes memory data) = abi.decode(
+            (uint256 operationType, address to, uint256 value, bytes memory data) = abi.decode(
                 payload[4:],
                 (uint256, address, uint256, bytes)
             );
@@ -413,7 +416,7 @@ abstract contract LSP6KeyManagerCore is
                 from,
                 permissions,
                 operationType,
-                callee,
+                to,
                 value,
                 data
             );
@@ -431,7 +434,7 @@ abstract contract LSP6KeyManagerCore is
                 operationTypes.length != callees.length ||
                 callees.length != values.length ||
                 values.length != datas.length
-            ) revert ERC725XBatchExecuteArrayParamsLengthMissmatch();
+            ) revert ERC725X_ExecuteParametersLengthMismatch();
 
             for (uint256 i = 0; i < operationTypes.length; i++) {
                 _verifyCanExecute(

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -65,12 +65,12 @@ abstract contract LSP6ExecuteModule {
         address controller,
         bytes32 permissions,
         uint256 operationType,
-        address callee,
+        address to,
         uint256 value,
         bytes memory data
     ) internal view virtual {
         // if to is the KeyManager address revert
-        if (callee == address(this)) {
+        if (to == address(this)) {
             revert CallingKeyManagerNotAllowed();
         }
 
@@ -98,7 +98,7 @@ abstract contract LSP6ExecuteModule {
                     controller,
                     permissions,
                     operationType,
-                    callee,
+                    to,
                     value,
                     data
                 );
@@ -123,7 +123,7 @@ abstract contract LSP6ExecuteModule {
                     controller,
                     permissions,
                     operationType,
-                    callee,
+                    to,
                     value,
                     data
                 );

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -29,7 +29,12 @@ contract KeyManagerInternalTester is LSP6KeyManager {
     }
 
     function verifyAllowedCall(address _sender, bytes calldata _payload) public view {
-        super._verifyAllowedCall(_target, _sender, _payload);
+        (uint256 operationType, address callee, uint256 value, bytes memory data) = abi.decode(
+            _payload[4:],
+            (uint256, address, uint256, bytes)
+        );
+
+        super._verifyAllowedCall(_target, _sender, operationType, callee, value, bytes4(data));
     }
 
     function isCompactBytesArrayOfAllowedCalls(bytes memory allowedCallsCompacted)

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -28,13 +28,14 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         return ERC725Y(_target).getAllowedERC725YDataKeysFor(_address);
     }
 
-    function verifyAllowedCall(address _sender, bytes calldata _payload) public view {
-        (uint256 operationType, address callee, uint256 value, bytes memory data) = abi.decode(
-            _payload[4:],
-            (uint256, address, uint256, bytes)
-        );
-
-        super._verifyAllowedCall(_target, _sender, operationType, callee, value, bytes4(data));
+    function verifyAllowedCall(
+        address _sender,
+        uint256 operationType,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) public view {
+        super._verifyAllowedCall(_target, _sender, operationType, to, value, bytes4(data));
     }
 
     function isCompactBytesArrayOfAllowedCalls(bytes memory allowedCallsCompacted)

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -239,20 +239,13 @@ export const testAllowedCallsInternals = (
     describe("`verifyAllowedCall(...)`", () => {
       describe("when the ERC725X payload (transfer 1 LYX) is for an address listed in the allowed calls", () => {
         it("should pass", async () => {
-          const payload = context.universalProfile.interface.encodeFunctionData(
-            "execute(uint256,address,uint256,bytes)",
-            [
-              OPERATION_TYPES.CALL,
-              allowedEOA.address,
-              ethers.utils.parseEther("1"),
-              "0x",
-            ]
-          );
-
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallOnlyTwoAddresses.address,
-              payload
+              OPERATION_TYPES.CALL,
+              allowedEOA.address,
+              ethers.utils.parseEther("1"),
+              "0x"
             )
           ).to.not.be.reverted;
         });
@@ -264,20 +257,13 @@ export const testAllowedCallsInternals = (
             "0xdeadbeefdeadbeefdeaddeadbeefdeadbeefdead"
           );
 
-          const payload = context.universalProfile.interface.encodeFunctionData(
-            "execute(uint256,address,uint256,bytes)",
-            [
-              OPERATION_TYPES.CALL,
-              disallowedAddress,
-              ethers.utils.parseEther("1"),
-              "0x",
-            ]
-          );
-
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallOnlyTwoAddresses.address,
-              payload
+              OPERATION_TYPES.CALL,
+              disallowedAddress,
+              ethers.utils.parseEther("1"),
+              "0x"
             )
           )
             .to.be.revertedWithCustomError(
@@ -296,20 +282,13 @@ export const testAllowedCallsInternals = (
         it("should revert", async () => {
           let randomAddress = ethers.Wallet.createRandom().address;
 
-          const payload = context.universalProfile.interface.encodeFunctionData(
-            "execute(uint256,address,uint256,bytes)",
-            [
-              OPERATION_TYPES.CALL,
-              randomAddress,
-              ethers.utils.parseEther("1"),
-              "0x",
-            ]
-          );
-
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallNoAllowedCalls.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              "0x"
             )
           )
             .to.be.revertedWithCustomError(
@@ -408,20 +387,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.CALL,
-            targetContractValue.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.CALL,
+            targetContractValue.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -436,39 +408,25 @@ export const testAllowedCallsInternals = (
       });
 
       it("should pass when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.CALL,
-            targetContractCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.CALL,
+            targetContractCall.address,
+            0,
+            randomPayload // random payload
           )
         ).to.not.be.reverted;
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.CALL,
-            targetContractStaticCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.CALL,
+            targetContractStaticCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -483,20 +441,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.CALL,
-            targetContractDelegateCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.CALL,
+            targetContractDelegateCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -547,20 +498,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.STATICCALL,
-            targetContractValue.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.STATICCALL,
+            targetContractValue.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -575,20 +519,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.STATICCALL,
-            targetContractCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.STATICCALL,
+            targetContractCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -603,39 +540,25 @@ export const testAllowedCallsInternals = (
       });
 
       it("should pass when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.STATICCALL,
-            targetContractStaticCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.STATICCALL,
+            targetContractStaticCall.address,
+            0,
+            randomPayload // random payload
           )
         ).to.not.be.reverted;
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.STATICCALL,
-            targetContractDelegateCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.STATICCALL,
+            targetContractDelegateCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -686,20 +609,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            targetContractValue.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.DELEGATECALL,
+            targetContractValue.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -714,20 +630,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            targetContractCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.DELEGATECALL,
+            targetContractCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -742,20 +651,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            targetContractStaticCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.DELEGATECALL,
+            targetContractStaticCall.address,
+            0,
+            randomPayload // random payload
           )
         )
           .to.be.revertedWithCustomError(
@@ -770,20 +672,13 @@ export const testAllowedCallsInternals = (
       });
 
       it("should pass when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData(
-          "execute(uint256,address,uint256,bytes)",
-          [
-            OPERATION_TYPES.DELEGATECALL,
-            targetContractDelegateCall.address,
-            0,
-            randomPayload, // random payload
-          ]
-        );
-
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(
             controller.address,
-            payload
+            OPERATION_TYPES.DELEGATECALL,
+            targetContractDelegateCall.address,
+            0,
+            randomPayload // random payload
           )
         ).to.not.be.reverted;
       });
@@ -861,25 +756,15 @@ export const testAllowedCallsInternals = (
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
       const randomData = "0xaabbccdd";
 
-      const universalProfileInterface =
-        UniversalProfile__factory.createInterface();
-
-      let payload: string = universalProfileInterface.encodeFunctionData(
-        "execute(uint256,address,uint256,bytes)",
-        [
-          OPERATION_TYPES.CALL,
-          randomAddress,
-          ethers.utils.parseEther("1"),
-          randomData,
-        ]
-      );
-
       describe("should revert with `NoAllowedCall` error", () => {
         it(`noBytes -> ${zeroBytesValues[0]}`, async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.noBytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -888,7 +773,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.oneZeroByte.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -897,7 +785,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.tenZeroBytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -906,7 +797,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.twentyZeroBytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -920,7 +814,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.thirtyTwoZeroBytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           )
             .to.be.revertedWithCustomError(
@@ -938,7 +835,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.fourtyZeroBytes.address,
-              randomAddress
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           )
             .to.be.revertedWithCustomError(
@@ -956,7 +856,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.sixtyFourZeroBytes.address,
-              randomAddress
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           )
             .to.be.revertedWithCustomError(
@@ -973,7 +876,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.hundredZeroBytes.address,
-              randomAddress
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           )
             .to.be.revertedWithCustomError(
@@ -1005,21 +911,10 @@ export const testAllowedCallsInternals = (
     const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
     const randomData = "0xaabbccdd";
 
-    let payload: string;
     let controller: ControllersContext;
 
     before(async () => {
       context = await buildContext();
-
-      payload = context.universalProfile.interface.encodeFunctionData(
-        "execute(uint256,address,uint256,bytes)",
-        [
-          OPERATION_TYPES.CALL,
-          randomAddress,
-          ethers.utils.parseEther("1"),
-          randomData,
-        ]
-      );
 
       controller = {
         multipleOf29Bytes: context.accounts[1],
@@ -1063,7 +958,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.multipleOf29Bytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           )
             .to.be.revertedWithCustomError(
@@ -1083,7 +981,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.shortBytes.address,
-              payload
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -1093,7 +994,10 @@ export const testAllowedCallsInternals = (
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controller.longBytes.address,
-              randomAddress
+              OPERATION_TYPES.CALL,
+              randomAddress,
+              ethers.utils.parseEther("1"),
+              randomData
             )
           ).to.be.reverted;
         });
@@ -1140,20 +1044,13 @@ export const testAllowedCallsInternals = (
       const randomData = "0xaabbccdd";
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
-      const payload = context.universalProfile.interface.encodeFunctionData(
-        "execute(uint256,address,uint256,bytes)",
-        [
-          OPERATION_TYPES.CALL,
-          randomAddress,
-          ethers.utils.parseEther("1"),
-          randomData,
-        ]
-      );
-
       await expect(
         context.keyManagerInternalTester.verifyAllowedCall(
           anyAllowedCalls.address,
-          payload
+          OPERATION_TYPES.CALL,
+          randomAddress,
+          ethers.utils.parseEther("1"),
+          randomData
         )
       )
         .to.be.revertedWithCustomError(

--- a/tests/Reentrancy/LSP20/ERC725XBatchExecuteToERC725XExecute.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XBatchExecuteToERC725XExecute.test.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import { BigNumber, BytesLike } from "ethers";
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys } from "../../../constants";
 
 // setup
 import { LSP6TestContext } from "../../utils/context";
@@ -302,8 +302,7 @@ export const testERC725XBatchExecuteToERC725XExecute = (
       const hardcodedPermissionKey =
         ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+      const hardcodedPermissionValue = ALL_PERMISSIONS;
 
       expect(
         await context.universalProfile["getData(bytes32)"](

--- a/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
@@ -27,7 +27,7 @@ export const shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios = (
   });
 
   // This tests will be enabled when we allow `ERC725X.execute(uint256[],address[],uint256[],bytes[])` in the LSP6.execute(bytes)
-  describe.skip("first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`", () => {
+  describe("first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`", () => {
     testERC725XBatchExecuteToERC725XExecute(
       buildContext,
       buildReentrancyContext

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -2,8 +2,11 @@ import { ethers } from "hardhat";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 import {
+  LSP1UniversalReceiverDelegateUP,
   LSP1UniversalReceiverDelegateUP__factory,
+  LSP6KeyManager,
   LSP6KeyManager__factory,
+  UniversalProfile,
   UniversalProfile__factory,
 } from "../../types";
 
@@ -106,7 +109,9 @@ export async function setupKeyManagerHelper(
  */
 export async function setupProfileWithKeyManagerWithURD(
   EOA: SignerWithAddress
-) {
+): Promise<
+  [UniversalProfile, LSP6KeyManager, LSP1UniversalReceiverDelegateUP]
+> {
   const universalProfile = await new UniversalProfile__factory(EOA).deploy(
     EOA.address
   );


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

This PR introduces the path `ERC725X.execute(uint256[],address[],uint256[],bytes[])` to LSP6KeyManager.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->
<!---
## ⚠️ BREAKING CHANGES
---->


## 🚀 Feature

Previously calling `ERC725X.execute(uint256[],address[],uint256[],bytes[])` would revert with the custom error `InvalidERC725Function`. Now the call goes to the `target` contract. 

<!---
## 🐛 Bug
---->

<!---
## ♻️ Refactor
---->

<!---
## 🧪 Tests
---->

<!---
## ⚡️ Performance
---->

<!---
## 🎨 Style
---->

<!---
## 📄 Documentation
---->

<!---
## 📦 Build
---->

<!---
## 🤖 CI
---->



<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote Documentation
- [x] Ran `npm run linter`
- [x] Ran `npm run prettier`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
