### PR TITLE
fix: [TRST-H-1] Disallow turning reentrancy bool to false in reentrantCalls

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -230,14 +230,14 @@ abstract contract LSP6KeyManagerCore is
             isSetData = true;
         }
 
-        _nonReentrantBefore(isSetData, caller);
+        bool reentrantCall = _nonReentrantBefore(isSetData, caller);
 
         _verifyPermissions(caller, msgValue, data);
         emit VerifiedCall(caller, msgValue, bytes4(data));
 
         // if it's a setData call, do not invoke the `lsp20VerifyCallResult(..)` function
         return
-            isSetData
+            isSetData || reentrantCall
                 ? bytes4(bytes.concat(bytes3(ILSP20.lsp20VerifyCall.selector), hex"00"))
                 : bytes4(bytes.concat(bytes3(ILSP20.lsp20VerifyCall.selector), hex"01"));
     }
@@ -268,14 +268,14 @@ abstract contract LSP6KeyManagerCore is
             isSetData = true;
         }
 
-        _nonReentrantBefore(isSetData, msg.sender);
+        bool reentrantCall = _nonReentrantBefore(isSetData, msg.sender);
 
         _verifyPermissions(msg.sender, msgValue, payload);
         emit VerifiedCall(msg.sender, msgValue, bytes4(payload));
 
         bytes memory result = _executePayload(msgValue, payload);
 
-        if (!isSetData) {
+        if (!reentrantCall && !isSetData) {
             _nonReentrantAfter();
         }
 
@@ -309,7 +309,7 @@ abstract contract LSP6KeyManagerCore is
             isSetData = true;
         }
 
