### PR TITLE
chore: simplify comments for PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,43 +9,17 @@
 <!-- Keep the sub-header that suits the PR and remove the rest -->
 
 <!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->
+
 <!---
 ## ⚠️ BREAKING CHANGES
----->
-
-<!---
 ## 🚀 Feature
----->
-
-<!---
 ## 🐛 Bug
----->
-
-<!---
 ## ♻️ Refactor
----->
-
-<!---
 ## 🧪 Tests
----->
-
-<!---
 ## ⚡️ Performance
----->
-
-<!---
 ## 🎨 Style
----->
-
-<!---
 ## 📄 Documentation
----->
-
-<!---
 ## 📦 Build
----->
-
-<!---
 ## 🤖 CI
 ---->
 


### PR DESCRIPTION
# What does this PR introduce?

Simplify the comments in the PR template, to have all the headings listed together in the same Markdown comment.