### PR TITLE
refactor: mark `_tokenSupplyCap` as `private` + `immutable` for optimisation

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -14,7 +14,7 @@ abstract contract LSP7CappedSupply is LSP7DigitalAsset {
     error LSP7CappedSupplyCannotMintOverCap();
 
     // --- Storage
-    uint256 internal _tokenSupplyCap;
+    uint256 private immutable _tokenSupplyCap;
 
     /**
      * @notice Sets the token max supply

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -14,7 +14,7 @@ abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInitAbstract {
     error LSP7CappedSupplyCannotMintOverCap();
 
     // --- Storage
-    uint256 internal _tokenSupplyCap;
+    uint256 private _tokenSupplyCap;
 
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -14,7 +14,7 @@ abstract contract LSP8CappedSupply is LSP8IdentifiableDigitalAsset {
     error LSP8CappedSupplyCannotMintOverCap();
 
     // --- Storage
-    uint256 internal _tokenSupplyCap;
+    uint256 private immutable _tokenSupplyCap;
 
     /**
      * @notice Sets the token max supply

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -16,7 +16,7 @@ abstract contract LSP8CappedSupplyInitAbstract is LSP8IdentifiableDigitalAssetIn
     error LSP8CappedSupplyCannotMintOverCap();
 
     // --- Storage
-    uint256 internal _tokenSupplyCap;
+    uint256 private _tokenSupplyCap;
 
     function _initialize(uint256 tokenSupplyCap_) internal virtual onlyInitializing {
         if (tokenSupplyCap_ == 0) {


### PR DESCRIPTION
# What does this PR introduce?

## ⚡️ Performance

In `LSP7CappedSupply` and `LSP8CappedSupply`, mark the variable `_tokenSupplyCap` as `immutable` as this variable is set only in the constructor. This will change the data location from storage to code and optimise the internal `_mint` function since the getter will not read from storage anymore (expensive) but from the contract bytecode.

## ♻️ Refactor

In `LSP7CappedSupply`, `LSP7CappedSupplyInit`, LSP8CappedSupply` and `LSP8CappedSupplyInit`, change the visibility of `_tokenSupplyCap` from `internal` to `private`.

This makes the code more robust and secure:
- for inheritance on `LSP7CappedSupply` and `LSP8CappedSupply` (prevent overriding this state variable in future inheriting contracts). This is similar to what was introduced in #584 
- in the 4 contracts, enforces the use of the getter function `tokenSupplyCap()`.


### PR Checklist

- [ ] Wrote Tests (N/A)
- [ ] Wrote Documentation (N/A)
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
