### PR TITLE
refactor: [TRST-M-6] Add LSP20 interfaceId to LSP0 & LSP6

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -34,6 +34,8 @@ export const INTERFACE_IDS = {
   LSP14Ownable2Step: "0x94be5999",
   LSP17Extendable: "0xa918fa6b",
   LSP17Extension: "0xcee78b40",
+  LSP20CallVerification: "0x1a0eb6a5",
+  LSP20CallVerifier: "0x480c0ec2",
 };
 
 // ERC1271

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -43,6 +43,7 @@ import {
 import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 
 import {_LSP17_EXTENSION_PREFIX} from "../LSP17ContractExtension/LSP17Constants.sol";
+import {_INTERFACEID_LSP20_CALL_VERIFICATION} from "../LSP20CallVerification/LSP20Constants.sol";
 
 // errors
 import {ERC725Y_DataKeysValuesLengthMismatch} from "@erc725/smart-contracts/contracts/errors.sol";
@@ -635,6 +636,7 @@ abstract contract LSP0ERC725AccountCore is
             interfaceId == _INTERFACEID_LSP0 ||
             interfaceId == _INTERFACEID_LSP1 ||
             interfaceId == _INTERFACEID_LSP14 ||
+            interfaceId == _INTERFACEID_LSP20_CALL_VERIFICATION ||
             super.supportsInterface(interfaceId) ||
             LSP17Extendable._supportsInterfaceInERC165Extension(interfaceId);
     }

--- a/contracts/LSP20CallVerification/LSP20Constants.sol
+++ b/contracts/LSP20CallVerification/LSP20Constants.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-// bytes4(keccack256("LSP20CallVerification"))
+// bytes4(keccak256("LSP20CallVerification"))
 bytes4 constant _INTERFACEID_LSP20_CALL_VERIFICATION = 0x1a0eb6a5;
 
 // Xor of `lsp20VerifyCall(address,uint256,bytes)` and `lsp20VerifyCallResult(bytes32,bytes)`

--- a/contracts/LSP20CallVerification/LSP20Constants.sol
+++ b/contracts/LSP20CallVerification/LSP20Constants.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.4;
 // bytes4(keccak256("LSP20CallVerification"))
 bytes4 constant _INTERFACEID_LSP20_CALL_VERIFICATION = 0x1a0eb6a5;
 
-// Xor of `lsp20VerifyCall(address,uint256,bytes)` and `lsp20VerifyCallResult(bytes32,bytes)`
+// `lsp20VerifyCall(address,uint256,bytes)` selector XOR `lsp20VerifyCallResult(bytes32,bytes)` selector
 bytes4 constant _INTERFACEID_LSP20_CALL_VERIFIER = 0x480c0ec2;

--- a/contracts/LSP20CallVerification/LSP20Constants.sol
+++ b/contracts/LSP20CallVerification/LSP20Constants.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+// bytes4(keccack256("LSP20CallVerification"))
+bytes4 constant _INTERFACEID_LSP20_CALL_VERIFICATION = 0x1a0eb6a5;
+
+// Xor of `lsp20VerifyCall(address,uint256,bytes)` and `lsp20VerifyCallResult(bytes32,bytes)`
+bytes4 constant _INTERFACEID_LSP20_CALL_VERIFIER = 0x480c0ec2;

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -56,6 +56,7 @@ import {
     _PERMISSION_SIGN,
     _PERMISSION_REENTRANCY
 } from "./LSP6Constants.sol";
