### PR TITLE
docs: rename deploy params to `initialOwner` and `contractOwner` for UP and LSP0 contracts

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -38,15 +38,20 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
  */
 contract LSP0ERC725Account is LSP0ERC725AccountCore {
     /**
-     * @dev Sets the owner of the contract on deployment and allows funding.
-     * Emits a {ValueReceived} event when funding the contract on deployment.
-     * @param newOwner The owner of the contract.
+     * @notice Deploying the contract with owner set to: `initialOwner`
+     * @dev Set `initialOwner` as the contract owner.
+     * The `constructor` also allows funding the contract on deployment.
+     *
+     * Emitted Events:
+     * - ValueReceived: when the contract is funded on deployment.
+     *
+     * @param initialOwner The owner of the contract
      */
-    constructor(address newOwner) payable {
+    constructor(address initialOwner) payable {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }
 
-        OwnableUnset._setOwner(newOwner);
+        OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -37,17 +37,27 @@ import {LSP0ERC725AccountInitAbstract} from "./LSP0ERC725AccountInitAbstract.sol
  */
 contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
     /**
-     * @dev initialize (= lock) base implementation contract on deployment
+     * @notice deploying a `LSP0ERC725AccountInit` base contract to be used behind proxy
+     * @dev Locks the base contract on deployment, so that it cannot be initialized, owned and controlled by anyone
+     * after it has been deployed. This is intended so that the sole purpose of this contract is to be used as a base
+     * contract behind a proxy.
      */
     constructor() {
         _disableInitializers();
     }
 
     /**
-     * @dev Sets the owner of the contract
-     * @param newOwner the owner of the contract
+     * @notice Initializing the contract owner to: `initialOwner`
+     * @dev Set `initialOwner` as the contract owner.
+     * The `initialOwner` will then be allowed to call protected functions marked with the `onlyOwner` modifier.
+     * The `initialize(address)` function also allows funding the contract on initialization.
+     *
+     * Emitted Events:
+     * - ValueReceived: when the contract is funded on initialization.
+     *
+     * @param initialOwner the owner of the contract
      */
-    function initialize(address newOwner) external payable virtual initializer {
-        LSP0ERC725AccountInitAbstract._initialize(newOwner);
+    function initialize(address initialOwner) external payable virtual initializer {
+        LSP0ERC725AccountInitAbstract._initialize(initialOwner);
     }
 }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -39,15 +39,20 @@ import {OwnableUnset} from "@erc725/smart-contracts/contracts/custom/OwnableUnse
  */
 abstract contract LSP0ERC725AccountInitAbstract is Initializable, LSP0ERC725AccountCore {
     /**
-     * @notice Initializing the contract owner to: `newOwner`
-     * @dev Sets the owner of the contract. ERC725X & ERC725Y parent contracts
+     * @dev Set `initialOwner` as the contract owner. ERC725X & ERC725Y parent contracts
      * are not initialised as they don't have non-zero initial state.
      * If you decide to add non-zero initial state to any of those
      * contracts, you MUST initialize them here
-     * @param newOwner the owner of the contract
+     *
+     * Emitted Events:
+     * - ValueReceived: if the transaction that triggered this internal `_initialize` function contained some `msg.value`.
+     *
+     * @param initialOwner the owner of the contract
      */
-    function _initialize(address newOwner) internal virtual onlyInitializing {
-        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
-        OwnableUnset._setOwner(newOwner);
+    function _initialize(address initialOwner) internal virtual onlyInitializing {
+        if (msg.value != 0) {
+            emit ValueReceived(msg.sender, msg.value);
+        }
+        OwnableUnset._setOwner(initialOwner);
     }
 }

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -17,11 +17,17 @@ import {
  */
 contract UniversalProfile is LSP0ERC725Account {
     /**
-     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP3UniversalProfile key
-     * @param newOwner the owner of the contract
+     * @notice Deploying the contract with owner set to: `initialOwner`
+     * @dev Set `initialOwner` as the contract owner and set the `SupportedStandards:LSP3UniversalProfile` data key
+     * in the ERC725Y data key/value store. The `constructor` also allows funding the contract on deployment.
+     *
+     * Emitted Events:
+     * - ValueReceived: when the contract is funded on deployment.
+     *
+     * @param initialOwner the owner of the contract
      */
-    constructor(address newOwner) payable LSP0ERC725Account(newOwner) {
-        // set key SupportedStandards:LSP3UniversalProfile
+    constructor(address initialOwner) payable LSP0ERC725Account(initialOwner) {
+        // set data key SupportedStandards:LSP3UniversalProfile
         _setData(_LSP3_SUPPORTED_STANDARDS_KEY, _LSP3_SUPPORTED_STANDARDS_VALUE);
     }
 }

--- a/contracts/UniversalProfileInit.sol
+++ b/contracts/UniversalProfileInit.sol
@@ -11,17 +11,27 @@ import {UniversalProfileInitAbstract} from "./UniversalProfileInitAbstract.sol";
  */
 contract UniversalProfileInit is UniversalProfileInitAbstract {
     /**
-     * @dev initialize (= lock) base implementation contract on deployment
+     * @notice deploying a `UniversalProfileInit` base contract to be used behind proxy
+     * @dev Locks the base contract on deployment, so that it cannot be initialized, owned and controlled by anyone
+     * after it has been deployed. This is intended so that the sole purpose of this contract is to be used as a base
+     * contract behind a proxy.
      */
     constructor() {
         _disableInitializers();
     }
 
     /**
-     * @notice Sets the owner of the contract and sets the SupportedStandards:LSP3UniversalProfile key
-     * @param newOwner the owner of the contract
+     * @notice Initializing the contract owner to: `initialOwner`
+     * @dev Set `initialOwner` as the contract owner and set the `SupportedStandards:LSP3UniversalProfile` data key in the ERC725Y data key/value store.
+     * The `initialOwner` will then be allowed to call protected functions marked with the `onlyOwner` modifier.
+     * The `initialize(address)` function also allows funding the contract on initialization.
+     *
+     * Emitted Events:
+     * - ValueReceived: when the contract is funded on initialization.
+     *
+     * @param initialOwner the owner of the contract
      */
-    function initialize(address newOwner) external payable virtual initializer {
-        UniversalProfileInitAbstract._initialize(newOwner);
+    function initialize(address initialOwner) external payable virtual initializer {
+        UniversalProfileInitAbstract._initialize(initialOwner);
     }
 }

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -17,14 +17,13 @@ import {
  */
 abstract contract UniversalProfileInitAbstract is LSP0ERC725AccountInitAbstract {
     /**
-     * @notice Initializing the contract owner to: `newOwner`
-     * @dev Sets the owner of the contract and sets the SupportedStandards:LSP3UniversalProfile key
-     * @param newOwner the owner of the contract
+     * @inheritdoc LSP0ERC725AccountInitAbstract
+     * @dev Set the `SupportedStandards:LSP3UniversalProfile` data key in the ERC725Y data key/value store.
      */
-    function _initialize(address newOwner) internal virtual override onlyInitializing {
-        LSP0ERC725AccountInitAbstract._initialize(newOwner);
+    function _initialize(address initialOwner) internal virtual override onlyInitializing {
+        LSP0ERC725AccountInitAbstract._initialize(initialOwner);
 
-        // set key SupportedStandards:LSP3UniversalProfile
+        // set data key SupportedStandards:LSP3UniversalProfile
         _setData(_LSP3_SUPPORTED_STANDARDS_KEY, _LSP3_SUPPORTED_STANDARDS_VALUE);
     }
 }


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation + Chore

In LSP0 and UP contracts, rename the parameter from `newOwner` to `initialOwner` for the `constructor`, public `initialize(address)` and ``_initialize(...)` function.

Improve the Natspec tags for these functions for the tags `@dev` and `@notice`.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote Documentation
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
