### PR TITLE
ci: replace deployment + verification of contracts from L16 to LUKSO Testnet

### DIFF
--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -1,10 +1,9 @@
-# This workflow deploys and verify the lsp-smart-contracts and verify them.
-
-name: Deploy + Verify Contracts
+# This workflow deploys and verify the lsp-smart-contracts and verify them on LUKSO Testnet.
+name: Deploy + Verify Contracts on Testnet
 
 env:
-  CONTRACT_VERIFICATION_PK: ${{ secrets.CONTRACT_VERIFICATION_PK }}
-  DEPLOYER_ADDRESS: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+  CONTRACT_VERIFICATION_TESTNET_PK: ${{ secrets.CONTRACT_VERIFICATION_TESTNET_PK }}
+  DEPLOYER_ADDRESS: "0x983aBC616f2442bAB7a917E6bb8660Df8b01F3bF"
 
 on:
   workflow_dispatch:
@@ -91,5 +90,5 @@ jobs:
       - name: Verify Deployer Balance
         run: npx ts-node ./scripts/ci/check-deployer-balance.ts
 
-      - name: Deploy + Verify ${{ matrix.contracts }} on L16
-        run: sh ./scripts/ci/deploy-verify.sh -n luksoL16 -c ${{ matrix.contracts }}
+      - name: Deploy + Verify ${{ matrix.contracts }} on Testnet
+        run: sh ./scripts/ci/deploy-verify.sh -n luksoTestnet -c ${{ matrix.contracts }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,23 +1,23 @@
 # Deployment
 
-You can find a deployment utility with hardhat to easily deploy the smart contracts locally or on our L16 test network,
-if you don't have some LYX test token visit [LUKSO l16 Faucet](http://faucet.l16.lukso.network/), for faucet.
+You can find a deployment utility with hardhat to easily deploy the smart contracts locally or on the LUKSO Testnet,
+if you don't have some LYX test token visit [LUKSO Testnet Faucet](https://faucet.testnet.lukso.network).
 
-All the deployment scripts for `base` contracts initialize the contract after deployment to the zero address for security.
+> **Note:** all the deployment scripts for `base` contracts initialize the contract after deployment to the zero address for security.
 
 &nbsp;
 
-## How to deploy on L16 with Hardhat?
+## How to deploy on Testnet with Hardhat?
 
-1. write a private key for an address you control in the `hardhat.config.ts` file. For instance for L16 network:
+1. write a private key for an address you control in the `hardhat.config.ts` file. For instance for LUKSO Testnet:
 
 ```ts
-    // public L16 test network
-    luksoL16: {
+    // public LUKSO Testnet
+    luksoTestnet: {
       live: true,
-      url: "https://rpc.l16.lukso.network",
-      chainId: 2828,
-      accounts: ["0xaabbccddeeff..."] // your private key here
+      url: "https://rpc.testnet.lukso.network",
+      chainId: 4201,
+      accounts: ["0x.."] // your private key here
     },
 ```
 
@@ -26,7 +26,7 @@ All the deployment scripts for `base` contracts initialize the contract after de
 2. run the command using one of the available `--tags`
 
 ```
-npx hardhat deploy --network luksoL16 --tags <options> --reset
+npx hardhat deploy --network luksoTestnet --tags <options> --reset
 ```
 
 Available `--tags <options>` are:
@@ -65,36 +65,36 @@ Available `--tags <options>` are:
 
 ```
 // Deploy the 3 contracts
-npx hardhat deploy --network luksoL16 --tags standard --reset
+npx hardhat deploy --network luksoTestnet --tags standard --reset
 
 
 // Deploy the 3 contracts as base contracts (to be used behind proxies)
-npx hardhat deploy --network luksoL16 --tags base --reset
+npx hardhat deploy --network luksoTestnet --tags base --reset
 
 // Deploy a specific contract
-npx hardhat deploy --network luksoL16 --tags UniversalProfile --reset
+npx hardhat deploy --network luksoTestnet --tags UniversalProfile --reset
 ```
 
-## Verify Contracts on L16
+## Verify Contracts on LUKSO Testnet
 
-We recommend using [`@nomiclabs/hardhat-etherscan`](https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan) plugin to verify the lsp-smart-contracts deployed on L16 network.
+We recommend using [`@nomiclabs/hardhat-etherscan`](https://hardhat.org/hardhat-runner/plugins/nomiclabs-hardhat-etherscan) plugin to verify the lsp-smart-contracts deployed on LUKSO Testnet.
 
-### 1. add the LUKSO L16 network in your hardhat config under `etherscan`
+### 1. add the LUKSO Testnet in your hardhat config under `etherscan`
 
-In your hardhat config file, under the `etherscan` property, add the following configurations for the [LUKSO L16 network](https://docs.lukso.tech/networks/l16-testnet/parameters).
+In your hardhat config file, under the `etherscan` property, add the following configurations for the [LUKSO Testnet](https://docs.lukso.tech/networks/testnet/parameters).
 
 ```js
 etherscan: {
     // no API is required to verify contracts
-    // via the Blockscout instance of L16 network
+    // via the Blockscout instance of LUKSO Testnet
     apiKey: "no-api-key-needed",
     customChains: [
       {
-        network: "luksoL16",
-        chainId: 2828,
+        network: "luksoTestnet",
+        chainId: 4201,
         urls: {
-          apiURL: "https://explorer.execution.l16.lukso.network/api",
-          browserURL: "https://explorer.execution.l16.lukso.network/",
+          apiURL: "https://explorer.execution.testnet.lukso.network/api",
+          browserURL: "https://explorer.execution.testnet.lukso.network",
         },
       },
     ],
@@ -107,19 +107,19 @@ See the following commands below for examples.
 
 ```bash
 # verify a Universal Profile
-npx hardhat verify <address of the deployed Universal Profile> "profile-owner" --network luksoL16 --contract path/to/UniversalProfileContract.sol:ContractName
+npx hardhat verify <address of the deployed Universal Profile> "profile-owner" --network luksoTestnet --contract path/to/UniversalProfileContract.sol:ContractName
 
 # verify a Key Manager
-npx hardhat verify <address of the deployed Key Manager> "address-of-UP-linked-to-KM" --network luksoL16
+npx hardhat verify <address of the deployed Key Manager> "address-of-UP-linked-to-KM" --network luksoTestnet
 
 # verify the Universal Receiver Delegate of a UP
-npx hardhat verify <address of the deployed URD> --network luksoL16
+npx hardhat verify <address of the deployed URD> --network luksoTestnet
 
 ## Verify a LSP8 contract
-npx hardhat verify <address of the LSP8 contract> "token-name" "token-symbol" "owner-address" --network luksoL16
+npx hardhat verify <address of the LSP8 contract> "token-name" "token-symbol" "owner-address" --network luksoTestnet
 
 ## Verify a LSP9 contracts
-npx hardhat verify <address of the LSP9 contract> "vault-owner" --network luksoL16
+npx hardhat verify <address of the LSP9 contract> "vault-owner" --network luksoTestnet
 ```
 
 For base contracts (to be used as implementation behind proxies), the same commands can be used without the constructor arguments.
@@ -127,7 +127,7 @@ For base contracts (to be used as implementation behind proxies), the same comma
 For LSP7 contracts, the constructor arguments provided to the command must be passed via a separate file. You can also use an external file for the arguments when verifying other contracts as well.
 
 ```bash
-npx hardhat verify <address of the LSP7 contract> --constructor-args arguments.js --network luksoL16
+npx hardhat verify <address of the LSP7 contract> --constructor-args arguments.js --network luksoTestnet
 ```
 
 ```js title="arguments.js"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,6 +44,20 @@ function getL16ChainConfig(): NetworkUserConfig {
   return config;
 }
 
+function getTestnetChainConfig(): NetworkUserConfig {
+  const config: NetworkUserConfig = {
+    live: true,
+    url: "https://rpc.testnet.lukso.network",
+    chainId: 4201,
+  };
+
+  if (process.env.CONTRACT_VERIFICATION_TESTNET_PK !== undefined) {
+    config["accounts"] = [process.env.CONTRACT_VERIFICATION_TESTNET_PK];
+  }
+
+  return config;
+}
+
 const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   networks: {
@@ -60,6 +74,7 @@ const config: HardhatUserConfig = {
       //   accounts: [privateKey1, privateKey2, ...]
     },
     luksoL16: getL16ChainConfig(),
+    luksoTestnet: getTestnetChainConfig(),
   },
   namedAccounts: {
     owner: 0,
@@ -83,6 +98,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://explorer.execution.l16.lukso.network/api",
           browserURL: "https://explorer.execution.l16.lukso.network/",
+        },
+      },
+      {
+        network: "luksoTestnet",
+        chainId: 4201,
+        urls: {
+          apiURL: "https://explorer.execution.testnet.lukso.network/api",
+          browserURL: "https://explorer.execution.testnet.lukso.network/",
         },
       },
     ],

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -30,20 +30,6 @@ import "@nomiclabs/hardhat-web3";
 
 dotenvConfig({ path: resolve(__dirname, "./.env") });
 
-function getL16ChainConfig(): NetworkUserConfig {
-  const config: NetworkUserConfig = {
-    live: true,
-    url: "https://rpc.l16.lukso.network",
-    chainId: 2828,
-  };
-
-  if (process.env.CONTRACT_VERIFICATION_PK !== undefined) {
-    config["accounts"] = [process.env.CONTRACT_VERIFICATION_PK];
-  }
-
-  return config;
-}
-
 function getTestnetChainConfig(): NetworkUserConfig {
   const config: NetworkUserConfig = {
     live: true,
@@ -66,40 +52,14 @@ const config: HardhatUserConfig = {
       saveDeployments: false,
       allowBlocksWithSameTimestamp: true,
     },
-    // public L14 test network
-    luksoL14: {
-      live: true,
-      url: "https://rpc.l14.lukso.network",
-      chainId: 22,
-      //   accounts: [privateKey1, privateKey2, ...]
-    },
-    luksoL16: getL16ChainConfig(),
     luksoTestnet: getTestnetChainConfig(),
   },
   namedAccounts: {
     owner: 0,
   },
   etherscan: {
-    // no API is required to verify contracts
-    // via the Blockscout instance of L14 or L16 network
     apiKey: "no-api-key-needed",
     customChains: [
-      {
-        network: "luksoL14",
-        chainId: 22,
-        urls: {
-          apiURL: "https://blockscout.com/lukso/l14/api",
-          browserURL: "https://blockscout.com/lukso/l14",
-        },
-      },
-      {
-        network: "luksoL16",
-        chainId: 2828,
-        urls: {
-          apiURL: "https://explorer.execution.l16.lukso.network/api",
-          browserURL: "https://explorer.execution.l16.lukso.network/",
-        },
-      },
       {
         network: "luksoTestnet",
         chainId: 4201,

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -13,13 +13,13 @@ The following folder contains 3 files intended to be used as part of the CI/CD o
 The `deploy-verify.sh` command can also be used standalone (outside of the CI) from the root folder of the repository as follows.
 
 ```
-./scripts/ci/deploy-verify.sh -n luksoL16 -c UniversalProfile
+./scripts/ci/deploy-verify.sh -n luksoTesnet -c UniversalProfile
 ```
 
-It requires to specify a private key in a local `.env` file under the global variable `CONTRACT_VERIFICATION_PK`.
+It requires to specify a private key in a local `.env` file under the global variable `CONTRACT_VERIFICATION_TESTNET_PK`.
 
 ```
-CONTRACT_VERIFICATION_PK=0x...
+CONTRACT_VERIFICATION_TESTNET_PK=0x...
 ```
 
 The following arguments must be specified:

--- a/scripts/ci/check-deployer-balance.ts
+++ b/scripts/ci/check-deployer-balance.ts
@@ -4,11 +4,11 @@ import { resolve } from "path";
 
 dotenvConfig({ path: resolve(__dirname, "./.env") });
 
-const wallet = new ethers.Wallet(process.env.CONTRACT_VERIFICATION_PK);
+const wallet = new ethers.Wallet(process.env.CONTRACT_VERIFICATION_TESTNET_PK);
 const deployerAddress = wallet.address;
 
 const provider = new ethers.providers.JsonRpcProvider(
-  config.networks.luksoL16["url"]
+  config.networks.luksoTestnet["url"]
 );
 
 // the CI deploys all the contracts, so we need to make sure that the deployer has enough balance
@@ -19,11 +19,11 @@ async function main() {
 
   if (deployerBalance.lt(MINIMUM_DEPLOYER_BALANCE)) {
     throw new Error(
-      `❌ Deployer balance is too low. Please fund the deployer address ${deployerAddress} with at least ${MINIMUM_DEPLOYER_BALANCE} LYXe`
+      `❌ Deployer balance is too low. Please fund the deployer address ${deployerAddress} on LUKSO Testnet with at least ${MINIMUM_DEPLOYER_BALANCE} LYXe`
     );
   } else {
     console.log(
-      `✅ Deployer balance sufficient to deploy + verify contracts. 
+      `✅ Deployer balance sufficient to deploy + verify contracts on LUKSO Testnet. 
       Deployer address: ${deployerAddress}
       Balance: ${ethers.utils.formatEther(deployerBalance)} LYXe`
     );

--- a/scripts/ci/deploy-verify.sh
+++ b/scripts/ci/deploy-verify.sh
@@ -47,14 +47,14 @@ CONTRACT_ADDRESS=$(grep -o -E '0x(\w|\s){40}' deployment.txt | tail -n 1)
 # Verify UniversalProfile with constructor arguments
 if [ "${contract}" = "UniversalProfile" ]
 then 
-    npx hardhat verify $CONTRACT_ADDRESS $DEPLOYER_ADDRESS --network luksoL16 --contract contracts/UniversalProfile.sol:UniversalProfile
+    npx hardhat verify $CONTRACT_ADDRESS $DEPLOYER_ADDRESS --network luksoTestnet --contract contracts/UniversalProfile.sol:UniversalProfile
 
 # Verify LSP6KeyManager contracts with constructor arguments
 elif [ "${contract}" = "LSP6KeyManager" ]
 then
     # specify the contract as UniversalProfile and LSP0ERC725Account have the same runtime code.
     LINKED_UP_IN_CONSTRUCTOR=$(grep -o -E '0x(\w|\s){40}' deployment.txt | head -n 2 | tail -n 1)
-    npx hardhat verify $CONTRACT_ADDRESS $LINKED_UP_IN_CONSTRUCTOR --network luksoL16
+    npx hardhat verify $CONTRACT_ADDRESS $LINKED_UP_IN_CONSTRUCTOR --network luksoTestnet
 
 # Verify LSP7Mintable contract with constructor arguments
 elif [ "${contract}" = "LSP7Mintable" ]
@@ -62,21 +62,21 @@ then
     # LSP7 constructor takes a boolean parameter that error when passed as CLI argument.
     # Create js file with constructor arguments to bypass this error.
     echo "module.exports = [ 'LSP7 Mintable', 'LSP7M', '$DEPLOYER_ADDRESS', false ];" >> lsp7arguments.js
-    npx hardhat verify $CONTRACT_ADDRESS --network luksoL16 --constructor-args lsp7arguments.js
+    npx hardhat verify $CONTRACT_ADDRESS --network luksoTestnet --constructor-args lsp7arguments.js
 
 # Verify LSP8Mintable contract with constructor arguments
 elif [ "${contract}" = "LSP8Mintable" ]
 then
-    npx hardhat verify $CONTRACT_ADDRESS 'LSP8 Mintable' 'LSP8M' $DEPLOYER_ADDRESS --network luksoL16
+    npx hardhat verify $CONTRACT_ADDRESS 'LSP8 Mintable' 'LSP8M' $DEPLOYER_ADDRESS --network luksoTestnet
 
 # Verify LSP9Vault contract with constructor arguments
 elif [ "${contract}" = "LSP9Vault" ]
 then
-    npx hardhat verify $CONTRACT_ADDRESS $DEPLOYER_ADDRESS --network luksoL16
+    npx hardhat verify $CONTRACT_ADDRESS $DEPLOYER_ADDRESS --network luksoTestnet
 
 # Default: verify contract without any constructor arguments (LSP!UniversalReceiverDelegate of UP or Vault)
 else
-    npx hardhat verify $CONTRACT_ADDRESS --network luksoL16
+    npx hardhat verify $CONTRACT_ADDRESS --network luksoTestnet
 fi
 
 


### PR DESCRIPTION
# What does this PR introduce?

## 🤖 CI

- Update CI to deploy and verify smart contracts on the new LUKSO testnet instead of L16.
- **:warning: Warning: deprecate the L14 and L16 test networks by removing them from the hardhat config.**


### PR Checklist

- [ ] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
