### PR TITLE
fix: typo in filename of exported `constant.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   "exports": {
     ".": {
       "import": "./dist/constants.cjs.js",
-      "require": "./dist/constant.es.js",
+      "require": "./dist/constants.es.js",
       "types": "./dist/constants.d.ts"
     },
     "./constants.js": {
       "import": "./dist/constants.cjs.js",
-      "require": "./dist/constant.es.js",
+      "require": "./dist/constants.es.js",
       "types": "./dist/constants.d.ts"
     },
     "./constants": {
       "import": "./dist/constants.cjs.js",
-      "require": "./dist/constant.es.js",
+      "require": "./dist/constants.es.js",
       "types": "./dist/constants.d.ts"
     },
     "./userdocs/*": "./userdocs",


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug

Fix a typo in `"exports"` fields of the `package.json`.

The file name for the constants should be marked as plural `constants.js` :white_check_mark:, not singular `constant.js` :x:

This lead to some errors and not being able able to import the constant in certain development environnements like React Native.


### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests (N/A)
- [ ] Wrote Documentation (N/a)
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
