### PR TITLE
refactor: move `ValueReceived` event in LSP0 + LSP9 interfaces + delete interface inheritance for LSP0/9

### DIFF
--- a/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
@@ -39,15 +39,10 @@ import {ILSP14Ownable2Step} from "../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
  *
  * - Verifying calls on the owner to allow unified and standard interaction with the account using LSP20
  *   https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-20-CallVerification.md
+ *
+ * This interface implicitly inherits: IERC165, IERC725X, IERC725Y, IERC1271, ILSP1UniversalReceiver, ILSP14Ownable2Step
  */
-interface ILSP0ERC725Account is
-    IERC165,
-    IERC725X,
-    IERC725Y,
-    IERC1271,
-    ILSP1UniversalReceiver,
-    ILSP14Ownable2Step
-{
+interface ILSP0ERC725Account {
     /**
      * @dev Allows a caller to batch different function calls in one call.
      * Perform a delegatecall on self, to call different functions with preserving the context

--- a/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
@@ -44,6 +44,13 @@ import {ILSP14Ownable2Step} from "../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
  */
 interface ILSP0ERC725Account {
     /**
+     * @notice Emitted when receiving native tokens
+     * @param sender The address of the sender
+     * @param value The amount of native tokens received
+     */
+    event ValueReceived(address indexed sender, uint256 indexed value);
+
+    /**
      * @dev Allows a caller to batch different function calls in one call.
      * Perform a delegatecall on self, to call different functions with preserving the context
      * It is not possible to send value along the functions call due to the use of delegatecall.

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -39,7 +39,7 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
 contract LSP0ERC725Account is LSP0ERC725AccountCore {
     /**
      * @dev Sets the owner of the contract on deployment and allows funding.
-     * Emits the ValueReceived event if native tokens were received.
+     * Emits a {ValueReceived} event when funding the contract on deployment.
      * @param newOwner The owner of the contract.
      */
     constructor(address newOwner) payable {

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -80,10 +80,11 @@ import {NoExtensionFoundForFunctionSelector} from "../LSP17ContractExtension/LSP
  *   https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-20-CallVerification.md
  */
 abstract contract LSP0ERC725AccountCore is
-    IERC1271,
-    ILSP0ERC725Account,
     ERC725XCore,
     ERC725YCore,
+    IERC1271,
+    ILSP0ERC725Account,
+    ILSP1UniversalReceiver,
     LSP14Ownable2Step,
     LSP17Extendable,
     LSP20CallVerification
@@ -336,10 +337,12 @@ abstract contract LSP0ERC725AccountCore is
      * Emits a {ValueReceived} event when receiving native tokens.
      * Emits a {DataChanged} event. (on each iteration of setting data)
      */
-    function setData(
-        bytes32[] memory dataKeys,
-        bytes[] memory dataValues
-    ) public payable virtual override {
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+        public
+        payable
+        virtual
+        override
+    {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }
@@ -411,10 +414,12 @@ abstract contract LSP0ERC725AccountCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(
-        bytes32 typeId,
-        bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        returns (bytes memory returnedValues)
+    {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }
@@ -489,9 +494,11 @@ abstract contract LSP0ERC725AccountCore is
      *
      * - pending owner cannot accept ownership in the same tx via the LSP1 hook.
      */
-    function transferOwnership(
-        address _pendingOwner
-    ) public virtual override(LSP14Ownable2Step, OwnableUnset) {
+    function transferOwnership(address _pendingOwner)
+        public
+        virtual
+        override(LSP14Ownable2Step, OwnableUnset)
+    {
         address currentOwner = owner();
 
         // If the caller is the owner perform transferOwnership directly
@@ -616,9 +623,13 @@ abstract contract LSP0ERC725AccountCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore, LSP17Extendable)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_ERC1271 ||
             interfaceId == _INTERFACEID_LSP0 ||
@@ -654,10 +665,12 @@ abstract contract LSP0ERC725AccountCore is
      *
      * @return magicValue A bytes4 value that indicates if the signature is valid or not.
      */
-    function isValidSignature(
-        bytes32 dataHash,
-        bytes memory signature
-    ) public view virtual returns (bytes4 magicValue) {
+    function isValidSignature(bytes32 dataHash, bytes memory signature)
+        public
+        view
+        virtual
+        returns (bytes4 magicValue)
+    {
         address _owner = owner();
 
         // If owner is a contract
@@ -747,9 +760,13 @@ abstract contract LSP0ERC725AccountCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(
-        bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    function _getExtension(bytes4 functionSelector)
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         // Generate the data key relevant for the functionSelector being called
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -49,10 +49,10 @@ interface ILSP6KeyManager is
     /**
      * @dev batch `execute(bytes)`
      */
-    function execute(
-        uint256[] calldata values,
-        bytes[] calldata payloads
-    ) external payable returns (bytes[] memory);
+    function execute(uint256[] calldata values, bytes[] calldata payloads)
+        external
+        payable
+        returns (bytes[] memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -11,6 +11,12 @@ interface ILSP6KeyManager is
     IERC1271
     /* is ERC165 */
 {
+    /**
+     * @dev Emitted when a calldata payload that includes `selector` and `value` as msg.value was verified for `signer`
+     * @param signer the address of the controller that executed the calldata payload.
+     * @param value the amount of native token to be transferred in the calldata payload.
+     * @param selector the bytes4 function of the function to run in the calldata payload.
+     */
     event VerifiedCall(address indexed signer, uint256 indexed value, bytes4 indexed selector);
 
     /**
@@ -43,10 +49,10 @@ interface ILSP6KeyManager is
     /**
      * @dev batch `execute(bytes)`
      */
-    function execute(uint256[] calldata values, bytes[] calldata payloads)
-        external
-        payable
-        returns (bytes[] memory);
+    function execute(
+        uint256[] calldata values,
+        bytes[] calldata payloads
+    ) external payable returns (bytes[] memory);
 
     /**
      * @dev allows anybody to execute given they have a signed message from an executor

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -471,7 +471,6 @@ abstract contract LSP6SetDataModule {
                 allowedKey := and(memoryAt, mask)
             }
 
-            // voila you found the key ;)
             if (allowedKey == (inputDataKey & mask)) return;
 
             // move the pointer to the index of the next allowed data key

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
@@ -42,7 +42,11 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @param to The receiving address
      * @param tokenId The tokenId to transfer
      */
-    function transferFrom(address from, address to, uint256 tokenId) external;
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
 
     /**
      * @dev Compatible with ERC721 transferFrom.
@@ -50,7 +54,11 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @param to The receiving address
      * @param tokenId The tokenId to transfer
      */
-    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) external;
 
     /**
      * @dev Compatible with ERC721 safeTransferFrom.

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
@@ -34,7 +34,7 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @dev This emits when an operator is enabled or disabled for an owner.
      * The operator can manage all NFTs of the owner.
      */
-    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     /**
      * @dev Compatible with ERC721 transferFrom.
@@ -42,11 +42,7 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @param to The receiving address
      * @param tokenId The tokenId to transfer
      */
-    function transferFrom(
-        address from,
-        address to,
-        uint256 tokenId
-    ) external;
+    function transferFrom(address from, address to, uint256 tokenId) external;
 
     /**
      * @dev Compatible with ERC721 transferFrom.
@@ -54,11 +50,7 @@ interface ILSP8CompatibleERC721 is ILSP8IdentifiableDigitalAsset {
      * @param to The receiving address
      * @param tokenId The tokenId to transfer
      */
-    function safeTransferFrom(
-        address from,
-        address to,
-        uint256 tokenId
-    ) external;
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
 
     /**
      * @dev Compatible with ERC721 safeTransferFrom.

--- a/contracts/LSP9Vault/ILSP9Vault.sol
+++ b/contracts/LSP9Vault/ILSP9Vault.sol
@@ -10,8 +10,16 @@ import {ILSP14Ownable2Step} from "../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
 
 /**
  * @title Interface of LSP9Vault built on top of ERC725, LSP1UniversalReceiver
+ * @dev this interface implicitly inherits: IERC165, IERC725X, IERC725Y, ILSP1UniversalReceiver, ILSP14Ownable2Step
  */
-interface ILSP9Vault is IERC165, IERC725X, IERC725Y, ILSP1UniversalReceiver, ILSP14Ownable2Step {
+interface ILSP9Vault {
+    /**
+     * @notice Emitted when receiving native tokens
+     * @param sender The address of the sender
+     * @param value The amount of native tokens received
+     */
+    event ValueReceived(address indexed sender, uint256 indexed value);
+
     /**
      * @dev Receives and executes a batch of function calls on this contract.
      */

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -165,9 +165,13 @@ contract LSP9VaultCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(
-        bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    function _getExtension(bytes4 functionSelector)
+        internal
+        view
+        virtual
+        override
+        returns (address)
+    {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector
@@ -187,9 +191,13 @@ contract LSP9VaultCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC725XCore, ERC725YCore, LSP17Extendable)
+        returns (bool)
+    {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
@@ -292,10 +300,12 @@ contract LSP9VaultCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(
-        bytes32[] memory dataKeys,
-        bytes[] memory dataValues
-    ) public payable virtual override {
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+        public
+        payable
+        virtual
+        override
+    {
         bool isURD = _validateAndIdentifyCaller();
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
@@ -340,10 +350,12 @@ contract LSP9VaultCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(
-        bytes32 typeId,
-        bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
+        public
+        payable
+        virtual
+        returns (bytes memory returnedValues)
+    {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -399,9 +411,12 @@ contract LSP9VaultCore is
      * Requirements:
      *  - when notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP9OwnershipTransferStarted')
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(LSP14Ownable2Step, OwnableUnset) onlyOwner {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(LSP14Ownable2Step, OwnableUnset)
+        onlyOwner
+    {
         LSP14Ownable2Step._transferOwnership(newOwner);
 
         address currentOwner = owner();

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 // interfaces
 import {ILSP1UniversalReceiver} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+import {ILSP9Vault} from "./ILSP9Vault.sol";
 
 // libraries
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
@@ -58,19 +59,13 @@ contract LSP9VaultCore is
     ERC725YCore,
     LSP14Ownable2Step,
     LSP17Extendable,
-    ILSP1UniversalReceiver
+    ILSP1UniversalReceiver,
+    ILSP9Vault
 {
     using ERC165Checker for address;
     using LSP1Utils for address;
 
     address private _reentrantDelegate;
-
-    /**
-     * @notice Emitted when receiving native tokens
-     * @param sender The address of the sender
-     * @param value The amount of native tokens received
-     */
-    event ValueReceived(address indexed sender, uint256 indexed value);
 
     /**
      * @dev Emits an event when receiving native tokens
@@ -170,13 +165,9 @@ contract LSP9VaultCore is
      *
      * If no extension is stored, returns the address(0)
      */
-    function _getExtension(bytes4 functionSelector)
-        internal
-        view
-        virtual
-        override
-        returns (address)
-    {
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view virtual override returns (address) {
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector
@@ -196,13 +187,9 @@ contract LSP9VaultCore is
      * `supportsInterface` extension according to LSP17, and checks if the extension
      * implements the interface defined by `interfaceId`.
      */
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC725XCore, ERC725YCore, LSP17Extendable)
-        returns (bool)
-    {
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC725XCore, ERC725YCore, LSP17Extendable) returns (bool) {
         return
             interfaceId == _INTERFACEID_LSP9 ||
             interfaceId == _INTERFACEID_LSP1 ||
@@ -305,12 +292,10 @@ contract LSP9VaultCore is
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
-        public
-        payable
-        virtual
-        override
-    {
+    function setData(
+        bytes32[] memory dataKeys,
+        bytes[] memory dataValues
+    ) public payable virtual override {
         bool isURD = _validateAndIdentifyCaller();
         if (dataKeys.length != dataValues.length) {
             revert ERC725Y_DataKeysValuesLengthMismatch(dataKeys.length, dataValues.length);
@@ -355,12 +340,10 @@ contract LSP9VaultCore is
      * @return returnedValues The ABI encoded return value of the LSP1UniversalReceiverDelegate call
      * and the LSP1TypeIdDelegate call.
      */
-    function universalReceiver(bytes32 typeId, bytes calldata receivedData)
-        public
-        payable
-        virtual
-        returns (bytes memory returnedValues)
-    {
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
         if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
         bytes memory lsp1DelegateValue = _getData(_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY);
         bytes memory resultDefaultDelegate;
@@ -416,12 +399,9 @@ contract LSP9VaultCore is
      * Requirements:
      *  - when notifying the new owner via LSP1, the typeId used MUST be keccak256('LSP9OwnershipTransferStarted')
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(LSP14Ownable2Step, OwnableUnset)
-        onlyOwner
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(LSP14Ownable2Step, OwnableUnset) onlyOwner {
         LSP14Ownable2Step._transferOwnership(newOwner);
 
         address currentOwner = owner();


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

- Remove inheritance list in interfaces to avoid C3 Linearization issue when `Core` contract inherit abstract contracts that inherit the same interface.

- Move `ValueReceived` event inside `ILSP0` interface.

- Make `LSP0ERC725AccountCore` inherit from the `ILSP0` interface.

## 📄 Documentation

Cleanup comments + add comment above `VerifiedCall` event in LSP6.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests **(NA)**
- [x] Wrote Documentation
- [x] Ran `npm run linter`
- [x] Ran `npm run prettier`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
