### PR TITLE
fix: initialize state var in inheritance of `LSP7Burnable` + add init version of this extension

### DIFF
--- a/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.4;
 
 // modules
-import {LSP7DigitalAssetCore} from "../LSP7DigitalAssetCore.sol";
+import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
 
 /**
  * @dev LSP7 extension that allows token holders to destroy both
  * their own tokens and those that they have an allowance for as an operator.
  */
-abstract contract LSP7Burnable is LSP7DigitalAssetCore {
+abstract contract LSP7Burnable is LSP7DigitalAsset {
     /**
      * @dev Destroys `amount` tokens from the `from` address.
      *

--- a/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+// modules
+import {LSP7DigitalAssetInitAbstract} from "../LSP7DigitalAssetInitAbstract.sol";
+
+/**
+ * @dev LSP7 extension that allows token holders to destroy both
+ * their own tokens and those that they have an allowance for as an operator.
+ */
+abstract contract LSP7BurnableInitAbstract is LSP7DigitalAssetInitAbstract {
+    /**
+     * @dev Destroys `amount` tokens from the `from` address.
+     *
+     * See internal _burn function for more details
+     */
+    function burn(
+        address from,
+        uint256 amount,
+        bytes memory data
+    ) public {
+        _burn(from, amount, data);
+    }
+}

--- a/contracts/Mocks/Tokens/LSP7InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7InitTester.sol
@@ -6,9 +6,11 @@ pragma solidity ^0.8.4;
 import {
     LSP7DigitalAssetInitAbstract
 } from "../../LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol";
-import {LSP7Burnable} from "../../LSP7DigitalAsset/extensions/LSP7Burnable.sol";
+import {
+    LSP7BurnableInitAbstract
+} from "../../LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol";
 
-contract LSP7InitTester is LSP7DigitalAssetInitAbstract, LSP7Burnable {
+contract LSP7InitTester is LSP7DigitalAssetInitAbstract, LSP7BurnableInitAbstract {
     function initialize(
         string memory tokenName_,
         string memory tokenSymbol_,


### PR DESCRIPTION
# What does this PR introduce?

## 🚀 Feature

Add Init version of `LSP7Burnable` extension.

## 🐛 Bug

Change the inheritance in `LSP7Burnable` to inherit from the standard version of LSP7 and prevent state variable `_isNonDivisible` to be uninitialized. See error reported by Slither below:

<img width="1150" alt="Screenshot 2023-05-15 at 14 36 06" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/fc308a50-142a-4402-9531-2d5eaf01df50">

### PR Checklist

- [ ] Wrote Tests (N/A)
- [ ] Wrote Documentation (N/A)
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
