### PR TITLE
chore: improve readability using number instead of long hex string

### DIFF
--- a/contracts/LSP17ContractExtension/LSP17Extension.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extension.sol
@@ -12,8 +12,6 @@ import {_INTERFACEID_LSP17_EXTENSION} from "./LSP17Constants.sol";
  * @dev To be inherited to provide context of the msg variable related to the extendable contract
  */
 abstract contract LSP17Extension is ERC165 {
-    // solhint-disable
-
     /**
      * @dev See {IERC165-supportsInterface}.
      */

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -61,10 +61,15 @@ abstract contract LSP6ExecuteModule {
         bytes calldata payload
     ) internal view virtual {
         // CHECK the offset of `data` is not pointing to the previous parameters
-        if (
-            bytes32(payload[100:132]) !=
-            0x0000000000000000000000000000000000000000000000000000000000000080
-        ) {
+        //
+        // offsets in calldata for ERC725X.execute(...) parameters (excluding function selector)
+        //
+        // - `operationType`: index 0 in calldata
+        // - `to`: index 32
+        // - `value`: index 64
+        // - `data`'s offset location: index 96
+        // - `data` starts at: index 128 (= 0x0000...0080)
+        if (bytes32(payload[100:132]) != bytes32(uint256(128))) {
             revert InvalidPayload(payload);
         }
 


### PR DESCRIPTION
# What does this PR introduce?

> Note: also removed in this PR a `// solhint-disable` comment that was unecessary

## ♻️ Refactor

Slither reports a literal with too many digits in `LSP6ExecuteModule`. The literal is related to the offset of `data` parameter when verifying `ERC725X.execute(...)` payloads in the Key Manager.

Refactor and use the offset as a plain number `128` to describe the index in the calldata where the `data` parameter is located + describe this line with code comments.

<img width="1521" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/22e3ba22-e450-4292-a724-2b0c88b3d088">

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote Documentation
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