-        _nonReentrantBefore(isSetData, signer);
+        bool reentrantCall = _nonReentrantBefore(isSetData, signer);
 
         if (!_isValidNonce(signer, nonce)) {
             revert InvalidRelayNonce(signer, nonce, signature);
@@ -323,7 +323,7 @@ abstract contract LSP6KeyManagerCore is
 
         bytes memory result = _executePayload(msgValue, payload);
 
-        if (!isSetData) {
+        if (!reentrantCall && !isSetData) {
             _nonReentrantAfter();
         }
 
@@ -425,8 +425,13 @@ abstract contract LSP6KeyManagerCore is
      * the status is `_ENTERED` in order to revert the call unless the caller has the REENTRANCY permission
      * Used in the beginning of the `nonReentrant` modifier, before the method execution starts.
      */
-    function _nonReentrantBefore(bool isSetData, address from) internal virtual {
-        if (_reentrancyStatus) {
+    function _nonReentrantBefore(bool isSetData, address from)
+        internal
+        virtual
+        returns (bool reentrantCall)
+    {
+        reentrantCall = _reentrancyStatus;
+        if (reentrantCall) {
             // CHECK the caller has REENTRANCY permission
             _requirePermissions(
                 from,

--- a/contracts/Mocks/Reentrancy/ThreeReentrancy.sol
+++ b/contracts/Mocks/Reentrancy/ThreeReentrancy.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {IERC725Y} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {IERC725X} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import "../../LSP6KeyManager/ILSP6KeyManager.sol";
+
+import {SETDATA_SELECTOR, EXECUTE_SELECTOR} from "@erc725/smart-contracts/contracts/constants.sol";
+
+// The purpose of these contracts is to perform tests on chained reentrancy scenarios
+// that involve interacting with the UniversalProfile through its owner (LSP6KeyManager)
+// or by directly using the LSP20 method.
+
+/**
+ * @dev contract used for testing
+ */
+contract FirstToCallLSP20 {
+    address public universalProfile;
+    SecondToCallLSP20 private _secondToCall;
+
+    constructor(address _universalProfile, address secondToCall_) {
+        universalProfile = _universalProfile;
+        _secondToCall = SecondToCallLSP20(secondToCall_);
+    }
+
+    function firstTarget() public {
+        // Calling execute function
+        IERC725X(universalProfile).execute(0, address(0), 0, hex"aabbccdd");
+
+        // Calling secondTarget function
+        _secondToCall.secondTarget();
+    }
+}
+
+/**
+ * @dev contract used for testing
+ */
+contract SecondToCallLSP20 {
+    address public universalProfile;
+
+    constructor(address _universalProfile) {
+        universalProfile = _universalProfile;
+    }
+
+    function secondTarget() public {
+        // Calling setData function
+        IERC725Y(universalProfile).setData(bytes32(0), hex"aabbccdd");
+    }
+}
+
+/**
+ * @dev contract used for testing
+ */
+contract FirstToCallLSP6 {
+    address public keyManager;
+    SecondToCallLSP20 private _secondToCall;
+
+    constructor(address _keyManager, address secondToCall_) {
+        keyManager = _keyManager;
+        _secondToCall = SecondToCallLSP20(secondToCall_);
+    }
+
+    function firstTarget() public {
+        bytes memory payload = abi.encodeWithSelector(
+            EXECUTE_SELECTOR,
+            0,
+            address(0),
+            0,
+            hex"aabbccdd"
+        );
+
+        // Calling execute function through the KeyManager
+        ILSP6KeyManager(keyManager).execute(payload);
+
+        // Calling secondTarget function
+        _secondToCall.secondTarget();
+    }
+}
+
+/**
+ * @dev contract used for testing
+ */
+contract SecondToCallLSP6 {
+    address public keyManager;
+
+    constructor(address _keyManager) {
+        keyManager = _keyManager;
+    }
+
+    function secondTarget() public {
+        bytes memory payload = abi.encodeWithSelector(SETDATA_SELECTOR, bytes32(0), hex"aabbccdd");
+
+        // Calling setData function through the KeyManager
+        ILSP6KeyManager(keyManager).execute(payload);
+    }
+}

--- a/tests/LSP20CallVerification/LSP6/Interactions/Security.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/Security.test.ts
@@ -285,7 +285,7 @@ export const testSecurityScenarios = (
       const permissionValues = [
         ALL_PERMISSIONS,
         combinePermissions(PERMISSIONS.SUPER_CALL, PERMISSIONS.REENTRANCY),
-        combinePermissions(PERMISSIONS.SUPER_SETDATA, PERMISSIONS.REENTRANCY),
+        combinePermissions(PERMISSIONS.SUPER_SETDATA),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
@@ -293,24 +293,65 @@ export const testSecurityScenarios = (
 
     describe("when executing reentrant calls from two different contracts", () => {
       describe("when the firstReentrant execute its first reentrant call to the UniversalProfile successfully", () => {
-        it("should require REENTRANCY Permission from the secondReentrant when reentering the UniversalProfile", async () => {
-          let firstTargetSelector =
-            firstReentrant.interface.encodeFunctionData("firstTarget");
+        describe("when the secondReentrant is not granted REENTRANCY Permission", () => {
+          it("shoul fail stating that the caller (secondReentrant) is not authorised (no reentrancy permission)", async () => {
+            let firstTargetSelector =
+              firstReentrant.interface.encodeFunctionData("firstTarget");
 
-          await context.universalProfile
-            .connect(context.owner)
-            ["execute(uint256,address,uint256,bytes)"](
-              OPERATION_TYPES.CALL,
-              firstReentrant.address,
-              0,
-              firstTargetSelector
+            await expect(
+              context.universalProfile
+                .connect(context.owner)
+                ["execute(uint256,address,uint256,bytes)"](
+                  OPERATION_TYPES.CALL,
+                  firstReentrant.address,
+                  0,
+                  firstTargetSelector
+                )
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                "NotAuthorised"
+              )
+              .withArgs(secondReentrant.address, "REENTRANCY");
+          });
+        });
+
+        describe("when the secondReentrant is granted REENTRANCY Permission", () => {
+          before(async () => {
+            const permissionKeys = [
+              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                secondReentrant.address.substring(2),
+            ];
+
+            const permissionValues = [
+              combinePermissions(
+                PERMISSIONS.SUPER_SETDATA,
+                PERMISSIONS.REENTRANCY
+              ),
+            ];
+
+            await setupKeyManager(context, permissionKeys, permissionValues);
+          });
+
+          it("should pass and setData from the second reentrantCall on the UniversalProfile correctly", async () => {
+            let firstTargetSelector =
+              firstReentrant.interface.encodeFunctionData("firstTarget");
+
+            await context.universalProfile
+              .connect(context.owner)
+              ["execute(uint256,address,uint256,bytes)"](
+                OPERATION_TYPES.CALL,
+                firstReentrant.address,
+                0,
+                firstTargetSelector
+              );
+
+            let result = await context.universalProfile["getData(bytes32)"](
+              ethers.constants.HashZero
             );
 
-          let result = await context.universalProfile["getData(bytes32)"](
-            ethers.constants.HashZero
-          );
-
-          expect(result).to.equal("0xaabbccdd");
+            expect(result).to.equal("0xaabbccdd");
+          });
         });
       });
     });


### PR DESCRIPTION
# What does this PR introduce?
## 🐛 Bug

<img width="672" alt="Screen Shot 2023-04-27 at 5 37 15 PM" src="https://user-images.githubusercontent.com/86341666/234896934-1384bc56-7efd-4ca8-95f2-0fe6833347fd.png">

### Explanation

The bug did not enable an attacker to execute an unauthorized action, but rather it permitted the execution of an action that the attacker was authorized to perform in a reentrant call without requiring Reentrancy Permission. This was possible by chaining the call with previous execute calls that deactivated the reentrancy guard.

### Fix 

The problem was fixed by making the function always tell if the call is a normal call or a reentrant call. If a reentrant call is detected, the function will not turn off the reentrancy guard/require a post-execution.

### PR Checklist

- [x] Wrote Tests
- [ ] Wrote Documentation **N/A**
- [X] Ran `npm run linter` (solhint)
- [X] Ran `npm run format` (prettier)
- [X] Ran `npm run build`
- [X] Ran `npm run test`
