### PR TITLE
perf: replace function `extractIndexFromMap(...)` and `BytesLib.slice` with explicit conversion

### DIFF
--- a/contracts/LSP10ReceivedVaults/LSP10Utils.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Utils.sol
@@ -132,7 +132,7 @@ library LSP10Utils {
         // Identify where the vault is located in the LSP10Vaults[] array
         // by extracting the index from the tuple value `(bytes4,uint128)`
         // fetched under the LSP10VaultsMap data key
-        uint128 index = extractIndexFromMap(vaultInterfaceIdAndIndex);
+        uint128 index = uint128(uint160(bytes20(vaultInterfaceIdAndIndex)));
 
         // Generate the element key in the array of the vault
         bytes32 vaultInArrayKey = LSP2Utils.generateArrayElementKeyAtIndex(
@@ -224,13 +224,5 @@ library LSP10Utils {
 
     function getLSP10ReceivedVaultsCount(IERC725Y account) internal view returns (bytes memory) {
         return account.getData(_LSP10_VAULTS_ARRAY_KEY);
-    }
-
-    /**
-     * @dev returns the index from the LSP10VaultMap
-     */
-    function extractIndexFromMap(bytes memory mapValue) internal pure returns (uint128) {
-        bytes memory val = BytesLib.slice(mapValue, 4, 16);
-        return BytesLib.toUint128(val, 0);
     }
 }

--- a/contracts/LSP10ReceivedVaults/LSP10Utils.sol
+++ b/contracts/LSP10ReceivedVaults/LSP10Utils.sol
@@ -102,12 +102,12 @@ library LSP10Utils {
      * @param sender The address sending the vault and where the Keys should be updated
      * @param vaultMapKey The map key of the vault being sent containing the interfaceId of the
      * vault and the index in the array
-     * @param vaultInterfaceIdAndIndex The value of the map key of the vault being sent
+     * @param vaultIndex The index where the vault address is stored under `LSP10Vaults[]` Array
      */
     function generateSentVaultKeys(
         address sender,
         bytes32 vaultMapKey,
-        bytes memory vaultInterfaceIdAndIndex
+        uint128 vaultIndex
     ) internal view returns (bytes32[] memory keys, bytes[] memory values) {
         IERC725Y account = IERC725Y(sender);
         bytes memory lsp10VaultsCountValue = getLSP10ReceivedVaultsCount(account);
@@ -129,19 +129,14 @@ library LSP10Utils {
         // Updating the number of the received vaults (decrementing by 1
         uint128 newArrayLength = oldArrayLength - 1;
 
-        // Identify where the vault is located in the LSP10Vaults[] array
-        // by extracting the index from the tuple value `(bytes4,uint128)`
-        // fetched under the LSP10VaultsMap data key
-        uint128 index = uint128(uint160(bytes20(vaultInterfaceIdAndIndex)));
-
         // Generate the element key in the array of the vault
         bytes32 vaultInArrayKey = LSP2Utils.generateArrayElementKeyAtIndex(
             _LSP10_VAULTS_ARRAY_KEY,
-            index
+            vaultIndex
         );
 
         // If the asset to remove is the last element in the array
-        if (index == newArrayLength) {
+        if (vaultIndex == newArrayLength) {
             /**
              * We will be updating/removing 3 keys:
              * - Keys[0]: [Update] The arrayLengthKey to contain the new number of the received vaults
@@ -165,7 +160,7 @@ library LSP10Utils {
 
             // Swapping last element in ArrayKey with the element in ArrayKey to remove || {Swap and pop} method;
             // check https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol#L80
-        } else if (index < newArrayLength) {
+        } else if (vaultIndex < newArrayLength) {
             /**
              * We will be updating/removing 5 keys:
              * - Keys[0]: [Update] The arrayLengthKey to contain the new number of the received vaults
@@ -215,7 +210,7 @@ library LSP10Utils {
             // Update the index and the interfaceId of the address swapped (last vault in the array)
             // to point to the new location in the LSP10Vaults array
             keys[4] = lastVaultInArrayMapKey;
-            values[4] = bytes.concat(_INTERFACEID_LSP9, bytes16(index));
+            values[4] = bytes.concat(_INTERFACEID_LSP9, bytes16(vaultIndex));
         } else {
             // If index is bigger than the array length, out of bounds
             return (keys, values);

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -112,11 +112,17 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
             // If the mapValue is not set, we assume that all other data keys relevant to the asset/vault
             // are not registered in the account, we cannot remove non-existing data keys for the asset being sent
             if (!isMapValueSet) return "LSP1: asset sent is not registered";
+
             // if the value under the `LSP5ReceivedAssetsMap:<asset-address>` or `LSP10VaultsMap:<vault-address>`
             // is not a valid tuple as `(bytes4,uint128)`
             if (notifierMapValue.length < 20) return "LSP1: asset data corrupted";
 
-            return _whenSending(typeId, notifier, notifierMapKey, notifierMapValue);
+            // Identify where the asset/vault is located in the `LSP5ReceivedAssets[]` / `LSP10Vaults[]` Array
+            // by extracting the index from the tuple value `(bytes4,uint128)`
+            // fetched under the `LSP5ReceivedAssetsMap` / `LSP10VaultsMap` data key
+            uint128 arrayIndex = uint128(uint160(bytes20(notifierMapValue)));
+
+            return _whenSending(typeId, notifier, notifierMapKey, arrayIndex);
         }
     }
 
@@ -174,7 +180,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
         bytes32 typeId,
         address notifier,
         bytes32 notifierMapKey,
-        bytes memory notifierMapValue
+        uint128 arrayIndex
     ) internal virtual returns (bytes memory) {
         bytes32[] memory dataKeys;
         bytes[] memory dataValues;
@@ -188,7 +194,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
             (dataKeys, dataValues) = LSP5Utils.generateSentAssetKeys(
                 msg.sender,
                 notifierMapKey,
-                notifierMapValue
+                arrayIndex
             );
 
             /**
@@ -205,7 +211,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
             (dataKeys, dataValues) = LSP10Utils.generateSentVaultKeys(
                 msg.sender,
                 notifierMapKey,
-                notifierMapValue
+                arrayIndex
             );
 
             /**

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -79,17 +79,24 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
             // if there is no map value for the asset to remove, then do nothing
             if (bytes20(notifierMapValue) == bytes20(0))
                 return "LSP1: asset sent is not registered";
+
             // if it's a token transfer (LSP7/LSP8)
             uint256 balance = ILSP7DigitalAsset(notifier).balanceOf(msg.sender);
             if (balance != 0) return "LSP1: full balance is not sent";
+
             // if the value under the `LSP5ReceivedAssetsMap:<asset-address>`
             // is not a valid tuple as `(bytes4,uint128)`
             if (notifierMapValue.length < 20) return "LSP1: asset data corrupted";
 
+            // Identify where the asset is located in the `LSP5ReceivedAssets[]` Array
+            // by extracting the index from the tuple value `(bytes4,uint128)`
+            // fetched under the LSP5ReceivedAssetsMap/LSP10VaultsMap data key
+            uint128 assetIndex = uint128(uint160(bytes20(notifierMapValue)));
+
             (dataKeys, dataValues) = LSP5Utils.generateSentAssetKeys(
                 msg.sender,
                 notifierMapKey,
-                notifierMapValue
+                assetIndex
             );
 
             /**

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -130,7 +130,7 @@ library LSP5Utils {
         // Identify where the vault is located in the LSP5ReceivedAssets[] array
         // by extracting the index from the tuple value `(bytes4,uint128)`
         // fetched under the LSP5ReceivedAssetsMap data key
-        uint128 index = extractIndexFromMap(assetInterfaceIdAndIndex);
+        uint128 index = uint128(uint160(bytes20(assetInterfaceIdAndIndex)));
 
         // Generate the element key in the array of the asset
         bytes32 assetInArrayKey = LSP2Utils.generateArrayElementKeyAtIndex(
@@ -230,13 +230,5 @@ library LSP5Utils {
 
     function getLSP5ReceivedAssetsCount(IERC725Y account) internal view returns (bytes memory) {
         return account.getData(_LSP5_RECEIVED_ASSETS_ARRAY_KEY);
-    }
-
-    /**
-     * @dev returns the index from the LSP5ReceivedAssetMap
-     */
-    function extractIndexFromMap(bytes memory mapValue) internal pure returns (uint128) {
-        bytes memory val = BytesLib.slice(mapValue, 4, 16);
-        return BytesLib.toUint128(val, 0);
     }
 }

--- a/contracts/LSP5ReceivedAssets/LSP5Utils.sol
+++ b/contracts/LSP5ReceivedAssets/LSP5Utils.sol
@@ -105,12 +105,12 @@ library LSP5Utils {
      * @param sender The address sending the asset and where the Keys should be updated
      * @param assetMapKey The map key of the asset being received containing the interfaceId of the
      * asset and the index in the array
-     * @param assetInterfaceIdAndIndex The value of the map key of the asset being sent
+     * @param assetIndex The index in the LSP5ReceivedAssets[] array
      */
     function generateSentAssetKeys(
         address sender,
         bytes32 assetMapKey,
-        bytes memory assetInterfaceIdAndIndex
+        uint128 assetIndex
     ) internal view returns (bytes32[] memory keys, bytes[] memory values) {
         IERC725Y account = IERC725Y(sender);
         bytes memory lsp5ReceivedAssetsCountValue = getLSP5ReceivedAssetsCount(account);
@@ -127,19 +127,14 @@ library LSP5Utils {
         // Updating the number of the received assets (decrementing by 1
         uint128 newArrayLength = oldArrayLength - 1;
 
-        // Identify where the vault is located in the LSP5ReceivedAssets[] array
-        // by extracting the index from the tuple value `(bytes4,uint128)`
-        // fetched under the LSP5ReceivedAssetsMap data key
-        uint128 index = uint128(uint160(bytes20(assetInterfaceIdAndIndex)));
-
         // Generate the element key in the array of the asset
         bytes32 assetInArrayKey = LSP2Utils.generateArrayElementKeyAtIndex(
             _LSP5_RECEIVED_ASSETS_ARRAY_KEY,
-            index
+            assetIndex
         );
 
         // If the asset to remove is the last element in the array
-        if (index == newArrayLength) {
+        if (assetIndex == newArrayLength) {
             /**
              * We will be updating/removing 3 keys:
              * - Keys[0]: [Update] The arrayLengthKey to contain the new number of the received assets
@@ -163,7 +158,7 @@ library LSP5Utils {
 
             // Swapping last element in ArrayKey with the element in ArrayKey to remove || {Swap and pop} method;
             // check https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/structs/EnumerableSet.sol#L80
-        } else if (index < newArrayLength) {
+        } else if (assetIndex < newArrayLength) {
             /**
              * We will be updating/removing 5 keys:
              * - Keys[0]: [Update] The arrayLengthKey to contain the new number of the received assets
@@ -221,7 +216,7 @@ library LSP5Utils {
             // Update the index and the interfaceId of the address swapped (last element in the array)
             // to point to the new location in the LSP5ReceivedAssets array
             keys[4] = lastAssetInArrayMapKey;
-            values[4] = bytes.concat(interfaceID, bytes16(index));
+            values[4] = bytes.concat(interfaceID, bytes16(assetIndex));
         } else {
             // If index is bigger than the array length, out of bounds
             return (keys, values);


### PR DESCRIPTION
# What does this PR introduce?

## ⚡️ Performance

Since PR #527 from @b00ste and this line change in the code:

https://github.com/lukso-network/lsp-smart-contracts/blob/2f984a954db0d673c83e78beb8989fc3a1d33cdd/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol#L127

It is guaranteed that the `mapValue` will always be at least 20 bytes long.
This make the use of the `BytesLib.slice(...)` library unecessary inside the `LSP5Utils` and `LSP10Utils` libraries.
Remove the use of the `.slice` function and the function `extractIndexFromMap` in favour of simply converting explicitly to extract the 16 right most bytes in the map value.

This save around:
- around 150 to 220 gas at runtime for token transfers.
- around 27,288 gas of deployment cost for deploying a LSP1Delegate contract.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote Documentation
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
