### PR TITLE
test: fix failing validity timestamp

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -50,6 +50,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       live: false,
       saveDeployments: false,
+      allowBlocksWithSameTimestamp: true,
     },
     // public L14 test network
     luksoL14: {

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -639,9 +639,6 @@ export const shouldBehaveLikeExecuteRelayCall = (
       });
 
       describe("When testing `validityTimestamps`", () => {
-        const oneDayInSeconds = 60 * 60 * 24;
-        let count = 0;
-
         describe("(invalid timestamps) `startingTimestamp` is greter than `endingTimestamp`", () => {
           describe("`now` is equal to `startingTimestamp` and `now` is greter than `endingTimestamp`", () => {
             it("reverts", async () => {


### PR DESCRIPTION
# What does this PR introduce?


## 🧪 Tests

- Fix failing validity timestamp

Old behavior was manipulating the timestamp with increasing time on each test
New behavior tests each case against the current timestamp