### PR TITLE
refactor: initialize local variables to `0` (iterators) and `false` for booleans

### DIFF
--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -304,7 +304,7 @@ library LSP2Utils {
          *
          * The pointer can only land on the length of the following bytes value.
          */
-        uint256 pointer;
+        uint256 pointer = 0;
 
         /**
          * Check each length byte and make sure that when you reach the last length byte.

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -155,7 +155,7 @@ abstract contract LSP6KeyManagerCore is
         bytes[] memory results = new bytes[](payloads.length);
         uint256 totalValues;
 
-        for (uint256 ii; ii < payloads.length; ) {
+        for (uint256 ii = 0; ii < payloads.length; ) {
             if ((totalValues += values[ii]) > msg.value) {
                 revert LSP6BatchInsufficientValueSent(totalValues, msg.value);
             }
@@ -208,7 +208,7 @@ abstract contract LSP6KeyManagerCore is
         bytes[] memory results = new bytes[](payloads.length);
         uint256 totalValues;
 
-        for (uint256 ii; ii < payloads.length; ) {
+        for (uint256 ii = 0; ii < payloads.length; ) {
             if ((totalValues += values[ii]) > msg.value) {
                 revert LSP6BatchInsufficientValueSent(totalValues, msg.value);
             }

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -226,7 +226,7 @@ abstract contract LSP6ExecuteModule {
 
         bytes4 requiredCallTypes = _extractCallType(operationType, value, isEmptyCall);
 
-        for (uint256 ii; ii < allowedCalls.length; ii += 34) {
+        for (uint256 ii = 0; ii < allowedCalls.length; ii += 34) {
             /// @dev structure of an AllowedCall
             //
             /// AllowedCall = 0x00200000000ncafecafecafecafecafecafecafecafecafecafe5a5a5a5af1f1f1f1

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -107,13 +107,13 @@ abstract contract LSP6SetDataModule {
             revert ERC725Y_DataKeysValuesLengthMismatch();
         }
 
-        bool isSettingERC725YKeys;
+        bool isSettingERC725YKeys = false;
         bool[] memory validatedInputDataKeys = new bool[](inputDataKeys.length);
         uint256 inputDataKeysAllowed = 0;
 
         bytes32 requiredPermission;
 
-        uint256 ii;
+        uint256 ii = 0;
         do {
             requiredPermission = _getPermissionRequiredToSetDataKey(
                 controlledContract,

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -91,7 +91,7 @@ library LSP6Utils {
         pure
         returns (bool)
     {
-        uint256 pointer;
+        uint256 pointer = 0;
 
         while (pointer < allowedCallsCompacted.length) {
             if (pointer + 1 >= allowedCallsCompacted.length) return false;
@@ -120,7 +120,7 @@ library LSP6Utils {
     function isCompactBytesArrayOfAllowedERC725YDataKeys(
         bytes memory allowedERC725YDataKeysCompacted
     ) internal pure returns (bool) {
-        uint256 pointer;
+        uint256 pointer = 0;
 
         while (pointer < allowedERC725YDataKeysCompacted.length) {
             if (pointer + 1 >= allowedERC725YDataKeysCompacted.length) return false;


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

Slither reports uninitialized local variables in `LSP2Utils` and the `LSP6KeyManager`.

Initialize these variables to their default values `0` and `false` for the boolean `isSettingERC725YDataKeys`.

This improves the readability a bit while not adding to much gas in the deployment cost of the Key Manager (+12 gas for deploying a `LSP6KeyManager`).

<img width="1384" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/9e32a066-bd75-42b6-be22-168e3ddf2789">


### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
