### PR TITLE
chore: [TRST-R-5] return `FAILVALUE` when the signature is invalid

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -699,10 +699,18 @@ abstract contract LSP0ERC725AccountCore is
         }
         // If owner is an EOA
         else {
-            return
-                _owner == ECDSA.recover(dataHash, signature)
-                    ? _ERC1271_MAGICVALUE
-                    : _ERC1271_FAILVALUE;
+            // if isValidSignature fail, the error is catched in returnedError
+            (address recoveredAddress, ECDSA.RecoverError returnedError) = ECDSA.tryRecover(
+                dataHash,
+                signature
+            );
+
+            // if recovering throws an error, return the fail value
+            if (returnedError != ECDSA.RecoverError.NoError) return _ERC1271_FAILVALUE;
+
+            // if recovering is successfull, return the magic value if the recovered address
+            // matches the address of the owner, otherwise return fail value
+            return recoveredAddress == _owner ? _ERC1271_MAGICVALUE : _ERC1271_FAILVALUE;
         }
     }
 

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -708,7 +708,8 @@ abstract contract LSP0ERC725AccountCore is
             // if recovering throws an error, return the fail value
             if (returnedError != ECDSA.RecoverError.NoError) return _ERC1271_FAILVALUE;
 
-            // if recovering is successfull, return the magic value if the recovered address
+            // if recovering is successful and the recovered address matches the owner's address,
+            // return the ERC1271 magic value. Otherwise, return the ERC1271 fail value
             // matches the address of the owner, otherwise return fail value
             return recoveredAddress == _owner ? _ERC1271_MAGICVALUE : _ERC1271_FAILVALUE;
         }

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -123,7 +123,7 @@ abstract contract LSP6KeyManagerCore is
         // if recovering throws an error, return the fail value
         if (returnedError != ECDSA.RecoverError.NoError) return _ERC1271_FAILVALUE;
 
-        // if the address recovered has SIGN permission return the magicValue, failValue otherwise
+        // if the address recovered has SIGN permission return the ERC1271 magic value, otherwise the fail value
         return (
             ERC725Y(_target).getPermissionsFor(recoveredAddress).hasPermission(_PERMISSION_SIGN)
                 ? _ERC1271_MAGICVALUE

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -114,8 +114,16 @@ abstract contract LSP6KeyManagerCore is
         view
         returns (bytes4 magicValue)
     {
-        address recoveredAddress = dataHash.recover(signature);
+        // if isValidSignature fail, the error is catched in returnedError
+        (address recoveredAddress, ECDSA.RecoverError returnedError) = ECDSA.tryRecover(
+            dataHash,
+            signature
+        );
 
+        // if recovering throws an error, return the fail value
+        if (returnedError != ECDSA.RecoverError.NoError) return _ERC1271_FAILVALUE;
+
+        // if the address recovered has SIGN permission return the magicValue, failValue otherwise
         return (
             ERC725Y(_target).getPermissionsFor(recoveredAddress).hasPermission(_PERMISSION_SIGN)
                 ? _ERC1271_MAGICVALUE

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -54,7 +54,7 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
     });
 
-    it("should fail when verifying signature from non-owner", async () => {
+    it("should return fail value when verifying signature from non-owner", async () => {
       const signer = context.accounts[1];
 
       const dataToSign = "0xcafecafe";
@@ -126,6 +126,18 @@ export const shouldBehaveLikeLSP3 = (
       const dataToSign = "0xcafecafe";
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
+
+      const result = await context.universalProfile.isValidSignature(
+        messageHash,
+        signature
+      );
+      expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
+    });
+
+    it("should return failValue when providing an invalid length signature", async () => {
+      const data = "0xcafecafe";
+      const messageHash = ethers.utils.hashMessage(data);
+      const signature = "0xbadbadbadb";
 
       const result = await context.universalProfile.isValidSignature(
         messageHash,


### PR DESCRIPTION
# What does this PR introduce?
<!-- Keep the sub-header that suits the PR and remove the rest -->

## ♻️ Chore

- Avoid reverts and return `FAILVALUE` when the signature is invalid in LSP0 and LSP6

### PR Checklist

- [X] Wrote Tests
- [ ] Wrote Documentation
- [X] Ran `npm run linter` (solhint)
- [X] Ran `npm run format` (prettier)
- [X] Ran `npm run build`
- [X] Ran `npm run test`
