### PR TITLE
fix: emit `Transfer` LSP7/8 compatible events before external calls

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -99,8 +99,8 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
         emit Transfer(from, to, amount);
+        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
     }
 
     function _mint(
@@ -109,8 +109,8 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._mint(to, amount, allowNonLSP1Recipient, data);
         emit Transfer(address(0), to, amount);
+        super._mint(to, amount, allowNonLSP1Recipient, data);
     }
 
     function _burn(
@@ -118,8 +118,8 @@ abstract contract LSP7CompatibleERC20 is ILSP7CompatibleERC20, LSP4Compatibility
         uint256 amount,
         bytes memory data
     ) internal virtual override {
-        super._burn(from, amount, data);
         emit Transfer(from, address(0), amount);
+        super._burn(from, amount, data);
     }
 
     function _setData(bytes32 key, bytes memory value)

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -110,8 +110,8 @@ abstract contract LSP7CompatibleERC20InitAbstract is
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
         emit Transfer(from, to, amount);
+        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
     }
 
     function _mint(
@@ -120,8 +120,8 @@ abstract contract LSP7CompatibleERC20InitAbstract is
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._mint(to, amount, allowNonLSP1Recipient, data);
         emit Transfer(address(0), to, amount);
+        super._mint(to, amount, allowNonLSP1Recipient, data);
     }
 
     function _burn(
@@ -129,8 +129,8 @@ abstract contract LSP7CompatibleERC20InitAbstract is
         uint256 amount,
         bytes memory data
     ) internal virtual override {
-        super._burn(from, amount, data);
         emit Transfer(from, address(0), amount);
+        super._burn(from, amount, data);
     }
 
     function _setData(bytes32 key, bytes memory value)

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -232,15 +232,15 @@ abstract contract LSP8CompatibleERC721 is
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
         emit Transfer(address(0), to, uint256(tokenId));
+        super._mint(to, tokenId, allowNonLSP1Recipient, data);
     }
 
     function _burn(bytes32 tokenId, bytes memory data) internal virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        super._burn(tokenId, data);
         emit Transfer(tokenOwner, address(0), uint256(tokenId));
+        super._burn(tokenId, data);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -205,8 +205,8 @@ abstract contract LSP8CompatibleERC721InitAbstract is
             revert LSP8NotTokenOperator(tokenId, operator);
         }
 
-        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
         emit Transfer(from, to, uint256(tokenId));
+        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
     }
 
     function _safeTransfer(
@@ -228,15 +228,15 @@ abstract contract LSP8CompatibleERC721InitAbstract is
         bool allowNonLSP1Recipient,
         bytes memory data
     ) internal virtual override {
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
         emit Transfer(address(0), to, uint256(tokenId));
+        super._mint(to, tokenId, allowNonLSP1Recipient, data);
     }
 
     function _burn(bytes32 tokenId, bytes memory data) internal virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        super._burn(tokenId, data);
         emit Transfer(tokenOwner, address(0), uint256(tokenId));
+        super._burn(tokenId, data);
     }
 
     /**


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug

**apply to:** `LSP7CompatibleERC20`, `LSP7CompatibleERC20Init`, `LSP8CompatibleERC721` and `LSP8CompatibleERC721`.

In these contracts, inside the internal `_mint`, `_burn` and `_transfer` functions, the `Transfer` event is emitted after the call to the `super` function (`super._mint`, `super._burn` and `super._transfer` functions).

Since the parent function performs an external call to notify the token sender and/or recipient, this can potentially lead to reentrancy scenarios.

In the context of reentrancy, the second `Transfer` event would appear first in the logs, and the initial `Transfer` event would appear second, leading to an incorrect order of event emission according to the interaction.

Refactor to emit the `Transfer` event first in the compatible functions before any external call is made.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests (N/A)
- [ ] Wrote Documentation (N/A)
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
