### PR TITLE
refactor: mark `mapping` and state variables as `private` in LSP7/8 Core contracts

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -25,15 +25,15 @@ import {_TYPEID_LSP7_TOKENSSENDER, _TYPEID_LSP7_TOKENSRECIPIENT} from "./LSP7Con
 abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     // --- Storage
 
-    bool internal _isNonDivisible;
-
-    uint256 internal _existingTokens;
-
     // Mapping from `tokenOwner` to an `amount` of tokens
-    mapping(address => uint256) internal _tokenOwnerBalances;
+    mapping(address => uint256) private _tokenOwnerBalances;
 
     // Mapping a `tokenOwner` to an `operator` to `amount` of tokens.
-    mapping(address => mapping(address => uint256)) internal _operatorAuthorizedAmount;
+    mapping(address => mapping(address => uint256)) private _operatorAuthorizedAmount;
+
+    uint256 private _existingTokens;
+
+    bool internal _isNonDivisible;
 
     // --- Token queries
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -27,18 +27,18 @@ abstract contract LSP8IdentifiableDigitalAssetCore is ILSP8IdentifiableDigitalAs
 
     // --- Storage
 
-    uint256 internal _existingTokens;
+    uint256 private _existingTokens;
 
     // Mapping from `tokenId` to `tokenOwner`
-    mapping(bytes32 => address) internal _tokenOwners;
+    mapping(bytes32 => address) private _tokenOwners;
 
     // Mapping `tokenOwner` to owned tokenIds
-    mapping(address => EnumerableSet.Bytes32Set) internal _ownedTokens;
+    mapping(address => EnumerableSet.Bytes32Set) private _ownedTokens;
 
     // Mapping a `tokenId` to its authorized operator addresses.
-    mapping(bytes32 => EnumerableSet.AddressSet) internal _operators;
+    mapping(bytes32 => EnumerableSet.AddressSet) private _operators;
 
-    mapping(address => EnumerableSet.Bytes32Set) internal _tokenIdsForOperator;
+    mapping(address => EnumerableSet.Bytes32Set) private _tokenIdsForOperator;
 
     // --- Token queries
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -100,8 +100,8 @@ abstract contract LSP8CompatibleERC721 is
         bytes32 tokenIdAsBytes32 = bytes32(tokenId);
         _existsOrError(tokenIdAsBytes32);
 
-        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[tokenIdAsBytes32];
-        uint256 operatorListLength = operatorsForTokenId.length();
+        address[] memory operatorsForTokenId = getOperatorsOf(tokenIdAsBytes32);
+        uint256 operatorListLength = operatorsForTokenId.length;
 
         if (operatorListLength == 0) {
             return address(0);
@@ -112,7 +112,7 @@ abstract contract LSP8CompatibleERC721 is
             // compatibility version the same is true, when the authorized operators were not previously
             // authorized. If addresses are removed, then `getApproved` returned address can change due
             // to implementation of `EnumberableSet._remove`.
-            return operatorsForTokenId.at(operatorListLength - 1);
+            return operatorsForTokenId[operatorListLength - 1];
         }
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -96,8 +96,8 @@ abstract contract LSP8CompatibleERC721InitAbstract is
         bytes32 tokenIdAsBytes32 = bytes32(tokenId);
         _existsOrError(tokenIdAsBytes32);
 
-        EnumerableSet.AddressSet storage operatorsForTokenId = _operators[tokenIdAsBytes32];
-        uint256 operatorListLength = operatorsForTokenId.length();
+        address[] memory operatorsForTokenId = getOperatorsOf(tokenIdAsBytes32);
+        uint256 operatorListLength = operatorsForTokenId.length;
 
         if (operatorListLength == 0) {
             return address(0);
@@ -108,7 +108,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
             // compatibility version the same is true, when the authorized operators were not previously
             // authorized. If addresses are removed, then `getApproved` returned address can change due
             // to implementation of `EnumberableSet._remove`.
-            return operatorsForTokenId.at(operatorListLength - 1);
+            return operatorsForTokenId[operatorListLength - 1];
         }
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
@@ -30,11 +30,11 @@ abstract contract LSP8Enumerable is LSP8IdentifiableDigitalAsset {
         bytes32 tokenId
     ) internal virtual override(LSP8IdentifiableDigitalAssetCore) {
         if (from == address(0)) {
-            uint256 index = _existingTokens;
+            uint256 index = totalSupply();
             _indexToken[index] = tokenId;
             _tokenIndex[tokenId] = index;
         } else if (to == address(0)) {
-            uint256 lastIndex = _existingTokens - 1;
+            uint256 lastIndex = totalSupply() - 1;
             uint256 index = _tokenIndex[tokenId];
             if (index < lastIndex) {
                 bytes32 lastTokenId = _indexToken[lastIndex];

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
@@ -32,11 +32,11 @@ abstract contract LSP8EnumerableInitAbstract is LSP8IdentifiableDigitalAssetInit
         bytes32 tokenId
     ) internal virtual override(LSP8IdentifiableDigitalAssetCore) {
         if (from == address(0)) {
-            uint256 index = _existingTokens;
+            uint256 index = totalSupply();
             _indexToken[index] = tokenId;
             _tokenIndex[tokenId] = index;
         } else if (to == address(0)) {
-            uint256 lastIndex = _existingTokens - 1;
+            uint256 lastIndex = totalSupply() - 1;
             uint256 index = _tokenIndex[tokenId];
             if (index < lastIndex) {
                 bytes32 lastTokenId = _indexToken[lastIndex];


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

Mark state variables in LSP7 and LSP8 Core contracts as `private` instead of `internal`.
This aims to prevent some potential issues in implementation contracts via inheritance, to update these state variables by accident.

This can prevent issues such as:
- updating the total number of existing tokens (if no tokens have been minted or burnt)
- other way around, like minting and adding to the `_balances` mapping directly in LSP7 without updating the `_existingTokens` state variable.

See this tweet for more details: https://twitter.com/zarfsec/status/1605211608464216064

![image](https://user-images.githubusercontent.com/31145285/236231746-bf21f0da-fbca-4b61-8e25-009cd20fd58c.png)


### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests **N/A**
- [ ] Wrote Documentation **N/A**
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
