### PR TITLE
ci: trigger foundry tests not only when PR is opened

### DIFF
--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -2,8 +2,6 @@ name: Foundry tests & Report gas diff
 
 on:
   pull_request:
-    types: [opened]
-
     # compare gas diff only when editing Solidity smart contract code
     paths:
       - "contracts/**/*.sol"


### PR DESCRIPTION
# What does this PR introduce?

## 🤖 CI

Have foundry tests triggered in PR also when the PR is edited, not only when it is opened. To see gas changes when refactoring code while the PR is open.

Done by removing the `types` field in the github workflow syntax.

### PR Checklist

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run linter`
- [x] Ran `npm run prettier`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