+import {_INTERFACEID_LSP20_CALL_VERIFIER} from "../LSP20CallVerification/LSP20Constants.sol";
 
 /**
  * @title Core implementation of the LSP6 Key Manager standard.
@@ -95,6 +96,7 @@ abstract contract LSP6KeyManagerCore is
         return
             interfaceId == _INTERFACEID_LSP6 ||
             interfaceId == _INTERFACEID_ERC1271 ||
+            interfaceId == _INTERFACEID_LSP20_CALL_VERIFIER ||
             super.supportsInterface(interfaceId);
     }
 

--- a/contracts/Mocks/ERC165Interfaces.sol
+++ b/contracts/Mocks/ERC165Interfaces.sol
@@ -191,7 +191,7 @@ contract CalculateLSPInterfaces {
 
         require(
             interfaceId == _INTERFACEID_LSP20_CALL_VERIFICATION,
-            "hardcoded _INTERFACEID_LSP17_EXTENSION does not match hash of LSP20CallVerification"
+            "hardcoded _INTERFACEID_LSP20_CALL_VERIFICATION does not match hash of LSP20CallVerification"
         );
 
         return interfaceId;

--- a/contracts/Mocks/ERC165Interfaces.sol
+++ b/contracts/Mocks/ERC165Interfaces.sol
@@ -25,11 +25,14 @@ import {
     ILSP8IdentifiableDigitalAsset as ILSP8
 } from "../LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol";
 
-import {ILSP9Vault} from "../LSP9Vault/ILSP9Vault.sol";
-import {ILSP14Ownable2Step} from "../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
-import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
-
-import {ILSP11BasicSocialRecovery} from "../LSP11BasicSocialRecovery/ILSP11BasicSocialRecovery.sol";
+import {ILSP9Vault as ILSP9} from "../LSP9Vault/ILSP9Vault.sol";
+import {
+    ILSP11BasicSocialRecovery as ILSP11
+} from "../LSP11BasicSocialRecovery/ILSP11BasicSocialRecovery.sol";
+import {ILSP14Ownable2Step as ILSP14} from "../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
+import {
+    ILSP20CallVerification as ILSP20
+} from "../LSP20CallVerification/ILSP20CallVerification.sol";
 
 // constants
 import {_INTERFACEID_LSP0} from "../LSP0ERC725Account/LSP0Constants.sol";
@@ -39,11 +42,15 @@ import {_INTERFACEID_LSP7} from "../LSP7DigitalAsset/LSP7Constants.sol";
 import {_INTERFACEID_LSP8} from "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
 import {_INTERFACEID_LSP9} from "../LSP9Vault/LSP9Constants.sol";
 import {_INTERFACEID_LSP11} from "../LSP11BasicSocialRecovery/LSP11Constants.sol";
-
+import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 import {
     _INTERFACEID_LSP17_EXTENDABLE,
     _INTERFACEID_LSP17_EXTENSION
 } from "../LSP17ContractExtension/LSP17Constants.sol";
+import {
+    _INTERFACEID_LSP20_CALL_VERIFICATION,
+    _INTERFACEID_LSP20_CALL_VERIFIER
+} from "../LSP20CallVerification/LSP20Constants.sol";
 
 // libraries
 
@@ -117,7 +124,7 @@ contract CalculateLSPInterfaces {
     function calculateInterfaceLSP9() public pure returns (bytes4) {
         // prettier-ignore
         bytes4 interfaceId =
-            ILSP9Vault.batchCalls.selector ^
+            ILSP9.batchCalls.selector ^
             type(IERC725X).interfaceId ^
             type(IERC725Y).interfaceId ^
             type(ILSP1).interfaceId ^
@@ -132,11 +139,22 @@ contract CalculateLSPInterfaces {
         return interfaceId;
     }
 
+    function calculateInterfaceLSP11() public pure returns (bytes4) {
+        bytes4 interfaceId = type(ILSP11).interfaceId;
+
+        require(
+            interfaceId == _INTERFACEID_LSP11,
+            "_LSP11_INTERFACE_ID does not match XOR of the functions"
+        );
+
+        return interfaceId;
+    }
+
     function calculateInterfaceLSP14() public pure returns (bytes4) {
         // prettier-ignore
         bytes4 interfaceId =
             OwnableUnset.owner.selector ^
-            type(ILSP14Ownable2Step).interfaceId;
+            type(ILSP14).interfaceId;
 
         require(
             interfaceId == _INTERFACEID_LSP14,
@@ -147,7 +165,6 @@ contract CalculateLSPInterfaces {
     }
 
     function calculateInterfaceLSP17Extendable() public pure returns (bytes4) {
-        // prettier-ignore
         bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP17Extendable")));
 
         require(
@@ -159,7 +176,6 @@ contract CalculateLSPInterfaces {
     }
 
     function calculateInterfaceLSP17Extension() public pure returns (bytes4) {
-        // prettier-ignore
         bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP17Extension")));
 
         require(
@@ -170,12 +186,23 @@ contract CalculateLSPInterfaces {
         return interfaceId;
     }
 
-    function calculateInterfaceLSP11() public pure returns (bytes4) {
-        bytes4 interfaceId = type(ILSP11BasicSocialRecovery).interfaceId;
+    function calculateInterfaceLSP20CallVerification() public pure returns (bytes4) {
+        bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP20CallVerification")));
 
         require(
-            interfaceId == _INTERFACEID_LSP11,
-            "_LSP11_INTERFACE_ID does not match XOR of the functions"
+            interfaceId == _INTERFACEID_LSP20_CALL_VERIFICATION,
+            "hardcoded _INTERFACEID_LSP17_EXTENSION does not match hash of LSP20CallVerification"
+        );
+
+        return interfaceId;
+    }
+
+    function calculateInterfaceLSP20CallVerifier() public pure returns (bytes4) {
+        bytes4 interfaceId = type(ILSP20).interfaceId;
+
+        require(
+            interfaceId == _INTERFACEID_LSP20_CALL_VERIFIER,
+            "hardcoded _INTERFACEID_LSP20_CALL_VERIFIER does not match XOR of the functions"
         );
 
         return interfaceId;

--- a/contracts/Mocks/ERC165Interfaces.sol
+++ b/contracts/Mocks/ERC165Interfaces.sol
@@ -165,33 +165,33 @@ contract CalculateLSPInterfaces {
     }
 
     function calculateInterfaceLSP17Extendable() public pure returns (bytes4) {
-        bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP17Extendable")));
+        bytes4 interfaceId = bytes4(keccak256("LSP17Extendable"));
 
         require(
             interfaceId == _INTERFACEID_LSP17_EXTENDABLE,
-            "hardcoded _INTERFACEID_LSP17_EXTENDABLE does not match hash of LSP17Extendable"
+            "hardcoded _INTERFACEID_LSP17_EXTENDABLE does not match hash of 'LSP17Extendable'"
         );
 
         return interfaceId;
     }
 
     function calculateInterfaceLSP17Extension() public pure returns (bytes4) {
-        bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP17Extension")));
+        bytes4 interfaceId = bytes4(keccak256("LSP17Extension"));
 
         require(
             interfaceId == _INTERFACEID_LSP17_EXTENSION,
-            "hardcoded _INTERFACEID_LSP17_EXTENSION does not match hash of LSP17Extension"
+            "hardcoded _INTERFACEID_LSP17_EXTENSION does not match hash of 'LSP17Extension'"
         );
 
         return interfaceId;
     }
 
     function calculateInterfaceLSP20CallVerification() public pure returns (bytes4) {
-        bytes4 interfaceId = bytes4(keccak256(abi.encodePacked("LSP20CallVerification")));
+        bytes4 interfaceId = bytes4(keccak256("LSP20CallVerification"));
 
         require(
             interfaceId == _INTERFACEID_LSP20_CALL_VERIFICATION,
-            "hardcoded _INTERFACEID_LSP20_CALL_VERIFICATION does not match hash of LSP20CallVerification"
+            "hardcoded _INTERFACEID_LSP20_CALL_VERIFICATION does not match hash of 'LSP20CallVerification'"
         );
 
         return interfaceId;

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -149,6 +149,13 @@ export const shouldInitializeLikeLSP6 = (
       expect(result).to.be.true;
     });
 
+    it("should support LSP20CallVerifier interface", async () => {
+      const result = await context.keyManager.supportsInterface(
+        INTERFACE_IDS.LSP20CallVerifier
+      );
+      expect(result).to.be.true;
+    });
+
     it("should be linked to the right ERC725 account contract", async () => {
       let account = await context.keyManager.target();
       expect(account).to.equal(context.universalProfile.address);

--- a/tests/Mocks/ERC165Interfaces.test.ts
+++ b/tests/Mocks/ERC165Interfaces.test.ts
@@ -60,7 +60,7 @@ describe("Calculate LSP interfaces", () => {
   });
 
   it("LSP11", async () => {
-    const result = await contract.callStatic.calculateInterfaceLSP11();
+    const result = await contract.calculateInterfaceLSP11();
     expect(result).to.equal(INTERFACE_IDS.LSP11BasicSocialRecovery);
   });
 
@@ -100,37 +100,37 @@ describe("Calculate ERC interfaces", () => {
   });
 
   it("ERC20", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC20();
+    const result = await contract.calculateInterfaceERC20();
     expect(result).to.equal(INTERFACE_IDS.ERC20);
   });
 
   it("ERC223", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC223();
+    const result = await contract.calculateInterfaceERC223();
     expect(result).to.equal(INTERFACE_IDS.ERC223);
   });
 
   it("ERC721", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC721();
+    const result = await contract.calculateInterfaceERC721();
     expect(result).to.equal(INTERFACE_IDS.ERC721);
   });
 
   it("ERC721Metadata", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC721Metadata();
+    const result = await contract.calculateInterfaceERC721Metadata();
     expect(result).to.equal(INTERFACE_IDS.ERC721Metadata);
   });
 
   it("ERC777", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC777();
+    const result = await contract.calculateInterfaceERC777();
     expect(result).to.equal(INTERFACE_IDS.ERC777);
   });
 
   it("ERC1155", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC1155();
+    const result = await contract.calculateInterfaceERC1155();
     expect(result).to.equal(INTERFACE_IDS.ERC1155);
   });
 
   it("ERC1271", async () => {
-    const result = await contract.callStatic.calculateInterfaceERC1271();
+    const result = await contract.calculateInterfaceERC1271();
     expect(result).to.equal(INTERFACE_IDS.ERC1271);
   });
 });

--- a/tests/Mocks/ERC165Interfaces.test.ts
+++ b/tests/Mocks/ERC165Interfaces.test.ts
@@ -59,6 +59,11 @@ describe("Calculate LSP interfaces", () => {
     expect(result).to.equal(INTERFACE_IDS.LSP9Vault);
   });
 
+  it("LSP11", async () => {
+    const result = await contract.callStatic.calculateInterfaceLSP11();
+    expect(result).to.equal(INTERFACE_IDS.LSP11BasicSocialRecovery);
+  });
+
   it("LSP14", async () => {
     const result = await contract.calculateInterfaceLSP14();
     expect(result).to.equal(INTERFACE_IDS.LSP14Ownable2Step);
@@ -74,9 +79,14 @@ describe("Calculate LSP interfaces", () => {
     expect(result).to.equal(INTERFACE_IDS.LSP17Extension);
   });
 
-  it("LSP11", async () => {
-    const result = await contract.callStatic.calculateInterfaceLSP11();
-    expect(result).to.equal(INTERFACE_IDS.LSP11BasicSocialRecovery);
+  it("LSP20CallVerification", async () => {
+    const result = await contract.calculateInterfaceLSP20CallVerification();
+    expect(result).to.equal(INTERFACE_IDS.LSP20CallVerification);
+  });
+
+  it("LSP20CallVerifier", async () => {
+    const result = await contract.calculateInterfaceLSP20CallVerifier();
+    expect(result).to.equal(INTERFACE_IDS.LSP20CallVerifier);
   });
 });
 

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -685,6 +685,13 @@ export const shouldInitializeLikeLSP3 = (
       expect(result).to.be.true;
     });
 
+    it("should support LSP20CallVerification interface", async () => {
+      const result = await context.universalProfile.supportsInterface(
+        INTERFACE_IDS.LSP20CallVerification
+      );
+      expect(result).to.be.true;
+    });
+
     it("should have set key 'SupportedStandards:LSP3UniversalProfile'", async () => {
       const result = await context.universalProfile["getData(bytes32)"](
         SupportedStandards.LSP3UniversalProfile.key


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

This PR introduces 2 new interface ids for LSP20.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->
<!---
## ⚠️ BREAKING CHANGES
---->

<!---
## 🚀 Feature
---->

<!---
## 🐛 Bug
---->

## ♻️ Refactor

Two new **interfaceIds**:

- The first one SHOULD be supported by the the LSP20 Verifier Contract, the contract that should verify if a call is valid. That interfaceId is constructed by using XOR of the selectors of the following function: `lsp20VerifyCall(address,uint256,bytes)` and `lsp20VerifyCallResult(bytes32,bytes)`
- The second one should be supported by the contract that implements LSP20CallVerification in its functions. And it is constructed by taking the first 4 bytes of "LSP20CallVerification" hash (`bytes4(keccack256("LSP20CallVerification"))`).

<!---
## 🧪 Tests
---->

<!---
## ⚡️ Performance
---->

<!---
## 🎨 Style
---->

<!---
## 📄 Documentation
---->

<!---
## 📦 Build
---->

<!---
## 🤖 CI
---->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [ ] Wrote Documentation
- [x] Ran `npm run linter`
- [x] Ran `npm run prettier`
- [x] Ran `npm run build`
- [x] Ran `npm run test`
