### PR TITLE
chore: set single quotes for strings in prettier configs 

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run linter
 
       - name: 🎨 Check Prettier Style
-        run: npx prettier --check .
+        run: npm run format:check
 
       # This will also generate the Typechain types used by the Chai tests
       - name: 🏗️ Build contract artifacts

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,7 +6,9 @@
       "options": {
         "tabWidth": 2,
         "printWidth": 100,
-        "trailingComma": "all"
+        "trailingComma": "all",
+        "singleQuote": true,
+        "semi": true
       }
     },
     {

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ["Mocks", "Legacy"],
+  skipFiles: ['Mocks', 'Legacy'],
 };

--- a/constants.ts
+++ b/constants.ts
@@ -3,7 +3,7 @@
  * @see https://github.com/lukso-network/LIPs/tree/main/LSPs
  */
 
-export * from "./contracts";
+export * from './contracts';
 
 // ERC165
 // ---------
@@ -14,28 +14,28 @@ export * from "./contracts";
  * with `supportsInterface(interfaceId)`.
  */
 export const INTERFACE_IDS = {
-  ERC165: "0x01ffc9a7",
-  ERC1271: "0x1626ba7e",
-  ERC20: "0x36372b07",
-  ERC223: "0x87d43052",
-  ERC721: "0x80ac58cd",
-  ERC721Metadata: "0x5b5e139f",
-  ERC777: "0xe58e113c",
-  ERC1155: "0xd9b67a26",
-  ERC725X: "0x7545acac",
-  ERC725Y: "0x629aa694",
-  LSP0ERC725Account: "0x3e89ad98",
-  LSP1UniversalReceiver: "0x6bb56a14",
-  LSP6KeyManager: "0x38bb3cdb",
-  LSP7DigitalAsset: "0xda1f85e4",
-  LSP8IdentifiableDigitalAsset: "0x622e7a01",
-  LSP9Vault: "0x28af17e6",
-  LSP11BasicSocialRecovery: "0x049a28f1",
-  LSP14Ownable2Step: "0x94be5999",
-  LSP17Extendable: "0xa918fa6b",
-  LSP17Extension: "0xcee78b40",
-  LSP20CallVerification: "0x1a0eb6a5",
-  LSP20CallVerifier: "0x480c0ec2",
+  ERC165: '0x01ffc9a7',
+  ERC1271: '0x1626ba7e',
+  ERC20: '0x36372b07',
+  ERC223: '0x87d43052',
+  ERC721: '0x80ac58cd',
+  ERC721Metadata: '0x5b5e139f',
+  ERC777: '0xe58e113c',
+  ERC1155: '0xd9b67a26',
+  ERC725X: '0x7545acac',
+  ERC725Y: '0x629aa694',
+  LSP0ERC725Account: '0x3e89ad98',
+  LSP1UniversalReceiver: '0x6bb56a14',
+  LSP6KeyManager: '0x38bb3cdb',
+  LSP7DigitalAsset: '0xda1f85e4',
+  LSP8IdentifiableDigitalAsset: '0x622e7a01',
+  LSP9Vault: '0x28af17e6',
+  LSP11BasicSocialRecovery: '0x049a28f1',
+  LSP14Ownable2Step: '0x94be5999',
+  LSP17Extendable: '0xa918fa6b',
+  LSP17Extension: '0xcee78b40',
+  LSP20CallVerification: '0x1a0eb6a5',
+  LSP20CallVerifier: '0x480c0ec2',
 };
 
 // ERC1271
@@ -46,8 +46,8 @@ export const INTERFACE_IDS = {
  * Can be used to check if a signature is valid or not.
  */
 export const ERC1271_VALUES = {
-  MAGIC_VALUE: "0x1626ba7e",
-  FAIL_VALUE: "0xffffffff",
+  MAGIC_VALUE: '0x1626ba7e',
+  FAIL_VALUE: '0xffffffff',
 };
 
 // LSP20
@@ -60,12 +60,12 @@ export const ERC1271_VALUES = {
 export const LSP20_MAGIC_VALUES = {
   VERIFY_CALL: {
     // bytes3(keccak256("lsp20VerifyCall(address,uint256,bytes)")) + "0x01"
-    WITH_POST_VERIFICATION: "0x9bf04b01",
+    WITH_POST_VERIFICATION: '0x9bf04b01',
     // bytes3(keccak256("lsp20VerifyCall(address,uint256,bytes)")) + "0x00"
-    NO_POST_VERIFICATION: "0x9bf04b00",
+    NO_POST_VERIFICATION: '0x9bf04b00',
   },
   // bytes4(keccak256("lsp20VerifyCallResult(bytes32,bytes)"))
-  VERIFY_CALL_RESULT: "0xd3fc45d3",
+  VERIFY_CALL_RESULT: '0xd3fc45d3',
 };
 
 // ERC725X
@@ -96,16 +96,16 @@ export type LSPSupportedStandard = { key: string; value: string };
  */
 export const SupportedStandards = {
   LSP3UniversalProfile: {
-    key: "0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38",
-    value: "0xabe425d6",
+    key: '0xeafec4d89fa9619884b60000abe425d64acd861a49b8ddf5c0b6962110481f38',
+    value: '0xabe425d6',
   } as LSPSupportedStandard,
   LSP4DigitalAsset: {
-    key: "0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c",
-    value: "0xa4d96624",
+    key: '0xeafec4d89fa9619884b60000a4d96624a38f7ac2d8d9a604ecf07c12c77e480c',
+    value: '0xa4d96624',
   } as LSPSupportedStandard,
   LSP9Vault: {
-    key: "0xeafec4d89fa9619884b600007c0334a14085fefa8b51ae5a40895018882bdb90",
-    value: "0x7c0334a1",
+    key: '0xeafec4d89fa9619884b600007c0334a14085fefa8b51ae5a40895018882bdb90',
+    value: '0x7c0334a1',
   } as LSPSupportedStandard,
 };
 
@@ -116,93 +116,93 @@ export const SupportedStandards = {
 export const ERC725YDataKeys = {
   LSP1: {
     // bytes10(keccak256('LSP1UniversalReceiverDelegate')) + bytes2(0)
-    LSP1UniversalReceiverDelegatePrefix: "0x0cfc51aec37c55a4d0b10000",
+    LSP1UniversalReceiverDelegatePrefix: '0x0cfc51aec37c55a4d0b10000',
 
     // keccak256('LSP1UniversalReceiverDelegate')
     LSP1UniversalReceiverDelegate:
-      "0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47",
+      '0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47',
   },
   LSP3: {
     SupportedStandards_LSP3: SupportedStandards.LSP3UniversalProfile.key,
 
     // keccak256('LSP3Profile')
-    LSP3Profile: "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5",
+    LSP3Profile: '0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5',
   },
   LSP4: {
     SupportedStandards_LSP4: SupportedStandards.LSP4DigitalAsset.key,
 
     // keccak256('LSP4TokenName')
-    LSP4TokenName: "0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1",
+    LSP4TokenName: '0xdeba1e292f8ba88238e10ab3c7f88bd4be4fac56cad5194b6ecceaf653468af1',
 
     // keccak256('LSP4TokenSymbol')
-    LSP4TokenSymbol: "0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756",
+    LSP4TokenSymbol: '0x2f0a68ab07768e01943a599e73362a0e17a63a72e94dd2e384d2c1d4db932756',
 
     // keccak256('LSP4Metadata')
-    LSP4Metadata: "0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e",
+    LSP4Metadata: '0x9afb95cacc9f95858ec44aa8c3b685511002e30ae54415823f406128b85b238e',
 
     // LSP4CreatorsMap:<address>  + bytes2(0)
-    LSP4CreatorsMap: "0x6de85eaf5d982b4e5da00000",
+    LSP4CreatorsMap: '0x6de85eaf5d982b4e5da00000',
 
     // keccak256('"LSP4Creators[]')
-    "LSP4Creators[]": {
-      length: "0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7",
-      index: "0x114bd03b3a46d48759680d81ebb2b414",
+    'LSP4Creators[]': {
+      length: '0x114bd03b3a46d48759680d81ebb2b414fda7d030a7105a851867accf1c2352e7',
+      index: '0x114bd03b3a46d48759680d81ebb2b414',
     } as LSP2ArrayKey,
   },
   LSP5: {
     // LSP5ReceivedAssetsMap:<address>  + bytes2(0)
-    LSP5ReceivedAssetsMap: "0x812c4334633eb816c80d0000",
+    LSP5ReceivedAssetsMap: '0x812c4334633eb816c80d0000',
 
     // keccak256('LSP5ReceivedAssets[]')
-    "LSP5ReceivedAssets[]": {
-      length: "0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b",
-      index: "0x6460ee3c0aac563ccbf76d6e1d07bada",
+    'LSP5ReceivedAssets[]': {
+      length: '0x6460ee3c0aac563ccbf76d6e1d07bada78e3a9514e6382b736ed3f478ab7b90b',
+      index: '0x6460ee3c0aac563ccbf76d6e1d07bada',
     } as LSP2ArrayKey,
   },
   LSP6: {
     // keccak256('AddressPermissions[]')
-    "AddressPermissions[]": {
-      length: "0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3",
-      index: "0xdf30dba06db6a30e65354d9a64c60986",
+    'AddressPermissions[]': {
+      length: '0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3',
+      index: '0xdf30dba06db6a30e65354d9a64c60986',
     } as LSP2ArrayKey,
 
-    AddressPermissionsPrefix: "0x4b80742de2bf",
+    AddressPermissionsPrefix: '0x4b80742de2bf',
 
     // AddressPermissions:Permissions:<address>  + bytes2(0)
-    "AddressPermissions:Permissions": "0x4b80742de2bf82acb3630000",
+    'AddressPermissions:Permissions': '0x4b80742de2bf82acb3630000',
 
     // AddressPermissions:AllowedERC725YDataKeys:<address>  + bytes2(0)
-    "AddressPermissions:AllowedERC725YDataKeys": "0x4b80742de2bf866c29110000",
+    'AddressPermissions:AllowedERC725YDataKeys': '0x4b80742de2bf866c29110000',
 
     // AddressPermissions:AllowedCalls:<address>  + bytes2(0)
-    "AddressPermissions:AllowedCalls": "0x4b80742de2bf393a64c70000",
+    'AddressPermissions:AllowedCalls': '0x4b80742de2bf393a64c70000',
   },
   LSP9: {
     SupportedStandards_LSP9: SupportedStandards.LSP9Vault.key,
   },
   LSP10: {
     // keccak256('LSP10VaultsMap') + bytes2(0)
-    LSP10VaultsMap: "0x192448c3c0f88c7f238c0000",
+    LSP10VaultsMap: '0x192448c3c0f88c7f238c0000',
 
     // keccak256('LSP10Vaults[]')
-    "LSP10Vaults[]": {
-      length: "0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06",
-      index: "0x55482936e01da86729a45d2b87a6b1d3",
+    'LSP10Vaults[]': {
+      length: '0x55482936e01da86729a45d2b87a6b1d3bc582bea0ec00e38bdb340e3af6f9f06',
+      index: '0x55482936e01da86729a45d2b87a6b1d3',
     } as LSP2ArrayKey,
   },
   LSP12: {
     // LSP12IssuedAssetsMap:<address>  + bytes2(0)
-    LSP12IssuedAssetsMap: "0x74ac2555c10b9349e78f0000",
+    LSP12IssuedAssetsMap: '0x74ac2555c10b9349e78f0000',
 
     // keccak256('LSP12IssuedAssets[]')
-    "LSP12IssuedAssets[]": {
-      length: "0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd",
-      index: "0x7c8c3416d6cda87cd42c71ea1843df28",
+    'LSP12IssuedAssets[]': {
+      length: '0x7c8c3416d6cda87cd42c71ea1843df28ac4850354f988d55ee2eaa47b6dc05cd',
+      index: '0x7c8c3416d6cda87cd42c71ea1843df28',
     } as LSP2ArrayKey,
   },
   LSP17: {
     // bytes10(keccak256('LSP17Extension')) + bytes2(0)
-    LSP17ExtensionPrefix: "0xcee78b4094da860110960000",
+    LSP17ExtensionPrefix: '0xcee78b4094da860110960000',
   },
 };
 
@@ -219,17 +219,17 @@ export const LSP6_VERSION: number = 6;
  * @dev The types of calls for an AllowedCall
  */
 export const CALLTYPE = {
-  VALUE: "0x00000001",
-  CALL: "0x00000002",
-  STATICCALL: "0x00000004",
-  DELEGATECALL: "0x00000008",
+  VALUE: '0x00000001',
+  CALL: '0x00000002',
+  STATICCALL: '0x00000004',
+  DELEGATECALL: '0x00000008',
 };
 
 /**
  * @dev `bytes32` hex value for all the LSP6 permissions excluding REENTRANCY, DELEGATECALL and SUPER_DELEGATECALL for security (these should be set manually)
  */
 export const ALL_PERMISSIONS: string =
-  "0x00000000000000000000000000000000000000000000000000000000003f3f7f";
+  '0x00000000000000000000000000000000000000000000000000000000003f3f7f';
 
 export type LSP6PermissionName = keyof typeof PERMISSIONS;
 
@@ -270,53 +270,53 @@ export const PERMISSIONS = {
 export const LSP1_TYPE_IDS = {
   // keccak256('LSP0OwnershipTransferStarted')
   LSP0OwnershipTransferStarted:
-    "0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926",
+    '0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926',
 
   // keccak256('LSP0OwnershipTransferred_SenderNotification')
   LSP0OwnershipTransferred_SenderNotification:
-    "0xa4e59c931d14f7c8a7a35027f92ee40b5f2886b9fdcdb78f30bc5ecce5a2f814",
+    '0xa4e59c931d14f7c8a7a35027f92ee40b5f2886b9fdcdb78f30bc5ecce5a2f814',
 
   // keccak256('LSP0OwnershipTransferred_RecipientNotification')
   LSP0OwnershipTransferred_RecipientNotification:
-    "0xceca317f109c43507871523e82dc2a3cc64dfa18f12da0b6db14f6e23f995538",
+    '0xceca317f109c43507871523e82dc2a3cc64dfa18f12da0b6db14f6e23f995538',
 
   // keccak256('LSP7Tokens_SenderNotification')
   LSP7Tokens_SenderNotification:
-    "0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea",
+    '0x429ac7a06903dbc9c13dfcb3c9d11df8194581fa047c96d7a4171fc7402958ea',
 
   // keccak256('LSP7Tokens_RecipientNotification')
   LSP7Tokens_RecipientNotification:
-    "0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c",
+    '0x20804611b3e2ea21c480dc465142210acf4a2485947541770ec1fb87dee4a55c',
 
   // keccak256('LSP8Tokens_SenderNotification')
   LSP8Tokens_SenderNotification:
-    "0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00",
+    '0xb23eae7e6d1564b295b4c3e3be402d9a2f0776c57bdf365903496f6fa481ab00',
 
   // keccak256('LSP8Tokens_RecipientNotification')
   LSP8Tokens_RecipientNotification:
-    "0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d",
+    '0x0b084a55ebf70fd3c06fd755269dac2212c4d3f0f4d09079780bfa50c1b2984d',
 
   // keccak256('LSP9OwnershipTransferStarted')
   LSP9OwnershipTransferStarted:
-    "0xaefd43f45fed1bcd8992f23c803b6f4ec45cf6b62b0d404d565f290a471e763f",
+    '0xaefd43f45fed1bcd8992f23c803b6f4ec45cf6b62b0d404d565f290a471e763f',
 
   // keccak256('LSP9OwnershipTransferred_SenderNotification')
   LSP9OwnershipTransferred_SenderNotification:
-    "0x0c622e58e6b7089ae35f1af1c86d997be92fcdd8c9509652022d41aa65169471",
+    '0x0c622e58e6b7089ae35f1af1c86d997be92fcdd8c9509652022d41aa65169471',
 
   // keccak256('LSP9OwnershipTransferred_RecipientNotification')
   LSP9OwnershipTransferred_RecipientNotification:
-    "0x79855c97dbc259ce395421d933d7bc0699b0f1561f988f09a9e8633fd542fe5c",
+    '0x79855c97dbc259ce395421d933d7bc0699b0f1561f988f09a9e8633fd542fe5c',
 
   // keccak256('LSP14OwnershipTransferStarted')
   LSP14OwnershipTransferStarted:
-    "0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0",
+    '0xee9a7c0924f740a2ca33d59b7f0c2929821ea9837ce043ce91c1823e9c4e52c0',
 
   // keccak256('LSP14OwnershipTransferred_SenderNotification')
   LSP14OwnershipTransferred_SenderNotification:
-    "0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c",
+    '0xa124442e1cc7b52d8e2ede2787d43527dc1f3ae0de87f50dd03e27a71834f74c',
 
   // keccak256('LSP14OwnershipTransferred_RecipientNotification')
   LSP14OwnershipTransferred_RecipientNotification:
-    "0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c",
+    '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
 };

--- a/deploy/001_deploy_universal_profile.ts
+++ b/deploy/001_deploy_universal_profile.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployUniversalProfile: DeployFunction = async ({
   deployments,
@@ -9,7 +9,7 @@ const deployUniversalProfile: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  await deploy("UniversalProfile", {
+  await deploy('UniversalProfile', {
     from: owner,
     args: [owner],
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
@@ -18,4 +18,4 @@ const deployUniversalProfile: DeployFunction = async ({
 };
 
 export default deployUniversalProfile;
-deployUniversalProfile.tags = ["UniversalProfile"];
+deployUniversalProfile.tags = ['UniversalProfile'];

--- a/deploy/002_deploy_key_manager.ts
+++ b/deploy/002_deploy_key_manager.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployKeyManager: DeployFunction = async ({
   deployments,
@@ -9,9 +9,9 @@ const deployKeyManager: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const UniversalProfile = await deployments.get("UniversalProfile");
+  const UniversalProfile = await deployments.get('UniversalProfile');
 
-  await deploy("LSP6KeyManager", {
+  await deploy('LSP6KeyManager', {
     from: owner,
     args: [UniversalProfile.address],
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
@@ -20,5 +20,5 @@ const deployKeyManager: DeployFunction = async ({
 };
 
 export default deployKeyManager;
-deployKeyManager.tags = ["LSP6KeyManager", "standard"];
-deployKeyManager.dependencies = ["UniversalProfile"];
+deployKeyManager.tags = ['LSP6KeyManager', 'standard'];
+deployKeyManager.dependencies = ['UniversalProfile'];

--- a/deploy/003_deploy_universal_receiver_delegate.ts
+++ b/deploy/003_deploy_universal_receiver_delegate.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployUniversalReceiverDelegateUP: DeployFunction = async ({
   deployments,
@@ -9,7 +9,7 @@ const deployUniversalReceiverDelegateUP: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  await deploy("LSP1UniversalReceiverDelegateUP", {
+  await deploy('LSP1UniversalReceiverDelegateUP', {
     from: owner,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
     log: true,
@@ -17,4 +17,4 @@ const deployUniversalReceiverDelegateUP: DeployFunction = async ({
 };
 
 export default deployUniversalReceiverDelegateUP;
-deployUniversalReceiverDelegateUP.tags = ["LSP1UniversalReceiverDelegateUP"];
+deployUniversalReceiverDelegateUP.tags = ['LSP1UniversalReceiverDelegateUP'];

--- a/deploy/005_deploy_universal_receiver_delegate_vault.ts
+++ b/deploy/005_deploy_universal_receiver_delegate_vault.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployUniversalReceiverDelegateVault: DeployFunction = async ({
   deployments,
@@ -9,7 +9,7 @@ const deployUniversalReceiverDelegateVault: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  await deploy("LSP1UniversalReceiverDelegateVault", {
+  await deploy('LSP1UniversalReceiverDelegateVault', {
     from: owner,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
     log: true,
@@ -17,4 +17,4 @@ const deployUniversalReceiverDelegateVault: DeployFunction = async ({
 };
 
 export default deployUniversalReceiverDelegateVault;
-deployUniversalReceiverDelegateVault.tags = ["LSP1UniversalReceiverDelegateVault"];
+deployUniversalReceiverDelegateVault.tags = ['LSP1UniversalReceiverDelegateVault'];

--- a/deploy/006_deploy_base_universal_profile.ts
+++ b/deploy/006_deploy_base_universal_profile.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployBaseUniversalProfile: DeployFunction = async ({
   deployments,
@@ -9,15 +9,15 @@ const deployBaseUniversalProfile: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("UniversalProfileInit", {
+  const deployResult = await deploy('UniversalProfileInit', {
     from: owner,
     log: true,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
   });
 
-  const UniversalProfileInit = await ethers.getContractFactory("UniversalProfileInit");
+  const UniversalProfileInit = await ethers.getContractFactory('UniversalProfileInit');
   const universalProfileInit = await UniversalProfileInit.attach(deployResult.address);
 };
 
 export default deployBaseUniversalProfile;
-deployBaseUniversalProfile.tags = ["UniversalProfileInit", "base"];
+deployBaseUniversalProfile.tags = ['UniversalProfileInit', 'base'];

--- a/deploy/007_deploy_base_key_manager.ts
+++ b/deploy/007_deploy_base_key_manager.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployBaseKeyManager: DeployFunction = async ({
   deployments,
@@ -9,16 +9,16 @@ const deployBaseKeyManager: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP6KeyManagerInit", {
+  const deployResult = await deploy('LSP6KeyManagerInit', {
     from: owner,
     log: true,
     gasLimit: 5_000_000,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
   });
 
-  const KeyManagerInit = await ethers.getContractFactory("LSP6KeyManagerInit");
+  const KeyManagerInit = await ethers.getContractFactory('LSP6KeyManagerInit');
   const keyManagerInit = await KeyManagerInit.attach(deployResult.address);
 };
 
 export default deployBaseKeyManager;
-deployBaseKeyManager.tags = ["LSP6KeyManagerInit", "base"];
+deployBaseKeyManager.tags = ['LSP6KeyManagerInit', 'base'];

--- a/deploy/008_deploy_lsp7_mintable.ts
+++ b/deploy/008_deploy_lsp7_mintable.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployLSP7Mintable: DeployFunction = async ({
   deployments,
@@ -9,13 +9,13 @@ const deployLSP7Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP7Mintable", {
+  const deployResult = await deploy('LSP7Mintable', {
     from: owner,
-    args: ["LSP7 Mintable", "LSP7M", owner, false],
+    args: ['LSP7 Mintable', 'LSP7M', owner, false],
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
     log: true,
   });
 };
 
 export default deployLSP7Mintable;
-deployLSP7Mintable.tags = ["LSP7Mintable", "standard"];
+deployLSP7Mintable.tags = ['LSP7Mintable', 'standard'];

--- a/deploy/009_deploy_lsp8_mintable.ts
+++ b/deploy/009_deploy_lsp8_mintable.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployLSP8Mintable: DeployFunction = async ({
   deployments,
@@ -9,13 +9,13 @@ const deployLSP8Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP8Mintable", {
+  const deployResult = await deploy('LSP8Mintable', {
     from: owner,
-    args: ["LSP8 Mintable", "LSP8M", owner],
+    args: ['LSP8 Mintable', 'LSP8M', owner],
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
     log: true,
   });
 };
 
 export default deployLSP8Mintable;
-deployLSP8Mintable.tags = ["LSP8Mintable", "standard"];
+deployLSP8Mintable.tags = ['LSP8Mintable', 'standard'];

--- a/deploy/010_deploy_base_lsp7_mintable.ts
+++ b/deploy/010_deploy_base_lsp7_mintable.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployBaseLSP7Mintable: DeployFunction = async ({
   deployments,
@@ -9,15 +9,15 @@ const deployBaseLSP7Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP7MintableInit", {
+  const deployResult = await deploy('LSP7MintableInit', {
     from: owner,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
     log: true,
   });
 
-  const LSP7MintableInit = await ethers.getContractFactory("LSP7MintableInit");
+  const LSP7MintableInit = await ethers.getContractFactory('LSP7MintableInit');
   const lsp7MintableInit = await LSP7MintableInit.attach(deployResult.address);
 };
 
 export default deployBaseLSP7Mintable;
-deployBaseLSP7Mintable.tags = ["LSP7MintableInit", "base"];
+deployBaseLSP7Mintable.tags = ['LSP7MintableInit', 'base'];

--- a/deploy/011_deploy_base_lsp8_mintable.ts
+++ b/deploy/011_deploy_base_lsp8_mintable.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployBaseLSP8Mintable: DeployFunction = async ({
   deployments,
@@ -9,15 +9,15 @@ const deployBaseLSP8Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP8MintableInit", {
+  const deployResult = await deploy('LSP8MintableInit', {
     from: owner,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
     log: true,
   });
 
-  const LSP8MintableInit = await ethers.getContractFactory("LSP8MintableInit");
+  const LSP8MintableInit = await ethers.getContractFactory('LSP8MintableInit');
   const lsp8MintableInit = await LSP8MintableInit.attach(deployResult.address);
 };
 
 export default deployBaseLSP8Mintable;
-deployBaseLSP8Mintable.tags = ["LSP8MintableInit", "base"];
+deployBaseLSP8Mintable.tags = ['LSP8MintableInit', 'base'];

--- a/deploy/012_deploy_vault.ts
+++ b/deploy/012_deploy_vault.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployVault: DeployFunction = async ({
   deployments,
@@ -9,7 +9,7 @@ const deployVault: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  await deploy("LSP9Vault", {
+  await deploy('LSP9Vault', {
     from: owner,
     args: [owner],
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
@@ -18,4 +18,4 @@ const deployVault: DeployFunction = async ({
 };
 
 export default deployVault;
-deployVault.tags = ["LSP9Vault"];
+deployVault.tags = ['LSP9Vault'];

--- a/deploy/013_deploy_base_vault.ts
+++ b/deploy/013_deploy_base_vault.ts
@@ -1,6 +1,6 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types";
-import { DeployFunction } from "hardhat-deploy/types";
-import { ethers } from "hardhat";
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+import { ethers } from 'hardhat';
 
 const deployBaseVault: DeployFunction = async ({
   deployments,
@@ -9,15 +9,15 @@ const deployBaseVault: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
-  const deployResult = await deploy("LSP9VaultInit", {
+  const deployResult = await deploy('LSP9VaultInit', {
     from: owner,
     log: true,
     gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
   });
 
-  const LSP9VaultInit = await ethers.getContractFactory("LSP9VaultInit");
+  const LSP9VaultInit = await ethers.getContractFactory('LSP9VaultInit');
   const vaultInit = await LSP9VaultInit.attach(deployResult.address);
 };
 
 export default deployBaseVault;
-deployBaseVault.tags = ["LSP9VaultInit", "base"];
+deployBaseVault.tags = ['LSP9VaultInit', 'base'];

--- a/dodoc/config.ts
+++ b/dodoc/config.ts
@@ -1,127 +1,127 @@
-import { ethers } from "ethers";
-import { HelperContent } from "squirrelly/dist/types/containers";
+import { ethers } from 'ethers';
+import { HelperContent } from 'squirrelly/dist/types/containers';
 
 export const dodocConfig = {
   runOnCompile: false,
   include: [
-    "UniversalProfile.sol",
-    "LSP0ERC725Account/LSP0ERC725Account.sol",
-    "LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol",
-    "LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol",
-    "LSP6KeyManager/LSP6KeyManager.sol",
-    "LSP9Vault/LSP9Vault.sol",
-    "LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol",
-    "LSP14Ownable2Step/LSP14Ownable2Step.sol",
-    "LSP16UniversalFactory/LSP16UniversalFactory.sol",
-    "LSP17ContractExtension/LSP17Extendable.sol",
-    "LSP17ContractExtension/LSP17Extension.sol",
-    "LSP20CallVerification/LSP20CallVerification.sol",
+    'UniversalProfile.sol',
+    'LSP0ERC725Account/LSP0ERC725Account.sol',
+    'LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol',
+    'LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol',
+    'LSP6KeyManager/LSP6KeyManager.sol',
+    'LSP9Vault/LSP9Vault.sol',
+    'LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol',
+    'LSP14Ownable2Step/LSP14Ownable2Step.sol',
+    'LSP16UniversalFactory/LSP16UniversalFactory.sol',
+    'LSP17ContractExtension/LSP17Extendable.sol',
+    'LSP17ContractExtension/LSP17Extension.sol',
+    'LSP20CallVerification/LSP20CallVerification.sol',
 
     // tokens
-    "LSP4DigitalAssetMetadata/LSP4Compatibility.sol",
-    "LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol",
-    "LSP7DigitalAsset/LSP7DigitalAsset.sol",
-    "LSP7DigitalAsset/extensions/LSP7Burnable.sol",
-    "LSP7DigitalAsset/extensions/LSP7CappedSupply.sol",
-    "LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol",
-    "LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol",
-    "LSP7DigitalAsset/presets/LSP7Mintable.sol",
-    "LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol",
-    "LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol",
-    "LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol",
-    "LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol",
-    "LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol",
-    "LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol",
-    "LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol",
+    'LSP4DigitalAssetMetadata/LSP4Compatibility.sol',
+    'LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol',
+    'LSP7DigitalAsset/LSP7DigitalAsset.sol',
+    'LSP7DigitalAsset/extensions/LSP7Burnable.sol',
+    'LSP7DigitalAsset/extensions/LSP7CappedSupply.sol',
+    'LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol',
+    'LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol',
+    'LSP7DigitalAsset/presets/LSP7Mintable.sol',
+    'LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol',
+    'LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol',
+    'LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol',
+    'LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol',
+    'LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol',
+    'LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol',
+    'LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol',
 
     // libraries --------------------
-    "LSP0ERC725Account/LSP0Utils.sol",
-    "LSP1UniversalReceiver/LSP1Utils.sol",
-    "LSP2ERC725YJSONSchema/LSP2Utils.sol",
-    "LSP5ReceivedAssets/LSP5Utils.sol",
-    "LSP6KeyManager/LSP6Utils.sol",
-    "LSP10ReceivedVaults/LSP10Utils.sol",
-    "LSP17ContractExtension/LSP17Utils.sol",
+    'LSP0ERC725Account/LSP0Utils.sol',
+    'LSP1UniversalReceiver/LSP1Utils.sol',
+    'LSP2ERC725YJSONSchema/LSP2Utils.sol',
+    'LSP5ReceivedAssets/LSP5Utils.sol',
+    'LSP6KeyManager/LSP6Utils.sol',
+    'LSP10ReceivedVaults/LSP10Utils.sol',
+    'LSP17ContractExtension/LSP17Utils.sol',
   ],
   libraries: [
-    "LSP0Utils",
-    "LSP1Utils",
-    "LSP2Utils",
-    "LSP5Utils",
-    "LSP6Utils",
-    "LSP10Utils",
-    "LSP17Utils",
+    'LSP0Utils',
+    'LSP1Utils',
+    'LSP2Utils',
+    'LSP5Utils',
+    'LSP6Utils',
+    'LSP10Utils',
+    'LSP17Utils',
   ],
-  templatePath: "./dodoc/template.sqrl",
+  templatePath: './dodoc/template.sqrl',
   helpers: [
     {
-      helperName: "formatTextWithLists",
+      helperName: 'formatTextWithLists',
       helperFunc: (content: HelperContent) => content.exec(formatTextWithLists(content.params[0])),
     },
     {
-      helperName: "createLocalLinks",
+      helperName: 'createLocalLinks',
       helperFunc: (content: HelperContent) => content.exec(createLocalLinks(content.params[0])),
     },
     {
-      helperName: "formatLinks",
+      helperName: 'formatLinks',
       helperFunc: (content: HelperContent) => content.exec(formatLinks(content.params[0])),
     },
     {
-      helperName: "splitMethods",
+      helperName: 'splitMethods',
       helperFunc: (content: HelperContent) => content.exec(splitMethods(content.params[0])),
     },
     {
-      helperName: "parseNotice",
+      helperName: 'parseNotice',
       helperFunc: (content: HelperContent) =>
         formatTextWithLists(createLocalLinks(content.params[0])),
     },
     {
-      helperName: "parseDetails",
+      helperName: 'parseDetails',
       helperFunc: (content: HelperContent) =>
         formatTextWithLists(createLocalLinks(content.params[0])),
     },
     {
-      helperName: "parseCustomRequirements",
+      helperName: 'parseCustomRequirements',
       helperFunc: (content: HelperContent) =>
-        formatBulletPointsWithTitle(createLocalLinks(content.params[0]), "Requirements:"),
+        formatBulletPointsWithTitle(createLocalLinks(content.params[0]), 'Requirements:'),
     },
     {
-      helperName: "parseCustomEvents",
+      helperName: 'parseCustomEvents',
       helperFunc: (content: HelperContent) =>
-        formatBulletPointsWithTitle(createLocalLinks(content.params[0]), "Emitted events:"),
+        formatBulletPointsWithTitle(createLocalLinks(content.params[0]), 'Emitted events:'),
     },
     {
-      helperName: "generateAdditionalMethodInfo",
+      helperName: 'generateAdditionalMethodInfo',
       helperFunc: (content: HelperContent) =>
         generateAdditionalMethodInfo(content.params[0], content.params[1]),
     },
     {
-      helperName: "generateAdditionalEventInfo",
+      helperName: 'generateAdditionalEventInfo',
       helperFunc: (content: HelperContent) =>
         generateAdditionalEventInfo(content.params[0], content.params[1]),
     },
     {
-      helperName: "generateAdditionalErrorInfo",
+      helperName: 'generateAdditionalErrorInfo',
       helperFunc: (content: HelperContent) =>
         generateAdditionalErrorInfo(content.params[0], content.params[1]),
     },
     {
-      helperName: "generateContractLink",
+      helperName: 'generateContractLink',
       helperFunc: (content: HelperContent) => generateContractLink(content.params[0]),
     },
   ],
 };
 
-const linkBase = "https://github.com/lukso-network/";
+const linkBase = 'https://github.com/lukso-network/';
 
 const createLocalLinks = (textToFormat: string) => {
   let formatedText = textToFormat;
 
   [...textToFormat.matchAll(/{.+?}/g)].forEach((elem) => {
-    if (!elem[0].includes(" ")) {
-      const clearedElem = elem[0].replace("{", "").replace("}", "");
+    if (!elem[0].includes(' ')) {
+      const clearedElem = elem[0].replace('{', '').replace('}', '');
       const linkFirstHalf = `[\`${clearedElem}\`]`;
-      const linkSecondHalf = `(#${clearedElem.toLowerCase().split("(")[0]})`;
+      const linkSecondHalf = `(#${clearedElem.toLowerCase().split('(')[0]})`;
       formatedText = formatedText.replace(elem[0], linkFirstHalf + linkSecondHalf);
     }
   });
@@ -135,9 +135,9 @@ const splitMethods = (methods) => {
 
   for (const method in methods) {
     if (
-      method.startsWith("constructor") ||
-      method.startsWith("fallback") ||
-      method.startsWith("receive")
+      method.startsWith('constructor') ||
+      method.startsWith('fallback') ||
+      method.startsWith('receive')
     )
       specialMethods[method] = methods[method];
     else normalMethods[method] = methods[method];
@@ -150,7 +150,7 @@ const formatLinks = (textToFormat: string) => {
   let formatedText: string = textToFormat;
   [...textToFormat.matchAll(/\s\w+\s+http\S+/g)].forEach((element) => {
     const tuple = element[0].trim();
-    const firstSpace = tuple.indexOf(" ");
+    const firstSpace = tuple.indexOf(' ');
     const title = tuple.substring(0, firstSpace);
     const link = tuple.substring(firstSpace).trim();
     formatedText = formatedText.replace(tuple, `[**${title}**](${link})`);
@@ -173,29 +173,29 @@ const formatTextWithLists = (textToFormat: string) => {
 
 const formatCode = (code: string, type: string) => {
   let formatedCode = code
-    .substring(0, code.indexOf(")") + 1)
-    .replace(`${type.toLowerCase()}`, "")
+    .substring(0, code.indexOf(')') + 1)
+    .replace(`${type.toLowerCase()}`, '')
     .trim();
 
-  if (!formatedCode.endsWith("()")) {
+  if (!formatedCode.endsWith('()')) {
     formatedCode =
       formatedCode
-        .split(",")
-        .map((elem) => elem.trim().substring(0, elem.trim().indexOf(" ")))
-        .toString() + ")";
+        .split(',')
+        .map((elem) => elem.trim().substring(0, elem.trim().indexOf(' ')))
+        .toString() + ')';
   }
 
   return formatedCode;
 };
 
 const formatBulletPointsWithTitle = (textToFormat: string, title: string) => {
-  if (textToFormat.length === 0) return "";
+  if (textToFormat.length === 0) return '';
 
   let formatedText: string = `**${title}**\n\n`;
 
-  if (textToFormat.startsWith("- ")) textToFormat = " " + textToFormat;
+  if (textToFormat.startsWith('- ')) textToFormat = ' ' + textToFormat;
 
-  textToFormat.split(" - ").forEach((elem) => {
+  textToFormat.split(' - ').forEach((elem) => {
     if (elem.trim().length !== 0) formatedText += `- ${elem.trim()}\n`;
   });
 
@@ -203,19 +203,19 @@ const formatBulletPointsWithTitle = (textToFormat: string, title: string) => {
 };
 
 const generateAdditionalMethodInfo = (contract: string, code: string) => {
-  const formatedCode = formatCode(code, "function");
+  const formatedCode = formatCode(code, 'function');
   const contractLink = generateContractLink(contract);
   const { specsName, specsLink } = generateContractSpecsDetails(contract);
 
   let infoBlock =
     `- Specification details in [**${specsName}**](${specsLink}#${formatedCode
-      .split("(")[0]
+      .split('(')[0]
       .toLowerCase()})\n` + `- Solidity implementation in [**${contract}**](${contractLink})\n`;
 
   if (
-    !formatedCode.startsWith("constructor") &&
-    !formatedCode.startsWith("fallback") &&
-    !formatedCode.startsWith("receive")
+    !formatedCode.startsWith('constructor') &&
+    !formatedCode.startsWith('fallback') &&
+    !formatedCode.startsWith('receive')
   ) {
     infoBlock +=
       `- Function signature: \`${formatedCode}\`\n` +
@@ -228,13 +228,13 @@ const generateAdditionalMethodInfo = (contract: string, code: string) => {
 };
 
 const generateAdditionalEventInfo = (contract: string, code: string) => {
-  const formatedCode = formatCode(code, "event");
+  const formatedCode = formatCode(code, 'event');
   const contractLink = generateContractLink(contract);
   const { specsName, specsLink } = generateContractSpecsDetails(contract);
 
   return (
     `- Specification details in [**${specsName}**](${specsLink}#${formatedCode
-      .split("(")[0]
+      .split('(')[0]
       .toLowerCase()})\n` +
     `- Solidity implementation in [**${contract}**](${contractLink})\n` +
     `- Event signature: \`${formatedCode}\`\n` +
@@ -243,13 +243,13 @@ const generateAdditionalEventInfo = (contract: string, code: string) => {
 };
 
 const generateAdditionalErrorInfo = (contract: string, code: string) => {
-  const formatedCode = formatCode(code, "error");
+  const formatedCode = formatCode(code, 'error');
   const contractLink = generateContractLink(contract);
   const { specsName, specsLink } = generateContractSpecsDetails(contract);
 
   return (
     `- Specification details in [**${specsName}**](${specsLink}#${formatedCode
-      .split("(")[0]
+      .split('(')[0]
       .toLowerCase()})\n` +
     `- Solidity implementation in [**${contract}**](${contractLink})\n` +
     `- Error signature: \`${formatedCode}\`\n` +
@@ -260,7 +260,7 @@ const generateAdditionalErrorInfo = (contract: string, code: string) => {
 };
 
 const generateContractLink = (contractName: string) => {
-  if (contractName === "UniversalProfile")
+  if (contractName === 'UniversalProfile')
     return `${linkBase}lsp-smart-contracts/blob/develop/contracts/UniversalProfile.sol`;
 
   const contractPath = dodocConfig.include.filter((value) => {
@@ -271,7 +271,7 @@ const generateContractLink = (contractName: string) => {
 };
 
 const generateContractSpecsDetails = (contractName: string) => {
-  if (contractName === "UniversalProfile")
+  if (contractName === 'UniversalProfile')
     return {
       specsName: `${contractName}`,
       specsLink: `${linkBase}lips/tree/main/LSPs/LSP-3-UniversalProfile-Metadata.md`,
@@ -281,7 +281,7 @@ const generateContractSpecsDetails = (contractName: string) => {
     if (value.endsWith(`${contractName}.sol`)) return value;
   })[0];
 
-  const specs = contractPath.split("/")[0];
+  const specs = contractPath.split('/')[0];
 
   const specsName = `LSP-${specs.match(/\d+/)[0]}-${specs.split(/LSP\d+/)[1]}`;
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,7 +1,7 @@
-import { HardhatUserConfig } from "hardhat/config";
-import { NetworkUserConfig } from "hardhat/types";
-import { config as dotenvConfig } from "dotenv";
-import { resolve } from "path";
+import { HardhatUserConfig } from 'hardhat/config';
+import { NetworkUserConfig } from 'hardhat/types';
+import { config as dotenvConfig } from 'dotenv';
+import { resolve } from 'path';
 
 /**
  * this package includes:
@@ -12,41 +12,41 @@ import { resolve } from "path";
  *  - @typechain/hardhat
  *  - solidity-coverage
  */
-import "@nomicfoundation/hardhat-toolbox";
+import '@nomicfoundation/hardhat-toolbox';
 
 // additional hardhat plugins
-import "hardhat-packager";
-import "hardhat-contract-sizer";
-import "hardhat-deploy";
-import "./scripts/ci/docs-generate";
+import 'hardhat-packager';
+import 'hardhat-contract-sizer';
+import 'hardhat-deploy';
+import './scripts/ci/docs-generate';
 
 // Typescript types for web3.js
-import "@nomiclabs/hardhat-web3";
+import '@nomiclabs/hardhat-web3';
 
 /**
  * @dev uncomment to generate contract docs in Markdown
  */
-import "@b00ste/hardhat-dodoc";
-import { dodocConfig } from "./dodoc/config";
+import '@b00ste/hardhat-dodoc';
+import { dodocConfig } from './dodoc/config';
 
-dotenvConfig({ path: resolve(__dirname, "./.env") });
+dotenvConfig({ path: resolve(__dirname, './.env') });
 
 function getTestnetChainConfig(): NetworkUserConfig {
   const config: NetworkUserConfig = {
     live: true,
-    url: "https://rpc.testnet.lukso.network",
+    url: 'https://rpc.testnet.lukso.network',
     chainId: 4201,
   };
 
   if (process.env.CONTRACT_VERIFICATION_TESTNET_PK !== undefined) {
-    config["accounts"] = [process.env.CONTRACT_VERIFICATION_TESTNET_PK];
+    config['accounts'] = [process.env.CONTRACT_VERIFICATION_TESTNET_PK];
   }
 
   return config;
 }
 
 const config: HardhatUserConfig = {
-  defaultNetwork: "hardhat",
+  defaultNetwork: 'hardhat',
   networks: {
     hardhat: {
       live: false,
@@ -59,28 +59,28 @@ const config: HardhatUserConfig = {
     owner: 0,
   },
   etherscan: {
-    apiKey: "no-api-key-needed",
+    apiKey: 'no-api-key-needed',
     customChains: [
       {
-        network: "luksoTestnet",
+        network: 'luksoTestnet',
         chainId: 4201,
         urls: {
-          apiURL: "https://explorer.execution.testnet.lukso.network/api",
-          browserURL: "https://explorer.execution.testnet.lukso.network/",
+          apiURL: 'https://explorer.execution.testnet.lukso.network/api',
+          browserURL: 'https://explorer.execution.testnet.lukso.network/',
         },
       },
     ],
   },
   gasReporter: {
     enabled: true,
-    currency: "USD",
+    currency: 'USD',
     gasPrice: 21,
-    excludeContracts: ["Helpers/"],
-    src: "./contracts",
+    excludeContracts: ['Helpers/'],
+    src: './contracts',
     showMethodSig: true,
   },
   solidity: {
-    version: "0.8.15",
+    version: '0.8.15',
     settings: {
       optimizer: {
         enabled: true,
@@ -93,8 +93,8 @@ const config: HardhatUserConfig = {
         runs: 1000,
       },
       outputSelection: {
-        "*": {
-          "*": ["storageLayout"],
+        '*': {
+          '*': ['storageLayout'],
         },
       },
     },
@@ -104,64 +104,64 @@ const config: HardhatUserConfig = {
     contracts: [
       // Standard version
       // ------------------
-      "UniversalProfile",
-      "LSP0ERC725Account",
-      "LSP1UniversalReceiverDelegateUP",
-      "LSP1UniversalReceiverDelegateVault",
-      "LSP4DigitalAssetMetadata",
-      "LSP6KeyManager",
-      "LSP7DigitalAsset",
-      "LSP7CappedSupply",
-      "LSP7Mintable",
-      "LSP8IdentifiableDigitalAsset",
-      "LSP8CappedSupply",
-      "LSP8Mintable",
-      "LSP9Vault",
-      "LSP11BasicSocialRecovery",
+      'UniversalProfile',
+      'LSP0ERC725Account',
+      'LSP1UniversalReceiverDelegateUP',
+      'LSP1UniversalReceiverDelegateVault',
+      'LSP4DigitalAssetMetadata',
+      'LSP6KeyManager',
+      'LSP7DigitalAsset',
+      'LSP7CappedSupply',
+      'LSP7Mintable',
+      'LSP8IdentifiableDigitalAsset',
+      'LSP8CappedSupply',
+      'LSP8Mintable',
+      'LSP9Vault',
+      'LSP11BasicSocialRecovery',
       // Proxy version
       // ------------------
-      "UniversalProfileInit",
-      "LSP0ERC725AccountInit",
-      "LSP4DigitalAssetMetadataInitAbstract",
-      "LSP6KeyManagerInit",
-      "LSP7DigitalAssetInitAbstract",
-      "LSP7CappedSupplyInitAbstract",
-      "LSP7MintableInit",
-      "LSP8IdentifiableDigitalAssetInitAbstract",
-      "LSP8CappedSupplyInitAbstract",
-      "LSP8MintableInit",
-      "LSP9VaultInit",
-      "LSP11BasicSocialRecoveryInit",
+      'UniversalProfileInit',
+      'LSP0ERC725AccountInit',
+      'LSP4DigitalAssetMetadataInitAbstract',
+      'LSP6KeyManagerInit',
+      'LSP7DigitalAssetInitAbstract',
+      'LSP7CappedSupplyInitAbstract',
+      'LSP7MintableInit',
+      'LSP8IdentifiableDigitalAssetInitAbstract',
+      'LSP8CappedSupplyInitAbstract',
+      'LSP8MintableInit',
+      'LSP9VaultInit',
+      'LSP11BasicSocialRecoveryInit',
       // ERC Compatible tokens
       // ------------------
-      "LSP4Compatibility",
-      "LSP7CompatibleERC20",
-      "LSP7CompatibleERC20InitAbstract",
-      "LSP7CompatibleERC20Mintable",
-      "LSP7CompatibleERC20MintableInit",
-      "LSP8CompatibleERC721",
-      "LSP8CompatibleERC721InitAbstract",
-      "LSP8CompatibleERC721Mintable",
-      "LSP8CompatibleERC721MintableInit",
+      'LSP4Compatibility',
+      'LSP7CompatibleERC20',
+      'LSP7CompatibleERC20InitAbstract',
+      'LSP7CompatibleERC20Mintable',
+      'LSP7CompatibleERC20MintableInit',
+      'LSP8CompatibleERC721',
+      'LSP8CompatibleERC721InitAbstract',
+      'LSP8CompatibleERC721Mintable',
+      'LSP8CompatibleERC721MintableInit',
       // Legacy L14
       // ------------------
-      "UniversalReceiverAddressStore",
+      'UniversalReceiverAddressStore',
       // Tools
       // ------------------
-      "Create2Factory",
-      "LSP16UniversalFactory",
+      'Create2Factory',
+      'LSP16UniversalFactory',
     ],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,
   },
   paths: {
-    artifacts: "artifacts",
-    tests: "tests",
+    artifacts: 'artifacts',
+    tests: 'tests',
   },
   typechain: {
-    outDir: "types",
-    target: "ethers-v5",
+    outDir: 'types',
+    target: 'ethers-v5',
   },
   dodoc: dodocConfig,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "npm-run-all": "^4.1.5",
         "pluralize": "^8.0.0",
         "prettier": "~2.8.8",
-        "prettier-plugin-solidity": "~1.1.0",
+        "prettier-plugin-solidity": "^1.1.3",
         "rollup-plugin-esbuild": "^5.0.0",
         "solhint": "^3.3.6",
         "standard-version": "^9.3.1",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "npm-run-all": "^4.1.5",
     "pluralize": "^8.0.0",
     "prettier": "~2.8.8",
-    "prettier-plugin-solidity": "~1.1.0",
+    "prettier-plugin-solidity": "^1.1.3",
     "rollup-plugin-esbuild": "^5.0.0",
     "solhint": "^3.3.6",
     "standard-version": "^9.3.1",

--- a/scripts/ci/check-deployer-balance.ts
+++ b/scripts/ci/check-deployer-balance.ts
@@ -1,16 +1,16 @@
-import { ethers, config } from "hardhat";
-import { config as dotenvConfig } from "dotenv";
-import { resolve } from "path";
+import { ethers, config } from 'hardhat';
+import { config as dotenvConfig } from 'dotenv';
+import { resolve } from 'path';
 
-dotenvConfig({ path: resolve(__dirname, "./.env") });
+dotenvConfig({ path: resolve(__dirname, './.env') });
 
 const wallet = new ethers.Wallet(process.env.CONTRACT_VERIFICATION_TESTNET_PK);
 const deployerAddress = wallet.address;
 
-const provider = new ethers.providers.JsonRpcProvider(config.networks.luksoTestnet["url"]);
+const provider = new ethers.providers.JsonRpcProvider(config.networks.luksoTestnet['url']);
 
 // the CI deploys all the contracts, so we need to make sure that the deployer has enough balance
-const MINIMUM_DEPLOYER_BALANCE = ethers.utils.parseUnits("1.0", "ether");
+const MINIMUM_DEPLOYER_BALANCE = ethers.utils.parseUnits('1.0', 'ether');
 
 async function main() {
   const deployerBalance = await provider.getBalance(deployerAddress);

--- a/scripts/ci/docs-generate.ts
+++ b/scripts/ci/docs-generate.ts
@@ -1,36 +1,36 @@
-import fs from "fs";
-import path from "path";
-import { task } from "hardhat/config";
-import { HardhatPluginError } from "hardhat/plugins";
-import { TASK_COMPILE } from "hardhat/builtin-tasks/task-names";
-import { ethers } from "ethers";
-import pluralize from "pluralize";
-import { mkdir, rm, stat, writeFile } from "fs/promises";
-import { CompilerOutputContract } from "hardhat/types";
-import { format } from "prettier";
+import fs from 'fs';
+import path from 'path';
+import { task } from 'hardhat/config';
+import { HardhatPluginError } from 'hardhat/plugins';
+import { TASK_COMPILE } from 'hardhat/builtin-tasks/task-names';
+import { ethers } from 'ethers';
+import pluralize from 'pluralize';
+import { mkdir, rm, stat, writeFile } from 'fs/promises';
+import { CompilerOutputContract } from 'hardhat/types';
+import { format } from 'prettier';
 
 task(TASK_COMPILE)
   .addFlag(
-    "noTsGen",
+    'noTsGen',
     "Don't generate documentation after running this task, even if runOnCompile option is enabled",
   )
   .setAction(async function (args, hre, runSuper) {
     for (let compiler of hre.config.solidity.compilers) {
-      compiler.settings.outputSelection["*"]["*"].push("devdoc");
-      compiler.settings.outputSelection["*"]["*"].push("userdoc");
+      compiler.settings.outputSelection['*']['*'].push('devdoc');
+      compiler.settings.outputSelection['*']['*'].push('userdoc');
     }
 
     await runSuper();
 
     if (!args.noTsGen) {
       // Disable compile to avoid an infinite loop
-      await hre.run("ts-gen", { noCompile: true });
+      await hre.run('ts-gen', { noCompile: true });
     }
   });
 
 // derive external signatures from internal types
 function getSigType({ type, components = [] }: { type: string; components?: any[] }): string {
-  return type.replace("tuple", `(${components.map(getSigType).join(",")})`);
+  return type.replace('tuple', `(${components.map(getSigType).join(',')})`);
 }
 
 function collect(items: any) {
@@ -50,27 +50,27 @@ function collect(items: any) {
 function serialize(obj: any) {
   const output = [];
   if (Array.isArray(obj)) {
-    output.push("[");
+    output.push('[');
     for (const child of obj) {
       output.push(serialize(child));
-      output.push(",");
+      output.push(',');
     }
-    output.push("]");
-  } else if (typeof obj === "object") {
-    output.push("{");
+    output.push(']');
+  } else if (typeof obj === 'object') {
+    output.push('{');
     for (const [key, value] of Object.entries(obj)) {
       if (value === undefined) {
         continue;
       }
       const v = value as any;
       if (v && v.sig) {
-        let docs = `\n\n/**\n * ${v.type ? `${v.type} ` : ""}${v.sig}`;
+        let docs = `\n\n/**\n * ${v.type ? `${v.type} ` : ''}${v.sig}`;
         if (v.inputs && v.inputs.length) {
           docs = docs.replace(
             /\(.*\)$/,
             `(\n *  ${v.inputs
-              .map(({ name, type, indexed }) => `${type}${indexed ? " indexed" : ""} ${name}`)
-              .join(",\n *  ")}\n * )`,
+              .map(({ name, type, indexed }) => `${type}${indexed ? ' indexed' : ''} ${name}`)
+              .join(',\n *  ')}\n * )`,
           );
         }
         if (/^0x/.test(key)) {
@@ -80,23 +80,23 @@ function serialize(obj: any) {
         output.push(docs);
       }
       output.push(`"${key}":`);
-      if (typeof v === "object" && v._doc && v._value) {
+      if (typeof v === 'object' && v._doc && v._value) {
         output.push(`/** ${v._doc} */`);
         output.push(serialize(v._value));
       } else {
         output.push(serialize(value));
       }
-      output.push(",");
+      output.push(',');
     }
-    output.push("}");
+    output.push('}');
   } else {
     output.push(JSON.stringify(obj));
   }
-  return output.join("");
+  return output.join('');
 }
 
-task("ts-gen", "Generate NatSpec documentation automatically on compilation")
-  .addFlag("noCompile", "Don't run hardhat compile task first")
+task('ts-gen', 'Generate NatSpec documentation automatically on compilation')
+  .addFlag('noCompile', "Don't run hardhat compile task first")
   .setAction(async function (args, hre) {
     if (!args.noCompile) {
       await hre.run(TASK_COMPILE, { noDocgen: true });
@@ -124,26 +124,26 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
 
     // Create userdocs
     if (
-      await stat("./userdocs")
+      await stat('./userdocs')
         .then((s) => s.isDirectory())
         .catch(() => false)
     ) {
-      await rm("./userdocs", { recursive: true });
+      await rm('./userdocs', { recursive: true });
     }
-    await mkdir("./userdocs");
+    await mkdir('./userdocs');
     if (
-      await stat("./devdocs")
+      await stat('./devdocs')
         .then((s) => s.isDirectory())
         .catch(() => false)
     ) {
-      await rm("./devdocs", { recursive: true });
+      await rm('./devdocs', { recursive: true });
     }
-    await mkdir("./devdocs");
+    await mkdir('./devdocs');
     let contractCount = 0;
     let userdocCount = 0;
     let devdocCount = 0;
     for (let contractName of contractNames) {
-      const [source, name] = contractName.split(":");
+      const [source, name] = contractName.split(':');
 
       if (!contracts.has(name)) {
         continue;
@@ -166,13 +166,13 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
 
       const fileName = `${name}.json`;
       if (devdoc) {
-        await writeFile(path.join("./devdocs", fileName), JSON.stringify(devdoc, undefined, "  "));
+        await writeFile(path.join('./devdocs', fileName), JSON.stringify(devdoc, undefined, '  '));
         devdocCount++;
       }
       if (userdoc) {
         await writeFile(
-          path.join("./userdocs", fileName),
-          JSON.stringify(userdoc, undefined, "  "),
+          path.join('./userdocs', fileName),
+          JSON.stringify(userdoc, undefined, '  '),
         );
         userdocCount++;
       }
@@ -198,7 +198,7 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
           const key = `${name}()`;
           let entry = allMembers[key];
           if (!entry) {
-            entry = allMembers[key] = { type: "stateVariable" };
+            entry = allMembers[key] = { type: 'stateVariable' };
           }
           if (Object.keys(stateVariable).length) {
             entry.devdoc = stateVariable;
@@ -232,18 +232,18 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
       }
 
       const constructorName: string | undefined = Object.keys(allMembers).find((k) =>
-        k.startsWith("constructor("),
+        k.startsWith('constructor('),
       );
 
       const {
-        "fallback()": fallback,
-        "receive()": receive,
-        [constructorName || "___JUNK___"]: constructor,
+        'fallback()': fallback,
+        'receive()': receive,
+        [constructorName || '___JUNK___']: constructor,
       } = allMembers;
 
       for (const [sig, member] of Object.entries(allMembers)) {
         const hash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(sig));
-        member.hash = member.type === "event" ? hash : hash.slice(0, 10);
+        member.hash = member.type === 'event' ? hash : hash.slice(0, 10);
       }
 
       const membersByType: Record<string, Record<string, any>> = {};
@@ -252,7 +252,7 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
         if (!type) {
           continue;
         }
-        const key = type === "function" ? "methods" : pluralize(type);
+        const key = type === 'function' ? 'methods' : pluralize(type);
         let entry = membersByType[key];
         if (!entry) {
           entry = membersByType[key] = {};
@@ -269,7 +269,7 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
       } = devdoc;
 
       const wholeContract = { ...contract, constructor, fallback, receive };
-      for (const name of ["constructor", "fallback", "receive"]) {
+      for (const name of ['constructor', 'fallback', 'receive']) {
         if (wholeContract[name]) {
           const { hash, ...rest } = wholeContract[name];
           wholeContract[name] = rest;
@@ -283,7 +283,7 @@ task("ts-gen", "Generate NatSpec documentation automatically on compilation")
       allStateVariables[name] = collect(stateVariables);
     }
     fs.writeFileSync(
-      "./contracts.ts",
+      './contracts.ts',
       format(
         `export const ErrorSelectors = ${serialize(allErrors)};
 export const EventSigHashes = ${serialize(allEvents)};
@@ -291,7 +291,7 @@ export const FunctionSelectors = ${serialize(allMethods)};
 export const ContractsDocs = ${serialize(allContracts)};
 export const StateVariables = ${serialize(allStateVariables)};
 `,
-        { parser: "babel-ts" },
+        { parser: 'babel-ts' },
       ),
     );
     console.log(`Successfully generated ${devdocCount} json files in devdocs`);

--- a/scripts/fix_flattener.js
+++ b/scripts/fix_flattener.js
@@ -1,14 +1,14 @@
-const fs = require("fs");
+const fs = require('fs');
 
-let file = "./flat_contracts/UniversalProfile_flat.sol";
+let file = './flat_contracts/UniversalProfile_flat.sol';
 
-fs.readFile(file, "utf8", (err, data) => {
+fs.readFile(file, 'utf8', (err, data) => {
   if (err) {
     console.error(err);
   }
 
   // create an array of lines
-  let lines = data.split("\n").slice(0);
+  let lines = data.split('\n').slice(0);
 
   let removeDuplicates = (substr, lines) => {
     let substrCount = 0;
@@ -25,11 +25,11 @@ fs.readFile(file, "utf8", (err, data) => {
   removeDuplicates(/^\/\/\WSPDX-License-Identifier/, lines);
   removeDuplicates(/^pragma/, lines);
 
-  data = lines.join("\n");
+  data = lines.join('\n');
 
   console.log(data);
 
   fs.writeFile(file, data, (err) => {
-    err | console.log("Duplicate pragma and SPDX statements removed successfully !");
+    err | console.log('Duplicate pragma and SPDX statements removed successfully !');
   });
 });

--- a/tests/Benchmark.test.ts
+++ b/tests/Benchmark.test.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { Align, getMarkdownTable, Row } from "markdown-table-ts";
+import fs from 'fs';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { Align, getMarkdownTable, Row } from 'markdown-table-ts';
 
 import {
   LSP6KeyManager__factory,
@@ -12,7 +12,7 @@ import {
   LSP8Mintable__factory,
   UniversalProfile,
   UniversalProfile__factory,
-} from "../types";
+} from '../types';
 
 import {
   ALL_PERMISSIONS,
@@ -21,12 +21,12 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../constants";
-import { LSP6TestContext } from "./utils/context";
-import { setupKeyManager, setupProfileWithKeyManagerWithURD } from "./utils/fixtures";
-import { combineAllowedCalls, combinePermissions, encodeCompactBytesArray } from "./utils/helpers";
-import { BigNumber } from "ethers";
-import { token } from "../types/@openzeppelin/contracts";
+} from '../constants';
+import { LSP6TestContext } from './utils/context';
+import { setupKeyManager, setupProfileWithKeyManagerWithURD } from './utils/fixtures';
+import { combineAllowedCalls, combinePermissions, encodeCompactBytesArray } from './utils/helpers';
+import { BigNumber } from 'ethers';
+import { token } from '../types/@openzeppelin/contracts';
 
 export type UniversalProfileContext = {
   accounts: SignerWithAddress[];
@@ -74,97 +74,97 @@ let restrictedControllerExecuteTable;
 let mainControllerSetDataTable;
 let restrictedControllerSetDataTable;
 
-describe("⛽📊 Gas Benchmark", () => {
-  describe("UniversalProfile", () => {
+describe('⛽📊 Gas Benchmark', () => {
+  describe('UniversalProfile', () => {
     let context: UniversalProfileContext;
     let executeUP: Row[] = [];
     let setDataUP: Row[] = [];
     let tokensUP: Row[] = [];
 
-    describe("execute", () => {
-      describe("execute Single", () => {
+    describe('execute', () => {
+      describe('execute Single', () => {
         before(async () => {
-          context = await buildUniversalProfileContext(ethers.utils.parseEther("50"));
+          context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
         });
 
-        it("Transfer 1 LYX to an EOA without data", async () => {
+        it('Transfer 1 LYX to an EOA without data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .execute(
               OPERATION_TYPES.CALL,
               context.accounts[1].address,
-              ethers.utils.parseEther("1"),
-              "0x",
+              ethers.utils.parseEther('1'),
+              '0x',
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 1 LYX to an EOA without data",
+            'Transfer 1 LYX to an EOA without data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 1 LYX to a UP without data", async () => {
+        it('Transfer 1 LYX to a UP without data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .execute(
               OPERATION_TYPES.CALL,
               context.universalProfile.address,
-              ethers.utils.parseEther("1"),
-              "0x",
+              ethers.utils.parseEther('1'),
+              '0x',
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 1 LYX to a UP without data",
+            'Transfer 1 LYX to a UP without data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 1 LYX to an EOA with 256 bytes of data", async () => {
+        it('Transfer 1 LYX to an EOA with 256 bytes of data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .execute(
               OPERATION_TYPES.CALL,
               context.accounts[1].address,
-              ethers.utils.parseEther("1"),
+              ethers.utils.parseEther('1'),
               generateRandomData(256),
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 1 LYX to an EOA with 256 bytes of data",
+            'Transfer 1 LYX to an EOA with 256 bytes of data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 1 LYX to a UP with 256 bytes of data", async () => {
+        it('Transfer 1 LYX to a UP with 256 bytes of data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .execute(
               OPERATION_TYPES.CALL,
               context.universalProfile.address,
-              ethers.utils.parseEther("1"),
-              ethers.utils.hexConcat(["0x00000000", generateRandomData(252)]),
+              ethers.utils.parseEther('1'),
+              ethers.utils.hexConcat(['0x00000000', generateRandomData(252)]),
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 1 LYX to a UP with 256 bytes of data",
+            'Transfer 1 LYX to a UP with 256 bytes of data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
       });
 
-      describe("execute Array", () => {
+      describe('execute Array', () => {
         let universalProfile1, universalProfile2, universalProfile3;
 
         before(async () => {
-          context = await buildUniversalProfileContext(ethers.utils.parseEther("50"));
+          context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
 
           universalProfile1 = await new UniversalProfile__factory(context.owner).deploy(
             context.accounts[2].address,
@@ -179,7 +179,7 @@ describe("⛽📊 Gas Benchmark", () => {
           );
         });
 
-        it("Transfer 0.1 LYX to 3x EOA without data", async () => {
+        it('Transfer 0.1 LYX to 3x EOA without data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .executeBatch(
@@ -190,44 +190,44 @@ describe("⛽📊 Gas Benchmark", () => {
                 context.accounts[3].address,
               ],
               [
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
               ],
-              ["0x", "0x", "0x"],
+              ['0x', '0x', '0x'],
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 0.1 LYX to 3x EOA without data",
+            'Transfer 0.1 LYX to 3x EOA without data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 0.1 LYX to 3x UP without data", async () => {
+        it('Transfer 0.1 LYX to 3x UP without data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .executeBatch(
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [universalProfile1.address, universalProfile2.address, universalProfile3.address],
               [
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
               ],
-              ["0x", "0x", "0x"],
+              ['0x', '0x', '0x'],
             );
 
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 0.1 LYX to 3x UP without data",
+            'Transfer 0.1 LYX to 3x UP without data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 0.1 LYX to 3x EOA with 256 bytes of data", async () => {
+        it('Transfer 0.1 LYX to 3x EOA with 256 bytes of data', async () => {
           const tx = await context.universalProfile
             .connect(context.owner)
             .executeBatch(
@@ -238,9 +238,9 @@ describe("⛽📊 Gas Benchmark", () => {
                 context.accounts[3].address,
               ],
               [
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
               ],
               [generateRandomData(256), generateRandomData(256), generateRandomData(256)],
             );
@@ -248,14 +248,14 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 0.1 LYX to 3x EOA with 256 bytes of data",
+            'Transfer 0.1 LYX to 3x EOA with 256 bytes of data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Transfer 0.1 LYX to 3x UP with 256 bytes of data", async () => {
+        it('Transfer 0.1 LYX to 3x UP with 256 bytes of data', async () => {
           const random256BytesData = ethers.utils.hexConcat([
-            "0x00000000",
+            '0x00000000',
             generateRandomData(252),
           ]);
 
@@ -265,9 +265,9 @@ describe("⛽📊 Gas Benchmark", () => {
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [universalProfile1.address, universalProfile2.address, universalProfile3.address],
               [
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
-                ethers.utils.parseEther("0.1"),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
+                ethers.utils.parseEther('0.1'),
               ],
               [random256BytesData, random256BytesData, random256BytesData],
             );
@@ -275,7 +275,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           executeUP.push([
-            "Transfer 0.1 LYX to 3x EOA with 256 bytes of data",
+            'Transfer 0.1 LYX to 3x EOA with 256 bytes of data',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -284,7 +284,7 @@ describe("⛽📊 Gas Benchmark", () => {
       after(async () => {
         UniversalProfileExecuteTable = getMarkdownTable({
           table: {
-            head: ["`execute` scenarios - 👑 UP Owner", "⛽ Gas Usage"],
+            head: ['`execute` scenarios - 👑 UP Owner', '⛽ Gas Usage'],
             body: executeUP,
           },
           alignment: [Align.Left, Align.Center],
@@ -292,69 +292,69 @@ describe("⛽📊 Gas Benchmark", () => {
       });
     });
 
-    describe("setData", () => {
-      describe("setData Single", () => {
+    describe('setData', () => {
+      describe('setData Single', () => {
         before(async () => {
-          context = await buildUniversalProfileContext(ethers.utils.parseEther("50"));
+          context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
         });
 
-        it("Set a 20 bytes long value", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('Set a 20 bytes long value', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = generateRandomData(20);
 
           const tx = await context.universalProfile.setData(key, value);
 
           const receipt = await tx.wait();
 
-          setDataUP.push(["Set a 20 bytes long value", receipt.gasUsed.toNumber().toString()]);
+          setDataUP.push(['Set a 20 bytes long value', receipt.gasUsed.toNumber().toString()]);
         });
 
-        it("Set a 60 bytes long value", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Other Key"));
+        it('Set a 60 bytes long value', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Other Key'));
           let value = generateRandomData(60);
 
           const tx = await context.universalProfile.setData(key, value);
 
           const receipt = await tx.wait();
 
-          setDataUP.push(["Set a 60 bytes long value", receipt.gasUsed.toNumber().toString()]);
+          setDataUP.push(['Set a 60 bytes long value', receipt.gasUsed.toNumber().toString()]);
         });
 
-        it("Set a 160 bytes long value", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Third Key"));
+        it('Set a 160 bytes long value', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Third Key'));
           let value = generateRandomData(160);
 
           const tx = await context.universalProfile.setData(key, value);
 
           const receipt = await tx.wait();
 
-          setDataUP.push(["Set a 160 bytes long value", receipt.gasUsed.toNumber().toString()]);
+          setDataUP.push(['Set a 160 bytes long value', receipt.gasUsed.toNumber().toString()]);
         });
 
-        it("Set a 300 bytes long value", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fourth Key"));
+        it('Set a 300 bytes long value', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fourth Key'));
           let value = generateRandomData(300);
 
           const tx = await context.universalProfile.setData(key, value);
 
           const receipt = await tx.wait();
 
-          setDataUP.push(["Set a 300 bytes long value", receipt.gasUsed.toNumber().toString()]);
+          setDataUP.push(['Set a 300 bytes long value', receipt.gasUsed.toNumber().toString()]);
         });
 
-        it("Set a 600 bytes long value", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fifth Key"));
+        it('Set a 600 bytes long value', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fifth Key'));
           let value = generateRandomData(600);
 
           const tx = await context.universalProfile.setData(key, value);
 
           const receipt = await tx.wait();
 
-          setDataUP.push(["Set a 600 bytes long value", receipt.gasUsed.toNumber().toString()]);
+          setDataUP.push(['Set a 600 bytes long value', receipt.gasUsed.toNumber().toString()]);
         });
 
-        it("Change the value of a data key already set", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fifth Key"));
+        it('Change the value of a data key already set', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fifth Key'));
           let value1 = generateRandomData(20);
           let value2 = generateRandomData(20);
 
@@ -365,38 +365,38 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Change the value of a data key already set",
+            'Change the value of a data key already set',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Remove the value of a data key already set", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fifth Key"));
+        it('Remove the value of a data key already set', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fifth Key'));
           let value = generateRandomData(20);
 
           await context.universalProfile.setData(key, value);
 
-          const tx = await context.universalProfile.setData(key, "0x");
+          const tx = await context.universalProfile.setData(key, '0x');
 
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Remove the value of a data key already set",
+            'Remove the value of a data key already set',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
       });
 
-      describe("setData Array", () => {
+      describe('setData Array', () => {
         before(async () => {
-          context = await buildUniversalProfileContext(ethers.utils.parseEther("50"));
+          context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
         });
 
-        it("Set 2 data keys of 20 bytes long value", async () => {
-          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key1"));
+        it('Set 2 data keys of 20 bytes long value', async () => {
+          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key1'));
           let value1 = generateRandomData(20);
 
-          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key2"));
+          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key2'));
           let value2 = generateRandomData(20);
 
           const tx = await context.universalProfile.setDataBatch([key1, key2], [value1, value2]);
@@ -404,16 +404,16 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Set 2 data keys of 20 bytes long value",
+            'Set 2 data keys of 20 bytes long value',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Set 2 data keys of 100 bytes long value", async () => {
-          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key3"));
+        it('Set 2 data keys of 100 bytes long value', async () => {
+          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key3'));
           let value1 = generateRandomData(100);
 
-          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key4"));
+          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key4'));
           let value2 = generateRandomData(100);
 
           const tx = await context.universalProfile.setDataBatch([key1, key2], [value1, value2]);
@@ -421,19 +421,19 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Set 2 data keys of 100 bytes long value",
+            'Set 2 data keys of 100 bytes long value',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Set 3 data keys of 20 bytes long value", async () => {
-          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key5"));
+        it('Set 3 data keys of 20 bytes long value', async () => {
+          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key5'));
           let value1 = generateRandomData(20);
 
-          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key6"));
+          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key6'));
           let value2 = generateRandomData(20);
 
-          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key7"));
+          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key7'));
           let value3 = generateRandomData(20);
 
           const tx = await context.universalProfile.setDataBatch(
@@ -444,19 +444,19 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Set 3 data keys of 20 bytes long value",
+            'Set 3 data keys of 20 bytes long value',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Change the value of three data keys already set of 20 bytes long value", async () => {
-          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key8"));
+        it('Change the value of three data keys already set of 20 bytes long value', async () => {
+          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key8'));
           let value1 = generateRandomData(20);
 
-          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key9"));
+          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key9'));
           let value2 = generateRandomData(20);
 
-          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key10"));
+          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key10'));
           let value3 = generateRandomData(20);
 
           await context.universalProfile.setDataBatch([key1, key2, key3], [value1, value2, value3]);
@@ -469,32 +469,32 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Change the value of three data keys already set of 20 bytes long value",
+            'Change the value of three data keys already set of 20 bytes long value',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("Remove the value of three data keys already set", async () => {
-          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key11"));
+        it('Remove the value of three data keys already set', async () => {
+          let key1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key11'));
           let value1 = generateRandomData(20);
 
-          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key12"));
+          let key2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key12'));
           let value2 = generateRandomData(20);
 
-          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key13"));
+          let key3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key13'));
           let value3 = generateRandomData(20);
 
           await context.universalProfile.setDataBatch([key1, key2, key3], [value1, value2, value3]);
 
           const tx = await context.universalProfile.setDataBatch(
             [key1, key2, key3],
-            ["0x", "0x", "0x"],
+            ['0x', '0x', '0x'],
           );
 
           const receipt = await tx.wait();
 
           setDataUP.push([
-            "Remove the value of three data keys already set",
+            'Remove the value of three data keys already set',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -503,7 +503,7 @@ describe("⛽📊 Gas Benchmark", () => {
       after(async () => {
         UniversalProfileSetDataTable = getMarkdownTable({
           table: {
-            head: ["`setData` scenarios - 👑 UP Owner", "⛽ Gas Usage"],
+            head: ['`setData` scenarios - 👑 UP Owner', '⛽ Gas Usage'],
             body: setDataUP,
           },
           alignment: [Align.Left, Align.Center],
@@ -511,25 +511,25 @@ describe("⛽📊 Gas Benchmark", () => {
       });
     });
 
-    describe("Tokens", () => {
+    describe('Tokens', () => {
       let lsp7Token: LSP7Mintable;
       let lsp8Token: LSP8Mintable;
       let universalProfile1;
 
       before(async () => {
-        context = await buildUniversalProfileContext(ethers.utils.parseEther("50"));
+        context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
         // deploy a LSP7 token
         lsp7Token = await new LSP7Mintable__factory(context.owner).deploy(
-          "Token",
-          "MTKN",
+          'Token',
+          'MTKN',
           context.owner.address,
           false,
         );
 
         // deploy a LSP7 token
         lsp8Token = await new LSP8Mintable__factory(context.owner).deploy(
-          "Token",
-          "MTKN",
+          'Token',
+          'MTKN',
           context.owner.address,
         );
 
@@ -538,36 +538,36 @@ describe("⛽📊 Gas Benchmark", () => {
         );
       });
 
-      describe("LSP7DigitalAsset", () => {
-        it("when minting LSP7Token to a UP without data", async () => {
-          const tx = await lsp7Token.mint(context.universalProfile.address, 20, false, "0x");
+      describe('LSP7DigitalAsset', () => {
+        it('when minting LSP7Token to a UP without data', async () => {
+          const tx = await lsp7Token.mint(context.universalProfile.address, 20, false, '0x');
 
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Minting a LSP7Token to a UP (No Delegate) from an EOA",
+            'Minting a LSP7Token to a UP (No Delegate) from an EOA',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("when minting LSP7Token to a EOA without data", async () => {
-          const tx = await lsp7Token.mint(context.accounts[5].address, 20, true, "0x");
+        it('when minting LSP7Token to a EOA without data', async () => {
+          const tx = await lsp7Token.mint(context.accounts[5].address, 20, true, '0x');
 
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Minting a LSP7Token to an EOA from an EOA",
+            'Minting a LSP7Token to an EOA from an EOA',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("when transferring LSP7Token from a UP to a UP without data", async () => {
-          const lsp7TransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+        it('when transferring LSP7Token from a UP to a UP without data', async () => {
+          const lsp7TransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             universalProfile1.address,
             5,
             false,
-            "0x",
+            '0x',
           ]);
 
           const tx = await context.universalProfile
@@ -577,54 +577,54 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Transferring an LSP7Token from a UP to another UP (No Delegate)",
+            'Transferring an LSP7Token from a UP to another UP (No Delegate)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
       });
 
-      describe("LSP8IdentifiableDigitalAsset", () => {
+      describe('LSP8IdentifiableDigitalAsset', () => {
         let metaNFTList: string[] = [
-          "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "0x0000000000000000000000000000000000000000000000000000000000000002",
-          "0x0000000000000000000000000000000000000000000000000000000000000003",
-          "0x0000000000000000000000000000000000000000000000000000000000000004",
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+          '0x0000000000000000000000000000000000000000000000000000000000000004',
         ];
 
-        it("when minting LSP8Token to a UP without data", async () => {
+        it('when minting LSP8Token to a UP without data', async () => {
           const tx = await lsp8Token.mint(
             context.universalProfile.address,
             metaNFTList[0],
             false,
-            "0x",
+            '0x',
           );
 
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Minting a LSP8Token to a UP (No Delegate) from an EOA",
+            'Minting a LSP8Token to a UP (No Delegate) from an EOA',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("when minting LSP8Token to a EOA without data", async () => {
-          const tx = await lsp8Token.mint(context.accounts[5].address, metaNFTList[1], true, "0x");
+        it('when minting LSP8Token to a EOA without data', async () => {
+          const tx = await lsp8Token.mint(context.accounts[5].address, metaNFTList[1], true, '0x');
 
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Minting a LSP8Token to an EOA from an EOA",
+            'Minting a LSP8Token to an EOA from an EOA',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("when transferring LSP8Token from a UP to a UP without data", async () => {
-          const lsp8TransferPayload = lsp8Token.interface.encodeFunctionData("transfer", [
+        it('when transferring LSP8Token from a UP to a UP without data', async () => {
+          const lsp8TransferPayload = lsp8Token.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             universalProfile1.address,
             metaNFTList[0],
             false,
-            "0x",
+            '0x',
           ]);
 
           const tx = await context.universalProfile
@@ -634,7 +634,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           tokensUP.push([
-            "Transferring an LSP8Token from a UP to another UP (No Delegate)",
+            'Transferring an LSP8Token from a UP to another UP (No Delegate)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -643,7 +643,7 @@ describe("⛽📊 Gas Benchmark", () => {
       after(async () => {
         UniversalProfileTokensTable = getMarkdownTable({
           table: {
-            head: ["`Tokens` scenarios - 👑 UP Owner", "⛽ Gas Usage"],
+            head: ['`Tokens` scenarios - 👑 UP Owner', '⛽ Gas Usage'],
             body: tokensUP,
           },
           alignment: [Align.Left, Align.Center],
@@ -652,9 +652,9 @@ describe("⛽📊 Gas Benchmark", () => {
     });
   });
 
-  describe("KeyManager", () => {
-    describe("`execute(...)` via Key Manager", () => {
-      describe("main controller (this browser extension)", () => {
+  describe('KeyManager', () => {
+    describe('`execute(...)` via Key Manager', () => {
+      describe('main controller (this browser extension)', () => {
         let casesExecuteMainController: Row[] = [];
 
         let context: LSP6TestContext;
@@ -667,14 +667,14 @@ describe("⛽📊 Gas Benchmark", () => {
         let lsp8MetaNFT: LSP8Mintable;
 
         let nftList: string[] = [
-          "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "0x0000000000000000000000000000000000000000000000000000000000000002",
-          "0x0000000000000000000000000000000000000000000000000000000000000003",
-          "0x0000000000000000000000000000000000000000000000000000000000000004",
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+          '0x0000000000000000000000000000000000000000000000000000000000000004',
         ];
 
         before(async () => {
-          context = await buildLSP6TestContext(ethers.utils.parseEther("50"));
+          context = await buildLSP6TestContext(ethers.utils.parseEther('50'));
 
           recipientEOA = context.accounts[1];
           let deployedContracts = await setupProfileWithKeyManagerWithURD(context.accounts[2]);
@@ -686,55 +686,55 @@ describe("⛽📊 Gas Benchmark", () => {
 
           // deploy a LSP7 token
           lsp7MetaCoin = await new LSP7Mintable__factory(context.owner).deploy(
-            "MetaCoin",
-            "MTC",
+            'MetaCoin',
+            'MTC',
             context.owner.address,
             false,
           );
 
           // deploy a LSP8 NFT
           lsp8MetaNFT = await new LSP8Mintable__factory(context.owner).deploy(
-            "MetaNFT",
-            "MNF",
+            'MetaNFT',
+            'MNF',
             context.owner.address,
           );
 
           // mint some tokens to the UP
-          await lsp7MetaCoin.mint(context.universalProfile.address, 1000, false, "0x");
+          await lsp7MetaCoin.mint(context.universalProfile.address, 1000, false, '0x');
 
           // mint some NFTs to the UP
           nftList.forEach(async (nft) => {
-            await lsp8MetaNFT.mint(context.universalProfile.address, nft, false, "0x");
+            await lsp8MetaNFT.mint(context.universalProfile.address, nft, false, '0x');
           });
         });
 
-        it("transfer some LYXes to an EOA", async () => {
-          const lyxAmount = ethers.utils.parseEther("3");
+        it('transfer some LYXes to an EOA', async () => {
+          const lyxAmount = ethers.utils.parseEther('3');
 
           // prettier-ignore
           const tx = await context.universalProfile.connect(context.owner).execute(OPERATION_TYPES.CALL, recipientEOA.address, lyxAmount, "0x");
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer LYX to an EOA",
+            'transfer LYX to an EOA',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers some LYXes to a UP", async () => {
-          const lyxAmount = ethers.utils.parseEther("3");
+        it('transfers some LYXes to a UP', async () => {
+          const lyxAmount = ethers.utils.parseEther('3');
 
           // prettier-ignore
           const tx = await context.universalProfile.connect(context.owner).execute(OPERATION_TYPES.CALL, aliceUP.address, lyxAmount, "0x");
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer LYX to a UP",
+            'transfer LYX to a UP',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers some tokens (LSP7) to an EOA (no data)", async () => {
+        it('transfers some tokens (LSP7) to an EOA (no data)', async () => {
           const tokenAmount = 100;
 
           // prettier-ignore
@@ -753,12 +753,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer tokens (LSP7) to an EOA (no data)",
+            'transfer tokens (LSP7) to an EOA (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfer some tokens (LSP7) to a UP (no data)", async () => {
+        it('transfer some tokens (LSP7) to a UP (no data)', async () => {
           const tokenAmount = 100;
 
           // prettier-ignore
@@ -777,12 +777,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer tokens (LSP7) to a UP (no data)",
+            'transfer tokens (LSP7) to a UP (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfer a NFT (LSP8) to a EOA (no data)", async () => {
+        it('transfer a NFT (LSP8) to a EOA (no data)', async () => {
           const nftId = nftList[0];
 
           // prettier-ignore
@@ -801,12 +801,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer a NFT (LSP8) to a EOA (no data)",
+            'transfer a NFT (LSP8) to a EOA (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfer a NFT (LSP8) to a UP (no data)", async () => {
+        it('transfer a NFT (LSP8) to a UP (no data)', async () => {
           const nftId = nftList[1];
 
           // prettier-ignore
@@ -825,7 +825,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteMainController.push([
-            "transfer a NFT (LSP8) to a UP (no data)",
+            'transfer a NFT (LSP8) to a UP (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -833,7 +833,7 @@ describe("⛽📊 Gas Benchmark", () => {
         after(async () => {
           mainControllerExecuteTable = getMarkdownTable({
             table: {
-              head: ["`execute` scenarios - 👑 main controller", "⛽ Gas Usage"],
+              head: ['`execute` scenarios - 👑 main controller', '⛽ Gas Usage'],
               body: casesExecuteMainController,
             },
             alignment: [Align.Left, Align.Center],
@@ -841,7 +841,7 @@ describe("⛽📊 Gas Benchmark", () => {
         });
       });
 
-      describe("controllers with some restrictions", () => {
+      describe('controllers with some restrictions', () => {
         let casesExecuteRestrictedController: Row[] = [];
         let context: LSP6TestContext;
 
@@ -859,21 +859,21 @@ describe("⛽📊 Gas Benchmark", () => {
         let lsp8MetaNFT: LSP8Mintable, lsp8LyxPunks: LSP8Mintable;
 
         const metaNFTList: string[] = [
-          "0x0000000000000000000000000000000000000000000000000000000000000001",
-          "0x0000000000000000000000000000000000000000000000000000000000000002",
-          "0x0000000000000000000000000000000000000000000000000000000000000003",
-          "0x0000000000000000000000000000000000000000000000000000000000000004",
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000000000000000000000000000003',
+          '0x0000000000000000000000000000000000000000000000000000000000000004',
         ];
 
         const lyxPunksList: string[] = [
-          "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
-          "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
-          "0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead",
-          "0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d",
+          '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe',
+          '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+          '0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddeaddead',
+          '0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d',
         ];
 
         before(async () => {
-          context = await buildLSP6TestContext(ethers.utils.parseEther("50"));
+          context = await buildLSP6TestContext(ethers.utils.parseEther('50'));
 
           recipientEOA = context.accounts[1];
 
@@ -888,35 +888,35 @@ describe("⛽📊 Gas Benchmark", () => {
           canTransferTwoTokens = context.accounts[3];
 
           lsp7MetaCoin = await new LSP7Mintable__factory(context.owner).deploy(
-            "MetaCoin",
-            "MTC",
+            'MetaCoin',
+            'MTC',
             context.owner.address,
             false,
           );
 
           lsp7LyxDai = await new LSP7Mintable__factory(context.owner).deploy(
-            "LyxDai",
-            "LDAI",
+            'LyxDai',
+            'LDAI',
             context.owner.address,
             false,
           );
 
           [lsp7MetaCoin, lsp7LyxDai].forEach(async (token) => {
-            await token.mint(context.universalProfile.address, 1000, false, "0x");
+            await token.mint(context.universalProfile.address, 1000, false, '0x');
           });
 
           // LSP8 NFT transfer scenarios
           canTransferTwoNFTs = context.accounts[4];
 
           lsp8MetaNFT = await new LSP8Mintable__factory(context.owner).deploy(
-            "MetaNFT",
-            "MNF",
+            'MetaNFT',
+            'MNF',
             context.owner.address,
           );
 
           lsp8LyxPunks = await new LSP8Mintable__factory(context.owner).deploy(
-            "LyxPunks",
-            "LPK",
+            'LyxPunks',
+            'LPK',
             context.owner.address,
           );
 
@@ -926,7 +926,7 @@ describe("⛽📊 Gas Benchmark", () => {
           ].forEach(async (nftContract) => {
             // mint some NFTs to the UP
             nftContract.tokenIds.forEach(async (nft) => {
-              await lsp8MetaNFT.mint(context.universalProfile.address, nft, false, "0x");
+              await lsp8MetaNFT.mint(context.universalProfile.address, nft, false, '0x');
             });
           });
 
@@ -962,21 +962,21 @@ describe("⛽📊 Gas Benchmark", () => {
           )
         });
 
-        it("transfer some LYXes to an EOA - restricted to 1 x allowed address only (TRANSFERVALUE + 1x AllowedCalls)", async () => {
+        it('transfer some LYXes to an EOA - restricted to 1 x allowed address only (TRANSFERVALUE + 1x AllowedCalls)', async () => {
           const lyxAmount = 10;
 
           const tx = await context.universalProfile
             .connect(canTransferValueToOneAddress)
-            .execute(OPERATION_TYPES.CALL, allowedAddressToTransferValue, lyxAmount, "0x");
+            .execute(OPERATION_TYPES.CALL, allowedAddressToTransferValue, lyxAmount, '0x');
           const receipt = await tx.wait();
 
           casesExecuteRestrictedController.push([
-            "transfer some LYXes to an EOA - restricted to 1 x allowed address only (TRANSFERVALUE + 1x AllowedCalls)",
+            'transfer some LYXes to an EOA - restricted to 1 x allowed address only (TRANSFERVALUE + 1x AllowedCalls)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers some tokens (LSP7) to an EOA - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)", async () => {
+        it('transfers some tokens (LSP7) to an EOA - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)', async () => {
           const tokenAmount = 100;
 
           // prettier-ignore
@@ -995,12 +995,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteRestrictedController.push([
-            "transfers some tokens (LSP7) to an EOA - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)",
+            'transfers some tokens (LSP7) to an EOA - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers some tokens (LSP7) to an other UP - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)", async () => {
+        it('transfers some tokens (LSP7) to an other UP - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)', async () => {
           const tokenAmount = 100;
 
           // prettier-ignore
@@ -1019,12 +1019,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteRestrictedController.push([
-            "transfers some tokens (LSP7) to an other UP - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)",
+            'transfers some tokens (LSP7) to an other UP - restricted to LSP7 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers a NFT (LSP8) to an EOA - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)", async () => {
+        it('transfers a NFT (LSP8) to an EOA - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)', async () => {
           const nftId = metaNFTList[0];
 
           // prettier-ignore
@@ -1043,12 +1043,12 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteRestrictedController.push([
-            "transfers a NFT (LSP8) to an EOA - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)",
+            'transfers a NFT (LSP8) to an EOA - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("transfers a NFT (LSP8) to an other UP - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)", async () => {
+        it('transfers a NFT (LSP8) to an other UP - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)', async () => {
           const nftId = metaNFTList[1];
 
           // prettier-ignore
@@ -1067,7 +1067,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           casesExecuteRestrictedController.push([
-            "transfers a NFT (LSP8) to an other UP - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)",
+            'transfers a NFT (LSP8) to an other UP - restricted to LSP8 + 2x allowed contracts only (CALL + 2x AllowedCalls) (no data)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -1075,7 +1075,7 @@ describe("⛽📊 Gas Benchmark", () => {
         after(async () => {
           restrictedControllerExecuteTable = getMarkdownTable({
             table: {
-              head: ["`execute` scenarios - 🛃 restricted controller", "⛽ Gas Usage"],
+              head: ['`execute` scenarios - 🛃 restricted controller', '⛽ Gas Usage'],
               body: casesExecuteRestrictedController,
             },
             alignment: [Align.Left, Align.Center],
@@ -1084,23 +1084,23 @@ describe("⛽📊 Gas Benchmark", () => {
       });
     });
 
-    describe("`setData(...)` via Key Manager", () => {
+    describe('`setData(...)` via Key Manager', () => {
       let context: LSP6TestContext;
 
       let controllerCanSetData: SignerWithAddress,
         controllerCanSetDataAndAddController: SignerWithAddress;
 
       const allowedERC725YDataKeys = [
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key1")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key2")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key3")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key4")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key5")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key6")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key7")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key8")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key9")),
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key10")),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key1')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key2')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key3')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key4')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key5')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key6')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key7')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key8')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key9')),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key10')),
       ];
 
       before(async () => {
@@ -1138,13 +1138,13 @@ describe("⛽📊 Gas Benchmark", () => {
         await setupKeyManager(context, permissionKeys, permissionValues);
       });
 
-      describe("main controller (this browser extension) has SUPER_SETDATA ", () => {
+      describe('main controller (this browser extension) has SUPER_SETDATA ', () => {
         let benchmarkCasesSetDataMainController: Row[] = [];
 
-        it("updates profile details (LSP3Profile metadata)", async () => {
-          const dataKey = ERC725YDataKeys.LSP3["LSP3Profile"];
+        it('updates profile details (LSP3Profile metadata)', async () => {
+          const dataKey = ERC725YDataKeys.LSP3['LSP3Profile'];
           const dataValue =
-            "0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178";
+            '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178';
 
           const tx = await context.universalProfile
             .connect(context.owner)
@@ -1152,7 +1152,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataMainController.push([
-            "updates profile details (LSP3Profile metadata)",
+            'updates profile details (LSP3Profile metadata)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -1164,8 +1164,8 @@ describe("⛽📊 Gas Benchmark", () => {
       `, async () => {
           const newController = context.accounts[3];
 
-          const AddressPermissionsArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+          const AddressPermissionsArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           // prettier-ignore
@@ -1191,18 +1191,18 @@ describe("⛽📊 Gas Benchmark", () => {
           expect(await context.universalProfile.getDataBatch(dataKeys)).to.deep.equal(dataValues);
 
           benchmarkCasesSetDataMainController.push([
-            "give permissions to a controller (AddressPermissions[] + AddressPermissions[index] + AddressPermissions:Permissions:<controller-address>)",
+            'give permissions to a controller (AddressPermissions[] + AddressPermissions[index] + AddressPermissions:Permissions:<controller-address>)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("restrict a controller to some specific ERC725Y Data Keys", async () => {
+        it('restrict a controller to some specific ERC725Y Data Keys', async () => {
           const controllerToEdit = context.accounts[3];
 
           const allowedDataKeys = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Allowed ERC725Y Data Key 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Allowed ERC725Y Data Key 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Allowed ERC725Y Data Key 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Allowed ERC725Y Data Key 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Allowed ERC725Y Data Key 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Allowed ERC725Y Data Key 3')),
           ];
 
           // prettier-ignore
@@ -1221,12 +1221,12 @@ describe("⛽📊 Gas Benchmark", () => {
           expect(await context.universalProfile.getData(dataKey)).to.equal(dataValue);
 
           benchmarkCasesSetDataMainController.push([
-            "restrict a controller to some specific ERC725Y Data Keys",
+            'restrict a controller to some specific ERC725Y Data Keys',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("restrict a controller to interact only with 3x specific addresses", async () => {
+        it('restrict a controller to interact only with 3x specific addresses', async () => {
           const controllerToEdit = context.accounts[3];
 
           const allowedAddresses = [
@@ -1241,8 +1241,8 @@ describe("⛽📊 Gas Benchmark", () => {
           const dataValue = combineAllowedCalls(
             [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
             [allowedAddresses[0], allowedAddresses[1], allowedAddresses[2]],
-            ["0xffffffff", "0xffffffff", "0xffffffff"],
-            ["0xffffffff", "0xffffffff", "0xffffffff"],
+            ['0xffffffff', '0xffffffff', '0xffffffff'],
+            ['0xffffffff', '0xffffffff', '0xffffffff'],
           );
 
           let tx = await context.universalProfile
@@ -1254,7 +1254,7 @@ describe("⛽📊 Gas Benchmark", () => {
           expect(await context.universalProfile.getData(dataKey)).to.equal(dataValue);
 
           benchmarkCasesSetDataMainController.push([
-            "restrict a controller to interact only with 3x specific addresses",
+            'restrict a controller to interact only with 3x specific addresses',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -1266,8 +1266,8 @@ describe("⛽📊 Gas Benchmark", () => {
       `, async () => {
           const newController = context.accounts[3];
 
-          const AddressPermissionsArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+          const AddressPermissionsArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           // prettier-ignore
@@ -1291,12 +1291,12 @@ describe("⛽📊 Gas Benchmark", () => {
           let receipt = await tx.wait();
 
           benchmarkCasesSetDataMainController.push([
-            "remove a controller (its permissions + its address from the AddressPermissions[] array)",
+            'remove a controller (its permissions + its address from the AddressPermissions[] array)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("write 5x LSP12 Issued Assets", async () => {
+        it('write 5x LSP12 Issued Assets', async () => {
           // prettier-ignore
           const issuedAssetsDataKeys = [
             ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length,
@@ -1310,7 +1310,7 @@ describe("⛽📊 Gas Benchmark", () => {
           // these are just random placeholder values
           // they should be replaced with actual token contract address
           const issuedAssetsDataValues = [
-            "0x0000000000000000000000000000000000000000000000000000000000000005",
+            '0x0000000000000000000000000000000000000000000000000000000000000005',
             context.accounts[5].address,
             context.accounts[6].address,
             context.accounts[7].address,
@@ -1329,7 +1329,7 @@ describe("⛽📊 Gas Benchmark", () => {
           );
 
           benchmarkCasesSetDataMainController.push([
-            "write 5x LSP12 Issued Assets",
+            'write 5x LSP12 Issued Assets',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -1337,7 +1337,7 @@ describe("⛽📊 Gas Benchmark", () => {
         after(async () => {
           mainControllerSetDataTable = getMarkdownTable({
             table: {
-              head: ["`setData` scenarios - 👑 main controller", "⛽ Gas Usage"],
+              head: ['`setData` scenarios - 👑 main controller', '⛽ Gas Usage'],
               body: benchmarkCasesSetDataMainController,
             },
             alignment: [Align.Left, Align.Center],
@@ -1345,12 +1345,12 @@ describe("⛽📊 Gas Benchmark", () => {
         });
       });
 
-      describe("a controller (EOA) can SETDATA, ADDCONTROLLER and on 10x AllowedERC725YKeys", () => {
+      describe('a controller (EOA) can SETDATA, ADDCONTROLLER and on 10x AllowedERC725YKeys', () => {
         let benchmarkCasesSetDataRestrictedController: Row[] = [];
 
-        it("`setData(bytes32,bytes)` -> updates 1x data key", async () => {
+        it('`setData(bytes32,bytes)` -> updates 1x data key', async () => {
           const dataKey = allowedERC725YDataKeys[5];
-          const dataValue = "0xaabbccdd";
+          const dataValue = '0xaabbccdd';
 
           const tx = await context.universalProfile
             .connect(controllerCanSetData)
@@ -1358,14 +1358,14 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataRestrictedController.push([
-            "`setData(bytes32,bytes)` -> updates 1x data key",
+            '`setData(bytes32,bytes)` -> updates 1x data key',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("`setData(bytes32[],bytes[])` -> updates 3x data keys (first x3)", async () => {
+        it('`setData(bytes32[],bytes[])` -> updates 3x data keys (first x3)', async () => {
           const dataKeys = allowedERC725YDataKeys.slice(0, 3);
-          const dataValues = ["0xaabbccdd", "0xaabbccdd", "0xaabbccdd"];
+          const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
             .connect(controllerCanSetData)
@@ -1373,14 +1373,14 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataRestrictedController.push([
-            "`setData(bytes32[],bytes[])` -> updates 3x data keys (first x3)",
+            '`setData(bytes32[],bytes[])` -> updates 3x data keys (first x3)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("`setData(bytes32[],bytes[])` -> updates 3x data keys (middle x3)", async () => {
+        it('`setData(bytes32[],bytes[])` -> updates 3x data keys (middle x3)', async () => {
           const dataKeys = allowedERC725YDataKeys.slice(3, 6);
-          const dataValues = ["0xaabbccdd", "0xaabbccdd", "0xaabbccdd"];
+          const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
             .connect(controllerCanSetData)
@@ -1388,14 +1388,14 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataRestrictedController.push([
-            "`setData(bytes32[],bytes[])` -> updates 3x data keys (middle x3)",
+            '`setData(bytes32[],bytes[])` -> updates 3x data keys (middle x3)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("`setData(bytes32[],bytes[])` -> updates 3x data keys (last x3)", async () => {
+        it('`setData(bytes32[],bytes[])` -> updates 3x data keys (last x3)', async () => {
           const dataKeys = allowedERC725YDataKeys.slice(7, 10);
-          const dataValues = ["0xaabbccdd", "0xaabbccdd", "0xaabbccdd"];
+          const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
             .connect(controllerCanSetData)
@@ -1403,26 +1403,26 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataRestrictedController.push([
-            "`setData(bytes32[],bytes[])` -> updates 3x data keys (last x3)",
+            '`setData(bytes32[],bytes[])` -> updates 3x data keys (last x3)',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
 
-        it("`setData(bytes32[],bytes[])` -> updates 2x data keys + add 3x new controllers (including setting the array length + indexes under AddressPermissions[index])", async () => {
+        it('`setData(bytes32[],bytes[])` -> updates 2x data keys + add 3x new controllers (including setting the array length + indexes under AddressPermissions[index])', async () => {
           const dataKeys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts[3].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts[4].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts[5].address.substring(2),
           ];
 
           const dataValues = [
-            "0xaabbccdd",
-            "0xaabbccdd",
+            '0xaabbccdd',
+            '0xaabbccdd',
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
@@ -1434,7 +1434,7 @@ describe("⛽📊 Gas Benchmark", () => {
           const receipt = await tx.wait();
 
           benchmarkCasesSetDataRestrictedController.push([
-            "`setData(bytes32[],bytes[])` -> updates 2x data keys + add 3x new controllers (including setting the array length + indexes under AddressPermissions[index])",
+            '`setData(bytes32[],bytes[])` -> updates 2x data keys + add 3x new controllers (including setting the array length + indexes under AddressPermissions[index])',
             receipt.gasUsed.toNumber().toString(),
           ]);
         });
@@ -1442,7 +1442,7 @@ describe("⛽📊 Gas Benchmark", () => {
         after(async () => {
           restrictedControllerSetDataTable = getMarkdownTable({
             table: {
-              head: ["`setData` scenarios - 🛃 restricted controller", "⛽ Gas Usage"],
+              head: ['`setData` scenarios - 🛃 restricted controller', '⛽ Gas Usage'],
               body: benchmarkCasesSetDataRestrictedController,
             },
             alignment: [Align.Left, Align.Center],
@@ -1516,7 +1516,7 @@ ${restrictedControllerSetDataTable}
 
 </details>
 `;
-    const file = "benchmark.md";
+    const file = 'benchmark.md';
 
     fs.writeFileSync(file, markdown);
   });

--- a/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.behaviour.ts
+++ b/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.behaviour.ts
@@ -1,13 +1,13 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
-import { LSP11BasicSocialRecovery, LSP6KeyManager, UniversalProfile } from "../../types";
+import { LSP11BasicSocialRecovery, LSP6KeyManager, UniversalProfile } from '../../types';
 
-import { ALL_PERMISSIONS, ERC725YDataKeys, INTERFACE_IDS } from "../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, INTERFACE_IDS } from '../../constants';
 
-import { callPayload } from "../utils/fixtures";
+import { callPayload } from '../utils/fixtures';
 
 export type LSP11TestAccounts = {
   owner: SignerWithAddress;
@@ -64,31 +64,31 @@ export type LSP11TestContext = {
 export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestContext>) => {
   let context: LSP11TestContext;
 
-  describe("When using the contract as password recovery", () => {
+  describe('When using the contract as password recovery', () => {
     before(async () => {
       context = await buildContext();
     });
 
-    describe("when testing owner functionalities", () => {
-      it("Should revert when non-owner calls `setRecoverySecretHash(..)`", async () => {
+    describe('when testing owner functionalities', () => {
+      it('Should revert when non-owner calls `setRecoverySecretHash(..)`', async () => {
         const txParams = {
-          hash: ethers.utils.solidityKeccak256(["string"], ["LUKSO"]),
+          hash: ethers.utils.solidityKeccak256(['string'], ['LUKSO']),
         };
 
         await expect(
           context.lsp11BasicSocialRecovery
             .connect(context.accounts.any)
             .setRecoverySecretHash(txParams.hash),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("Should revert when owner calls `setRecoverySecretHash(..)` with bytes32(0) as secret", async () => {
+      it('Should revert when owner calls `setRecoverySecretHash(..)` with bytes32(0) as secret', async () => {
         const txParams = {
-          hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+          hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setRecoverySecretHash",
+          'setRecoverySecretHash',
           [txParams.hash],
         );
 
@@ -102,16 +102,16 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 payload,
               ),
             ),
-        ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "SecretHashCannotBeZero");
+        ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'SecretHashCannotBeZero');
       });
 
-      it("Should pass when owner calls `setRecoverySecretHash(..)`", async () => {
+      it('Should pass when owner calls `setRecoverySecretHash(..)`', async () => {
         const txParams = {
-          hash: ethers.utils.solidityKeccak256(["string"], ["LUKSO"]),
+          hash: ethers.utils.solidityKeccak256(['string'], ['LUKSO']),
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setRecoverySecretHash",
+          'setRecoverySecretHash',
           [txParams.hash],
         );
 
@@ -126,17 +126,17 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
             ),
         )
-          .to.emit(context.lsp11BasicSocialRecovery, "SecretHashChanged")
+          .to.emit(context.lsp11BasicSocialRecovery, 'SecretHashChanged')
           .withArgs(txParams.hash);
       });
     });
 
-    describe("when testing recovery", () => {
-      describe("when providing the wrong plainSecret", () => {
-        it("should revert", async () => {
+    describe('when testing recovery', () => {
+      describe('when providing the wrong plainSecret', () => {
+        it('should revert', async () => {
           const txParams = {
-            secret: "NotLUKSO",
-            newHash: ethers.utils.solidityKeccak256(["string"], ["UniversalProfiles"]),
+            secret: 'NotLUKSO',
+            newHash: ethers.utils.solidityKeccak256(['string'], ['UniversalProfiles']),
           };
 
           await expect(
@@ -147,15 +147,15 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 txParams.secret,
                 txParams.newHash,
               ),
-          ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "WrongPlainSecret");
+          ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'WrongPlainSecret');
         });
       });
 
-      describe("when providing bytes32(0) as newSecretHash", () => {
-        it("should revert", async () => {
+      describe('when providing bytes32(0) as newSecretHash', () => {
+        it('should revert', async () => {
           const txParams = {
-            secret: "LUKSO",
-            newHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            secret: 'LUKSO',
+            newHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           };
 
           await expect(
@@ -168,19 +168,19 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
           ).to.be.revertedWithCustomError(
             context.lsp11BasicSocialRecovery,
-            "SecretHashCannotBeZero",
+            'SecretHashCannotBeZero',
           );
         });
       });
 
-      describe("when providing the correct plainSecret and a valid newHash", () => {
+      describe('when providing the correct plainSecret and a valid newHash', () => {
         let recoveryTx;
         let txParams;
         let recoveryCounterBeforeRecovery;
         before(async () => {
           txParams = {
-            secret: "LUKSO",
-            newHash: ethers.utils.solidityKeccak256(["string"], ["UniversalProfiles"]),
+            secret: 'LUKSO',
+            newHash: ethers.utils.solidityKeccak256(['string'], ['UniversalProfiles']),
           };
 
           recoveryCounterBeforeRecovery =
@@ -195,18 +195,18 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
             );
         });
 
-        it("should increment the recovery counter", async () => {
+        it('should increment the recovery counter', async () => {
           const recoveryCounterAfterRecovery =
             await context.lsp11BasicSocialRecovery.callStatic.getRecoveryCounter();
 
           expect(recoveryCounterAfterRecovery).to.equal(recoveryCounterBeforeRecovery.add(1));
         });
 
-        it("should emit RecoveryProcessSuccessful event", async () => {
+        it('should emit RecoveryProcessSuccessful event', async () => {
           const guardians = await context.lsp11BasicSocialRecovery.callStatic.getGuardians();
 
           expect(recoveryTx)
-            .to.emit(context.lsp11BasicSocialRecovery, "RecoveryProcessSuccessful")
+            .to.emit(context.lsp11BasicSocialRecovery, 'RecoveryProcessSuccessful')
             .withArgs(
               recoveryCounterBeforeRecovery,
               context.accounts.addressASelected.address,
@@ -215,14 +215,14 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
             );
         });
 
-        it("should have set the correct AddressPermissions Keys on target", async () => {
+        it('should have set the correct AddressPermissions Keys on target', async () => {
           const txParams = {
-            permissionArrayKey: ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            permissionArrayKey: ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
             permissionInArrayKey:
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000003",
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000003',
             permissionMap:
-              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts.addressASelected.address.substr(2),
           };
           const [permissionArrayLength, controllerAddress, controllerPermissions] =
@@ -243,22 +243,22 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
       });
     });
 
-    describe("when testing execution on target after recovery", () => {
-      describe("when setting data on the target", () => {
-        it("should pass", async () => {
+    describe('when testing execution on target after recovery', () => {
+      describe('when setting data on the target', () => {
+        it('should pass', async () => {
           const txParams = {
-            key: ethers.utils.solidityKeccak256(["string"], ["MyKey"]),
-            value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes("I have access")),
+            key: ethers.utils.solidityKeccak256(['string'], ['MyKey']),
+            value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes('I have access')),
           };
 
-          const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
             txParams.key,
             txParams.value,
           ]);
 
           await context.lsp6KeyManager.connect(context.accounts.addressASelected).execute(payload);
 
-          const value = await context.universalProfile.callStatic["getData(bytes32)"](txParams.key);
+          const value = await context.universalProfile.callStatic['getData(bytes32)'](txParams.key);
 
           expect(value).to.equal(txParams.value);
         });
@@ -266,13 +266,13 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
     });
   });
 
-  describe("When using the contract as social recovery", () => {
+  describe('When using the contract as social recovery', () => {
     before(async () => {
       context = await buildContext();
     });
 
-    describe("when testing owner functionalities", () => {
-      it("Should revert when non-owner calls addGuardian function", async () => {
+    describe('when testing owner functionalities', () => {
+      it('Should revert when non-owner calls addGuardian function', async () => {
         const txParams = {
           guardianAddress: context.accounts.guardian1.address,
         };
@@ -280,16 +280,16 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           context.lsp11BasicSocialRecovery
             .connect(context.accounts.any)
             .addGuardian(txParams.guardianAddress),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("Should pass and emit GuardianAdded event when owner calls addGuardian function", async () => {
+      it('Should pass and emit GuardianAdded event when owner calls addGuardian function', async () => {
         const txParams = {
           guardianAddress: context.accounts.guardian1.address,
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "addGuardian",
+          'addGuardian',
           [txParams.guardianAddress],
         );
 
@@ -304,7 +304,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
             ),
         )
-          .to.emit(context.lsp11BasicSocialRecovery, "GuardianAdded")
+          .to.emit(context.lsp11BasicSocialRecovery, 'GuardianAdded')
           .withArgs(txParams.guardianAddress);
 
         const isGuardian = await context.lsp11BasicSocialRecovery.callStatic.isGuardian(
@@ -314,7 +314,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         expect(isGuardian).to.be.true;
       });
 
-      it("Should revert when non-owner calls removeGuardian function", async () => {
+      it('Should revert when non-owner calls removeGuardian function', async () => {
         const txParams = {
           guardianAddress: context.accounts.guardian1.address,
         };
@@ -322,16 +322,16 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           context.lsp11BasicSocialRecovery
             .connect(context.accounts.any)
             .removeGuardian(txParams.guardianAddress),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("Should pass and emit GuardianRemoved event when owner calls removeGuardian function", async () => {
+      it('Should pass and emit GuardianRemoved event when owner calls removeGuardian function', async () => {
         const txParams = {
           guardianAddress: context.accounts.guardian1.address,
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "removeGuardian",
+          'removeGuardian',
           [txParams.guardianAddress],
         );
 
@@ -346,7 +346,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
             ),
         )
-          .to.emit(context.lsp11BasicSocialRecovery, "GuardianRemoved")
+          .to.emit(context.lsp11BasicSocialRecovery, 'GuardianRemoved')
           .withArgs(txParams.guardianAddress);
 
         const isGuardian = await context.lsp11BasicSocialRecovery.callStatic.isGuardian(
@@ -356,7 +356,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         expect(isGuardian).to.be.false;
       });
 
-      it("Should revert when non-owner calls `setGuardiansThreshold(..)`", async () => {
+      it('Should revert when non-owner calls `setGuardiansThreshold(..)`', async () => {
         const txParams = {
           newThreshold: 1,
         };
@@ -365,16 +365,16 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           context.lsp11BasicSocialRecovery
             .connect(context.accounts.any)
             .setGuardiansThreshold(txParams.newThreshold),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("Should pass and emit GuardiansThresholdChanged event when owner `setGuardiansThreshold(..)`", async () => {
+      it('Should pass and emit GuardiansThresholdChanged event when owner `setGuardiansThreshold(..)`', async () => {
         const txParams = {
           newThreshold: 0,
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setGuardiansThreshold",
+          'setGuardiansThreshold',
           [txParams.newThreshold],
         );
 
@@ -389,7 +389,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
             ),
         )
-          .to.emit(context.lsp11BasicSocialRecovery, "GuardiansThresholdChanged")
+          .to.emit(context.lsp11BasicSocialRecovery, 'GuardiansThresholdChanged')
           .withArgs(txParams.newThreshold);
 
         const guardiansThreshold = (
@@ -399,25 +399,25 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         expect(guardiansThreshold).to.equal(txParams.newThreshold);
       });
 
-      it("Should revert when non-owner calls `setRecoverySecretHash(..)`", async () => {
+      it('Should revert when non-owner calls `setRecoverySecretHash(..)`', async () => {
         const txParams = {
-          hash: ethers.utils.solidityKeccak256(["string"], ["LUKSO"]),
+          hash: ethers.utils.solidityKeccak256(['string'], ['LUKSO']),
         };
 
         await expect(
           context.lsp11BasicSocialRecovery
             .connect(context.accounts.any)
             .setRecoverySecretHash(txParams.hash),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("Should pass and emit SecretHashChanged event when owner calls `setRecoverySecretHash(..)`", async () => {
+      it('Should pass and emit SecretHashChanged event when owner calls `setRecoverySecretHash(..)`', async () => {
         const txParams = {
-          hash: ethers.utils.solidityKeccak256(["string"], ["LUKSO"]),
+          hash: ethers.utils.solidityKeccak256(['string'], ['LUKSO']),
         };
 
         const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setRecoverySecretHash",
+          'setRecoverySecretHash',
           [txParams.hash],
         );
 
@@ -432,22 +432,22 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
             ),
         )
-          .to.emit(context.lsp11BasicSocialRecovery, "SecretHashChanged")
+          .to.emit(context.lsp11BasicSocialRecovery, 'SecretHashChanged')
           .withArgs(txParams.hash);
       });
     });
 
-    describe("when testing function logic", () => {
-      describe("when owner calls addGuardian(..) with an existing Guardian address", () => {
+    describe('when testing function logic', () => {
+      describe('when owner calls addGuardian(..) with an existing Guardian address', () => {
         let txParams;
         let payload;
-        before("Adding the guardian first", async () => {
+        before('Adding the guardian first', async () => {
           // Add the guardian
           txParams = {
             guardianAddress: context.accounts.guardian1.address,
           };
 
-          payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData("addGuardian", [
+          payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData('addGuardian', [
             txParams.guardianAddress,
           ]);
 
@@ -462,11 +462,11 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 ),
               ),
           )
-            .to.emit(context.lsp11BasicSocialRecovery, "GuardianAdded")
+            .to.emit(context.lsp11BasicSocialRecovery, 'GuardianAdded')
             .withArgs(txParams.guardianAddress);
         });
 
-        it("Should revert with GuardianAlreadyExist error ", async () => {
+        it('Should revert with GuardianAlreadyExist error ', async () => {
           await expect(
             context.lsp6KeyManager
               .connect(context.accounts.owner)
@@ -478,7 +478,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 ),
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "GuardianAlreadyExist")
+            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'GuardianAlreadyExist')
             .withArgs(txParams.guardianAddress);
 
           const isGuardian = await context.lsp11BasicSocialRecovery.callStatic.isGuardian(
@@ -488,14 +488,14 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         });
       });
 
-      describe("when owner calls removeGuardian(..) with a non-existing Guardian address", () => {
-        it("Should revert with GuardianDoNotExist error", async () => {
+      describe('when owner calls removeGuardian(..) with a non-existing Guardian address', () => {
+        it('Should revert with GuardianDoNotExist error', async () => {
           const txParams = {
             guardianAddress: context.accounts.random.address,
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "removeGuardian",
+            'removeGuardian',
             [txParams.guardianAddress],
           );
 
@@ -510,13 +510,13 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 ),
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "GuardianDoNotExist")
+            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'GuardianDoNotExist')
             .withArgs(txParams.guardianAddress);
         });
       });
 
-      describe("when owner calls setGuardiansThreshold(..) with a threshold higher than the guardians count", () => {
-        it("should revert with ThresholdCannotBeHigherThanGuardiansNumber error", async () => {
+      describe('when owner calls setGuardiansThreshold(..) with a threshold higher than the guardians count', () => {
+        it('should revert with ThresholdCannotBeHigherThanGuardiansNumber error', async () => {
           const guardians = await context.lsp11BasicSocialRecovery.callStatic.getGuardians();
 
           expect(guardians.length).to.equal(1);
@@ -526,7 +526,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "setGuardiansThreshold",
+            'setGuardiansThreshold',
             [txParams.newThreshold],
           );
 
@@ -543,14 +543,14 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           )
             .to.be.revertedWithCustomError(
               context.lsp11BasicSocialRecovery,
-              "ThresholdCannotBeHigherThanGuardiansNumber",
+              'ThresholdCannotBeHigherThanGuardiansNumber',
             )
             .withArgs(txParams.newThreshold, guardians.length);
         });
       });
 
-      describe("when owner calls setGuardiansThreshold(..) with a threshold lower than the guardians count", () => {
-        it("should pass", async () => {
+      describe('when owner calls setGuardiansThreshold(..) with a threshold lower than the guardians count', () => {
+        it('should pass', async () => {
           const guardians = await context.lsp11BasicSocialRecovery.callStatic.getGuardians();
 
           expect(guardians.length).to.equal(1);
@@ -560,7 +560,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "setGuardiansThreshold",
+            'setGuardiansThreshold',
             [txParams.newThreshold],
           );
 
@@ -575,7 +575,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 ),
               ),
           )
-            .to.emit(context.lsp11BasicSocialRecovery, "GuardiansThresholdChanged")
+            .to.emit(context.lsp11BasicSocialRecovery, 'GuardiansThresholdChanged')
             .withArgs(txParams.newThreshold);
 
           const guardiansThreshold =
@@ -584,8 +584,8 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         });
       });
 
-      describe("when owner calls setGuardiansThreshold(..) with a threshold equal to the guardians count", () => {
-        it("should pass", async () => {
+      describe('when owner calls setGuardiansThreshold(..) with a threshold equal to the guardians count', () => {
+        it('should pass', async () => {
           const guardians = await context.lsp11BasicSocialRecovery.callStatic.getGuardians();
 
           expect(guardians.length).to.equal(1);
@@ -595,7 +595,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "setGuardiansThreshold",
+            'setGuardiansThreshold',
             [txParams.newThreshold],
           );
 
@@ -610,7 +610,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 ),
               ),
           )
-            .to.emit(context.lsp11BasicSocialRecovery, "GuardiansThresholdChanged")
+            .to.emit(context.lsp11BasicSocialRecovery, 'GuardiansThresholdChanged')
             .withArgs(txParams.newThreshold);
 
           const guardiansThreshold =
@@ -619,10 +619,10 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         });
       });
 
-      describe("when owner calls removeGuardian(..) when the threshold is equal to the guardians count", () => {
+      describe('when owner calls removeGuardian(..) when the threshold is equal to the guardians count', () => {
         let guardians;
         let guardiansThreshold;
-        before("Check that the guardians number is equal to the guardians threshold", async () => {
+        before('Check that the guardians number is equal to the guardians threshold', async () => {
           guardians = await context.lsp11BasicSocialRecovery.callStatic.getGuardians();
           guardiansThreshold =
             await context.lsp11BasicSocialRecovery.callStatic.getGuardiansThreshold();
@@ -630,13 +630,13 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           expect(guardians.length).to.equal(guardiansThreshold);
         });
 
-        it("Should revert with GuardiansNumberCannotGoBelowThreshold error", async () => {
+        it('Should revert with GuardiansNumberCannotGoBelowThreshold error', async () => {
           const txParams = {
             guardianAddress: context.accounts.guardian1.address,
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "removeGuardian",
+            'removeGuardian',
             [txParams.guardianAddress],
           );
 
@@ -653,20 +653,20 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           )
             .to.be.revertedWithCustomError(
               context.lsp11BasicSocialRecovery,
-              "GuardiansNumberCannotGoBelowThreshold",
+              'GuardiansNumberCannotGoBelowThreshold',
             )
             .withArgs(guardiansThreshold);
         });
       });
 
-      describe("when owner calls setRecoverySecretHash(..) with bytes32(0) as secret", () => {
-        it("should revert with SecretHashCannotBeZero error", async () => {
+      describe('when owner calls setRecoverySecretHash(..) with bytes32(0) as secret', () => {
+        it('should revert with SecretHashCannotBeZero error', async () => {
           const txParams = {
-            hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           };
 
           const payload = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-            "setRecoverySecretHash",
+            'setRecoverySecretHash',
             [txParams.hash],
           );
 
@@ -682,14 +682,14 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
           ).to.be.revertedWithCustomError(
             context.lsp11BasicSocialRecovery,
-            "SecretHashCannotBeZero",
+            'SecretHashCannotBeZero',
           );
         });
       });
     });
 
-    describe("when testing guardians functionalities", () => {
-      before("Checking guardians and add few more", async () => {
+    describe('when testing guardians functionalities', () => {
+      before('Checking guardians and add few more', async () => {
         // Checking that guardian1 address is set
         const isAddress1Guardian = await context.lsp11BasicSocialRecovery.callStatic.isGuardian(
           context.accounts.guardian1.address,
@@ -700,17 +700,17 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         // Adding more guardians
 
         const payload1 = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "addGuardian",
+          'addGuardian',
           [context.accounts.guardian2.address],
         );
 
         const payload2 = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "addGuardian",
+          'addGuardian',
           [context.accounts.guardian3.address],
         );
 
         const payload3 = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "addGuardian",
+          'addGuardian',
           [context.accounts.guardian4.address],
         );
 
@@ -754,8 +754,8 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         expect(isAddress4Guardian).to.be.true;
       });
 
-      describe("when non-guardian calls selectNewController(..) function", () => {
-        it("should revert with CallerIsNotGuardian error", async () => {
+      describe('when non-guardian calls selectNewController(..) function', () => {
+        it('should revert with CallerIsNotGuardian error', async () => {
           const txParams = {
             addressToSelect: context.accounts.addressASelected.address,
           };
@@ -773,13 +773,13 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               .connect(caller)
               .selectNewController(txParams.addressToSelect),
           )
-            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "CallerIsNotGuardian")
+            .to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'CallerIsNotGuardian')
             .withArgs(caller.address);
         });
       });
 
-      describe("when a guardian calls selectNewController(..) function", () => {
-        it("should pass and emit SelectedNewController event", async () => {
+      describe('when a guardian calls selectNewController(..) function', () => {
+        it('should pass and emit SelectedNewController event', async () => {
           const txParams = {
             addressToSelect: context.accounts.addressASelected.address,
           };
@@ -800,20 +800,20 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               .connect(caller)
               .selectNewController(txParams.addressToSelect),
           )
-            .to.emit(context.lsp11BasicSocialRecovery, "SelectedNewController")
+            .to.emit(context.lsp11BasicSocialRecovery, 'SelectedNewController')
             .withArgs(currentRecoveryCounter, caller.address, txParams.addressToSelect);
         });
       });
     });
 
-    describe("when finalizing recovery", () => {
+    describe('when finalizing recovery', () => {
       let plainSecret;
       let recoverySecretHash;
       let beforeRecoveryCounter;
       let guardiansThreshold;
       let addressAselection;
       let addressBselection;
-      before("Distribution selection of the guardians and setting recovery params", async () => {
+      before('Distribution selection of the guardians and setting recovery params', async () => {
         // Checks that recoveryCounter equal 0 before recovery
         beforeRecoveryCounter =
           await context.lsp11BasicSocialRecovery.callStatic.getRecoveryCounter();
@@ -822,7 +822,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
 
         // Changing the threshold to 3 out of 4 guardians
         const payload1 = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setGuardiansThreshold",
+          'setGuardiansThreshold',
           [3],
         );
 
@@ -841,11 +841,11 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         expect(guardiansThreshold).to.equal(3);
 
         // Changing the secretHash to "LUKSO"
-        plainSecret = "LUKSO";
-        recoverySecretHash = ethers.utils.solidityKeccak256(["string"], [plainSecret]);
+        plainSecret = 'LUKSO';
+        recoverySecretHash = ethers.utils.solidityKeccak256(['string'], [plainSecret]);
 
         const payload2 = context.lsp11BasicSocialRecovery.interface.encodeFunctionData(
-          "setRecoverySecretHash",
+          'setRecoverySecretHash',
           [recoverySecretHash],
         );
 
@@ -908,10 +908,10 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
       });
 
       describe("When address B calls recoverOwnership(..) when it didn't reached the guardians threshold", () => {
-        it("should revert with ThresholdNotReachedForRecoverer error", async () => {
+        it('should revert with ThresholdNotReachedForRecoverer error', async () => {
           const txParams = {
             secret: plainSecret,
-            newHash: ethers.utils.solidityKeccak256(["string"], ["NotLUKSO"]),
+            newHash: ethers.utils.solidityKeccak256(['string'], ['NotLUKSO']),
           };
 
           await expect(
@@ -925,7 +925,7 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
           )
             .to.be.revertedWithCustomError(
               context.lsp11BasicSocialRecovery,
-              "ThresholdNotReachedForRecoverer",
+              'ThresholdNotReachedForRecoverer',
             )
             .withArgs(
               context.accounts.addressBSelected.address,
@@ -935,11 +935,11 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
         });
       });
 
-      describe("When address A calls recoverOwnership(..) with bytes32(0) as new secretHash", () => {
-        it("should revert with SecretHashCannotBeZero error", async () => {
+      describe('When address A calls recoverOwnership(..) with bytes32(0) as new secretHash', () => {
+        it('should revert with SecretHashCannotBeZero error', async () => {
           const txParams = {
             secret: plainSecret,
-            newHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
+            newHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
           };
 
           await expect(
@@ -952,16 +952,16 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
               ),
           ).to.be.revertedWithCustomError(
             context.lsp11BasicSocialRecovery,
-            "SecretHashCannotBeZero",
+            'SecretHashCannotBeZero',
           );
         });
       });
 
-      describe("When address A calls recoverOwnership(..) with the incorrect plainSecret", () => {
-        it("should revert with WrongPlainSecret error", async () => {
+      describe('When address A calls recoverOwnership(..) with the incorrect plainSecret', () => {
+        it('should revert with WrongPlainSecret error', async () => {
           const txParams = {
-            secret: "NotTheValidPlainSecret",
-            newHash: ethers.utils.solidityKeccak256(["string"], ["NotLUKSO"]),
+            secret: 'NotTheValidPlainSecret',
+            newHash: ethers.utils.solidityKeccak256(['string'], ['NotLUKSO']),
           };
 
           await expect(
@@ -972,17 +972,17 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
                 txParams.secret,
                 txParams.newHash,
               ),
-          ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, "WrongPlainSecret");
+          ).to.be.revertedWithCustomError(context.lsp11BasicSocialRecovery, 'WrongPlainSecret');
         });
       });
 
-      describe("When address A calls recoverOwnership(..) with the correct plainSecret", () => {
+      describe('When address A calls recoverOwnership(..) with the correct plainSecret', () => {
         let ownershipRecoveryTx;
         let newPlainSecret;
         let newSecretHash;
-        before("Creating the tx of recovering", async () => {
-          newPlainSecret = "UniversalProfiles";
-          newSecretHash = ethers.utils.solidityKeccak256(["string"], [newPlainSecret]);
+        before('Creating the tx of recovering', async () => {
+          newPlainSecret = 'UniversalProfiles';
+          newSecretHash = ethers.utils.solidityKeccak256(['string'], [newPlainSecret]);
 
           const txParams = {
             secret: plainSecret,
@@ -998,9 +998,9 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
             );
         });
 
-        it("should pass and emit RecoveryProcessSuccessful event", async () => {
+        it('should pass and emit RecoveryProcessSuccessful event', async () => {
           expect(ownershipRecoveryTx)
-            .to.emit(context.lsp11BasicSocialRecovery, "RecoveryProcessSuccessful")
+            .to.emit(context.lsp11BasicSocialRecovery, 'RecoveryProcessSuccessful')
             .withArgs(
               beforeRecoveryCounter,
               context.accounts.addressASelected,
@@ -1009,27 +1009,27 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
             );
         });
 
-        it("should increment the recovery counter", async () => {
+        it('should increment the recovery counter', async () => {
           const afterRecoveryCounter =
             await context.lsp11BasicSocialRecovery.callStatic.getRecoveryCounter();
 
           expect(afterRecoveryCounter).to.equal(beforeRecoveryCounter + 1);
         });
 
-        it("should update the recoverySecretHash ", async () => {
+        it('should update the recoverySecretHash ', async () => {
           expect(ownershipRecoveryTx)
-            .to.emit(context.lsp11BasicSocialRecovery, "SecretHashChanged")
+            .to.emit(context.lsp11BasicSocialRecovery, 'SecretHashChanged')
             .withArgs(newSecretHash);
         });
 
-        it("should add the AddressPermissions Key for address A in the target ", async () => {
+        it('should add the AddressPermissions Key for address A in the target ', async () => {
           const txParams = {
-            permissionArrayKey: ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            permissionArrayKey: ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
             permissionInArrayKey:
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000003",
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000003',
             permissionMap:
-              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts.addressASelected.address.substr(2),
           };
           const [permissionArrayLength, controllerAddress, controllerPermissions] =
@@ -1050,30 +1050,30 @@ export const shouldBehaveLikeLSP11 = (buildContext: () => Promise<LSP11TestConte
       });
     });
 
-    describe("when testing execution on target after recovery", () => {
-      describe("when setting data on the target", () => {
-        it("should pass", async () => {
+    describe('when testing execution on target after recovery', () => {
+      describe('when setting data on the target', () => {
+        it('should pass', async () => {
           const txParams = {
-            key: ethers.utils.solidityKeccak256(["string"], ["MyKey"]),
-            value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes("I have access")),
+            key: ethers.utils.solidityKeccak256(['string'], ['MyKey']),
+            value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes('I have access')),
           };
 
-          const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
             txParams.key,
             txParams.value,
           ]);
 
           await context.lsp6KeyManager.connect(context.accounts.addressASelected).execute(payload);
 
-          const value = await context.universalProfile.callStatic["getData(bytes32)"](txParams.key);
+          const value = await context.universalProfile.callStatic['getData(bytes32)'](txParams.key);
 
           expect(value).to.equal(txParams.value);
         });
       });
     });
 
-    describe("when checking guardians choice", () => {
-      it("should be reset", async () => {
+    describe('when checking guardians choice', () => {
+      it('should be reset', async () => {
         const guardian1Choice = await context.lsp11BasicSocialRecovery.callStatic.getGuardianChoice(
           context.accounts.guardian1.address,
         );
@@ -1105,14 +1105,14 @@ export const shouldInitializeLikeLSP11 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("Should have registered the ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('Should have registered the ERC165 interface', async () => {
       expect(
         await context.lsp11BasicSocialRecovery.callStatic.supportsInterface(INTERFACE_IDS.ERC165),
       ).to.be.true;
     });
 
-    it("Should have registered the LSP11 interface", async () => {
+    it('Should have registered the LSP11 interface', async () => {
       expect(
         await context.lsp11BasicSocialRecovery.callStatic.supportsInterface(
           INTERFACE_IDS.LSP11BasicSocialRecovery,
@@ -1120,12 +1120,12 @@ export const shouldInitializeLikeLSP11 = (
       ).to.be.true;
     });
 
-    it("Should have set the owner", async () => {
+    it('Should have set the owner', async () => {
       const owner = await context.lsp11BasicSocialRecovery.callStatic.owner();
       expect(owner).to.equal(context.deployParams.owner.address);
     });
 
-    it("Should have set the linked target", async () => {
+    it('Should have set the linked target', async () => {
       const target = await context.lsp11BasicSocialRecovery.callStatic.target();
       expect(target).to.equal(context.deployParams.target.address);
     });

--- a/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.test.ts
+++ b/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.test.ts
@@ -1,18 +1,18 @@
-import { LSP11BasicSocialRecovery__factory, LSP6KeyManager, UniversalProfile } from "../../types";
+import { LSP11BasicSocialRecovery__factory, LSP6KeyManager, UniversalProfile } from '../../types';
 
 import {
   getNamedAccounts,
   shouldInitializeLikeLSP11,
   LSP11TestContext,
   shouldBehaveLikeLSP11,
-} from "./LSP11BasicSocialRecovery.behaviour";
+} from './LSP11BasicSocialRecovery.behaviour';
 
 import {
   setupProfileWithKeyManagerWithURD,
   grantLSP11PermissionViaKeyManager,
-} from "../utils/fixtures";
+} from '../utils/fixtures';
 
-describe("LSP11BasicSocialRecovery with constructor", () => {
+describe('LSP11BasicSocialRecovery with constructor', () => {
   let context: LSP11TestContext;
 
   const buildTestContext = async (): Promise<LSP11TestContext> => {
@@ -52,8 +52,8 @@ describe("LSP11BasicSocialRecovery with constructor", () => {
     context = await buildTestContext();
   });
 
-  describe("When deploying the contract", () => {
-    describe("When initializing the contract", () => {
+  describe('When deploying the contract', () => {
+    describe('When initializing the contract', () => {
       shouldInitializeLikeLSP11(async () => {
         const { lsp11BasicSocialRecovery, deployParams } = context;
         return {
@@ -65,7 +65,7 @@ describe("LSP11BasicSocialRecovery with constructor", () => {
     });
   });
 
-  describe("When testing deployed contract", () => {
+  describe('When testing deployed contract', () => {
     shouldBehaveLikeLSP11(buildTestContext);
   });
 });

--- a/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInit.test.ts
+++ b/tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInit.test.ts
@@ -1,25 +1,25 @@
-import { expect } from "chai";
+import { expect } from 'chai';
 
 import {
   LSP6KeyManager,
   UniversalProfile,
   LSP11BasicSocialRecoveryInit__factory,
-} from "../../types";
+} from '../../types';
 
 import {
   getNamedAccounts,
   shouldInitializeLikeLSP11,
   LSP11TestContext,
   shouldBehaveLikeLSP11,
-} from "./LSP11BasicSocialRecovery.behaviour";
+} from './LSP11BasicSocialRecovery.behaviour';
 
 import {
   setupProfileWithKeyManagerWithURD,
   deployProxy,
   grantLSP11PermissionViaKeyManager,
-} from "../utils/fixtures";
+} from '../utils/fixtures';
 
-describe("LSP11BasicSocialRecoveryInit with proxy", () => {
+describe('LSP11BasicSocialRecoveryInit with proxy', () => {
   const buildTestContext = async (): Promise<LSP11TestContext> => {
     const accounts = await getNamedAccounts();
 
@@ -63,20 +63,20 @@ describe("LSP11BasicSocialRecoveryInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP11TestContext) => {
-    return context.lsp11BasicSocialRecovery["initialize(address,address)"](
+    return context.lsp11BasicSocialRecovery['initialize(address,address)'](
       context.deployParams.owner.address,
       context.deployParams.target.address,
     );
   };
 
-  describe("When deploying the contract as proxy", () => {
+  describe('When deploying the contract as proxy', () => {
     let context: LSP11TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("When initializing the proxy contract", () => {
+    describe('When initializing the proxy contract', () => {
       shouldInitializeLikeLSP11(async () => {
         const { lsp11BasicSocialRecovery, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -89,16 +89,16 @@ describe("LSP11BasicSocialRecoveryInit with proxy", () => {
       });
     });
 
-    describe("When calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('When calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("When testing deployed contract", () => {
+  describe('When testing deployed contract', () => {
     shouldBehaveLikeLSP11(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
+++ b/tests/LSP14Ownable2Step/LSP14Ownable2Step.behaviour.ts
@@ -1,19 +1,19 @@
-import { expect } from "chai";
-import { ethers, network, artifacts } from "hardhat";
+import { expect } from 'chai';
+import { ethers, network, artifacts } from 'hardhat';
 
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   LSP9Vault,
   UPWithInstantAcceptOwnership__factory,
   UPWithInstantAcceptOwnership,
-} from "../../types";
+} from '../../types';
 
 // constants
-import { OPERATION_TYPES } from "../../constants";
+import { OPERATION_TYPES } from '../../constants';
 
 // helpers
-import { provider } from "../utils/helpers";
-import { BigNumber, ContractTransaction } from "ethers";
+import { provider } from '../utils/helpers';
+import { BigNumber, ContractTransaction } from 'ethers';
 
 export type LSP14TestContext = {
   accounts: SignerWithAddress[];
@@ -29,23 +29,23 @@ export const shouldBehaveLikeLSP14 = (
   let newOwner: SignerWithAddress;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("50"));
+    context = await buildContext(ethers.utils.parseEther('50'));
     newOwner = context.accounts[1];
   });
 
-  describe("when owner call transferOwnership(...)", () => {
+  describe('when owner call transferOwnership(...)', () => {
     before(async () => {
       await context.contract
         .connect(context.deployParams.owner)
         .transferOwnership(newOwner.address);
     });
 
-    it("should have set the pendingOwner", async () => {
+    it('should have set the pendingOwner', async () => {
       let pendingOwner = await context.contract.pendingOwner();
       expect(pendingOwner).to.equal(newOwner.address);
     });
 
-    it("owner should remain the current owner", async () => {
+    it('owner should remain the current owner', async () => {
       let newOwner = ethers.Wallet.createRandom();
 
       const ownerBefore = await context.contract.owner();
@@ -59,7 +59,7 @@ export const shouldBehaveLikeLSP14 = (
       expect(ownerBefore).to.equal(ownerAfter);
     });
 
-    it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+    it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
       let overridenNewOwner = ethers.Wallet.createRandom();
 
       await context.contract
@@ -70,18 +70,18 @@ export const shouldBehaveLikeLSP14 = (
       expect(pendingOwner).to.equal(overridenNewOwner.address);
     });
 
-    it("should revert when transferring Ownership to the contract itself", async () => {
+    it('should revert when transferring Ownership to the contract itself', async () => {
       await expect(
         context.contract
           .connect(context.deployParams.owner)
           .transferOwnership(context.contract.address),
-      ).to.be.revertedWithCustomError(context.contract, "CannotTransferOwnershipToSelf");
+      ).to.be.revertedWithCustomError(context.contract, 'CannotTransferOwnershipToSelf');
     });
 
-    describe("it should still be allowed to call onlyOwner functions", () => {
-      it("setData(...)", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('it should still be allowed to call onlyOwner functions', () => {
+      it('setData(...)', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
         await context.contract.connect(context.deployParams.owner).setData(key, value);
 
@@ -89,16 +89,16 @@ export const shouldBehaveLikeLSP14 = (
         expect(result).to.equal(value);
       });
 
-      it("execute(...) - LYX transfer", async () => {
+      it('execute(...) - LYX transfer', async () => {
         const recipient = context.accounts[3];
-        const amount = ethers.utils.parseEther("3");
+        const amount = ethers.utils.parseEther('3');
 
         const recipientBalanceBefore = await provider.getBalance(recipient.address);
         const accountBalanceBefore = await provider.getBalance(context.contract.address);
 
         await context.contract
           .connect(context.deployParams.owner)
-          .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x");
+          .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x');
 
         const recipientBalanceAfter = await provider.getBalance(recipient.address);
         const accountBalanceAfter = await provider.getBalance(context.contract.address);
@@ -111,7 +111,7 @@ export const shouldBehaveLikeLSP14 = (
       });
     });
 
-    describe("when `acceptOwnership(...)` is called in the same tx as `transferOwnership(...)`", () => {
+    describe('when `acceptOwnership(...)` is called in the same tx as `transferOwnership(...)`', () => {
       let upWithCustomURD: UPWithInstantAcceptOwnership;
 
       before(async () => {
@@ -125,7 +125,7 @@ export const shouldBehaveLikeLSP14 = (
           context.contract
             .connect(context.deployParams.owner)
             .transferOwnership(upWithCustomURD.address),
-        ).to.be.revertedWith("LSP14: newOwner MUST accept ownership in a separate transaction");
+        ).to.be.revertedWith('LSP14: newOwner MUST accept ownership in a separate transaction');
       });
     });
 
@@ -136,24 +136,24 @@ export const shouldBehaveLikeLSP14 = (
     });
   });
 
-  describe("when non-owner call transferOwnership(...)", () => {
-    it("should revert", async () => {
+  describe('when non-owner call transferOwnership(...)', () => {
+    it('should revert', async () => {
       let randomAddress = context.accounts[2];
 
       await expect(
         context.contract.connect(randomAddress).transferOwnership(randomAddress.address),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
   });
 
-  describe("when calling acceptOwnership(...)", () => {
-    it("should revert when caller is not the pending owner", async () => {
+  describe('when calling acceptOwnership(...)', () => {
+    it('should revert when caller is not the pending owner', async () => {
       await expect(
         context.contract.connect(context.accounts[2]).acceptOwnership(),
-      ).to.be.revertedWith("LSP14: caller is not the pendingOwner");
+      ).to.be.revertedWith('LSP14: caller is not the pendingOwner');
     });
 
-    describe("when caller is the pending owner", () => {
+    describe('when caller is the pending owner', () => {
       let pendingOwner: string;
       let acceptOwnershipTx: ContractTransaction;
 
@@ -162,63 +162,63 @@ export const shouldBehaveLikeLSP14 = (
         acceptOwnershipTx = await context.contract.connect(newOwner).acceptOwnership();
       });
 
-      it("should change the contract owner to the pendingOwner", async () => {
+      it('should change the contract owner to the pendingOwner', async () => {
         let updatedOwner = await context.contract.owner();
         expect(updatedOwner).to.equal(pendingOwner);
       });
 
-      it("should have cleared the pendingOwner after transferring ownership", async () => {
+      it('should have cleared the pendingOwner after transferring ownership', async () => {
         let newPendingOwner = await context.contract.pendingOwner();
         expect(newPendingOwner).to.equal(ethers.constants.AddressZero);
       });
 
-      it("should have emitted a OwnershipTransferred event", async () => {
-        await expect(acceptOwnershipTx).to.emit(context.contract, "OwnershipTransferred").withArgs(
+      it('should have emitted a OwnershipTransferred event', async () => {
+        await expect(acceptOwnershipTx).to.emit(context.contract, 'OwnershipTransferred').withArgs(
           context.deployParams.owner.address, // previous owner
           newOwner.address, // new owner
         );
       });
     });
 
-    describe("after pendingOwner has claimed ownership", () => {
+    describe('after pendingOwner has claimed ownership', () => {
       let previousOwner: SignerWithAddress;
 
       before(async () => {
         previousOwner = context.deployParams.owner;
       });
 
-      describe("previous owner should not be allowed anymore to call onlyOwner functions", () => {
-        it("should revert when calling `setData(...)`", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('previous owner should not be allowed anymore to call onlyOwner functions', () => {
+        it('should revert when calling `setData(...)`', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
           await expect(
             context.contract.connect(previousOwner).setData(key, value),
           ).to.be.revertedWith(context.onlyOwnerRevertString);
         });
 
-        it("should revert when calling `execute(...)`", async () => {
+        it('should revert when calling `execute(...)`', async () => {
           const recipient = context.accounts[3];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           await expect(
             context.contract
               .connect(previousOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x"),
-          ).to.be.revertedWith("Ownable: caller is not the owner");
+              .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x'),
+          ).to.be.revertedWith('Ownable: caller is not the owner');
         });
 
-        it("should revert when calling `renounceOwnership(...)`", async () => {
+        it('should revert when calling `renounceOwnership(...)`', async () => {
           await expect(
             context.contract.connect(previousOwner).renounceOwnership(),
-          ).to.be.revertedWith("Ownable: caller is not the owner");
+          ).to.be.revertedWith('Ownable: caller is not the owner');
         });
       });
 
-      describe("new owner should be allowed to call onlyOwner functions", () => {
-        it("setData(...)", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('new owner should be allowed to call onlyOwner functions', () => {
+        it('setData(...)', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
           await context.contract.connect(newOwner).setData(key, value);
 
@@ -226,14 +226,14 @@ export const shouldBehaveLikeLSP14 = (
           expect(result).to.equal(value);
         });
 
-        it("execute(...) - LYX transfer", async () => {
+        it('execute(...) - LYX transfer', async () => {
           const recipient = context.accounts[3];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           await expect(() =>
             context.contract
               .connect(newOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x'),
           ).to.changeEtherBalances(
             [context.contract.address, recipient.address],
             [
@@ -246,23 +246,23 @@ export const shouldBehaveLikeLSP14 = (
     });
   });
 
-  describe("renounceOwnership(...)", () => {
-    describe("when calling renounceOwnership() with a non-owner account", () => {
-      it("should revert with custom message", async () => {
+  describe('renounceOwnership(...)', () => {
+    describe('when calling renounceOwnership() with a non-owner account', () => {
+      it('should revert with custom message', async () => {
         const tx = context.contract.connect(context.accounts[5]).renounceOwnership();
 
-        await expect(tx).to.be.revertedWith("Ownable: caller is not the owner");
+        await expect(tx).to.be.revertedWith('Ownable: caller is not the owner');
       });
     });
 
-    describe("when calling renounceOwnership() the first time", () => {
+    describe('when calling renounceOwnership() the first time', () => {
       let currentOwner: SignerWithAddress;
       let renounceOwnershipTx: ContractTransaction;
 
       let anotherOwner: string;
 
       before(async () => {
-        context = await buildContext(ethers.utils.parseEther("20"));
+        context = await buildContext(ethers.utils.parseEther('20'));
 
         currentOwner = context.accounts[0];
 
@@ -272,21 +272,21 @@ export const shouldBehaveLikeLSP14 = (
         await context.contract.connect(currentOwner).transferOwnership(anotherOwner);
 
         // mine 1,000 blocks
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(1000)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(1000)]);
 
         renounceOwnershipTx = await context.contract.connect(currentOwner).renounceOwnership();
 
         await renounceOwnershipTx.wait();
       });
 
-      it("should instantiate the renounceOwnership process correctly", async () => {
+      it('should instantiate the renounceOwnership process correctly', async () => {
         const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
           (
-            await artifacts.getBuildInfo("contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault")
+            await artifacts.getBuildInfo('contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault')
           )?.output.contracts[
-            "contracts/LSP9Vault/LSP9Vault.sol"
+            'contracts/LSP9Vault/LSP9Vault.sol'
           ].LSP9Vault.storageLayout.storage.filter((elem) => {
-            if (elem.label === "_renounceOwnershipStartedAt") return elem;
+            if (elem.label === '_renounceOwnershipStartedAt') return elem;
           })[0].slot,
         );
 
@@ -300,22 +300,22 @@ export const shouldBehaveLikeLSP14 = (
         );
       });
 
-      it("should have emitted a RenounceOwnershipStarted event", async () => {
-        await expect(renounceOwnershipTx).to.emit(context.contract, "RenounceOwnershipStarted");
+      it('should have emitted a RenounceOwnershipStarted event', async () => {
+        await expect(renounceOwnershipTx).to.emit(context.contract, 'RenounceOwnershipStarted');
       });
 
-      it("should not change the current owner", async () => {
+      it('should not change the current owner', async () => {
         expect(await context.contract.owner()).to.equal(currentOwner.address);
       });
 
-      it("should reset the pendingOwner", async () => {
+      it('should reset the pendingOwner', async () => {
         expect(await context.contract.pendingOwner()).to.equal(ethers.constants.AddressZero);
       });
 
-      describe("currentOwner should still be able to interact with contract before confirming", () => {
-        it("`setData(...)`", async () => {
-          const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Random Key"));
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Value"));
+      describe('currentOwner should still be able to interact with contract before confirming', () => {
+        it('`setData(...)`', async () => {
+          const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Random Key'));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Value'));
 
           await context.contract.connect(currentOwner).setData(key, value);
 
@@ -324,26 +324,26 @@ export const shouldBehaveLikeLSP14 = (
           expect(result).to.equal(value);
         });
 
-        it("transfer LYX via `execute(...)`", async () => {
+        it('transfer LYX via `execute(...)`', async () => {
           const recipient = context.accounts[3].address;
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           // verify that balances have been updated
           await expect(() =>
             context.contract
               .connect(currentOwner)
-              .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
           ).to.changeEtherBalances([context.contract.address, recipient], [`-${amount}`, amount]);
         });
       });
     });
 
-    describe("when calling renounceOwnership() the second time", () => {
+    describe('when calling renounceOwnership() the second time', () => {
       before(async () => {
-        context = await buildContext(ethers.utils.parseEther("20"));
+        context = await buildContext(ethers.utils.parseEther('20'));
       });
 
-      it("should revert if called in the delay period", async () => {
+      it('should revert if called in the delay period', async () => {
         const renounceOwnershipOnce = await context.contract
           .connect(context.deployParams.owner)
           .renounceOwnership();
@@ -351,10 +351,10 @@ export const shouldBehaveLikeLSP14 = (
         const renounceOwnershipOnceReceipt = await renounceOwnershipOnce.wait();
 
         // skip 98 blocks, but not enough to reach the delay period
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(98)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(98)]);
 
         await expect(context.contract.connect(context.deployParams.owner).renounceOwnership())
-          .to.be.revertedWithCustomError(context.contract, "NotInRenounceOwnershipInterval")
+          .to.be.revertedWithCustomError(context.contract, 'NotInRenounceOwnershipInterval')
           .withArgs(
             renounceOwnershipOnceReceipt.blockNumber + 200,
             renounceOwnershipOnceReceipt.blockNumber + 400,
@@ -363,23 +363,23 @@ export const shouldBehaveLikeLSP14 = (
         expect(await context.contract.owner()).to.equal(context.deployParams.owner.address);
 
         // skip 500 blocks for the next test
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(500)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(500)]);
       });
 
-      it("should initialize again if the confirmation period passed", async () => {
+      it('should initialize again if the confirmation period passed', async () => {
         const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
           (
-            await artifacts.getBuildInfo("contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault")
+            await artifacts.getBuildInfo('contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault')
           )?.output.contracts[
-            "contracts/LSP9Vault/LSP9Vault.sol"
+            'contracts/LSP9Vault/LSP9Vault.sol'
           ].LSP9Vault.storageLayout.storage.filter((elem) => {
-            if (elem.label === "_renounceOwnershipStartedAt") return elem;
+            if (elem.label === '_renounceOwnershipStartedAt') return elem;
           })[0].slot,
         );
 
         await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(400)]); // skip 400 blocks
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(400)]); // skip 400 blocks
 
         let tx = await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
@@ -395,12 +395,12 @@ export const shouldBehaveLikeLSP14 = (
         );
       });
 
-      describe("when called after the delay and before the confirmation period end", () => {
+      describe('when called after the delay and before the confirmation period end', () => {
         let renounceOwnershipFirstTx: ContractTransaction;
         let renounceOwnershipSecondTx: ContractTransaction;
 
         before(async () => {
-          context = await buildContext(ethers.utils.parseEther("20"));
+          context = await buildContext(ethers.utils.parseEther('20'));
 
           // Call renounceOwnership for the first time
           renounceOwnershipFirstTx = await context.contract
@@ -408,7 +408,7 @@ export const shouldBehaveLikeLSP14 = (
             .renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(199)]);
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(199)]);
 
           // Call renounceOwnership for the second time
           renounceOwnershipSecondTx = await context.contract
@@ -416,32 +416,32 @@ export const shouldBehaveLikeLSP14 = (
             .renounceOwnership();
         });
 
-        it("should have emitted a OwnershipTransferred event", async () => {
+        it('should have emitted a OwnershipTransferred event', async () => {
           await expect(renounceOwnershipSecondTx)
-            .to.emit(context.contract, "OwnershipTransferred")
+            .to.emit(context.contract, 'OwnershipTransferred')
             .withArgs(context.deployParams.owner.address, ethers.constants.AddressZero);
 
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("should have emitted a OwnershipRenounced event", async () => {
-          await expect(renounceOwnershipSecondTx).to.emit(context.contract, "OwnershipRenounced");
+        it('should have emitted a OwnershipRenounced event', async () => {
+          await expect(renounceOwnershipSecondTx).to.emit(context.contract, 'OwnershipRenounced');
 
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("owner should now be address(0)", async () => {
+        it('owner should now be address(0)', async () => {
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("should have reset the `_renounceOwnershipStartedAt` state variable to zero", async () => {
+        it('should have reset the `_renounceOwnershipStartedAt` state variable to zero', async () => {
           const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
             (
-              await artifacts.getBuildInfo("contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault")
+              await artifacts.getBuildInfo('contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault')
             )?.output.contracts[
-              "contracts/LSP9Vault/LSP9Vault.sol"
+              'contracts/LSP9Vault/LSP9Vault.sol'
             ].LSP9Vault.storageLayout.storage.filter((elem) => {
-              if (elem.label === "_renounceOwnershipStartedAt") return elem;
+              if (elem.label === '_renounceOwnershipStartedAt') return elem;
             })[0].slot,
           );
 
@@ -453,34 +453,34 @@ export const shouldBehaveLikeLSP14 = (
           expect(ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()).to.equal(0);
         });
 
-        describe("currentOwner should not be able to interact with contract anymore after confirming", () => {
-          it("`setData(...)`", async () => {
-            const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Random Key"));
-            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Value"));
+        describe('currentOwner should not be able to interact with contract anymore after confirming', () => {
+          it('`setData(...)`', async () => {
+            const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Random Key'));
+            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Value'));
 
             await expect(
               context.contract.connect(context.deployParams.owner).setData(key, value),
-            ).to.be.revertedWith("Only Owner or reentered Universal Receiver Delegate allowed");
+            ).to.be.revertedWith('Only Owner or reentered Universal Receiver Delegate allowed');
           });
 
-          it("transfer LYX via `execute(...)`", async () => {
+          it('transfer LYX via `execute(...)`', async () => {
             const recipient = context.accounts[3].address;
-            const amount = ethers.utils.parseEther("3");
+            const amount = ethers.utils.parseEther('3');
 
             await expect(
               context.contract
                 .connect(context.deployParams.owner)
-                .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
-            ).to.be.revertedWith("Ownable: caller is not the owner");
+                .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
+            ).to.be.revertedWith('Ownable: caller is not the owner');
           });
         });
       });
 
-      describe("if there was a pendingOwner set before confirming `renounceOwnership(...)", () => {
+      describe('if there was a pendingOwner set before confirming `renounceOwnership(...)', () => {
         let newOwner: SignerWithAddress;
 
         before(async () => {
-          context = await buildContext(ethers.utils.parseEther("20"));
+          context = await buildContext(ethers.utils.parseEther('20'));
 
           // transferOwnership to a new owner
           newOwner = context.accounts[3];
@@ -493,42 +493,42 @@ export const shouldBehaveLikeLSP14 = (
           await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(199)]);
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(199)]);
 
           // Call renounceOwnership for the second time
           await context.contract.connect(context.deployParams.owner).renounceOwnership();
         });
 
-        it("should reset the pendingOwner whenever renounceOwnership(..) is confirmed", async () => {
+        it('should reset the pendingOwner whenever renounceOwnership(..) is confirmed', async () => {
           expect(await context.contract.pendingOwner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("previous pendingOwner should not be able to call acceptOwnership(...) anymore", async () => {
+        it('previous pendingOwner should not be able to call acceptOwnership(...) anymore', async () => {
           await expect(context.contract.connect(newOwner).acceptOwnership()).to.be.revertedWith(
-            "LSP14: caller is not the pendingOwner",
+            'LSP14: caller is not the pendingOwner',
           );
         });
       });
     });
   });
 
-  describe("when calling `renounceOwnership()` when `block.number` is less than 400 blocks (RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY + RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD)`", () => {
+  describe('when calling `renounceOwnership()` when `block.number` is less than 400 blocks (RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY + RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD)`', () => {
     before(async () => {
       context = await buildContext();
 
       // Simulate a scenario where we are at just few hundred blocks after the blockchain started
       // (few hundred blocks after genesis)
-      await network.provider.send("hardhat_mine", [ethers.utils.hexValue(138)]);
+      await network.provider.send('hardhat_mine', [ethers.utils.hexValue(138)]);
     });
 
-    it("should instantiate the renounceOwnership process in 2 steps correctly", async () => {
+    it('should instantiate the renounceOwnership process in 2 steps correctly', async () => {
       const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
         (
-          await artifacts.getBuildInfo("contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault")
+          await artifacts.getBuildInfo('contracts/LSP9Vault/LSP9Vault.sol:LSP9Vault')
         )?.output.contracts[
-          "contracts/LSP9Vault/LSP9Vault.sol"
+          'contracts/LSP9Vault/LSP9Vault.sol'
         ].LSP9Vault.storageLayout.storage.filter((elem) => {
-          if (elem.label === "_renounceOwnershipStartedAt") return elem;
+          if (elem.label === '_renounceOwnershipStartedAt') return elem;
         })[0].slot,
       );
 

--- a/tests/LSP16UniversalFactory/LSP16UniversalFactory.test.ts
+++ b/tests/LSP16UniversalFactory/LSP16UniversalFactory.test.ts
@@ -1,6 +1,6 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { FakeContract, smock } from "@defi-wonderland/smock";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { FakeContract, smock } from '@defi-wonderland/smock';
 
 import {
   LSP1UniversalReceiverDelegateUP__factory,
@@ -17,18 +17,18 @@ import {
   ImplementationTester__factory,
   FallbackInitializer,
   FallbackInitializer__factory,
-} from "../../types";
+} from '../../types';
 
-import web3 from "web3";
+import web3 from 'web3';
 
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { provider, AddressOffset } from "../utils/helpers";
+import { provider, AddressOffset } from '../utils/helpers';
 
-import { bytecode as UniversalProfileBytecode } from "../../artifacts/contracts/UniversalProfile.sol/UniversalProfile.json";
-import { bytecode as LSP6KeyManagerBytecode } from "../../artifacts/contracts/LSP6KeyManager/LSP6KeyManager.sol/LSP6KeyManager.json";
-import { bytecode as ImplementationTesterBytecode } from "../../artifacts/contracts/Mocks/ImplementationTester.sol/ImplementationTester.json";
-import { bytecode as FallbackInitializerBytecode } from "../../artifacts/contracts/Mocks/FallbackInitializer.sol/FallbackInitializer.json";
+import { bytecode as UniversalProfileBytecode } from '../../artifacts/contracts/UniversalProfile.sol/UniversalProfile.json';
+import { bytecode as LSP6KeyManagerBytecode } from '../../artifacts/contracts/LSP6KeyManager/LSP6KeyManager.sol/LSP6KeyManager.json';
+import { bytecode as ImplementationTesterBytecode } from '../../artifacts/contracts/Mocks/ImplementationTester.sol/ImplementationTester.json';
+import { bytecode as FallbackInitializerBytecode } from '../../artifacts/contracts/Mocks/FallbackInitializer.sol/FallbackInitializer.json';
 
 type UniversalFactoryTestAccounts = {
   random: SignerWithAddress;
@@ -48,7 +48,7 @@ type UniversalFactoryTestContext = {
   universalFactory: LSP16UniversalFactory;
 };
 
-describe("UniversalFactory contract", () => {
+describe('UniversalFactory contract', () => {
   const buildTestContext = async (): Promise<UniversalFactoryTestContext> => {
     const accounts = await getNamedAccounts();
 
@@ -57,7 +57,7 @@ describe("UniversalFactory contract", () => {
     return { accounts, universalFactory };
   };
 
-  describe("When using LSP16UniversalFactory", () => {
+  describe('When using LSP16UniversalFactory', () => {
     let context: UniversalFactoryTestContext;
     let universalProfileConstructor: UniversalProfile;
     let universalProfileBaseContract: UniversalProfileInit;
@@ -86,8 +86,8 @@ describe("UniversalFactory contract", () => {
 
       fallbackContract = await smock.fake([
         {
-          stateMutability: "payable",
-          type: "fallback",
+          stateMutability: 'payable',
+          type: 'fallback',
         },
       ]);
       fallbackContract.fallback.returns();
@@ -101,15 +101,15 @@ describe("UniversalFactory contract", () => {
       ).deploy();
     });
 
-    describe("when using deployCreate2", () => {
-      it("should calculate the address of a non-initializable contract correctly", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+    describe('when using deployCreate2', () => {
+      it('should calculate the address of a non-initializable contract correctly', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         // Set the Owner as the ZeroAddress
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode]);
+        let bytecodeHash = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode]);
 
         const calulcatedAddress = await context.universalFactory.computeAddress(
           bytecodeHash,
@@ -125,26 +125,26 @@ describe("UniversalFactory contract", () => {
         expect(calulcatedAddress).to.equal(contractCreated);
       });
 
-      it("should calculate the same address of a contract if the initializeCalldata changed and the contract is not initializable", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate the same address of a contract if the initializeCalldata changed and the contract is not initializable', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode]);
+        let bytecodeHash = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode]);
 
         const calulcatedAddressSalt1 = await context.universalFactory.computeAddress(
           bytecodeHash,
           salt,
           false,
-          "0xaabbccdd",
+          '0xaabbccdd',
         );
 
         const calulcatedAddressSalt2 = await context.universalFactory.computeAddress(
           bytecodeHash,
           salt,
           false,
-          "0xddccbbaa",
+          '0xddccbbaa',
         );
 
         let equalAddresses = calulcatedAddressSalt1 == calulcatedAddressSalt2;
@@ -152,27 +152,27 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.true;
       });
 
-      it("should calculate a different address of a contract if the salt changed", async () => {
-        let salt1 = ethers.utils.solidityKeccak256(["string"], ["Salt1"]);
-        let salt2 = ethers.utils.solidityKeccak256(["string"], ["Salt2"]);
+      it('should calculate a different address of a contract if the salt changed', async () => {
+        let salt1 = ethers.utils.solidityKeccak256(['string'], ['Salt1']);
+        let salt2 = ethers.utils.solidityKeccak256(['string'], ['Salt2']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode]);
+        let bytecodeHash = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode]);
 
         const calulcatedAddressSalt1 = await context.universalFactory.computeAddress(
           bytecodeHash,
           salt1,
           false,
-          "0x",
+          '0x',
         );
 
         const calulcatedAddressSalt2 = await context.universalFactory.computeAddress(
           bytecodeHash,
           salt2,
           false,
-          "0x",
+          '0x',
         );
 
         let equalAddresses = calulcatedAddressSalt1 == calulcatedAddressSalt2;
@@ -180,31 +180,31 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should calculate a different address of a contract if the bytecode changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a contract if the bytecode changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode1 =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash1 = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode1]);
+        let bytecodeHash1 = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode1]);
 
         let UPBytecode2 =
-          UniversalProfileBytecode + AddressOffset + "cafecafecafecafecafecafecafecafecafecafe";
+          UniversalProfileBytecode + AddressOffset + 'cafecafecafecafecafecafecafecafecafecafe';
 
-        let bytecodeHash2 = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode2]);
+        let bytecodeHash2 = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode2]);
 
         const calulcatedAddressBytecode1 = await context.universalFactory.computeAddress(
           bytecodeHash1,
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         const calulcatedAddressBytecode2 = await context.universalFactory.computeAddress(
           bytecodeHash2,
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         let equalAddresses = calulcatedAddressBytecode1 == calulcatedAddressBytecode2;
@@ -212,8 +212,8 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should revert when deploying a non-initializable contract with the same bytecode and salt ", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying a non-initializable contract with the same bytecode and salt ', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
@@ -221,12 +221,12 @@ describe("UniversalFactory contract", () => {
         await context.universalFactory.deployCreate2(UPBytecode, salt);
 
         await expect(context.universalFactory.deployCreate2(UPBytecode, salt)).to.be.revertedWith(
-          "Create2: Failed on deploy",
+          'Create2: Failed on deploy',
         );
       });
 
-      it("should revert when sending value while deploying a non payable non-initializable contract", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["OtherSalt"]);
+      it('should revert when sending value while deploying a non payable non-initializable contract', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['OtherSalt']);
 
         let KMBytecode =
           LSP6KeyManagerBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
@@ -235,11 +235,11 @@ describe("UniversalFactory contract", () => {
           context.universalFactory.deployCreate2(KMBytecode, salt, {
             value: 100,
           }),
-        ).to.be.revertedWith("Create2: Failed on deploy");
+        ).to.be.revertedWith('Create2: Failed on deploy');
       });
 
-      it("should pass when sending value while deploying a payable non-initializable contract", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["OtherSalt"]);
+      it('should pass when sending value while deploying a payable non-initializable contract', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['OtherSalt']);
 
         const valueSent = 100;
 
@@ -259,8 +259,8 @@ describe("UniversalFactory contract", () => {
         expect(balance).to.equal(valueSent);
       });
 
-      it("should deploy an un-initializable contract and get the owner successfully", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should deploy an un-initializable contract and get the owner successfully', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + context.accounts.deployer3.address.substr(2);
@@ -273,12 +273,12 @@ describe("UniversalFactory contract", () => {
         let generatedSalt = await context.universalFactory.callStatic.generateSalt(
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         await expect(context.universalFactory.deployCreate2(UPBytecode, salt))
-          .to.emit(context.universalFactory, "ContractCreated")
-          .withArgs(contractCreatedAddress, salt, generatedSalt, false, "0x");
+          .to.emit(context.universalFactory, 'ContractCreated')
+          .withArgs(contractCreatedAddress, salt, generatedSalt, false, '0x');
 
         const universalProfile = universalProfileConstructor.attach(contractCreatedAddress);
 
@@ -287,16 +287,16 @@ describe("UniversalFactory contract", () => {
       });
     });
 
-    describe("when using deployCreate2AndInitialize", () => {
-      it("should calculate the address of an initializable contract correctly", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+    describe('when using deployCreate2AndInitialize', () => {
+      it('should calculate the address of an initializable contract correctly', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let initializeCallData = implementationTester.interface.encodeFunctionData("initialize", [
+        let initializeCallData = implementationTester.interface.encodeFunctionData('initialize', [
           ethers.constants.AddressZero,
         ]);
 
         let bytecodeHash = ethers.utils.solidityKeccak256(
-          ["bytes"],
+          ['bytes'],
           [ImplementationTester__factory.bytecode],
         );
 
@@ -320,17 +320,17 @@ describe("UniversalFactory contract", () => {
         expect(calulcatedAddress).to.equal(contractCreated);
       });
 
-      it("should calculate a different address of a contract if the salt changed", async () => {
-        let salt1 = ethers.utils.solidityKeccak256(["string"], ["Salt1"]);
-        let salt2 = ethers.utils.solidityKeccak256(["string"], ["Salt2"]);
+      it('should calculate a different address of a contract if the salt changed', async () => {
+        let salt1 = ethers.utils.solidityKeccak256(['string'], ['Salt1']);
+        let salt2 = ethers.utils.solidityKeccak256(['string'], ['Salt2']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode]);
+        let bytecodeHash = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode]);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -353,16 +353,16 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should calculate a different address of a contract if the initializeCalldata changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a contract if the initializeCalldata changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
-        let bytecodeHash = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode]);
+        let bytecodeHash = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode]);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -370,7 +370,7 @@ describe("UniversalFactory contract", () => {
           bytecodeHash,
           salt,
           true,
-          "0xaabbccdd",
+          '0xaabbccdd',
         );
 
         const calculatedAddressInitializableTrue = await context.universalFactory.computeAddress(
@@ -386,23 +386,23 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should calculate a different address of a contract if the bytecode changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a contract if the bytecode changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode1 =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
-        let bytecodeHash1 = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode1]);
+        let bytecodeHash1 = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode1]);
 
         let UPBytecode2 =
-          UniversalProfileBytecode + AddressOffset + "cafecafecafecafecafecafecafecafecafecafe";
+          UniversalProfileBytecode + AddressOffset + 'cafecafecafecafecafecafecafecafecafecafe';
 
-        let bytecodeHash2 = ethers.utils.solidityKeccak256(["bytes"], [UPBytecode2]);
+        let bytecodeHash2 = ethers.utils.solidityKeccak256(['bytes'], [UPBytecode2]);
 
         const calulcatedAddressBytecode1 = await context.universalFactory.computeAddress(
           bytecodeHash1,
@@ -423,8 +423,8 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should revert when deploying an initializable contract with the same bytecode and salt ", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying an initializable contract with the same bytecode and salt ', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
@@ -432,7 +432,7 @@ describe("UniversalFactory contract", () => {
         await context.universalFactory.deployCreate2AndInitialize(
           UPBytecode,
           salt,
-          "0x00000000aabbccdd", // send some random data along prepended with `0x00000000`
+          '0x00000000aabbccdd', // send some random data along prepended with `0x00000000`
           0,
           0,
         );
@@ -441,21 +441,21 @@ describe("UniversalFactory contract", () => {
           context.universalFactory.deployCreate2AndInitialize(
             UPBytecode,
             salt,
-            "0x00000000aabbccdd", // send some random data along prepended with `0x00000000`
+            '0x00000000aabbccdd', // send some random data along prepended with `0x00000000`
             0,
             0,
           ),
-        ).to.be.revertedWith("Create2: Failed on deploy");
+        ).to.be.revertedWith('Create2: Failed on deploy');
       });
 
-      it("should revert when deploying an initializable contract with sending value unmatched to the msgValue arguments", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying an initializable contract with sending value unmatched to the msgValue arguments', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let UPBytecode =
           UniversalProfileBytecode + AddressOffset + ethers.constants.AddressZero.substr(2);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -468,11 +468,11 @@ describe("UniversalFactory contract", () => {
             2,
             { value: 2 },
           ),
-        ).to.be.revertedWithCustomError(context.universalFactory, "InvalidValueSum");
+        ).to.be.revertedWithCustomError(context.universalFactory, 'InvalidValueSum');
       });
 
-      it("should pass when deploying an initializable contract without passing an initialize calldata", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should pass when deploying an initializable contract without passing an initialize calldata', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let fallbackInitializerBytecode = FallbackInitializerBytecode;
 
@@ -499,10 +499,10 @@ describe("UniversalFactory contract", () => {
         expect(caller).to.equal(context.universalFactory.address);
       });
 
-      it("should pass when deploying an initializable contract that constructor and initialize function is payable", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should pass when deploying an initializable contract that constructor and initialize function is payable', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let PayableTrueCalldata = payableContract.interface.encodeFunctionData("payableTrue");
+        let PayableTrueCalldata = payableContract.interface.encodeFunctionData('payableTrue');
 
         let valueSentToConstructor = 100;
         let valueSentToInitialize = 200;
@@ -534,10 +534,10 @@ describe("UniversalFactory contract", () => {
         expect(balance).to.equal(sumValueSent);
       });
 
-      it("should deploy an initializable CREATE2 contract and emit the event and get the owner successfully", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should deploy an initializable CREATE2 contract and emit the event and get the owner successfully', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let initializeCallData = implementationTester.interface.encodeFunctionData("initialize", [
+        let initializeCallData = implementationTester.interface.encodeFunctionData('initialize', [
           context.accounts.deployer1.address,
         ]);
 
@@ -565,7 +565,7 @@ describe("UniversalFactory contract", () => {
             0,
           ),
         )
-          .to.emit(context.universalFactory, "ContractCreated")
+          .to.emit(context.universalFactory, 'ContractCreated')
           .withArgs(contractCreatedAddress, salt, generatedSalt, true, initializeCallData);
 
         const factoryTesterContract = implementationTester.attach(contractCreatedAddress);
@@ -574,15 +574,15 @@ describe("UniversalFactory contract", () => {
       });
     });
 
-    describe("when using deployERC1167Proxy", () => {
+    describe('when using deployERC1167Proxy', () => {
       it("should calculate the address of a proxy correctly if it's not initializable", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         const calculatedAddress = await context.universalFactory.computeERC1167Address(
           universalReceiverDelegate.address,
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         const contractCreated = await context.universalFactory
@@ -592,22 +592,22 @@ describe("UniversalFactory contract", () => {
         expect(calculatedAddress).to.equal(contractCreated);
       });
 
-      it("should calculate a different address of a proxy if the `salt` changed", async () => {
-        let salt1 = ethers.utils.solidityKeccak256(["string"], ["Salt1"]);
-        let salt2 = ethers.utils.solidityKeccak256(["string"], ["Salt2"]);
+      it('should calculate a different address of a proxy if the `salt` changed', async () => {
+        let salt1 = ethers.utils.solidityKeccak256(['string'], ['Salt1']);
+        let salt2 = ethers.utils.solidityKeccak256(['string'], ['Salt2']);
 
         const calculatedAddressSalt1 = await context.universalFactory.computeERC1167Address(
           universalProfileBaseContract.address,
           salt1,
           false,
-          "0x",
+          '0x',
         );
 
         const calculatedAddressSalt2 = await context.universalFactory.computeERC1167Address(
           universalProfileBaseContract.address,
           salt2,
           false,
-          "0x",
+          '0x',
         );
 
         let equalAddresses = calculatedAddressSalt1 == calculatedAddressSalt2;
@@ -616,10 +616,10 @@ describe("UniversalFactory contract", () => {
       });
 
       it("should calculate the same address of a proxy if the initializeCalldata changed (because it's not initializable)", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -636,7 +636,7 @@ describe("UniversalFactory contract", () => {
             universalProfileBaseContract.address,
             salt,
             false,
-            "0xaabb",
+            '0xaabb',
           );
 
         let equalAddresses =
@@ -645,21 +645,21 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.true;
       });
 
-      it("should calculate a different address of a proxy if the `baseContract` changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a proxy if the `baseContract` changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         const calulcatedAddressBaseContract1 = await context.universalFactory.computeERC1167Address(
           universalProfileBaseContract.address,
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         const calulcatedAddressBaseContract2 = await context.universalFactory.computeERC1167Address(
           universalReceiverDelegate.address,
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         let equalAddresses = calulcatedAddressBaseContract1 == calulcatedAddressBaseContract2;
@@ -667,8 +667,8 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should revert when deploying a proxy contract with the same `baseContract` and salt ", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying a proxy contract with the same `baseContract` and salt ', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         await context.universalFactory.deployERC1167Proxy(
           universalProfileBaseContract.address,
@@ -677,11 +677,11 @@ describe("UniversalFactory contract", () => {
 
         await expect(
           context.universalFactory.deployERC1167Proxy(universalProfileBaseContract.address, salt),
-        ).to.be.revertedWith("ERC1167: create2 failed");
+        ).to.be.revertedWith('ERC1167: create2 failed');
       });
 
-      it("should deploy an un-initializable CREATE2 proxy contract and emit the event and get the default owner successfully", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt#2"]);
+      it('should deploy an un-initializable CREATE2 proxy contract and emit the event and get the default owner successfully', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt#2']);
 
         const contractCreatedAddress = await context.universalFactory.callStatic.deployERC1167Proxy(
           universalProfileBaseContract.address,
@@ -691,14 +691,14 @@ describe("UniversalFactory contract", () => {
         let generatedSalt = await context.universalFactory.callStatic.generateSalt(
           salt,
           false,
-          "0x",
+          '0x',
         );
 
         await expect(
           context.universalFactory.deployERC1167Proxy(universalProfileBaseContract.address, salt),
         )
-          .to.emit(context.universalFactory, "ContractCreated")
-          .withArgs(contractCreatedAddress, salt, generatedSalt, false, "0x");
+          .to.emit(context.universalFactory, 'ContractCreated')
+          .withArgs(contractCreatedAddress, salt, generatedSalt, false, '0x');
 
         const universalProfile = universalProfileBaseContract.attach(contractCreatedAddress);
 
@@ -707,12 +707,12 @@ describe("UniversalFactory contract", () => {
       });
     });
 
-    describe("when using deployERC1167ProxyAndInitialize", () => {
+    describe('when using deployERC1167ProxyAndInitialize', () => {
       it("should calculate the address of a proxy correctly if it's initializable", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -734,12 +734,12 @@ describe("UniversalFactory contract", () => {
         expect(calculatedAddress).to.equal(contractCreated);
       });
 
-      it("should calculate a different address of a proxy if the `salt` changed", async () => {
-        let salt1 = ethers.utils.solidityKeccak256(["string"], ["Salt1"]);
-        let salt2 = ethers.utils.solidityKeccak256(["string"], ["Salt2"]);
+      it('should calculate a different address of a proxy if the `salt` changed', async () => {
+        let salt1 = ethers.utils.solidityKeccak256(['string'], ['Salt1']);
+        let salt2 = ethers.utils.solidityKeccak256(['string'], ['Salt2']);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -762,16 +762,16 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should calculate a different address of a proxy if the `initializeCallData` changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a proxy if the `initializeCallData` changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let initializeCallData1 = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
         let initializeCallData2 = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer2.address],
         );
 
@@ -797,11 +797,11 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should calculate a different address of a proxy if the `baseContract` changed", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should calculate a different address of a proxy if the `baseContract` changed', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer1.address],
         );
 
@@ -824,41 +824,41 @@ describe("UniversalFactory contract", () => {
         expect(equalAddresses).to.be.false;
       });
 
-      it("should revert when deploying a proxy contract with the same `baseContract` and salt ", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying a proxy contract with the same `baseContract` and salt ', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         await context.universalFactory.deployERC1167ProxyAndInitialize(
           universalProfileBaseContract.address,
           salt,
-          "0x",
+          '0x',
         );
 
         await expect(
           context.universalFactory.deployERC1167ProxyAndInitialize(
             universalProfileBaseContract.address,
             salt,
-            "0x",
+            '0x',
           ),
-        ).to.be.revertedWith("ERC1167: create2 failed");
+        ).to.be.revertedWith('ERC1167: create2 failed');
       });
 
-      it("should pass and initialize local variable when sending value while deploying a CREATE2 proxy without `initializeCallData`", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should pass and initialize local variable when sending value while deploying a CREATE2 proxy without `initializeCallData`', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
         const contractCreated =
           await context.universalFactory.callStatic.deployERC1167ProxyAndInitialize(
             fallbackInitializer.address,
             salt,
-            "0x",
+            '0x',
             {
-              value: ethers.utils.parseEther("1300"),
+              value: ethers.utils.parseEther('1300'),
             },
           );
 
         await context.universalFactory
           .connect(context.accounts.deployer1)
-          .deployERC1167ProxyAndInitialize(fallbackInitializer.address, salt, "0x", {
-            value: ethers.utils.parseEther("1300"),
+          .deployERC1167ProxyAndInitialize(fallbackInitializer.address, salt, '0x', {
+            value: ethers.utils.parseEther('1300'),
           });
 
         const fallbackInitializerCreated = fallbackInitializer.attach(contractCreated);
@@ -867,10 +867,10 @@ describe("UniversalFactory contract", () => {
         expect(caller).to.equal(context.universalFactory.address);
       });
 
-      it("should revert when deploying a proxy and sending value to a non payable function in deployERC1167Proxy", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should revert when deploying a proxy and sending value to a non payable function in deployERC1167Proxy', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let PayableFalseCalldata = payableContract.interface.encodeFunctionData("payableFalse");
+        let PayableFalseCalldata = payableContract.interface.encodeFunctionData('payableFalse');
 
         await expect(
           context.universalFactory
@@ -878,13 +878,13 @@ describe("UniversalFactory contract", () => {
             .deployERC1167ProxyAndInitialize(payableContract.address, salt, PayableFalseCalldata, {
               value: 100,
             }),
-        ).to.be.revertedWithCustomError(context.universalFactory, "ContractInitializationFailed");
+        ).to.be.revertedWithCustomError(context.universalFactory, 'ContractInitializationFailed');
       });
 
-      it("should pass when deploying a proxy and sending value to a payable function in deployERC1167Proxy", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should pass when deploying a proxy and sending value to a payable function in deployERC1167Proxy', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let PayableTrueCalldata = payableContract.interface.encodeFunctionData("payableTrue");
+        let PayableTrueCalldata = payableContract.interface.encodeFunctionData('payableTrue');
 
         const contractCreated = await context.universalFactory
           .connect(context.accounts.deployer1)
@@ -907,21 +907,21 @@ describe("UniversalFactory contract", () => {
       });
 
       it("should revert when deploying a proxy and passing calldata for a non-existing function where fallback function doesn't exist", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let RandomCalldata = "0xcafecafe";
+        let RandomCalldata = '0xcafecafe';
 
         await expect(
           context.universalFactory
             .connect(context.accounts.deployer1)
             .deployERC1167ProxyAndInitialize(payableContract.address, salt, RandomCalldata),
-        ).to.be.revertedWithCustomError(context.universalFactory, "ContractInitializationFailed");
+        ).to.be.revertedWithCustomError(context.universalFactory, 'ContractInitializationFailed');
       });
 
-      it("should pass when deploying a proxy and passing calldata for a non-existing function where fallback function exist", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt"]);
+      it('should pass when deploying a proxy and passing calldata for a non-existing function where fallback function exist', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt']);
 
-        let RandomCalldata = "0xcafecafe";
+        let RandomCalldata = '0xcafecafe';
 
         await expect(
           context.universalFactory
@@ -930,11 +930,11 @@ describe("UniversalFactory contract", () => {
         ).to.not.be.reverted;
       });
 
-      it("should deploy an initializable CREATE2 proxy contract and emit the event and get the owner successfully", async () => {
-        let salt = ethers.utils.solidityKeccak256(["string"], ["Salt#3"]);
+      it('should deploy an initializable CREATE2 proxy contract and emit the event and get the owner successfully', async () => {
+        let salt = ethers.utils.solidityKeccak256(['string'], ['Salt#3']);
 
         let initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-          "initialize",
+          'initialize',
           [context.accounts.deployer4.address],
         );
 
@@ -958,7 +958,7 @@ describe("UniversalFactory contract", () => {
             initializeCallData,
           ),
         )
-          .to.emit(context.universalFactory, "ContractCreated")
+          .to.emit(context.universalFactory, 'ContractCreated')
           .withArgs(contractCreatedAddress, salt, generatedSalt, true, initializeCallData);
 
         const universalProfile = universalProfileBaseContract.attach(contractCreatedAddress);
@@ -968,16 +968,16 @@ describe("UniversalFactory contract", () => {
       });
     });
 
-    describe("when testing edge cases", () => {
-      describe("When deploying initializable minimal proxies via deployERC1167ProxyAndInitialize", () => {
+    describe('when testing edge cases', () => {
+      describe('When deploying initializable minimal proxies via deployERC1167ProxyAndInitialize', () => {
         let salt;
         let initializeCallData;
         let contractCreatedWithdeployERC1167ProxyAndInitialize;
         before(async () => {
-          salt = ethers.utils.solidityKeccak256(["string"], ["SaltEdge"]);
+          salt = ethers.utils.solidityKeccak256(['string'], ['SaltEdge']);
 
           initializeCallData = universalProfileBaseContract.interface.encodeFunctionData(
-            "initialize",
+            'initialize',
             [context.accounts.deployer1.address],
           );
 
@@ -989,7 +989,7 @@ describe("UniversalFactory contract", () => {
             );
         });
 
-        it("should result in a different address if deployed without initializing with deployERC1167Proxy function", async () => {
+        it('should result in a different address if deployed without initializing with deployERC1167Proxy function', async () => {
           const contractCreatedWithdeployERC1167Proxy =
             await context.universalFactory.callStatic.deployERC1167Proxy(
               universalProfileBaseContract.address,
@@ -1003,13 +1003,13 @@ describe("UniversalFactory contract", () => {
           expect(equalAddresses).to.be.false;
         });
 
-        it("should result in a diffferent address if deployed without initializing with deployCreate2 function", async () => {
+        it('should result in a diffferent address if deployed without initializing with deployCreate2 function', async () => {
           const eip1167RuntimeCodeTemplate =
-            "0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3";
+            '0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3';
 
           // deploy proxy contract
           let proxyBytecode = eip1167RuntimeCodeTemplate.replace(
-            "bebebebebebebebebebebebebebebebebebebebe",
+            'bebebebebebebebebebebebebebebebebebebebe',
             universalProfileBaseContract.address.substr(2),
           );
 
@@ -1021,13 +1021,13 @@ describe("UniversalFactory contract", () => {
 
           expect(equalAddresses).to.be.false;
         });
-        it("should result in the same address if deployed with initializing with deployCreate2AndInitialize function", async () => {
+        it('should result in the same address if deployed with initializing with deployCreate2AndInitialize function', async () => {
           const eip1167RuntimeCodeTemplate =
-            "0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3";
+            '0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3';
 
           // deploy proxy contract
           let proxyBytecode = eip1167RuntimeCodeTemplate.replace(
-            "bebebebebebebebebebebebebebebebebebebebe",
+            'bebebebebebebebebebebebebebebebebebebebe',
             universalProfileBaseContract.address.substr(2),
           );
 
@@ -1049,16 +1049,16 @@ describe("UniversalFactory contract", () => {
       });
     });
 
-    describe("`generateSalt(...)`", () => {
-      it("should generate the same salt as with `ethers.utils.keccak256`", async () => {
-        const providedSalt = "0x7d1f4b76de4cdffc4ebac16883d3a7c9cbd95b6130494c4ad48e6a8e24083572";
+    describe('`generateSalt(...)`', () => {
+      it('should generate the same salt as with `ethers.utils.keccak256`', async () => {
+        const providedSalt = '0x7d1f4b76de4cdffc4ebac16883d3a7c9cbd95b6130494c4ad48e6a8e24083572';
 
         const initializeCallData =
-          "0xc4d66de8000000000000000000000000d208a16f18a3bab276dff0b62ef591a846c86cba";
+          '0xc4d66de8000000000000000000000000d208a16f18a3bab276dff0b62ef591a846c86cba';
 
         const generatedSalt = ethers.utils.keccak256(
           ethers.utils.solidityPack(
-            ["bool", "bytes", "bytes32"],
+            ['bool', 'bytes', 'bytes32'],
             [true, initializeCallData, providedSalt],
           ),
         );
@@ -1068,15 +1068,15 @@ describe("UniversalFactory contract", () => {
         ).to.equal(generatedSalt);
       });
 
-      it("should generate the same salt as with `web3.utils.keccak256`", async () => {
-        const providedSalt = "0x7d1f4b76de4cdffc4ebac16883d3a7c9cbd95b6130494c4ad48e6a8e24083572";
+      it('should generate the same salt as with `web3.utils.keccak256`', async () => {
+        const providedSalt = '0x7d1f4b76de4cdffc4ebac16883d3a7c9cbd95b6130494c4ad48e6a8e24083572';
 
         const initializeCallData =
-          "0xc4d66de8000000000000000000000000d208a16f18a3bab276dff0b62ef591a846c86cba";
+          '0xc4d66de8000000000000000000000000d208a16f18a3bab276dff0b62ef591a846c86cba';
 
         const generatedSalt = web3.utils.keccak256(
           ethers.utils.solidityPack(
-            ["bool", "bytes", "bytes32"],
+            ['bool', 'bytes', 'bytes32'],
             [true, initializeCallData, providedSalt],
           ),
         );

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { FakeContract, smock } from "@defi-wonderland/smock";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { FakeContract, smock } from '@defi-wonderland/smock';
 
 import {
   LSP0ERC725Account,
@@ -24,13 +24,13 @@ import {
   RequireCallbackToken__factory,
   RevertFallbackExtension,
   RevertFallbackExtension__factory,
-} from "../../types";
+} from '../../types';
 
 // helpers
-import { abiCoder, provider } from "../utils/helpers";
+import { abiCoder, provider } from '../utils/helpers';
 
 // constants
-import { ERC725YDataKeys } from "../../constants";
+import { ERC725YDataKeys } from '../../constants';
 
 export type LSP17TestContext = {
   accounts: SignerWithAddress[];
@@ -71,102 +71,102 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
     newOwner = context.accounts[1];
 
     // withdraw()
-    notExistingFunctionSignature = "0x3ccfd60b";
+    notExistingFunctionSignature = '0x3ccfd60b';
 
     // checkMsgVariable(address,uint256)
-    checkMsgVariableFunctionSelector = "0xe825d37d";
+    checkMsgVariableFunctionSelector = '0xe825d37d';
 
     // name()
-    nameFunctionSelector = "0x06fdde03";
+    nameFunctionSelector = '0x06fdde03';
 
     // age()
-    ageFunctionSelector = "0x262a9dff";
+    ageFunctionSelector = '0x262a9dff';
 
     // transfer(uint256)
-    transferFunctionSelector = "0x12514bba";
+    transferFunctionSelector = '0x12514bba';
 
     // revertString(string)
-    revertStringFunctionSelector = "0xb678618b";
+    revertStringFunctionSelector = '0xb678618b';
 
     // revertCustom()
-    revertCustomFunctionSelector = "0x1ed106b8";
+    revertCustomFunctionSelector = '0x1ed106b8';
 
     // emitEvent()
-    emitEventFunctionSelector = "0x7b0cb839";
+    emitEventFunctionSelector = '0x7b0cb839';
 
     // reenterAccount(bytes)
-    reenterAccountFunctionSelector = "0x864e5589";
+    reenterAccountFunctionSelector = '0x864e5589';
 
     // onERC721Received(address,address,uint256,bytes)
-    onERC721ReceivedFunctionSelector = "0x150b7a02";
+    onERC721ReceivedFunctionSelector = '0x150b7a02';
 
     // supportsInterface(bytes4)
-    supportsInterfaceFunctionSelector = "0x01ffc9a7";
+    supportsInterfaceFunctionSelector = '0x01ffc9a7';
 
     checkMsgVariableFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       checkMsgVariableFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     nameFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       nameFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     ageFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       ageFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     transferFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       transferFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     reenterAccountFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       reenterAccountFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     revertStringFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       revertStringFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     revertCustomFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       revertCustomFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     emitEventFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       emitEventFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     onERC721ReceivedFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       onERC721ReceivedFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
 
     supportsInterfaceFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       supportsInterfaceFunctionSelector.substring(2) +
-      "00000000000000000000000000000000"; // zero padded
+      '00000000000000000000000000000000'; // zero padded
   });
 
-  describe("when calling the contract with empty calldata", () => {
-    describe("when making a call without any value", () => {
-      it("should pass and not emit ValueReceived", async () => {
+  describe('when calling the contract with empty calldata', () => {
+    describe('when making a call without any value', () => {
+      it('should pass and not emit ValueReceived', async () => {
         await expect(
           context.accounts[0].sendTransaction({
             to: context.contract.address,
           }),
-        ).to.not.be.reverted.to.not.emit(context.contract, "ValueReceived");
+        ).to.not.be.reverted.to.not.emit(context.contract, 'ValueReceived');
       });
     });
 
-    describe("when making a call with sending value", () => {
-      it("should pass and emit ValueReceived", async () => {
+    describe('when making a call with sending value', () => {
+      it('should pass and emit ValueReceived', async () => {
         const amountSent = 200;
         await expect(
           context.accounts[0].sendTransaction({
@@ -174,21 +174,21 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             value: amountSent,
           }),
         )
-          .to.emit(context.contract, "ValueReceived")
+          .to.emit(context.contract, 'ValueReceived')
           .withArgs(context.accounts[0].address, amountSent);
       });
     });
   });
 
-  describe("when calling the contract with calldata", () => {
-    describe("when calling method that exist", () => {
-      describe("when calling the contract with transferOwnership Signature", () => {
-        it("should pass and set the pending owner", async () => {
+  describe('when calling the contract with calldata', () => {
+    describe('when calling method that exist', () => {
+      describe('when calling the contract with transferOwnership Signature', () => {
+        it('should pass and set the pending owner', async () => {
           const pendingOwnerBefore = await context.contract.callStatic.pendingOwner();
           expect(pendingOwnerBefore).to.equal(ethers.constants.AddressZero);
 
           const transferOwnershipPayload = context.contract.interface.encodeFunctionData(
-            "transferOwnership",
+            'transferOwnership',
             [context.accounts[2].address],
           );
 
@@ -205,9 +205,9 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
     });
 
     describe("when calling method that doesn't exist", () => {
-      describe("when there is no extension for the function called", () => {
-        describe("when calling without sending any value", () => {
-          it("should revert with NoExtensionForFunctionSignature error", async () => {
+      describe('when there is no extension for the function called', () => {
+        describe('when calling without sending any value', () => {
+          it('should revert with NoExtensionForFunctionSignature error', async () => {
             await expect(
               context.accounts[0].sendTransaction({
                 to: context.contract.address,
@@ -216,14 +216,14 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             )
               .to.be.revertedWithCustomError(
                 context.contract,
-                "NoExtensionFoundForFunctionSelector",
+                'NoExtensionFoundForFunctionSelector',
               )
               .withArgs(notExistingFunctionSignature);
           });
         });
 
-        describe("when calling with sending value", () => {
-          it("should revert with NoExtensionForFunctionSignature error", async () => {
+        describe('when calling with sending value', () => {
+          it('should revert with NoExtensionForFunctionSignature error', async () => {
             const amountSent = 200;
             await expect(
               context.accounts[0].sendTransaction({
@@ -234,24 +234,24 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             )
               .to.be.revertedWithCustomError(
                 context.contract,
-                "NoExtensionFoundForFunctionSelector",
+                'NoExtensionFoundForFunctionSelector',
               )
               .withArgs(notExistingFunctionSignature);
           });
         });
       });
 
-      describe("when there is an extension for the function called", () => {
-        describe("when double checking that the msg.sender & msg.value were sent with the calldata to the extension", () => {
-          describe("when relying on the Checker Extension", () => {
-            describe("when the extension is not set yet", () => {
-              it("should revert with NoExtensionFoundForFunctionSelector", async () => {
+      describe('when there is an extension for the function called', () => {
+        describe('when double checking that the msg.sender & msg.value were sent with the calldata to the extension', () => {
+          describe('when relying on the Checker Extension', () => {
+            describe('when the extension is not set yet', () => {
+              it('should revert with NoExtensionFoundForFunctionSelector', async () => {
                 const supposedSender = context.accounts[0];
                 const value = 200;
                 const checkMsgVariableFunctionSignature =
                   checkMsgVariableFunctionSelector +
                   abiCoder
-                    .encode(["address", "uint256"], [supposedSender.address, value])
+                    .encode(['address', 'uint256'], [supposedSender.address, value])
                     .substring(2);
 
                 // different sender
@@ -264,18 +264,18 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 )
                   .to.be.revertedWithCustomError(
                     context.contract,
-                    "NoExtensionFoundForFunctionSelector",
+                    'NoExtensionFoundForFunctionSelector',
                   )
                   .withArgs(checkMsgVariableFunctionSelector);
               });
 
-              it("should pass even if passed a different value from the msg.value", async () => {
+              it('should pass even if passed a different value from the msg.value', async () => {
                 const sender = context.accounts[0];
                 const supposedValue = 200;
                 const checkMsgVariableFunctionSignature =
                   checkMsgVariableFunctionSelector +
                   abiCoder
-                    .encode(["address", "uint256"], [sender.address, supposedValue])
+                    .encode(['address', 'uint256'], [sender.address, supposedValue])
                     .substring(2);
 
                 await expect(
@@ -287,13 +287,13 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 )
                   .to.be.revertedWithCustomError(
                     context.contract,
-                    "NoExtensionFoundForFunctionSelector",
+                    'NoExtensionFoundForFunctionSelector',
                   )
                   .withArgs(checkMsgVariableFunctionSelector);
               });
             });
 
-            describe("when the extension is set", () => {
+            describe('when the extension is set', () => {
               before(async () => {
                 const checkerExtension = await new CheckerExtension__factory(
                   context.accounts[0],
@@ -304,13 +304,13 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   .setData(checkMsgVariableFunctionExtensionHandlerKey, checkerExtension.address);
               });
 
-              it("should fail if passed a different value from the msg.value", async () => {
+              it('should fail if passed a different value from the msg.value', async () => {
                 const sender = context.accounts[0];
                 const supposedValue = 200;
                 const checkMsgVariableFunctionSignature =
                   checkMsgVariableFunctionSelector +
                   abiCoder
-                    .encode(["address", "uint256"], [sender.address, supposedValue])
+                    .encode(['address', 'uint256'], [sender.address, supposedValue])
                     .substring(2);
 
                 await expect(
@@ -322,13 +322,13 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 ).to.be.reverted;
               });
 
-              it("should fail if passed a different address from the msg.sender", async () => {
+              it('should fail if passed a different address from the msg.sender', async () => {
                 const supposedSender = context.accounts[0];
                 const value = 200;
                 const checkMsgVariableFunctionSignature =
                   checkMsgVariableFunctionSelector +
                   abiCoder
-                    .encode(["address", "uint256"], [supposedSender.address, value])
+                    .encode(['address', 'uint256'], [supposedSender.address, value])
                     .substring(2);
 
                 // different sender
@@ -341,12 +341,12 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 ).to.be.reverted;
               });
 
-              it("should pass if passed the same address and value as the msg.sender and msg.value", async () => {
+              it('should pass if passed the same address and value as the msg.sender and msg.value', async () => {
                 const sender = context.accounts[0];
                 const value = 200;
                 const checkMsgVariableFunctionSignature =
                   checkMsgVariableFunctionSelector +
-                  abiCoder.encode(["address", "uint256"], [sender.address, value]).substring(2);
+                  abiCoder.encode(['address', 'uint256'], [sender.address, value]).substring(2);
 
                 await sender.sendTransaction({
                   to: context.contract.address,
@@ -358,7 +358,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
           });
         });
 
-        describe("when calling an extension that reverts with string error", () => {
+        describe('when calling an extension that reverts with string error', () => {
           before(async () => {
             const revertStringExtension = await new RevertStringExtension__factory(
               context.accounts[0],
@@ -369,12 +369,12 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(revertStringFunctionExtensionHandlerKey, revertStringExtension.address);
           });
 
-          it("should revert with a string error provided as argument", async () => {
-            const revertString = "I failed";
+          it('should revert with a string error provided as argument', async () => {
+            const revertString = 'I failed';
 
             const revertStringFunctionSignature =
               revertStringFunctionSelector +
-              abiCoder.encode(["string"], [revertString]).substring(2);
+              abiCoder.encode(['string'], [revertString]).substring(2);
 
             await expect(
               context.accounts[0].sendTransaction({
@@ -386,7 +386,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
           });
         });
 
-        describe("when calling an extension that reverts with Custom error with tx.origin and msg.sender as parameters", () => {
+        describe('when calling an extension that reverts with Custom error with tx.origin and msg.sender as parameters', () => {
           let revertCustomExtension: RevertCustomExtension;
 
           before(async () => {
@@ -399,7 +399,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(revertCustomFunctionExtensionHandlerKey, revertCustomExtension.address);
           });
 
-          it("should revert with a custom error with tx.origin and msg.sender as argument", async () => {
+          it('should revert with a custom error with tx.origin and msg.sender as argument', async () => {
             const sender = context.accounts[0];
 
             await expect(
@@ -409,12 +409,12 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 value: 0,
               }),
             )
-              .to.be.revertedWithCustomError(revertCustomExtension, "RevertWithAddresses")
+              .to.be.revertedWithCustomError(revertCustomExtension, 'RevertWithAddresses')
               .withArgs(sender.address, context.contract.address);
           });
         });
 
-        describe("when calling an extension that emits an event", () => {
+        describe('when calling an extension that emits an event', () => {
           let emitEventExtension: EmitEventExtension;
 
           before(async () => {
@@ -427,71 +427,71 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(emitEventFunctionExtensionHandlerKey, emitEventExtension.address);
           });
 
-          it("should pass and emit the event on the extension", async () => {
+          it('should pass and emit the event on the extension', async () => {
             await expect(
               context.accounts[0].sendTransaction({
                 to: context.contract.address,
                 data: emitEventFunctionSelector,
                 value: 0,
               }),
-            ).to.emit(emitEventExtension, "EventEmittedInExtension");
+            ).to.emit(emitEventExtension, 'EventEmittedInExtension');
           });
         });
 
-        describe("when calling an extension that returns a string", () => {
+        describe('when calling an extension that returns a string', () => {
           let nameExtension: FakeContract;
 
           before(async () => {
             nameExtension = await smock.fake([
               {
                 inputs: [],
-                name: "name",
+                name: 'name',
                 outputs: [
                   {
-                    internalType: "string",
-                    name: "",
-                    type: "string",
+                    internalType: 'string',
+                    name: '',
+                    type: 'string',
                   },
                 ],
-                stateMutability: "view",
-                type: "function",
+                stateMutability: 'view',
+                type: 'function',
               },
             ]);
-            nameExtension.name.returns("LUKSO");
+            nameExtension.name.returns('LUKSO');
 
             await context.contract
               .connect(context.deployParams.owner)
               .setData(nameFunctionExtensionHandlerKey, nameExtension.address);
           });
 
-          it("should pass and return the name correctly", async () => {
+          it('should pass and return the name correctly', async () => {
             const returnValue = await provider.call({
               from: context.accounts[0].address,
               to: context.contract.address,
               data: nameFunctionSelector,
             });
 
-            expect(returnValue).to.equal(abiCoder.encode(["string"], ["LUKSO"]));
+            expect(returnValue).to.equal(abiCoder.encode(['string'], ['LUKSO']));
           });
         });
 
-        describe("when calling an extension that returns a number", () => {
+        describe('when calling an extension that returns a number', () => {
           let ageExtension: FakeContract;
 
           before(async () => {
             ageExtension = await smock.fake([
               {
                 inputs: [],
-                name: "age",
+                name: 'age',
                 outputs: [
                   {
-                    internalType: "uint256",
-                    name: "",
-                    type: "uint256",
+                    internalType: 'uint256',
+                    name: '',
+                    type: 'uint256',
                   },
                 ],
-                stateMutability: "view",
-                type: "function",
+                stateMutability: 'view',
+                type: 'function',
               },
             ]);
             ageExtension.age.returns(20);
@@ -501,18 +501,18 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(ageFunctionExtensionHandlerKey, ageExtension.address);
           });
 
-          it("should pass and return the age correctly", async () => {
+          it('should pass and return the age correctly', async () => {
             const returnValue = await provider.call({
               from: context.accounts[0].address,
               to: context.contract.address,
               data: ageFunctionSelector,
             });
 
-            expect(returnValue).to.equal(abiCoder.encode(["uint256"], [20]));
+            expect(returnValue).to.equal(abiCoder.encode(['uint256'], [20]));
           });
         });
 
-        describe("when calling an extension that modify the state of the extension", () => {
+        describe('when calling an extension that modify the state of the extension', () => {
           let transferExtension: TransferExtension;
 
           before(async () => {
@@ -523,7 +523,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(transferFunctionExtensionHandlerKey, transferExtension.address);
           });
 
-          it("should pass and change the state accordingly", async () => {
+          it('should pass and change the state accordingly', async () => {
             const balanceBefore = await transferExtension.callStatic.balances(
               context.accounts[0].address,
             );
@@ -534,7 +534,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
             const transferFunctionSignature =
               transferFunctionSelector +
-              abiCoder.encode(["uint256"], [amountTransferred]).substring(2);
+              abiCoder.encode(['uint256'], [amountTransferred]).substring(2);
 
             await context.accounts[0].sendTransaction({
               to: context.contract.address,
@@ -549,7 +549,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
           });
         });
 
-        describe("when calling an extension that reenter the fallback function of the account", () => {
+        describe('when calling an extension that reenter the fallback function of the account', () => {
           let reenterAccountExtension: ReenterAccountExtension;
 
           before(async () => {
@@ -562,10 +562,10 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               .setData(reenterAccountFunctionExtensionHandlerKey, reenterAccountExtension.address);
           });
 
-          describe("when reentering the fallback function without calling any other extension", () => {
-            it("should pass", async () => {
+          describe('when reentering the fallback function without calling any other extension', () => {
+            it('should pass', async () => {
               const reenterAccountFunctionSignature =
-                reenterAccountFunctionSelector + abiCoder.encode(["bytes"], ["0x"]).substring(2);
+                reenterAccountFunctionSelector + abiCoder.encode(['bytes'], ['0x']).substring(2);
 
               await expect(
                 context.accounts[0].sendTransaction({
@@ -576,8 +576,8 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             });
           });
 
-          describe("when reentering with a call to an extension that emits an event", () => {
-            describe("when reentering before setting the extension", () => {
+          describe('when reentering with a call to an extension that emits an event', () => {
+            describe('when reentering before setting the extension', () => {
               let emitEventExtension: EmitEventExtension;
 
               before(async () => {
@@ -586,20 +586,20 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 ).deploy();
               });
 
-              it("should not emit any event", async () => {
+              it('should not emit any event', async () => {
                 const reenterAccountFunctionSignature =
                   reenterAccountFunctionSelector +
-                  abiCoder.encode(["bytes"], [emitEventFunctionSelector]).substring(2);
+                  abiCoder.encode(['bytes'], [emitEventFunctionSelector]).substring(2);
 
                 await expect(
                   context.accounts[0].sendTransaction({
                     to: context.contract.address,
                     data: reenterAccountFunctionSignature,
                   }),
-                ).to.not.emit(emitEventExtension, "EventEmittedInExtension");
+                ).to.not.emit(emitEventExtension, 'EventEmittedInExtension');
               });
             });
-            describe("when reentering after setting the extension", () => {
+            describe('when reentering after setting the extension', () => {
               let emitEventExtension: EmitEventExtension;
 
               before(async () => {
@@ -611,10 +611,10 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   .connect(context.deployParams.owner)
                   .setData(emitEventFunctionExtensionHandlerKey, emitEventExtension.address);
               });
-              it("should emit the event on 3rd extension called", async () => {
+              it('should emit the event on 3rd extension called', async () => {
                 const reenterAccountFunctionSignature =
                   reenterAccountFunctionSelector +
-                  abiCoder.encode(["bytes"], [emitEventFunctionSelector]).substring(2);
+                  abiCoder.encode(['bytes'], [emitEventFunctionSelector]).substring(2);
 
                 await expect(
                   context.accounts[0].sendTransaction({
@@ -622,20 +622,20 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                     data: reenterAccountFunctionSignature,
                     value: 0,
                   }),
-                ).to.emit(emitEventExtension, "EventEmittedInExtension");
+                ).to.emit(emitEventExtension, 'EventEmittedInExtension');
               });
             });
           });
         });
 
-        describe("when calling the supportsInterface of the extendable contract with `0xaabbccdd` value", () => {
-          describe("when the ERC165 extension was not set", () => {
-            it("should return false", async () => {
-              expect(await context.contract.supportsInterface("0xaabbccdd")).to.be.false;
+        describe('when calling the supportsInterface of the extendable contract with `0xaabbccdd` value', () => {
+          describe('when the ERC165 extension was not set', () => {
+            it('should return false', async () => {
+              expect(await context.contract.supportsInterface('0xaabbccdd')).to.be.false;
             });
           });
 
-          describe("when the ERC165 extension was set", () => {
+          describe('when the ERC165 extension was set', () => {
             let erc165Extension: ERC165Extension;
             before(async () => {
               erc165Extension = await new ERC165Extension__factory(context.accounts[0]).deploy();
@@ -645,16 +645,16 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 .setData(supportsInterfaceFunctionExtensionHandlerKey, erc165Extension.address);
             });
 
-            it("should return true", async () => {
-              expect(await context.contract.supportsInterface("0xaabbccdd")).to.be.true;
+            it('should return true', async () => {
+              expect(await context.contract.supportsInterface('0xaabbccdd')).to.be.true;
             });
           });
         });
       });
     });
 
-    describe("when calling with calldata that is not checked for extension", () => {
-      describe("when calling with a payload of length less than 4bytes", () => {
+    describe('when calling with calldata that is not checked for extension', () => {
+      describe('when calling with a payload of length less than 4bytes', () => {
         let revertFallbackExtension: RevertFallbackExtension;
 
         before(async () => {
@@ -664,59 +664,59 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
           const bytes1ZeroPaddedExtensionHandlerKey =
             ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-            "01000000" +
-            "00000000000000000000000000000000"; // zero padded
+            '01000000' +
+            '00000000000000000000000000000000'; // zero padded
 
           await context.contract
             .connect(context.deployParams.owner)
             .setData(bytes1ZeroPaddedExtensionHandlerKey, revertFallbackExtension.address);
         });
-        it("should pass even if there is an extension for it that reverts", async () => {
+        it('should pass even if there is an extension for it that reverts', async () => {
           await expect(
             context.accounts[0].sendTransaction({
               to: context.contract.address,
-              data: "0x01",
+              data: '0x01',
             }),
           ).to.not.be.reverted;
         });
       });
 
-      describe("when calling with a payload preprended with 4 bytes of 0", () => {
-        describe("when no extension is set for bytes4(0)", () => {
-          describe("when the payload is `0x00000000`", () => {
-            describe("with sending value", () => {
-              it("should pass and emit ValueReceived value", async () => {
+      describe('when calling with a payload preprended with 4 bytes of 0', () => {
+        describe('when no extension is set for bytes4(0)', () => {
+          describe('when the payload is `0x00000000`', () => {
+            describe('with sending value', () => {
+              it('should pass and emit ValueReceived value', async () => {
                 const amountSent = 2;
                 await expect(
                   context.accounts[0].sendTransaction({
                     to: context.contract.address,
-                    data: "0x00000000",
+                    data: '0x00000000',
                     value: amountSent,
                   }),
                 )
-                  .to.emit(context.contract, "ValueReceived")
+                  .to.emit(context.contract, 'ValueReceived')
                   .withArgs(context.accounts[0].address, amountSent);
               });
             });
-            describe("without sending value", () => {
-              it("should pass", async () => {
+            describe('without sending value', () => {
+              it('should pass', async () => {
                 await expect(
                   context.accounts[0].sendTransaction({
                     to: context.contract.address,
-                    data: "0x00000000",
+                    data: '0x00000000',
                   }),
                 ).to.not.be.reverted;
               });
             });
           });
           describe("when the payload is `0x00000000` + some random data ('graffiti')", () => {
-            describe("with sending value", () => {
-              it("should pass and emit ValueReceived value", async () => {
+            describe('with sending value', () => {
+              it('should pass and emit ValueReceived value', async () => {
                 const amountSent = 2;
                 const graffiti =
-                  "0x00000000" +
+                  '0x00000000' +
                   ethers.utils
-                    .hexlify(ethers.utils.toUtf8Bytes("This is a small tip for you!"))
+                    .hexlify(ethers.utils.toUtf8Bytes('This is a small tip for you!'))
                     .substring(2);
 
                 await expect(
@@ -726,16 +726,16 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                     value: amountSent,
                   }),
                 )
-                  .to.emit(context.contract, "ValueReceived")
+                  .to.emit(context.contract, 'ValueReceived')
                   .withArgs(context.accounts[0].address, amountSent);
               });
             });
-            describe("without sending value", () => {
-              it("should pass", async () => {
+            describe('without sending value', () => {
+              it('should pass', async () => {
                 const graffiti =
-                  "0x00000000" +
+                  '0x00000000' +
                   ethers.utils
-                    .hexlify(ethers.utils.toUtf8Bytes("Sending a decentralized message"))
+                    .hexlify(ethers.utils.toUtf8Bytes('Sending a decentralized message'))
                     .substring(2);
 
                 await expect(
@@ -748,8 +748,8 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             });
           });
         });
-        describe("when there is an extension set for bytes4(0)", () => {
-          describe("when setting an extension that reverts", () => {
+        describe('when there is an extension set for bytes4(0)', () => {
+          describe('when setting an extension that reverts', () => {
             let revertFallbackExtension: RevertFallbackExtension;
 
             before(async () => {
@@ -759,29 +759,29 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
               const bytes1ZeroPaddedExtensionHandlerKey =
                 ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-                "00000000" +
-                "00000000000000000000000000000000"; // zero padded
+                '00000000' +
+                '00000000000000000000000000000000'; // zero padded
 
               await context.contract
                 .connect(context.deployParams.owner)
                 .setData(bytes1ZeroPaddedExtensionHandlerKey, revertFallbackExtension.address);
             });
-            describe("when the payload is `0x00000000`", () => {
-              it("should revert", async () => {
+            describe('when the payload is `0x00000000`', () => {
+              it('should revert', async () => {
                 await expect(
                   context.accounts[0].sendTransaction({
                     to: context.contract.address,
-                    data: "0x00000000",
+                    data: '0x00000000',
                   }),
                 ).to.be.reverted;
               });
             });
             describe("when the payload is `0x00000000` + some random data ('graffiti')", () => {
-              it("should revert", async () => {
+              it('should revert', async () => {
                 const graffiti =
-                  "0x00000000" +
+                  '0x00000000' +
                   ethers.utils
-                    .hexlify(ethers.utils.toUtf8Bytes("Sending a decentralized message"))
+                    .hexlify(ethers.utils.toUtf8Bytes('Sending a decentralized message'))
                     .substring(2);
 
                 await expect(
@@ -797,22 +797,22 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
       });
     });
 
-    describe("use cases", async () => {
-      describe("when interacting with a contract that require the recipient to implement onERC721Received function to mint", () => {
+    describe('use cases', async () => {
+      describe('when interacting with a contract that require the recipient to implement onERC721Received function to mint', () => {
         let token: RequireCallbackToken;
 
         before(async () => {
           token = await new RequireCallbackToken__factory(context.accounts[0]).deploy();
         });
 
-        describe("when minitng to the account", () => {
-          describe("before setting the onERC721ReceivedExtension", () => {
-            it("should fail since onERC721Received is not implemented", async () => {
+        describe('when minitng to the account', () => {
+          describe('before setting the onERC721ReceivedExtension', () => {
+            it('should fail since onERC721Received is not implemented', async () => {
               await expect(token.mint(context.contract.address)).to.be.reverted;
             });
           });
 
-          describe("after setting the onERC721ReceivedExtension", () => {
+          describe('after setting the onERC721ReceivedExtension', () => {
             let onERC721ReceivedExtension: OnERC721ReceivedExtension;
 
             before(async () => {
@@ -827,8 +827,8 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   onERC721ReceivedExtension.address,
                 );
             });
-            it("should pass since onERC721Received is implemented as a fallback extension", async () => {
-              await expect(token.mint(context.contract.address)).to.emit(token, "Minted");
+            it('should pass since onERC721Received is implemented as a fallback extension', async () => {
+              await expect(token.mint(context.contract.address)).to.emit(token, 'Minted');
             });
           });
         });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour.ts
@@ -1,6 +1,6 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // types
 import {
@@ -8,13 +8,13 @@ import {
   UniversalReceiverTester,
   UniversalReceiverDelegateRevert__factory,
   UniversalReceiverDelegateRevert,
-} from "../../types";
+} from '../../types';
 
 // helpers
-import { abiCoder, LSP1_HOOK_PLACEHOLDER } from "../utils/helpers";
+import { abiCoder, LSP1_HOOK_PLACEHOLDER } from '../utils/helpers';
 
 // constants
-import { ERC725YDataKeys } from "../../constants";
+import { ERC725YDataKeys } from '../../constants';
 
 export type LSP1TestContext = {
   accounts: SignerWithAddress[];
@@ -27,17 +27,17 @@ export type LSP1TestContext = {
 export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext>) => {
   let context: LSP1TestContext;
 
-  describe("when calling the `universalReceiver(...)` function", () => {
+  describe('when calling the `universalReceiver(...)` function', () => {
     const valueSent = 0;
 
     before(async () => {
       context = await buildContext();
     });
 
-    describe("from an EOA", () => {
-      it("should emit a UniversalReceiver(...) event with correct topics", async () => {
+    describe('from an EOA', () => {
+      it('should emit a UniversalReceiver(...) event with correct topics', async () => {
         const caller = context.accounts[2];
-        const data = "0xaabbccdd";
+        const data = '0xaabbccdd';
 
         await expect(
           context.lsp1Implementation
@@ -46,7 +46,7 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               value: valueSent,
             }),
         )
-          .to.emit(context.lsp1Implementation, "UniversalReceiver")
+          .to.emit(context.lsp1Implementation, 'UniversalReceiver')
           .withArgs(
             // from
             caller.address,
@@ -57,21 +57,21 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
             // receivedData
             data,
             // returnedValue
-            abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+            abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
           );
       });
     });
 
-    describe("from a Contract", () => {
-      describe("via a contract call - `contract.universalReceiver(...)`", () => {
-        it("should emit an UniversalReceiver(...) event", async () => {
+    describe('from a Contract', () => {
+      describe('via a contract call - `contract.universalReceiver(...)`', () => {
+        it('should emit an UniversalReceiver(...) event', async () => {
           await expect(
             context.lsp1Checker.checkImplementation(
               context.lsp1Implementation.address,
               LSP1_HOOK_PLACEHOLDER,
             ),
           )
-            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .to.emit(context.lsp1Implementation, 'UniversalReceiver')
             .withArgs(
               // from
               context.lsp1Checker.address,
@@ -80,22 +80,22 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               // typeId
               LSP1_HOOK_PLACEHOLDER,
               // receivedData
-              "0x",
+              '0x',
               // returnedValue
-              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+              abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
             );
         });
       });
 
-      describe("via a low-level call - `address(contract).call(...)`", () => {
-        it("should emit an UniversalReceiver(...) event", async () => {
+      describe('via a low-level call - `address(contract).call(...)`', () => {
+        it('should emit an UniversalReceiver(...) event', async () => {
           await expect(
             context.lsp1Checker.checkImplementationLowLevelCall(
               context.lsp1Implementation.address,
               LSP1_HOOK_PLACEHOLDER,
             ),
           )
-            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .to.emit(context.lsp1Implementation, 'UniversalReceiver')
             .withArgs(
               // from
               context.lsp1Checker.address,
@@ -104,9 +104,9 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               // typeId
               LSP1_HOOK_PLACEHOLDER,
               // receivedData
-              "0x",
+              '0x',
               // returnedValue
-              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+              abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
             );
         });
       });
@@ -119,10 +119,10 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
        */
     });
 
-    describe("to test typeId delegate feature", () => {
+    describe('to test typeId delegate feature', () => {
       let revertableURD: UniversalReceiverDelegateRevert;
 
-      describe("when setting a revertable typeId", () => {
+      describe('when setting a revertable typeId', () => {
         before(async () => {
           context = await buildContext();
 
@@ -139,59 +139,59 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
             );
         });
 
-        it("should revert", async () => {
+        it('should revert', async () => {
           const caller = context.accounts[2];
-          const data = "0xaabbccdd";
+          const data = '0xaabbccdd';
 
           await expect(
             context.lsp1Implementation
               .connect(caller)
               .universalReceiver(LSP1_HOOK_PLACEHOLDER, data),
-          ).to.be.revertedWith("I Revert");
+          ).to.be.revertedWith('I Revert');
         });
       });
     });
   });
 
-  describe("when calling the `universalReceiver(...)` function while sending native tokens", () => {
-    const valueSent = ethers.utils.parseEther("3");
+  describe('when calling the `universalReceiver(...)` function while sending native tokens', () => {
+    const valueSent = ethers.utils.parseEther('3');
 
     before(async () => {
       context = await buildContext();
     });
 
-    describe("from an EOA", () => {
-      it("should emit a UniversalReceiver(...) event with correct topics", async () => {
+    describe('from an EOA', () => {
+      it('should emit a UniversalReceiver(...) event with correct topics', async () => {
         let caller = context.accounts[2];
 
         await expect(
           context.lsp1Implementation
             .connect(caller)
-            .universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x", {
+            .universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x', {
               value: valueSent,
             }),
         )
-          .to.emit(context.lsp1Implementation, "UniversalReceiver")
+          .to.emit(context.lsp1Implementation, 'UniversalReceiver')
           .withArgs(
             caller.address,
             valueSent,
             LSP1_HOOK_PLACEHOLDER,
-            "0x",
-            abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+            '0x',
+            abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
           );
       });
     });
 
-    describe("from a Contract", () => {
+    describe('from a Contract', () => {
       before(async () => {
         await context.accounts[0].sendTransaction({
           to: context.lsp1Checker.address,
-          value: ethers.utils.parseEther("50"),
+          value: ethers.utils.parseEther('50'),
         });
       });
 
-      describe("via a contract call - `contract.universalReceiver(...)`", () => {
-        it("should emit an UniversalReceiver(...) event", async () => {
+      describe('via a contract call - `contract.universalReceiver(...)`', () => {
+        it('should emit an UniversalReceiver(...) event', async () => {
           await expect(
             context.lsp1Checker.checkImplementation(
               context.lsp1Implementation.address,
@@ -199,7 +199,7 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               { value: valueSent },
             ),
           )
-            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .to.emit(context.lsp1Implementation, 'UniversalReceiver')
             .withArgs(
               // from
               context.lsp1Checker.address,
@@ -208,15 +208,15 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               // typeId
               LSP1_HOOK_PLACEHOLDER,
               // receivedData
-              "0x",
+              '0x',
               // returnedValue
-              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+              abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
             );
         });
       });
 
-      describe("via a low-level call - `address(contract).call(...)`", () => {
-        it("should emit an UniversalReceiver(...) event", async () => {
+      describe('via a low-level call - `address(contract).call(...)`', () => {
+        it('should emit an UniversalReceiver(...) event', async () => {
           await expect(
             context.lsp1Checker.checkImplementationLowLevelCall(
               context.lsp1Implementation.address,
@@ -224,7 +224,7 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               { value: valueSent },
             ),
           )
-            .to.emit(context.lsp1Implementation, "UniversalReceiver")
+            .to.emit(context.lsp1Implementation, 'UniversalReceiver')
             .withArgs(
               // from
               context.lsp1Checker.address,
@@ -233,9 +233,9 @@ export const shouldBehaveLikeLSP1 = (buildContext: () => Promise<LSP1TestContext
               // typeId
               LSP1_HOOK_PLACEHOLDER,
               // receivedData
-              "0x",
+              '0x',
               // returnedValue
-              abiCoder.encode(["bytes", "bytes"], ["0x", "0x"]),
+              abiCoder.encode(['bytes', 'bytes'], ['0x', '0x']),
             );
         });
       });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -1,6 +1,6 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // types
 import {
@@ -22,18 +22,18 @@ import {
   LSP1UniversalReceiverDelegateUP__factory,
   LSP7MintWhenDeployed__factory,
   LSP7MintWhenDeployed,
-} from "../../types";
+} from '../../types';
 
 // helpers
-import { ARRAY_LENGTH, LSP1_HOOK_PLACEHOLDER, abiCoder } from "../utils/helpers";
+import { ARRAY_LENGTH, LSP1_HOOK_PLACEHOLDER, abiCoder } from '../utils/helpers';
 
 // constants
-import { ERC725YDataKeys, INTERFACE_IDS, OPERATION_TYPES, LSP1_TYPE_IDS } from "../../constants";
+import { ERC725YDataKeys, INTERFACE_IDS, OPERATION_TYPES, LSP1_TYPE_IDS } from '../../constants';
 
 // fixtures
-import { callPayload, getLSP5MapAndArrayKeysValue, setupKeyManager } from "../utils/fixtures";
-import { LSP6TestContext } from "../utils/context";
-import { BigNumber, BytesLike, Transaction } from "ethers";
+import { callPayload, getLSP5MapAndArrayKeysValue, setupKeyManager } from '../utils/fixtures';
+import { LSP6TestContext } from '../utils/context';
+import { BigNumber, BytesLike, Transaction } from 'ethers';
 
 export type LSP1TestAccounts = {
   owner1: SignerWithAddress;
@@ -60,21 +60,21 @@ async function getLSP10MapAndArrayKeysValue(account, lsp9Vault) {
     ethers.utils.hexConcat([ERC725YDataKeys.LSP10.LSP10VaultsMap, lsp9Vault.address]),
   );
 
-  const indexInHex = "0x" + mapValue.substr(10, mapValue.length);
+  const indexInHex = '0x' + mapValue.substr(10, mapValue.length);
   const interfaceId = mapValue.substr(0, 10);
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
 
   const rawIndexInArray = ethers.utils.hexZeroPad(ethers.utils.hexValue(indexInNumber), 16);
 
   const elementInArrayKey = ethers.utils.hexConcat([
-    ERC725YDataKeys.LSP10["LSP10Vaults[]"].index,
+    ERC725YDataKeys.LSP10['LSP10Vaults[]'].index,
     rawIndexInArray,
   ]);
 
-  let arrayKey = ERC725YDataKeys.LSP10["LSP10Vaults[]"].length;
+  let arrayKey = ERC725YDataKeys.LSP10['LSP10Vaults[]'].length;
   let [arrayLength, elementAddress] = await account.getDataBatch([arrayKey, elementInArrayKey]);
 
-  if (elementAddress != "0x") {
+  if (elementAddress != '0x') {
     elementAddress = ethers.utils.getAddress(elementAddress);
   }
   return [indexInNumber, interfaceId, arrayLength, elementAddress];
@@ -102,9 +102,9 @@ export const shouldBehaveLikeLSP1Delegate = (
     context = await buildContext();
   });
 
-  describe("When testing EOA call to URD through the UR function", () => {
-    describe("when calling with token/vault typeId", () => {
-      it("should revert with custom error", async () => {
+  describe('When testing EOA call to URD through the UR function', () => {
+    describe('when calling with token/vault typeId', () => {
+      it('should revert with custom error', async () => {
         let URD_TypeIds = [
           LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
           LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
@@ -118,36 +118,36 @@ export const shouldBehaveLikeLSP1Delegate = (
           await expect(
             context.universalProfile1
               .connect(context.accounts.any)
-              .universalReceiver(URD_TypeIds[i], "0x"),
+              .universalReceiver(URD_TypeIds[i], '0x'),
           )
             .to.be.revertedWithCustomError(
               context.lsp1universalReceiverDelegateUP,
-              "CannotRegisterEOAsAsAssets",
+              'CannotRegisterEOAsAsAssets',
             )
             .withArgs(context.accounts.any.address);
         }
       });
     });
 
-    describe("when calling with random bytes32 typeId", () => {
-      it("should pass and return typeId out of scope return value", async () => {
+    describe('when calling with random bytes32 typeId', () => {
+      it('should pass and return typeId out of scope return value', async () => {
         let result = await context.universalProfile1
           .connect(context.accounts.any)
-          .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
+          .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x');
 
-        const [resultDelegate, resultTypeID] = abiCoder.decode(["bytes", "bytes"], result);
+        const [resultDelegate, resultTypeID] = abiCoder.decode(['bytes', 'bytes'], result);
 
         expect(resultDelegate).to.equal(
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
         );
 
-        expect(resultTypeID).to.equal("0x");
+        expect(resultTypeID).to.equal('0x');
       });
     });
   });
 
-  describe("when testing LSP0-ERC725Account", () => {
-    describe("when accepting ownership of an LSP0", () => {
+  describe('when testing LSP0-ERC725Account', () => {
+    describe('when accepting ownership of an LSP0', () => {
       let sentUniversalProfile: LSP0ERC725Account;
       before(async () => {
         sentUniversalProfile = await new LSP0ERC725Account__factory(context.accounts.owner1).deploy(
@@ -155,7 +155,7 @@ export const shouldBehaveLikeLSP1Delegate = (
         );
       });
 
-      it("should not register universal profile as received vault", async () => {
+      it('should not register universal profile as received vault', async () => {
         const acceptingUniversalProfile: LSP0ERC725Account = context.universalProfile1;
         const acceptingUniversalProfileKM: LSP6KeyManager = context.lsp6KeyManager1;
 
@@ -164,8 +164,8 @@ export const shouldBehaveLikeLSP1Delegate = (
           .transferOwnership(acceptingUniversalProfile.address);
 
         const acceptOwnershipPayload =
-          sentUniversalProfile.interface.encodeFunctionData("acceptOwnership");
-        const payloadToExecute = acceptingUniversalProfile.interface.encodeFunctionData("execute", [
+          sentUniversalProfile.interface.encodeFunctionData('acceptOwnership');
+        const payloadToExecute = acceptingUniversalProfile.interface.encodeFunctionData('execute', [
           0,
           sentUniversalProfile.address,
           0,
@@ -177,11 +177,11 @@ export const shouldBehaveLikeLSP1Delegate = (
           .execute(payloadToExecute);
 
         const receivedVaultsKeys = [
-          ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-          ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "0".repeat(32),
+          ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+          ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '0'.repeat(32),
           ERC725YDataKeys.LSP10.LSP10VaultsMap + sentUniversalProfile.address.substring(2),
         ];
-        const receivedVaultsValues = ["0x", "0x", "0x"];
+        const receivedVaultsValues = ['0x', '0x', '0x'];
 
         expect(await acceptingUniversalProfile.getDataBatch(receivedVaultsKeys)).to.deep.equal(
           receivedVaultsValues,
@@ -190,60 +190,60 @@ export const shouldBehaveLikeLSP1Delegate = (
     });
   });
 
-  describe("when testing LSP7-DigitalAsset", () => {
+  describe('when testing LSP7-DigitalAsset', () => {
     let lsp7TokenA: LSP7Tester, lsp7TokenB: LSP7Tester, lsp7TokenC: LSP7Tester;
 
     before(async () => {
       lsp7TokenA = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenAlpha",
-        "TA",
+        'TokenAlpha',
+        'TA',
         context.accounts.random.address,
       );
 
       lsp7TokenB = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenBeta",
-        "TB",
+        'TokenBeta',
+        'TB',
         context.accounts.random.address,
       );
 
       lsp7TokenC = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenGamma",
-        "TA",
+        'TokenGamma',
+        'TA',
         context.accounts.random.address,
       );
     });
 
-    describe("when minting tokens", () => {
-      describe("when tokens are minted through the constructor (on LSP7 deployment)", () => {
+    describe('when minting tokens', () => {
+      describe('when tokens are minted through the constructor (on LSP7 deployment)', () => {
         let deployedLSP7Token: LSP7MintWhenDeployed;
 
-        before("deploy LSP7 token which mint tokens in `constructor`", async () => {
+        before('deploy LSP7 token which mint tokens in `constructor`', async () => {
           deployedLSP7Token = await new LSP7MintWhenDeployed__factory(context.accounts.any).deploy(
-            "LSP7 Token",
-            "TKN",
+            'LSP7 Token',
+            'TKN',
             context.universalProfile1.address,
           );
         });
 
-        after("clear LSP5 storage", async () => {
+        after('clear LSP5 storage', async () => {
           // cleanup and reset the `LSP5ReceivedAssets[]` length, index and map value to 0x
           const setDataPayload = context.universalProfile1.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [
               [
-                ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-                ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00".repeat(16),
-                ERC725YDataKeys.LSP5["LSP5ReceivedAssetsMap"] +
+                ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+                ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00'.repeat(16),
+                ERC725YDataKeys.LSP5['LSP5ReceivedAssetsMap'] +
                   deployedLSP7Token.address.substring(2),
               ],
-              ["0x", "0x", "0x"],
+              ['0x', '0x', '0x'],
             ],
           );
 
           await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(setDataPayload);
         });
 
-        it("it should have registered the token in LSP5ReceivedAssets Map and Array", async () => {
+        it('it should have registered the token in LSP5ReceivedAssets Map and Array', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, deployedLSP7Token);
 
@@ -254,38 +254,38 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when calling `mint(...)` with `amount == 0` and a `to == universalProfile`", () => {
-        it("should not revert, not register any LSP5ReceivedAssets[] and just emit the `UniversalReceiver` event on the UP", async () => {
+      describe('when calling `mint(...)` with `amount == 0` and a `to == universalProfile`', () => {
+        it('should not revert, not register any LSP5ReceivedAssets[] and just emit the `UniversalReceiver` event on the UP', async () => {
           await expect(
             lsp7TokenA
               .connect(context.accounts.random)
-              .mint(context.universalProfile1.address, 0, false, "0x"),
+              .mint(context.universalProfile1.address, 0, false, '0x'),
           )
-            .to.emit(lsp7TokenA, "Transfer")
+            .to.emit(lsp7TokenA, 'Transfer')
             .withArgs(
               context.accounts.random.address,
               ethers.constants.AddressZero,
               context.universalProfile1.address,
               0,
               false,
-              "0x",
+              '0x',
             );
 
           const result = await context.universalProfile1.getData(
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
           );
 
-          expect(result).to.equal("0x");
+          expect(result).to.equal('0x');
         });
       });
 
-      describe("when minting 10 tokenA to universalProfile1", () => {
+      describe('when minting 10 tokenA to universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -293,7 +293,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenA.address, abi));
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenA);
           expect(indexInMap).to.equal(0);
@@ -303,13 +303,13 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting 10 tokenB to universalProfile1", () => {
+      describe('when minting 10 tokenB to universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -317,7 +317,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
 
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -327,13 +327,13 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting 10 of the same tokenB to universalProfile1", () => {
+      describe('when minting 10 of the same tokenB to universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -341,7 +341,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
 
-        it("should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -351,20 +351,20 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting 10 tokenC to universalProfile1", () => {
+      describe('when minting 10 tokenC to universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp7TokenC.address, abi));
         });
-        it("should register lsp5keys: arrayLength 3, index 2, tokenC address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 3, index 2, tokenC address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenC);
           expect(indexInMap).to.equal(2);
@@ -375,17 +375,17 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when burning tokens", () => {
-      describe("when calling `burn(...)` with `amount == 0` and a `to == a universalProfile`", () => {
-        it("should revert and not remove any LSP5ReceivedAssets[] on the UP", async () => {
-          const lsp5ReceivedAssetsArrayLength = await context.universalProfile1["getData(bytes32)"](
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+    describe('when burning tokens', () => {
+      describe('when calling `burn(...)` with `amount == 0` and a `to == a universalProfile`', () => {
+        it('should revert and not remove any LSP5ReceivedAssets[] on the UP', async () => {
+          const lsp5ReceivedAssetsArrayLength = await context.universalProfile1['getData(bytes32)'](
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
           );
 
-          const abi = lsp7TokenC.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('burn', [
             context.universalProfile1.address,
-            "0",
-            "0x",
+            '0',
+            '0x',
           ]);
 
           await expect(
@@ -393,31 +393,31 @@ export const shouldBehaveLikeLSP1Delegate = (
               .connect(context.accounts.owner1)
               .execute(callPayload(context.universalProfile1, lsp7TokenA.address, abi)),
           )
-            .to.emit(lsp7TokenA, "Transfer")
+            .to.emit(lsp7TokenA, 'Transfer')
             .withArgs(
               context.universalProfile1.address,
               context.universalProfile1.address,
               ethers.constants.AddressZero,
-              "0",
+              '0',
               false,
-              "0x",
+              '0x',
             );
 
           // CHECK that LSP5ReceivedAssets[] has not changed
           expect(
             await context.universalProfile1.getData(
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
             ),
           ).to.equal(lsp5ReceivedAssetsArrayLength);
         });
       });
 
-      describe("when burning 10 tokenC (last token) from universalProfile1", () => {
+      describe('when burning 10 tokenC (last token) from universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('burn', [
             context.universalProfile1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -425,27 +425,27 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenC.address, abi));
         });
 
-        it("should update lsp5keys: arrayLength 2, no map, no tokenC address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenC address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenC.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000002",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000002',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 10 tokenA (first token) from universalProfile1", () => {
+      describe('when burning 10 tokenA (first token) from universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('burn', [
             context.universalProfile1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -453,7 +453,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenA.address, abi));
         });
 
-        it("should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in UP1", async () => {
+        it('should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -462,34 +462,34 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should update lsp5keys: arrayLength 1, no map, no tokenA address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 1, no map, no tokenA address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenA.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 10 (half of the amount) tokenB from universalProfile1", () => {
+      describe('when burning 10 (half of the amount) tokenB from universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('burn', [
             context.universalProfile1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
-        it("should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -499,39 +499,39 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when burning 10 (remaining) tokenB from universalProfile1", () => {
+      describe('when burning 10 (remaining) tokenB from universalProfile1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('burn', [
             context.universalProfile1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
-        it("should update lsp5keys: arrayLength 0, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 0, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000000",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000000',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
     });
 
-    describe("when transferring tokens", () => {
-      describe("when calling `transfer(...)` with `amount == 0` and `to == universalProfile`", () => {
-        it("should revert", async () => {
-          const lsp5ReceivedAssetsArrayLength = await context.universalProfile1["getData(bytes32)"](
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+    describe('when transferring tokens', () => {
+      describe('when calling `transfer(...)` with `amount == 0` and `to == universalProfile`', () => {
+        it('should revert', async () => {
+          const lsp5ReceivedAssetsArrayLength = await context.universalProfile1['getData(bytes32)'](
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
           );
 
           await expect(
@@ -542,43 +542,43 @@ export const shouldBehaveLikeLSP1Delegate = (
                 context.universalProfile1.address,
                 0,
                 false,
-                "0x",
+                '0x',
               ),
           )
-            .to.emit(lsp7TokenA, "Transfer")
+            .to.emit(lsp7TokenA, 'Transfer')
             .withArgs(
               context.accounts.random.address,
               context.accounts.random.address,
               context.universalProfile1.address,
               0,
               false,
-              "0x",
+              '0x',
             );
 
           // CHECK that LSP5ReceivedAssets[] has not changed
           expect(
             await context.universalProfile1.getData(
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
             ),
           ).to.equal(lsp5ReceivedAssetsArrayLength);
         });
       });
 
-      it("should fund the universalProfle with 10 tokens (each) to test token transfers (TokenA, TokenB, TokenC)", async () => {
+      it('should fund the universalProfle with 10 tokens (each) to test token transfers (TokenA, TokenB, TokenC)', async () => {
         await lsp7TokenA
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, "10", false, "0x");
+          .mint(context.universalProfile1.address, '10', false, '0x');
 
         await lsp7TokenB
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, "10", false, "0x");
+          .mint(context.universalProfile1.address, '10', false, '0x');
 
         await lsp7TokenC
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, "10", false, "0x");
+          .mint(context.universalProfile1.address, '10', false, '0x');
       });
 
-      it("should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in UP1 ", async () => {
+      it('should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in UP1 ', async () => {
         const [indexInMapTokenA, interfaceIdTokenA, arrayLength, elementAddressTokenA] =
           await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenA);
 
@@ -600,14 +600,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(elementAddressTokenC).to.equal(lsp7TokenC.address);
       });
 
-      describe("When transferring 10 (all) token A from UP1 to UP2", () => {
+      describe('When transferring 10 (all) token A from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -615,7 +615,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenA.address, abi));
         });
 
-        it("should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in UP1", async () => {
+        it('should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenC);
           expect(indexInMap).to.equal(0);
@@ -624,21 +624,21 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp7TokenC.address);
         });
 
-        it("should update lsp5keys: arrayLength 2, no map, no tokenA address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenA address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenA.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000002",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000002',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in UP2", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp7TokenA);
           expect(indexInMap).to.equal(0);
@@ -648,14 +648,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 5 (half of amount) token B from UP1 to UP2", () => {
+      describe('When transferring 5 (half of amount) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
-            "5",
+            '5',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -663,7 +663,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -672,7 +672,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in UP2", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -682,14 +682,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 4 (few) token B from UP1 to UP2", () => {
+      describe('When transferring 4 (few) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
-            "4",
+            '4',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -697,7 +697,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -706,7 +706,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -716,14 +716,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 1 (remaining) token B from UP1 to UP2", () => {
+      describe('When transferring 1 (remaining) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
-            "1",
+            '1',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -731,21 +731,21 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi));
         });
 
-        it("should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -755,14 +755,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 10 (all) token C from UP1 to UP2", () => {
+      describe('When transferring 10 (all) token C from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -770,21 +770,21 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp7TokenC.address, abi));
         });
 
-        it("should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys : arrayLength 3, index = 2, tokenC address in UP2", async () => {
+        it('should register lsp5keys : arrayLength 3, index = 2, tokenC address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp7TokenC);
           expect(indexInMap).to.equal(2);
@@ -794,14 +794,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 1 (few) token B from UP2 to UP1", () => {
+      describe('When transferring 1 (few) token B from UP2 to UP1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile2.address,
             context.universalProfile1.address,
-            "1",
+            '1',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager2
@@ -809,7 +809,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile2, lsp7TokenB.address, abi));
         });
 
-        it("should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in UP1", async () => {
+        it('should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -820,55 +820,55 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when removing all keys", () => {
+    describe('when removing all keys', () => {
       before(async () => {
-        const abi1 = lsp7TokenB.interface.encodeFunctionData("burn", [
+        const abi1 = lsp7TokenB.interface.encodeFunctionData('burn', [
           context.universalProfile1.address,
-          "1",
-          "0x",
+          '1',
+          '0x',
         ]);
 
         await context.lsp6KeyManager1
           .connect(context.accounts.owner1)
           .execute(callPayload(context.universalProfile1, lsp7TokenB.address, abi1));
 
-        const abi2 = lsp7TokenB.interface.encodeFunctionData("burn", [
+        const abi2 = lsp7TokenB.interface.encodeFunctionData('burn', [
           context.universalProfile2.address,
-          "9",
-          "0x",
+          '9',
+          '0x',
         ]);
 
         await context.lsp6KeyManager2
           .connect(context.accounts.owner2)
           .execute(callPayload(context.universalProfile2, lsp7TokenB.address, abi2));
 
-        const abi3 = lsp7TokenA.interface.encodeFunctionData("burn", [
+        const abi3 = lsp7TokenA.interface.encodeFunctionData('burn', [
           context.universalProfile2.address,
-          "10",
-          "0x",
+          '10',
+          '0x',
         ]);
 
         await context.lsp6KeyManager2
           .connect(context.accounts.owner2)
           .execute(callPayload(context.universalProfile2, lsp7TokenA.address, abi3));
 
-        const abi4 = lsp7TokenC.interface.encodeFunctionData("burn", [
+        const abi4 = lsp7TokenC.interface.encodeFunctionData('burn', [
           context.universalProfile2.address,
-          "10",
-          "0x",
+          '10',
+          '0x',
         ]);
 
         await context.lsp6KeyManager2
           .connect(context.accounts.owner2)
           .execute(callPayload(context.universalProfile2, lsp7TokenC.address, abi4));
       });
-      it("should remove all lsp5 keys on both UP", async () => {
-        const arrayLengthUP1 = await context.universalProfile1["getData(bytes32)"](
-          ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+      it('should remove all lsp5 keys on both UP', async () => {
+        const arrayLengthUP1 = await context.universalProfile1['getData(bytes32)'](
+          ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
         );
 
-        const arrayLengthUP2 = await context.universalProfile2["getData(bytes32)"](
-          ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+        const arrayLengthUP2 = await context.universalProfile2['getData(bytes32)'](
+          ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
         );
 
         expect(arrayLengthUP1).to.equal(ARRAY_LENGTH.ZERO);
@@ -876,13 +876,13 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when UP does not have any balance of a LSP7 token and transfer with amount == 0", () => {
+    describe('when UP does not have any balance of a LSP7 token and transfer with amount == 0', () => {
       let lsp7Token: LSP7Tester;
 
       before(async () => {
         lsp7Token = await new LSP7Tester__factory(context.accounts.random).deploy(
-          "Example LSP7 token",
-          "EL7T",
+          'Example LSP7 token',
+          'EL7T',
           context.accounts.random.address,
         );
       });
@@ -893,10 +893,10 @@ export const shouldBehaveLikeLSP1Delegate = (
           to: context.accounts.random.address,
           amount: 0,
           allowedNonLSP1Recipient: true,
-          data: "0x",
+          data: '0x',
         };
 
-        const emptyTokenTransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+        const emptyTokenTransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
           txParams.from,
           txParams.to,
           txParams.amount,
@@ -904,7 +904,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           txParams.data,
         ]);
 
-        const executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp7Token.address,
           0,
@@ -914,24 +914,24 @@ export const shouldBehaveLikeLSP1Delegate = (
         const tx = context.lsp6KeyManager1.connect(context.accounts.owner1).execute(executePayload);
 
         const expectedReturnedValues = abiCoder.encode(
-          ["bytes", "bytes"],
+          ['bytes', 'bytes'],
           [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")),
-            "0x",
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: asset sent is not registered')),
+            '0x',
           ],
         );
 
         // the call to the universalReceiver(...) in LSP7 sends the transfer details as `data` argument
         // all the params are packed/concatenated together.
         const expectedReceivedData = ethers.utils.solidityPack(
-          ["address", "address", "uint256", "bytes"],
+          ['address', 'address', 'uint256', 'bytes'],
           [txParams.from, txParams.to, txParams.amount, txParams.data],
         );
 
         // TODO: debug the 4th argument for the receivedData: why is it not empty?
         // receivedData = 0xa513e6e4b8f2a923d98304ec87f64353c4d5c8533c44cdddb6a900fa2b585dd299e03d12fa4293bc0000000000000000000000000000000000000000000000000000000000000000
         await expect(tx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             lsp7Token.address,
             0,
@@ -942,7 +942,7 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when a non-LSP7 token contract calls the `universalReceiver(...)` function", () => {
+    describe('when a non-LSP7 token contract calls the `universalReceiver(...)` function', () => {
       let notTokenContract: GenericExecutor;
 
       before(async () => {
@@ -951,8 +951,8 @@ export const shouldBehaveLikeLSP1Delegate = (
 
       it("should not revert and return 'LSP1: asset sent is not registered' when calling with typeId == LSP7Tokens_SenderNotification", async () => {
         const universalReceiverPayload = context.universalProfile1.interface.encodeFunctionData(
-          "universalReceiver",
-          [LSP1_TYPE_IDS.LSP7Tokens_SenderNotification, "0x"],
+          'universalReceiver',
+          [LSP1_TYPE_IDS.LSP7Tokens_SenderNotification, '0x'],
         );
 
         // check that it does not revert
@@ -971,34 +971,34 @@ export const shouldBehaveLikeLSP1Delegate = (
           universalReceiverPayload,
         );
 
-        const [genericExecutorResult] = abiCoder.decode(["bytes"], universalReceiverResult);
+        const [genericExecutorResult] = abiCoder.decode(['bytes'], universalReceiverResult);
 
         const [resultDelegate, resultTypeID] = abiCoder.decode(
-          ["bytes", "bytes"],
+          ['bytes', 'bytes'],
           genericExecutorResult,
         );
 
         expect(resultDelegate).to.equal(
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: asset sent is not registered')),
         );
 
         // check that the correct string is emitted in the event
         await expect(
           notTokenContract.call(context.universalProfile1.address, 0, universalReceiverPayload),
         )
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             notTokenContract.address,
             0,
             LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
-            "0x",
+            '0x',
             genericExecutorResult,
           );
       });
     });
   });
 
-  describe("testing values set under `LSP5ReceivedAssets[]`", () => {
+  describe('testing values set under `LSP5ReceivedAssets[]`', () => {
     let context: LSP1DelegateTestContext;
     let token: LSP7Tester;
     let arrayKey: BytesLike;
@@ -1010,24 +1010,24 @@ export const shouldBehaveLikeLSP1Delegate = (
       context = await buildContext();
 
       token = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "Example LSP7 token",
-        "EL7T",
+        'Example LSP7 token',
+        'EL7T',
         context.accounts.random.address,
       );
 
-      arrayKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
-      arrayIndexKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "0".repeat(32);
+      arrayKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
+      arrayIndexKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '0'.repeat(32);
       assetMapKey = ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2);
     });
 
-    describe("when `LSP5ReceivedAssets[]` length value is `max(uint128)`", () => {
-      const lsp5ArrayLengthDataKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
+    describe('when `LSP5ReceivedAssets[]` length value is `max(uint128)`', () => {
+      const lsp5ArrayLengthDataKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
 
       // set the `LSP5ReceivedAssets[]` length value to the max(uint128)`
       const lsp5ArrayLengthDataValue = ethers.BigNumber.from(2).pow(128).sub(1);
 
       before(async () => {
-        const setDataPayload = context.universalProfile1.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile1.interface.encodeFunctionData('setData', [
           lsp5ArrayLengthDataKey,
           lsp5ArrayLengthDataValue,
         ]);
@@ -1040,9 +1040,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         );
       });
 
-      it("should revert when trying to transfer some tokens to UP but UP cannot register any more tokens", async () => {
-        const lsp1DelegateAddress = await context.universalProfile1["getData(bytes32)"](
-          ERC725YDataKeys.LSP1["LSP1UniversalReceiverDelegate"],
+      it('should revert when trying to transfer some tokens to UP but UP cannot register any more tokens', async () => {
+        const lsp1DelegateAddress = await context.universalProfile1['getData(bytes32)'](
+          ERC725YDataKeys.LSP1['LSP1UniversalReceiverDelegate'],
         );
 
         const lsp1DelegateInstance = await new LSP1UniversalReceiverDelegateUP__factory(
@@ -1051,20 +1051,20 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         // try to transfer (= mint) some tokens to the UP
         // this should revert because the UP cannot register any more tokens
-        await expect(token.mint(context.universalProfile1.address, 10_000, false, "0x"))
-          .to.be.revertedWithCustomError(lsp1DelegateInstance, "MaxLSP5ReceivedAssetsCountReached")
+        await expect(token.mint(context.universalProfile1.address, 10_000, false, '0x'))
+          .to.be.revertedWithCustomError(lsp1DelegateInstance, 'MaxLSP5ReceivedAssetsCountReached')
           .withArgs(token.address);
       });
     });
 
-    describe("when `LSP5ReceivedAssets[]` length value is `max(uint128) - 1`", () => {
-      const lsp5ArrayLengthDataKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
+    describe('when `LSP5ReceivedAssets[]` length value is `max(uint128) - 1`', () => {
+      const lsp5ArrayLengthDataKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
 
       // set the `LSP5ReceivedAssets[]` length value to the max(uint128)`
       const lsp5ArrayLengthDataValue = ethers.BigNumber.from(2).pow(128).sub(2);
 
       before(async () => {
-        const setDataPayload = context.universalProfile1.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile1.interface.encodeFunctionData('setData', [
           lsp5ArrayLengthDataKey,
           lsp5ArrayLengthDataValue,
         ]);
@@ -1080,24 +1080,24 @@ export const shouldBehaveLikeLSP1Delegate = (
       after(async () => {
         // cleanup and reset the `LSP5ReceivedAssets[]` length, index and map value to 0x
         const setDataPayload = context.universalProfile1.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [
             [
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00".repeat(16),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssetsMap"] + token.address.substring(2),
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00'.repeat(16),
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssetsMap'] + token.address.substring(2),
             ],
-            ["0x", "0x", "0x"],
+            ['0x', '0x', '0x'],
           ],
         );
 
         await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(setDataPayload);
       });
 
-      it("should not revert when trying to transfer some tokens to UP and UP (can register ONLY ONE MORE more tokens)", async () => {
+      it('should not revert when trying to transfer some tokens to UP and UP (can register ONLY ONE MORE more tokens)', async () => {
         // try to transfer (= mint) some tokens to the UP
         // this should not revert because the UP can register one more asset
-        await token.mint(context.universalProfile1.address, 10_000, false, "0x");
+        await token.mint(context.universalProfile1.address, 10_000, false, '0x');
 
         // check the `LSP5ReceivedAssets[]` length value was set correctly
         expect(await context.universalProfile1.getData(lsp5ArrayLengthDataKey)).to.equal(
@@ -1107,7 +1107,7 @@ export const shouldBehaveLikeLSP1Delegate = (
         const index = lsp5ArrayLengthDataValue.toHexString();
 
         const lsp5ArrayIndexDataKey =
-          ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + index.substring(2);
+          ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + index.substring(2);
 
         // checksummed address of the token
         const storedAssetAddress = ethers.utils.getAddress(
@@ -1120,46 +1120,46 @@ export const shouldBehaveLikeLSP1Delegate = (
         // Check that the correct tuple (interfaceId, index) was set under LSP5ReceivedAssetsMap + token address
         expect(
           await context.universalProfile1.getData(
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssetsMap"] + token.address.substring(2),
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssetsMap'] + token.address.substring(2),
           ),
         ).to.equal(
-          ethers.utils.solidityPack(["bytes4", "uint128"], [INTERFACE_IDS.LSP7DigitalAsset, index]),
+          ethers.utils.solidityPack(['bytes4', 'uint128'], [INTERFACE_IDS.LSP7DigitalAsset, index]),
         );
       });
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is less than 20 bytes", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is less than 20 bytes', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.universalProfile1.address, 100, false, "0x");
+          .mint(context.universalProfile1.address, 100, false, '0x');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-            "0xcafecafecafecafe",
+            '0xcafecafecafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
 
         balance = await token.balanceOf(context.universalProfile1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.universalProfile1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         tokenTransferTx = await context.universalProfile1
@@ -1167,11 +1167,11 @@ export const shouldBehaveLikeLSP1Delegate = (
           .execute(OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata);
       });
 
-      it("should pass", async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -1181,12 +1181,12 @@ export const shouldBehaveLikeLSP1Delegate = (
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -1200,45 +1200,45 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
       });
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.universalProfile1.address, 100, false, "0x");
+          .mint(context.universalProfile1.address, 100, false, '0x');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-            "0xda1f85e400000000000000000000000000000000cafecafe",
+            '0xda1f85e400000000000000000000000000000000cafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xda1f85e400000000000000000000000000000000cafecafe",
+          '0xda1f85e400000000000000000000000000000000cafecafe',
         ]);
 
         balance = await token.balanceOf(context.universalProfile1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.universalProfile1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         tokenTransferTx = await context.universalProfile1
@@ -1246,11 +1246,11 @@ export const shouldBehaveLikeLSP1Delegate = (
           .execute(OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata);
       });
 
-      it("should pass", async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -1260,12 +1260,12 @@ export const shouldBehaveLikeLSP1Delegate = (
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["bytes", "bytes"],
-          ["0x", "0x"],
+          ['bytes', 'bytes'],
+          ['0x', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -1275,45 +1275,45 @@ export const shouldBehaveLikeLSP1Delegate = (
           );
       });
 
-      it("should de-register the asset properly", async () => {
+      it('should de-register the asset properly', async () => {
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
-        ).to.deep.equal(["0x" + "00".repeat(16), "0x", "0x"]);
+        ).to.deep.equal(['0x' + '00'.repeat(16), '0x', '0x']);
       });
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is 20 random bytes", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is 20 random bytes', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.universalProfile1.address, 100, false, "0x");
+          .mint(context.universalProfile1.address, 100, false, '0x');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-            "0xcafecafecafecafecafecafecafecafecafecafe",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
 
         balance = await token.balanceOf(context.universalProfile1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.universalProfile1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         tokenTransferTx = await context.universalProfile1
@@ -1321,11 +1321,11 @@ export const shouldBehaveLikeLSP1Delegate = (
           .execute(OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata);
       });
 
-      it("should pass", async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -1335,12 +1335,12 @@ export const shouldBehaveLikeLSP1Delegate = (
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -1354,15 +1354,15 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
       });
     });
   });
 
-  describe("testing values set under `LSP10ReceivedVaults[]`", () => {
+  describe('testing values set under `LSP10ReceivedVaults[]`', () => {
     let context: LSP1DelegateTestContext;
     let vault: LSP9Vault;
     let arrayKey: BytesLike;
@@ -1377,12 +1377,12 @@ export const shouldBehaveLikeLSP1Delegate = (
         context.accounts.owner1.address,
       );
 
-      arrayKey = ERC725YDataKeys.LSP10["LSP10Vaults[]"].length;
-      arrayIndexKey = ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "0".repeat(32);
+      arrayKey = ERC725YDataKeys.LSP10['LSP10Vaults[]'].length;
+      arrayIndexKey = ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '0'.repeat(32);
       vaultMapKey = ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2);
     });
 
-    describe("when the Map value of LSP10VaultsMap is less than 20 bytes", () => {
+    describe('when the Map value of LSP10VaultsMap is less than 20 bytes', () => {
       let acceptOwnershipTx: Transaction;
 
       before(async () => {
@@ -1390,7 +1390,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .transferOwnership(context.universalProfile1.address);
 
-        const acceptOwnershipCalldata = vault.interface.encodeFunctionData("acceptOwnership");
+        const acceptOwnershipCalldata = vault.interface.encodeFunctionData('acceptOwnership');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
@@ -1400,18 +1400,18 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2),
-            "0xcafecafecafecafe",
+            '0xcafecafecafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, vaultMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           vault.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
 
-        const vaultTrasferCalldata = vault.interface.encodeFunctionData("transferOwnership", [
+        const vaultTrasferCalldata = vault.interface.encodeFunctionData('transferOwnership', [
           context.accounts.owner1.address,
         ]);
 
@@ -1422,23 +1422,23 @@ export const shouldBehaveLikeLSP1Delegate = (
         acceptOwnershipTx = await vault.connect(context.accounts.owner1).acceptOwnership();
       });
 
-      it("it should pass", async () => {
+      it('it should pass', async () => {
         expect(acceptOwnershipTx).to.not.be.reverted;
       });
 
-      it("it should emit UniversalReceiver event", async () => {
+      it('it should emit UniversalReceiver event', async () => {
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(acceptOwnershipTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             vault.address,
             0,
             LSP1_TYPE_IDS.LSP9OwnershipTransferred_SenderNotification,
-            "0x",
+            '0x',
             lsp1ReturnedData,
           );
       });
@@ -1447,14 +1447,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, vaultMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           vault.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
       });
     });
 
-    describe("when the Map value of LSP10VaultsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)", () => {
+    describe('when the Map value of LSP10VaultsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)', () => {
       let acceptOwnershipTx: Transaction;
 
       before(async () => {
@@ -1462,7 +1462,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .transferOwnership(context.universalProfile1.address);
 
-        const acceptOwnershipCalldata = vault.interface.encodeFunctionData("acceptOwnership");
+        const acceptOwnershipCalldata = vault.interface.encodeFunctionData('acceptOwnership');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
@@ -1472,22 +1472,22 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2),
-            "0x28af17e600000000000000000000000000000000cafecafe",
+            '0x28af17e600000000000000000000000000000000cafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([
-            ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-            ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "0".repeat(32),
+            ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+            ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '0'.repeat(32),
             ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2),
           ]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           vault.address.toLowerCase(),
-          "0x28af17e600000000000000000000000000000000cafecafe",
+          '0x28af17e600000000000000000000000000000000cafecafe',
         ]);
 
-        const vaultTrasferCalldata = vault.interface.encodeFunctionData("transferOwnership", [
+        const vaultTrasferCalldata = vault.interface.encodeFunctionData('transferOwnership', [
           context.accounts.owner1.address,
         ]);
 
@@ -1498,35 +1498,35 @@ export const shouldBehaveLikeLSP1Delegate = (
         acceptOwnershipTx = await vault.connect(context.accounts.owner1).acceptOwnership();
       });
 
-      it("it should pass", async () => {
+      it('it should pass', async () => {
         expect(acceptOwnershipTx).to.not.be.reverted;
       });
 
-      it("it should emit UniversalReceiver event", async () => {
+      it('it should emit UniversalReceiver event', async () => {
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["bytes", "bytes"],
-          ["0x", "0x"],
+          ['bytes', 'bytes'],
+          ['0x', '0x'],
         );
 
         await expect(acceptOwnershipTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             vault.address,
             0,
             LSP1_TYPE_IDS.LSP9OwnershipTransferred_SenderNotification,
-            "0x",
+            '0x',
             lsp1ReturnedData,
           );
       });
 
-      it("should de-register the asset properly", async () => {
+      it('should de-register the asset properly', async () => {
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, vaultMapKey]),
-        ).to.deep.equal(["0x" + "00".repeat(16), "0x", "0x"]);
+        ).to.deep.equal(['0x' + '00'.repeat(16), '0x', '0x']);
       });
     });
 
-    describe("when the Map value of LSP10VaultsMap is 20 random bytes", () => {
+    describe('when the Map value of LSP10VaultsMap is 20 random bytes', () => {
       let acceptOwnershipTx: Transaction;
 
       before(async () => {
@@ -1534,7 +1534,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .transferOwnership(context.universalProfile1.address);
 
-        const acceptOwnershipCalldata = vault.interface.encodeFunctionData("acceptOwnership");
+        const acceptOwnershipCalldata = vault.interface.encodeFunctionData('acceptOwnership');
 
         await context.universalProfile1
           .connect(context.accounts.owner1)
@@ -1544,22 +1544,22 @@ export const shouldBehaveLikeLSP1Delegate = (
           .connect(context.accounts.owner1)
           .setData(
             ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2),
-            "0xcafecafecafecafecafecafecafecafecafecafe",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
           );
 
         expect(
           await context.universalProfile1.getDataBatch([
-            ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-            ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "0".repeat(32),
+            ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+            ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '0'.repeat(32),
             ERC725YDataKeys.LSP10.LSP10VaultsMap + vault.address.substring(2),
           ]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           vault.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
 
-        const vaultTrasferCalldata = vault.interface.encodeFunctionData("transferOwnership", [
+        const vaultTrasferCalldata = vault.interface.encodeFunctionData('transferOwnership', [
           context.accounts.owner1.address,
         ]);
 
@@ -1570,23 +1570,23 @@ export const shouldBehaveLikeLSP1Delegate = (
         acceptOwnershipTx = await vault.connect(context.accounts.owner1).acceptOwnership();
       });
 
-      it("it should pass", async () => {
+      it('it should pass', async () => {
         expect(acceptOwnershipTx).to.not.be.reverted;
       });
 
-      it("it should emit UniversalReceiver event", async () => {
+      it('it should emit UniversalReceiver event', async () => {
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(acceptOwnershipTx)
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             vault.address,
             0,
             LSP1_TYPE_IDS.LSP9OwnershipTransferred_SenderNotification,
-            "0x",
+            '0x',
             lsp1ReturnedData,
           );
       });
@@ -1595,45 +1595,45 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(
           await context.universalProfile1.getDataBatch([arrayKey, arrayIndexKey, vaultMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           vault.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
       });
     });
   });
 
-  describe("when testing LSP8-IdentifiableDigitalAsset", () => {
+  describe('when testing LSP8-IdentifiableDigitalAsset', () => {
     let lsp8TokenA: LSP8Tester, lsp8TokenB: LSP8Tester, lsp8TokenC: LSP8Tester;
 
     before(async () => {
       lsp8TokenA = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenAlpha",
-        "TA",
+        'TokenAlpha',
+        'TA',
         context.accounts.random.address,
       );
 
       lsp8TokenB = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenBeta",
-        "TB",
+        'TokenBeta',
+        'TB',
         context.accounts.random.address,
       );
 
       lsp8TokenC = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenGamma",
-        "TA",
+        'TokenGamma',
+        'TA',
         context.accounts.random.address,
       );
     });
 
-    describe("when minting tokens", () => {
-      describe("when minting tokenId 1 of tokenA to universalProfile1", () => {
+    describe('when minting tokens', () => {
+      describe('when minting tokenId 1 of tokenA to universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenA.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -1641,7 +1641,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenA.address, abi));
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenA);
           expect(indexInMap).to.equal(0);
@@ -1651,20 +1651,20 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting tokenId 1 of tokenB to universalProfile1", () => {
+      describe('when minting tokenId 1 of tokenB to universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1674,20 +1674,20 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting tokenId 2 of tokenB (another) to universalProfile1", () => {
+      describe('when minting tokenId 2 of tokenB (another) to universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
             TOKEN_ID.TWO,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
-        it("should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1697,20 +1697,20 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when minting tokenId 1 of tokenC to universalProfile1", () => {
+      describe('when minting tokenId 1 of tokenC to universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenC.interface.encodeFunctionData('mint', [
             context.universalProfile1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenC.address, abi));
         });
-        it("should register lsp5keys: arrayLength 3, index 2, tokenC address in UP1", async () => {
+        it('should register lsp5keys: arrayLength 3, index 2, tokenC address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenC);
           expect(indexInMap).to.equal(2);
@@ -1721,40 +1721,40 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when burning tokens", () => {
-      describe("when burning tokenId 1 (all balance) of tokenC (last token) from universalProfile1", () => {
+    describe('when burning tokens', () => {
+      describe('when burning tokenId 1 (all balance) of tokenC (last token) from universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenC.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenC.address, abi));
         });
-        it("should update lsp5keys: arrayLength 2, no map, no tokenC address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenC address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenC.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000002",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000002',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning tokenId 1 (all balance) of tokenA (first token) from universalProfile1", () => {
+      describe('when burning tokenId 1 (all balance) of tokenA (first token) from universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenA.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenA.address, abi));
         });
 
-        it("should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in UP1", async () => {
+        it('should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(0);
@@ -1763,30 +1763,30 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should update lsp5keys: arrayLength 1, no map, no tokenA address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 1, no map, no tokenA address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenA.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 1 tokenId (not all balance) of tokenB from universalProfile1", () => {
+      describe('when burning 1 tokenId (not all balance) of tokenB from universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenB.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
-        it("should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(0);
@@ -1796,55 +1796,55 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("when burning all tokenB from universalProfile1", () => {
+      describe('when burning all tokenB from universalProfile1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("burn", [TOKEN_ID.TWO, "0x"]);
+          const abi = lsp8TokenB.interface.encodeFunctionData('burn', [TOKEN_ID.TWO, '0x']);
 
           await context.lsp6KeyManager1
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
-        it("should update lsp5keys: arrayLength 0, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 0, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000000",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000000',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
     });
 
-    describe("when transferring tokens", () => {
-      it("should fund the universalProfle with tokens to test token transfers (TokenA, TokenB, TokenC)", async () => {
+    describe('when transferring tokens', () => {
+      it('should fund the universalProfle with tokens to test token transfers (TokenA, TokenB, TokenC)', async () => {
         // 1 tokenId of TokenA
         await lsp8TokenA
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, '0x');
 
         // 3 tokenIds of TokenB
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, '0x');
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, TOKEN_ID.TWO, false, "0x");
+          .mint(context.universalProfile1.address, TOKEN_ID.TWO, false, '0x');
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, TOKEN_ID.THREE, false, "0x");
+          .mint(context.universalProfile1.address, TOKEN_ID.THREE, false, '0x');
 
         // 1 tokenId of TokenC
         await lsp8TokenC
           .connect(context.accounts.random)
-          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.universalProfile1.address, TOKEN_ID.ONE, false, '0x');
       });
 
-      it("should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in UP1 ", async () => {
+      it('should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in UP1 ', async () => {
         const [indexInMapTokenA, interfaceIdTokenA, arrayLength, elementAddressTokenA] =
           await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenA);
 
@@ -1866,14 +1866,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(elementAddressTokenC).to.equal(lsp8TokenC.address);
       });
 
-      describe("When transferring tokenId 1 (all) of token A from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (all) of token A from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenA.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -1881,7 +1881,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenA.address, abi));
         });
 
-        it("should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in UP1", async () => {
+        it('should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenC);
           expect(indexInMap).to.equal(0);
@@ -1890,21 +1890,21 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp8TokenC.address);
         });
 
-        it("should update lsp5keys: arrayLength 2, no map, no tokenA address in UP1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenA address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenA.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000002",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000002',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in UP2", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp8TokenA);
           expect(indexInMap).to.equal(0);
@@ -1914,14 +1914,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring tokenId 1 (not all balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (not all balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -1929,7 +1929,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1938,7 +1938,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in UP2", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1948,14 +1948,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring tokenId 2 (not all balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 2 (not all balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
             TOKEN_ID.TWO,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -1963,7 +1963,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1972,7 +1972,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1982,14 +1982,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring tokenId 3 (remaining balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 3 (remaining balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
             TOKEN_ID.THREE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -1997,21 +1997,21 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenB.address, abi));
         });
 
-        it("should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -2021,14 +2021,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring tokenId 1 (all balance) of token C from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (all balance) of token C from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenC.interface.encodeFunctionData('transfer', [
             context.universalProfile1.address,
             context.universalProfile2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager1
@@ -2036,21 +2036,21 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile1, lsp8TokenC.address, abi));
         });
 
-        it("should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in UP1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index +
-                "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index +
+                '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys : arrayLength 3, index = 2, tokenC address in UP2", async () => {
+        it('should register lsp5keys : arrayLength 3, index = 2, tokenC address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile2, lsp8TokenC);
           expect(indexInMap).to.equal(2);
@@ -2060,14 +2060,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring 1 tokenId (not all balance) of token B from UP2 to UP1", () => {
+      describe('When transferring 1 tokenId (not all balance) of token B from UP2 to UP1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.universalProfile2.address,
             context.universalProfile1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.lsp6KeyManager2
@@ -2075,7 +2075,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             .execute(callPayload(context.universalProfile2, lsp8TokenB.address, abi));
         });
 
-        it("should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in UP1", async () => {
+        it('should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.universalProfile1, lsp8TokenB);
           expect(indexInMap).to.equal(0);
@@ -2086,7 +2086,7 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when a non-LSP8 token contract calls the `universalReceiver(...)` function", () => {
+    describe('when a non-LSP8 token contract calls the `universalReceiver(...)` function', () => {
       let notTokenContract: GenericExecutor;
 
       before(async () => {
@@ -2095,8 +2095,8 @@ export const shouldBehaveLikeLSP1Delegate = (
 
       it("should not revert and return 'LSP1: asset sent is not registered' when calling with typeId == LSP8Tokens_SenderNotification", async () => {
         const universalReceiverPayload = context.universalProfile1.interface.encodeFunctionData(
-          "universalReceiver",
-          [LSP1_TYPE_IDS.LSP8Tokens_SenderNotification, "0x"],
+          'universalReceiver',
+          [LSP1_TYPE_IDS.LSP8Tokens_SenderNotification, '0x'],
         );
 
         // check that it does not revert
@@ -2115,15 +2115,15 @@ export const shouldBehaveLikeLSP1Delegate = (
           universalReceiverPayload,
         );
 
-        const [genericExecutorResult] = abiCoder.decode(["bytes"], universalReceiverResult);
+        const [genericExecutorResult] = abiCoder.decode(['bytes'], universalReceiverResult);
 
         const [resultDelegate, resultTypeID] = abiCoder.decode(
-          ["bytes", "bytes"],
+          ['bytes', 'bytes'],
           genericExecutorResult,
         );
 
         expect(resultDelegate).to.equal(
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: asset sent is not registered')),
         );
 
         // check that the correct string is emitted in the event
@@ -2134,19 +2134,19 @@ export const shouldBehaveLikeLSP1Delegate = (
             universalReceiverPayload,
           ),
         )
-          .to.emit(context.universalProfile1, "UniversalReceiver")
+          .to.emit(context.universalProfile1, 'UniversalReceiver')
           .withArgs(
             notTokenContract.address,
             0,
             LSP1_TYPE_IDS.LSP8Tokens_SenderNotification,
-            "0x",
+            '0x',
             genericExecutorResult,
           );
       });
     });
   });
 
-  describe("when testing LSP9-Vault", () => {
+  describe('when testing LSP9-Vault', () => {
     let lsp9VaultA: LSP9Vault, lsp9VaultB: LSP9Vault, lsp9VaultC: LSP9Vault;
 
     before(async () => {
@@ -2163,24 +2163,24 @@ export const shouldBehaveLikeLSP1Delegate = (
       );
     });
 
-    describe("when transferring ownership of vaults from EOA to UP", () => {
-      describe("When transfering Ownership of VaultA to UP1", () => {
+    describe('when transferring ownership of vaults from EOA to UP', () => {
+      describe('When transfering Ownership of VaultA to UP1', () => {
         before(async () => {
           await lsp9VaultA
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
 
-          let executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultA.address,
             0,
-            lsp9VaultA.interface.getSighash("acceptOwnership"),
+            lsp9VaultA.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(executePayload);
         });
 
-        it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
+        it('should register lsp10key: arrayLength 1, index 0, VaultA address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultA);
           expect(indexInMap).to.equal(0);
@@ -2190,23 +2190,23 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transfering Ownership of VaultB to UP1", () => {
+      describe('When transfering Ownership of VaultB to UP1', () => {
         before(async () => {
           await lsp9VaultB
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
 
-          let executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultB.address,
             0,
-            lsp9VaultB.interface.getSighash("acceptOwnership"),
+            lsp9VaultB.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(executePayload);
         });
 
-        it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
+        it('should register lsp10key: arrayLength 1, index 0, VaultA address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultB);
           expect(indexInMap).to.equal(1);
@@ -2216,23 +2216,23 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transfering Ownership of VaultC to UP1", () => {
+      describe('When transfering Ownership of VaultC to UP1', () => {
         before(async () => {
           await lsp9VaultC
             .connect(context.accounts.random)
             .transferOwnership(context.universalProfile1.address);
 
-          let executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultC.address,
             0,
-            lsp9VaultC.interface.getSighash("acceptOwnership"),
+            lsp9VaultC.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(executePayload);
         });
 
-        it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP1", async () => {
+        it('should register lsp10key: arrayLength 1, index 0, VaultA address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultC);
           expect(indexInMap).to.equal(2);
@@ -2243,10 +2243,10 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when transferring ownership of vaults from UP to UP", () => {
-      describe("When transfering Ownership of VaultA from UP1 to UP2", () => {
+    describe('when transferring ownership of vaults from UP to UP', () => {
+      describe('When transfering Ownership of VaultA from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp9VaultA.interface.encodeFunctionData("transferOwnership", [
+          const abi = lsp9VaultA.interface.encodeFunctionData('transferOwnership', [
             context.universalProfile2.address,
           ]);
 
@@ -2254,17 +2254,17 @@ export const shouldBehaveLikeLSP1Delegate = (
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp9VaultA.address, abi));
 
-          let executePayload = context.universalProfile2.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile2.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultA.address,
             0,
-            lsp9VaultA.interface.getSighash("acceptOwnership"),
+            lsp9VaultA.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager2.connect(context.accounts.owner2).execute(executePayload);
         });
 
-        it("should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 2, index = 0, VaultC address in UP1", async () => {
+        it('should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 2, index = 0, VaultC address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultC);
           expect(indexInMap).to.equal(0);
@@ -2273,7 +2273,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           expect(elementAddress).to.equal(lsp9VaultC.address);
         });
 
-        it("should register lsp10key: arrayLength 1, index 0, VaultA address in UP2", async () => {
+        it('should register lsp10key: arrayLength 1, index 0, VaultA address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile2, lsp9VaultA);
           expect(indexInMap).to.equal(0);
@@ -2283,9 +2283,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transfering Ownership of VaultB from UP1 to UP2", () => {
+      describe('When transfering Ownership of VaultB from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp9VaultB.interface.encodeFunctionData("transferOwnership", [
+          const abi = lsp9VaultB.interface.encodeFunctionData('transferOwnership', [
             context.universalProfile2.address,
           ]);
 
@@ -2293,30 +2293,30 @@ export const shouldBehaveLikeLSP1Delegate = (
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp9VaultB.address, abi));
 
-          let executePayload = context.universalProfile2.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile2.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultB.address,
             0,
-            lsp9VaultB.interface.getSighash("acceptOwnership"),
+            lsp9VaultB.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager2.connect(context.accounts.owner2).execute(executePayload);
         });
 
-        it("should update lsp10keys (no pop and swap as VaultB has the last index): arrayLength 1, no map, no VaultB address in UP1", async () => {
+        it('should update lsp10keys (no pop and swap as VaultB has the last index): arrayLength 1, no map, no VaultB address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP10.LSP10VaultsMap + lsp9VaultB.address.substr(2),
-              ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-              ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00000000000000000000000000000001",
+              ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+              ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00000000000000000000000000000001',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp10key: arrayLength 2, index 1, VaultB address in UP2", async () => {
+        it('should register lsp10key: arrayLength 2, index 1, VaultB address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile2, lsp9VaultB);
           expect(indexInMap).to.equal(1);
@@ -2326,9 +2326,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transfering Ownership of VaultC from UP1 to UP2", () => {
+      describe('When transfering Ownership of VaultC from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp9VaultC.interface.encodeFunctionData("transferOwnership", [
+          const abi = lsp9VaultC.interface.encodeFunctionData('transferOwnership', [
             context.universalProfile2.address,
           ]);
 
@@ -2336,30 +2336,30 @@ export const shouldBehaveLikeLSP1Delegate = (
             .connect(context.accounts.owner1)
             .execute(callPayload(context.universalProfile1, lsp9VaultC.address, abi));
 
-          let executePayload = context.universalProfile2.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile2.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultC.address,
             0,
-            lsp9VaultC.interface.getSighash("acceptOwnership"),
+            lsp9VaultC.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager2.connect(context.accounts.owner2).execute(executePayload);
         });
 
-        it("should remove all lsp10keys : arrayLength 0, no map, no VaultC address in UP1", async () => {
+        it('should remove all lsp10keys : arrayLength 0, no map, no VaultC address in UP1', async () => {
           const [mapValue, arrayLength, elementAddress] =
             await context.universalProfile1.getDataBatch([
               ERC725YDataKeys.LSP10.LSP10VaultsMap + lsp9VaultB.address.substr(2),
-              ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-              ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00000000000000000000000000000000",
+              ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+              ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00000000000000000000000000000000',
             ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp10key: arrayLength 3, index 2, VaultC address in UP2", async () => {
+        it('should register lsp10key: arrayLength 3, index 2, VaultC address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile2, lsp9VaultC);
           expect(indexInMap).to.equal(2);
@@ -2369,9 +2369,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         });
       });
 
-      describe("When transferring Ownership of VaultB from UP2 to UP1", () => {
+      describe('When transferring Ownership of VaultB from UP2 to UP1', () => {
         before(async () => {
-          const abi = lsp9VaultB.interface.encodeFunctionData("transferOwnership", [
+          const abi = lsp9VaultB.interface.encodeFunctionData('transferOwnership', [
             context.universalProfile1.address,
           ]);
 
@@ -2379,16 +2379,16 @@ export const shouldBehaveLikeLSP1Delegate = (
             .connect(context.accounts.owner2)
             .execute(callPayload(context.universalProfile2, lsp9VaultB.address, abi));
 
-          let executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp9VaultB.address,
             0,
-            lsp9VaultB.interface.getSighash("acceptOwnership"),
+            lsp9VaultB.interface.getSighash('acceptOwnership'),
           ]);
 
           await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(executePayload);
         });
-        it("should register lsp10key (UP1 able to re-write) : arrayLength 1, index 0, VaultB address in UP1", async () => {
+        it('should register lsp10key (UP1 able to re-write) : arrayLength 1, index 0, VaultB address in UP1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultB);
           expect(indexInMap).to.equal(0);
@@ -2399,10 +2399,10 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when transferring ownership of vaults from UP to EOA", () => {
-      describe("When transfering Ownership of VaultA from UP2 to EOA", () => {
+    describe('when transferring ownership of vaults from UP to EOA', () => {
+      describe('When transfering Ownership of VaultA from UP2 to EOA', () => {
         before(async () => {
-          const abi = lsp9VaultA.interface.encodeFunctionData("transferOwnership", [
+          const abi = lsp9VaultA.interface.encodeFunctionData('transferOwnership', [
             context.accounts.any.address,
           ]);
 
@@ -2413,7 +2413,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           await lsp9VaultA.connect(context.accounts.any).acceptOwnership();
         });
 
-        it("should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 1, index = 0, VaultC address in UP2", async () => {
+        it('should pop and swap VaultA with VaultC, lsp10keys (VaultC should become first vault) : arrayLength 1, index = 0, VaultC address in UP2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP10MapAndArrayKeysValue(context.universalProfile2, lsp9VaultC);
           expect(indexInMap).to.equal(0);
@@ -2424,7 +2424,7 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("when deploying vault to a UP directly", () => {
+    describe('when deploying vault to a UP directly', () => {
       let lsp9VaultD: LSP9Vault;
 
       before(async () => {
@@ -2433,7 +2433,7 @@ export const shouldBehaveLikeLSP1Delegate = (
         );
       });
 
-      it("should register the data key relevant to the vault deployed in the UP storage", async () => {
+      it('should register the data key relevant to the vault deployed in the UP storage', async () => {
         const [indexInMap, interfaceId, arrayLength, elementAddress] =
           await getLSP10MapAndArrayKeysValue(context.universalProfile1, lsp9VaultD);
 
@@ -2444,30 +2444,30 @@ export const shouldBehaveLikeLSP1Delegate = (
       });
     });
 
-    describe("testing values stored under `LSP10Vaults[]` array length", () => {
+    describe('testing values stored under `LSP10Vaults[]` array length', () => {
       before(async () => {
         // start with a new setup
         context = await buildContext();
       });
 
-      it("should revert if `LSP10Vaults[]` vault value is the max `uint128`", async () => {
+      it('should revert if `LSP10Vaults[]` vault value is the max `uint128`', async () => {
         const maxUint128 = ethers.BigNumber.from(2).pow(128).sub(1).toHexString();
 
-        const key = ERC725YDataKeys.LSP10["LSP10Vaults[]"].length;
+        const key = ERC725YDataKeys.LSP10['LSP10Vaults[]'].length;
         const value = maxUint128;
 
         // force settingup on the UP
         await context.lsp6KeyManager1
           .connect(context.accounts.owner1)
-          .execute(context.universalProfile1.interface.encodeFunctionData("setData", [key, value]));
+          .execute(context.universalProfile1.interface.encodeFunctionData('setData', [key, value]));
 
         // check that LSP10Vaults[] length is set to maxUint128
         expect(await context.universalProfile1.getData(key)).to.equal(maxUint128);
 
         // deploy a Vault setting the UP as owner
         // this should revert because the UP has already the max number of vaults allowed
-        const lsp1DelegateAddress = await context.universalProfile1["getData(bytes32)"](
-          ERC725YDataKeys.LSP1["LSP1UniversalReceiverDelegate"],
+        const lsp1DelegateAddress = await context.universalProfile1['getData(bytes32)'](
+          ERC725YDataKeys.LSP1['LSP1UniversalReceiverDelegate'],
         );
 
         const lsp1DelegateInstance = await new LSP1UniversalReceiverDelegateUP__factory(
@@ -2476,12 +2476,12 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         await expect(
           new LSP9Vault__factory(context.accounts.random).deploy(context.universalProfile1.address),
-        ).to.be.revertedWithCustomError(lsp1DelegateInstance, "MaxLSP10VaultsCountReached");
+        ).to.be.revertedWithCustomError(lsp1DelegateInstance, 'MaxLSP10VaultsCountReached');
       });
     });
   });
 
-  describe("when a UP owns a LSP9Vault before having a URD set", () => {
+  describe('when a UP owns a LSP9Vault before having a URD set', () => {
     let testContext: LSP6TestContext;
     let vault: LSP9Vault;
     let lsp1Delegate: LSP1UniversalReceiverDelegateUP;
@@ -2514,31 +2514,31 @@ export const shouldBehaveLikeLSP1Delegate = (
       lsp1Delegate = await new LSP1UniversalReceiverDelegateUP__factory(profileOwner).deploy();
 
       const setLSP1DelegatePayload = testContext.universalProfile.interface.encodeFunctionData(
-        "setData",
+        'setData',
         [ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate, lsp1Delegate.address],
       );
 
       await testContext.keyManager.connect(testContext.owner).execute(setLSP1DelegatePayload);
     });
 
-    it("check that the LSP9Vault address is not set under LSP10", async () => {
-      const lsp10VaultArrayLengthValue = await testContext.universalProfile["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
+    it('check that the LSP9Vault address is not set under LSP10', async () => {
+      const lsp10VaultArrayLengthValue = await testContext.universalProfile['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
       );
 
-      expect(lsp10VaultArrayLengthValue).to.equal("0x");
+      expect(lsp10VaultArrayLengthValue).to.equal('0x');
 
-      const lsp10VaultArrayIndexValue = await testContext.universalProfile["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00".repeat(16),
+      const lsp10VaultArrayIndexValue = await testContext.universalProfile['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00'.repeat(16),
       );
 
-      expect(lsp10VaultArrayIndexValue).to.equal("0x");
+      expect(lsp10VaultArrayIndexValue).to.equal('0x');
 
-      const lsp10VaultMapValue = await testContext.universalProfile["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10VaultsMap"] + vault.address.substring(2),
+      const lsp10VaultMapValue = await testContext.universalProfile['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10VaultsMap'] + vault.address.substring(2),
       );
 
-      expect(lsp10VaultMapValue).to.equal("0x");
+      expect(lsp10VaultMapValue).to.equal('0x');
     });
 
     it("check that the LSP1Delegate address is set in the UP's storage", async () => {
@@ -2549,17 +2549,17 @@ export const shouldBehaveLikeLSP1Delegate = (
       expect(ethers.utils.getAddress(result)).to.equal(lsp1Delegate.address);
     });
 
-    describe("when transfering + accepting ownership of the Vault", () => {
+    describe('when transfering + accepting ownership of the Vault', () => {
       it("should not revert and return the string 'LSP1: asset not registered'", async () => {
         const newVaultOwner = testContext.accounts[1];
 
         // 4. transfer ownership of the Vault to another address
-        const transferOwnershipPayload = vault.interface.encodeFunctionData("transferOwnership", [
+        const transferOwnershipPayload = vault.interface.encodeFunctionData('transferOwnership', [
           newVaultOwner.address,
         ]);
 
         const executePayload = testContext.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, vault.address, 0, transferOwnershipPayload],
         );
 
@@ -2569,10 +2569,10 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(await vault.pendingOwner()).to.equal(newVaultOwner.address);
 
         const expectedReturnedValues = abiCoder.encode(
-          ["bytes", "bytes"],
+          ['bytes', 'bytes'],
           [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")),
-            "0x",
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: asset sent is not registered')),
+            '0x',
           ],
         );
 
@@ -2580,12 +2580,12 @@ export const shouldBehaveLikeLSP1Delegate = (
         const acceptOwnershipTx = vault.connect(newVaultOwner).acceptOwnership();
 
         await expect(acceptOwnershipTx)
-          .to.emit(testContext.universalProfile, "UniversalReceiver")
+          .to.emit(testContext.universalProfile, 'UniversalReceiver')
           .withArgs(
             vault.address,
             0,
             LSP1_TYPE_IDS.LSP9OwnershipTransferred_SenderNotification,
-            "0x",
+            '0x',
             expectedReturnedValues,
           );
 
@@ -2593,17 +2593,17 @@ export const shouldBehaveLikeLSP1Delegate = (
         expect(await vault.owner()).to.equal(newVaultOwner.address);
 
         // check that LSP10 data keys are still empty
-        const lsp10VaultArrayLengthValue = await testContext.universalProfile["getData(bytes32)"](
-          ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
+        const lsp10VaultArrayLengthValue = await testContext.universalProfile['getData(bytes32)'](
+          ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
         );
 
-        expect(lsp10VaultArrayLengthValue).to.equal("0x");
+        expect(lsp10VaultArrayLengthValue).to.equal('0x');
 
-        const lsp10VaultMapValue = await testContext.universalProfile["getData(bytes32)"](
-          ERC725YDataKeys.LSP10["LSP10VaultsMap"] + vault.address.substring(2),
+        const lsp10VaultMapValue = await testContext.universalProfile['getData(bytes32)'](
+          ERC725YDataKeys.LSP10['LSP10VaultsMap'] + vault.address.substring(2),
         );
 
-        expect(lsp10VaultMapValue).to.equal("0x");
+        expect(lsp10VaultMapValue).to.equal('0x');
       });
     });
   });
@@ -2620,49 +2620,49 @@ export const shouldBehaveLikeLSP1Delegate = (
 
       // 2. set the address of the Vault in the UP's storage under the LSP10 data keys
       const lsp10DataKeys = [
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00".repeat(16),
-        ERC725YDataKeys.LSP10["LSP10VaultsMap"] + vault.address.substring(2),
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00'.repeat(16),
+        ERC725YDataKeys.LSP10['LSP10VaultsMap'] + vault.address.substring(2),
       ];
 
       const lsp10DataValues = [
-        abiCoder.encode(["uint256"], ["1"]),
+        abiCoder.encode(['uint256'], ['1']),
         vault.address,
-        abiCoder.encode(["bytes4", "uint64"], [INTERFACE_IDS.LSP9Vault, 0]),
+        abiCoder.encode(['bytes4', 'uint64'], [INTERFACE_IDS.LSP9Vault, 0]),
       ];
 
       const setLSP10VaultPayload = context.universalProfile1.interface.encodeFunctionData(
-        "setDataBatch",
+        'setDataBatch',
         [lsp10DataKeys, lsp10DataValues],
       );
 
       await context.lsp6KeyManager1.connect(context.accounts.owner1).execute(setLSP10VaultPayload);
     });
 
-    it("check that the vault owner", async () => {
+    it('check that the vault owner', async () => {
       expect(await vault.owner()).to.equal(vaultOwner.address);
     });
 
     it("check that the LSP10Vault address is set in the UP's storage", async () => {
-      const lsp10VaultArrayLengthValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
+      const lsp10VaultArrayLengthValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
       );
 
-      expect(lsp10VaultArrayLengthValue).to.equal(abiCoder.encode(["uint256"], ["1"]));
+      expect(lsp10VaultArrayLengthValue).to.equal(abiCoder.encode(['uint256'], ['1']));
 
-      const lsp10VaultArrayIndexValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00".repeat(16),
+      const lsp10VaultArrayIndexValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00'.repeat(16),
       );
 
       // checksum the address
       expect(ethers.utils.getAddress(lsp10VaultArrayIndexValue)).to.equal(vault.address);
 
-      const lsp10VaultMapValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10VaultsMap"] + vault.address.substring(2),
+      const lsp10VaultMapValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10VaultsMap'] + vault.address.substring(2),
       );
 
       expect(lsp10VaultMapValue).to.equal(
-        abiCoder.encode(["bytes4", "uint64"], [INTERFACE_IDS.LSP9Vault, 0]),
+        abiCoder.encode(['bytes4', 'uint64'], [INTERFACE_IDS.LSP9Vault, 0]),
       );
     });
 
@@ -2674,9 +2674,9 @@ export const shouldBehaveLikeLSP1Delegate = (
       expect(await vault.pendingOwner()).to.equal(context.universalProfile1.address);
 
       // 2. UP accepts ownership of the vault
-      const acceptOwnershipPayload = vault.interface.getSighash("acceptOwnership");
+      const acceptOwnershipPayload = vault.interface.getSighash('acceptOwnership');
 
-      const executePayload = context.universalProfile1.interface.encodeFunctionData("execute", [
+      const executePayload = context.universalProfile1.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         vault.address,
         0,
@@ -2691,47 +2691,47 @@ export const shouldBehaveLikeLSP1Delegate = (
       expect(await vault.owner()).to.equal(context.universalProfile1.address);
 
       const expectedReturnedValues = abiCoder.encode(
-        ["bytes", "bytes"],
+        ['bytes', 'bytes'],
         [
           ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("LSP1: asset received is already registered"),
+            ethers.utils.toUtf8Bytes('LSP1: asset received is already registered'),
           ),
-          "0x",
+          '0x',
         ],
       );
 
       // check that the right return string is emitted in the UniversalReceiver event
       await expect(acceptOwnershipTx)
-        .to.emit(context.universalProfile1, "UniversalReceiver")
+        .to.emit(context.universalProfile1, 'UniversalReceiver')
         .withArgs(
           vault.address,
           0,
           LSP1_TYPE_IDS.LSP9OwnershipTransferred_RecipientNotification,
-          "0x",
+          '0x',
           expectedReturnedValues,
         );
 
       // check that the LSP10Vault address is still set in the UP's storage
       // and that the address is not duplicated
-      const lsp10VaultArrayLengthValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
+      const lsp10VaultArrayLengthValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
       );
 
-      expect(lsp10VaultArrayLengthValue).to.equal(abiCoder.encode(["uint256"], ["1"]));
+      expect(lsp10VaultArrayLengthValue).to.equal(abiCoder.encode(['uint256'], ['1']));
 
-      const lsp10VaultArrayIndexValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10Vaults[]"].index + "00".repeat(16),
+      const lsp10VaultArrayIndexValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10Vaults[]'].index + '00'.repeat(16),
       );
 
       // checksum the address
       expect(ethers.utils.getAddress(lsp10VaultArrayIndexValue)).to.equal(vault.address);
 
-      const lsp10VaultMapValue = await context.universalProfile1["getData(bytes32)"](
-        ERC725YDataKeys.LSP10["LSP10VaultsMap"] + vault.address.substring(2),
+      const lsp10VaultMapValue = await context.universalProfile1['getData(bytes32)'](
+        ERC725YDataKeys.LSP10['LSP10VaultsMap'] + vault.address.substring(2),
       );
 
       expect(lsp10VaultMapValue).to.equal(
-        abiCoder.encode(["bytes4", "uint64"], [INTERFACE_IDS.LSP9Vault, 0]),
+        abiCoder.encode(['bytes4', 'uint64'], [INTERFACE_IDS.LSP9Vault, 0]),
       );
     });
   });
@@ -2750,12 +2750,12 @@ export const shouldInitializeLikeLSP1Delegate = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered the ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered the ERC165 interface', async () => {
       expect(await context.lsp1universalReceiverDelegateUP.supportsInterface(INTERFACE_IDS.ERC165));
     });
 
-    it("should have registered the LSP1 interface", async () => {
+    it('should have registered the LSP1 interface', async () => {
       expect(
         await context.lsp1universalReceiverDelegateUP.supportsInterface(
           INTERFACE_IDS.LSP1UniversalReceiver,
@@ -2763,20 +2763,20 @@ export const shouldInitializeLikeLSP1Delegate = (
       );
     });
   });
-  describe("edge cases", () => {
-    describe("when sending value to universalReceiver(...)", () => {
-      it("should revert with custom error", async () => {
+  describe('edge cases', () => {
+    describe('when sending value to universalReceiver(...)', () => {
+      it('should revert with custom error', async () => {
         // value of 1 ethers
-        const value = ethers.utils.parseEther("1");
+        const value = ethers.utils.parseEther('1');
         await expect(
           context.lsp1universalReceiverDelegateUP.universalReceiver(
             LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
-            "0x",
+            '0x',
             { value },
           ),
         ).to.be.revertedWithCustomError(
           context.lsp1universalReceiverDelegateUP,
-          "NativeTokensNotAccepted",
+          'NativeTokensNotAccepted',
         );
       });
     });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.test.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.test.ts
@@ -1,14 +1,14 @@
-import { ethers } from "hardhat";
-import { LSP1UniversalReceiverDelegateUP, UniversalProfile, LSP6KeyManager } from "../../types";
+import { ethers } from 'hardhat';
+import { LSP1UniversalReceiverDelegateUP, UniversalProfile, LSP6KeyManager } from '../../types';
 
-import { setupProfileWithKeyManagerWithURD } from "../utils/fixtures";
+import { setupProfileWithKeyManagerWithURD } from '../utils/fixtures';
 
 import {
   LSP1DelegateTestContext,
   shouldBehaveLikeLSP1Delegate,
   shouldInitializeLikeLSP1Delegate,
   LSP1TestAccounts,
-} from "./LSP1UniversalReceiverDelegateUP.behaviour";
+} from './LSP1UniversalReceiverDelegateUP.behaviour';
 
 async function getNamedAccounts(): Promise<LSP1TestAccounts> {
   const [owner1, owner2, random, any] = await ethers.getSigners();
@@ -20,8 +20,8 @@ async function getNamedAccounts(): Promise<LSP1TestAccounts> {
   };
 }
 
-describe("LSP1UniversalReceiverDelegateUP", () => {
-  describe("when testing deployed contract", () => {
+describe('LSP1UniversalReceiverDelegateUP', () => {
+  describe('when testing deployed contract', () => {
     const buildLSP1DelegateTestContext = async (): Promise<LSP1DelegateTestContext> => {
       const accounts = await getNamedAccounts();
 
@@ -44,14 +44,14 @@ describe("LSP1UniversalReceiverDelegateUP", () => {
       };
     };
 
-    describe("when deploying the contract", () => {
+    describe('when deploying the contract', () => {
       let context: LSP1DelegateTestContext;
 
       before(async () => {
         context = await buildLSP1DelegateTestContext();
       });
 
-      describe("when initializing the contract", () => {
+      describe('when initializing the contract', () => {
         shouldInitializeLikeLSP1Delegate(async () => {
           const { lsp1universalReceiverDelegateUP } = context;
 
@@ -62,7 +62,7 @@ describe("LSP1UniversalReceiverDelegateUP", () => {
       });
     });
 
-    describe("when testing deployed contract", () => {
+    describe('when testing deployed contract', () => {
       shouldBehaveLikeLSP1Delegate(buildLSP1DelegateTestContext);
     });
   });

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -1,6 +1,6 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // types
 import {
@@ -13,14 +13,14 @@ import {
   LSP1UniversalReceiverDelegateVault,
   LSP7MintWhenDeployed__factory,
   LSP7MintWhenDeployed,
-} from "../../types";
+} from '../../types';
 
-import { ARRAY_LENGTH, LSP1_HOOK_PLACEHOLDER, abiCoder } from "../utils/helpers";
+import { ARRAY_LENGTH, LSP1_HOOK_PLACEHOLDER, abiCoder } from '../utils/helpers';
 
 // constants
-import { ERC725YDataKeys, INTERFACE_IDS, OPERATION_TYPES, LSP1_TYPE_IDS } from "../../constants";
-import { callPayload, getLSP5MapAndArrayKeysValue } from "../utils/fixtures";
-import { BigNumber, BytesLike, Transaction } from "ethers";
+import { ERC725YDataKeys, INTERFACE_IDS, OPERATION_TYPES, LSP1_TYPE_IDS } from '../../constants';
+import { callPayload, getLSP5MapAndArrayKeysValue } from '../utils/fixtures';
+import { BigNumber, BytesLike, Transaction } from 'ethers';
 
 export type LSP1TestAccounts = {
   owner1: SignerWithAddress;
@@ -65,15 +65,15 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
     context = await buildContext();
   });
 
-  describe("when testing ERC165 standard", () => {
-    it("should support ERC165 interface", async () => {
+  describe('when testing ERC165 standard', () => {
+    it('should support ERC165 interface', async () => {
       const result = await context.lsp1universalReceiverDelegateVault.supportsInterface(
         INTERFACE_IDS.ERC165,
       );
       expect(result).to.be.true;
     });
 
-    it("should support LSP1 interface", async () => {
+    it('should support LSP1 interface', async () => {
       const result = await context.lsp1universalReceiverDelegateVault.supportsInterface(
         INTERFACE_IDS.LSP1UniversalReceiver,
       );
@@ -81,9 +81,9 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
     });
   });
 
-  describe("When testing EOA call to URD through the UR function", () => {
-    describe("when calling with tokens typeId", () => {
-      it("should revert with custom error", async () => {
+  describe('When testing EOA call to URD through the UR function', () => {
+    describe('when calling with tokens typeId', () => {
+      it('should revert with custom error', async () => {
         let URD_TypeIds = [
           LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
           LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
@@ -95,19 +95,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           await expect(
             context.lsp9Vault1
               .connect(context.accounts.any)
-              .universalReceiver(URD_TypeIds[i], "0x"),
+              .universalReceiver(URD_TypeIds[i], '0x'),
           )
             .to.be.revertedWithCustomError(
               context.lsp1universalReceiverDelegateVault,
-              "CannotRegisterEOAsAsAssets",
+              'CannotRegisterEOAsAsAssets',
             )
             .withArgs(context.accounts.any.address);
         }
       });
     });
 
-    describe("when calling with vaults sender and recipient typeIds", () => {
-      it("should pass and return typeId out of scope return value", async () => {
+    describe('when calling with vaults sender and recipient typeIds', () => {
+      it('should pass and return typeId out of scope return value', async () => {
         let Vault_TypeIds = [
           LSP1_TYPE_IDS.LSP14OwnershipTransferred_RecipientNotification,
           LSP1_TYPE_IDS.LSP14OwnershipTransferred_SenderNotification,
@@ -116,80 +116,80 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         for (let i = 0; i < Vault_TypeIds.length; i++) {
           let result = await context.lsp9Vault1
             .connect(context.accounts.any)
-            .callStatic.universalReceiver(Vault_TypeIds[i], "0x");
+            .callStatic.universalReceiver(Vault_TypeIds[i], '0x');
 
-          const [resultDelegate, resultTypeID] = abiCoder.decode(["bytes", "bytes"], result);
+          const [resultDelegate, resultTypeID] = abiCoder.decode(['bytes', 'bytes'], result);
 
           expect(resultDelegate).to.equal(
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
           );
 
-          expect(resultTypeID).to.equal("0x");
+          expect(resultTypeID).to.equal('0x');
         }
       });
     });
 
-    describe("when calling with random bytes32 typeId", () => {
-      it("should pass and return typeId out of scope return value", async () => {
+    describe('when calling with random bytes32 typeId', () => {
+      it('should pass and return typeId out of scope return value', async () => {
         let result = await context.lsp9Vault1
           .connect(context.accounts.any)
-          .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, "0x");
+          .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x');
 
-        const [resultDelegate, resultTypeID] = abiCoder.decode(["bytes", "bytes"], result);
+        const [resultDelegate, resultTypeID] = abiCoder.decode(['bytes', 'bytes'], result);
 
         expect(resultDelegate).to.equal(
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
         );
 
-        expect(resultTypeID).to.equal("0x");
+        expect(resultTypeID).to.equal('0x');
       });
     });
   });
 
-  describe("when testing LSP7-DigitalAsset", () => {
+  describe('when testing LSP7-DigitalAsset', () => {
     let lsp7TokenA: LSP7Tester, lsp7TokenB: LSP7Tester, lsp7TokenC: LSP7Tester;
     before(async () => {
       lsp7TokenA = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenAlpha",
-        "TA",
+        'TokenAlpha',
+        'TA',
         context.accounts.random.address,
       );
 
       lsp7TokenB = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenBeta",
-        "TB",
+        'TokenBeta',
+        'TB',
         context.accounts.random.address,
       );
 
       lsp7TokenC = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "TokenGamma",
-        "TA",
+        'TokenGamma',
+        'TA',
         context.accounts.random.address,
       );
     });
 
-    describe("when minting tokens", () => {
-      describe("when tokens are minted through the constructor (on LSP7 deployment)", () => {
+    describe('when minting tokens', () => {
+      describe('when tokens are minted through the constructor (on LSP7 deployment)', () => {
         let deployedLSP7Token: LSP7MintWhenDeployed;
 
-        before("deploy LSP7 token which mint tokens in `constructor`", async () => {
+        before('deploy LSP7 token which mint tokens in `constructor`', async () => {
           deployedLSP7Token = await new LSP7MintWhenDeployed__factory(context.accounts.any).deploy(
-            "LSP7 Token",
-            "TKN",
+            'LSP7 Token',
+            'TKN',
             context.lsp9Vault1.address,
           );
         });
 
-        after("clear LSP5 storage", async () => {
+        after('clear LSP5 storage', async () => {
           // cleanup and reset the `LSP5ReceivedAssets[]` length, index and map value to 0x
-          const setDataPayload = context.lsp9Vault1.interface.encodeFunctionData("setDataBatch", [
+          const setDataPayload = context.lsp9Vault1.interface.encodeFunctionData('setDataBatch', [
             [
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00".repeat(16),
-              ERC725YDataKeys.LSP5["LSP5ReceivedAssetsMap"] +
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00'.repeat(16),
+              ERC725YDataKeys.LSP5['LSP5ReceivedAssetsMap'] +
                 deployedLSP7Token.address.substring(2),
             ],
-            ["0x", "0x", "0x"],
+            ['0x', '0x', '0x'],
           ]);
 
           // vault is owned by UP so we need to execute via the UP
@@ -198,7 +198,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             .execute(OPERATION_TYPES.CALL, context.lsp9Vault1.address, 0, setDataPayload);
         });
 
-        it("it should have registered the token in LSP5ReceivedAssets Map and Array", async () => {
+        it('it should have registered the token in LSP5ReceivedAssets Map and Array', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, deployedLSP7Token);
 
@@ -209,13 +209,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting 10 tokenA to lsp9Vault1", () => {
+      describe('when minting 10 tokenA to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -227,7 +227,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenA.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenA);
           expect(indexInMap).to.equal(0);
@@ -237,13 +237,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting 10 tokenB to lsp9Vault1", () => {
+      describe('when minting 10 tokenB to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -255,7 +255,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenB.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -265,13 +265,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting 10 of the same tokenB to lsp9Vault1", () => {
+      describe('when minting 10 of the same tokenB to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -283,7 +283,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenB.address, abi),
             );
         });
-        it("should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -293,13 +293,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting 10 tokenC to lsp9Vault1", () => {
+      describe('when minting 10 tokenC to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("mint", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -311,7 +311,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenC.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 3, index 2, tokenC address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 3, index 2, tokenC address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenC);
           expect(indexInMap).to.equal(2);
@@ -322,13 +322,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       });
     });
 
-    describe("when burning tokens", () => {
-      describe("when burning 10 tokenC (last token) from lsp9Vault1", () => {
+    describe('when burning tokens', () => {
+      describe('when burning 10 tokenC (last token) from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('burn', [
             context.lsp9Vault1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.universalProfile
@@ -340,25 +340,25 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenC.address, abi),
             );
         });
-        it("should update lsp5keys: arrayLength 2, no map, no tokenC address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenC address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenC.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000002",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000002',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 10 tokenA (first token) from lsp9Vault1", () => {
+      describe('when burning 10 tokenA (first token) from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('burn', [
             context.lsp9Vault1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.universalProfile
@@ -371,7 +371,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in Vault1", async () => {
+        it('should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -380,25 +380,25 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should update lsp5keys: arrayLength 1, no map, no tokenA address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 1, no map, no tokenA address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenA.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 10 (half of the amount) tokenB from lsp9Vault1", () => {
+      describe('when burning 10 (half of the amount) tokenB from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('burn', [
             context.lsp9Vault1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.universalProfile
@@ -410,7 +410,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenB.address, abi),
             );
         });
-        it("should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -420,12 +420,12 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when burning 10 (remaining) tokenB from lsp9Vault1", () => {
+      describe('when burning 10 (remaining) tokenB from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("burn", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('burn', [
             context.lsp9Vault1.address,
-            "10",
-            "0x",
+            '10',
+            '0x',
           ]);
 
           await context.universalProfile
@@ -437,36 +437,36 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp7TokenB.address, abi),
             );
         });
-        it("should update lsp5keys: arrayLength 0, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 0, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000000",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000000',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
     });
 
-    describe("when transferring tokens", () => {
-      it("should fund the universalProfle with 10 tokens (each) to test token transfers (TokenA, TokenB, TokenC)", async () => {
+    describe('when transferring tokens', () => {
+      it('should fund the universalProfle with 10 tokens (each) to test token transfers (TokenA, TokenB, TokenC)', async () => {
         await lsp7TokenA
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, "10", false, "0x");
+          .mint(context.lsp9Vault1.address, '10', false, '0x');
 
         await lsp7TokenB
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, "10", false, "0x");
+          .mint(context.lsp9Vault1.address, '10', false, '0x');
 
         await lsp7TokenC
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, "10", false, "0x");
+          .mint(context.lsp9Vault1.address, '10', false, '0x');
       });
 
-      it("should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in Vault1 ", async () => {
+      it('should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in Vault1 ', async () => {
         const [indexInMapTokenA, interfaceIdTokenA, arrayLength, elementAddressTokenA] =
           await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenA);
 
@@ -488,14 +488,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(elementAddressTokenC).to.equal(lsp7TokenC.address);
       });
 
-      describe("When transferring 10 (all) token A from UP1 to UP2", () => {
+      describe('When transferring 10 (all) token A from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenA.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenA.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -508,7 +508,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in Vault1", async () => {
+        it('should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenC);
           expect(indexInMap).to.equal(0);
@@ -517,19 +517,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp7TokenC.address);
         });
 
-        it("should update lsp5keys: arrayLength 2, no map, no tokenA address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenA address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenA.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000002",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000002',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault2", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp7TokenA);
           expect(indexInMap).to.equal(0);
@@ -539,14 +539,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 5 (half of amount) token B from UP1 to UP2", () => {
+      describe('When transferring 5 (half of amount) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
-            "5",
+            '5',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -559,7 +559,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -568,7 +568,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault2", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -578,14 +578,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 4 (few) token B from UP1 to UP2", () => {
+      describe('When transferring 4 (few) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
-            "4",
+            '4',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -598,7 +598,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -607,7 +607,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp7TokenB.address);
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -617,14 +617,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 1 (remaining) token B from UP1 to UP2", () => {
+      describe('When transferring 1 (remaining) token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
-            "1",
+            '1',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -637,19 +637,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp7TokenB);
           expect(indexInMap).to.equal(1);
@@ -659,14 +659,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 10 (all) token C from UP1 to UP2", () => {
+      describe('When transferring 10 (all) token C from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp7TokenC.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenC.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
-            "10",
+            '10',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -679,19 +679,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp7TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys : arrayLength 3, index = 2, tokenC address in Vault2", async () => {
+        it('should register lsp5keys : arrayLength 3, index = 2, tokenC address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp7TokenC);
           expect(indexInMap).to.equal(2);
@@ -701,14 +701,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 1 (few) token B from UP2 to UP1", () => {
+      describe('When transferring 1 (few) token B from UP2 to UP1', () => {
         before(async () => {
-          const abi = lsp7TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp7TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault2.address,
             context.lsp9Vault1.address,
-            "1",
+            '1',
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -721,7 +721,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in Vault1", async () => {
+        it('should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp7TokenB);
           expect(indexInMap).to.equal(0);
@@ -732,12 +732,12 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       });
     });
 
-    describe("when removing all keys", () => {
+    describe('when removing all keys', () => {
       before(async () => {
-        const abi1 = lsp7TokenB.interface.encodeFunctionData("burn", [
+        const abi1 = lsp7TokenB.interface.encodeFunctionData('burn', [
           context.lsp9Vault1.address,
-          "1",
-          "0x",
+          '1',
+          '0x',
         ]);
 
         await context.universalProfile
@@ -749,10 +749,10 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             callPayload(context.lsp9Vault1, lsp7TokenB.address, abi1),
           );
 
-        const abi2 = lsp7TokenB.interface.encodeFunctionData("burn", [
+        const abi2 = lsp7TokenB.interface.encodeFunctionData('burn', [
           context.lsp9Vault2.address,
-          "9",
-          "0x",
+          '9',
+          '0x',
         ]);
 
         await context.universalProfile
@@ -764,10 +764,10 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             callPayload(context.lsp9Vault2, lsp7TokenB.address, abi2),
           );
 
-        const abi3 = lsp7TokenA.interface.encodeFunctionData("burn", [
+        const abi3 = lsp7TokenA.interface.encodeFunctionData('burn', [
           context.lsp9Vault2.address,
-          "10",
-          "0x",
+          '10',
+          '0x',
         ]);
 
         await context.universalProfile
@@ -779,10 +779,10 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             callPayload(context.lsp9Vault2, lsp7TokenA.address, abi3),
           );
 
-        const abi4 = lsp7TokenC.interface.encodeFunctionData("burn", [
+        const abi4 = lsp7TokenC.interface.encodeFunctionData('burn', [
           context.lsp9Vault2.address,
-          "10",
-          "0x",
+          '10',
+          '0x',
         ]);
 
         await context.universalProfile
@@ -794,13 +794,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             callPayload(context.lsp9Vault2, lsp7TokenC.address, abi4),
           );
       });
-      it("should remove all lsp5 keys on both UP", async () => {
+      it('should remove all lsp5 keys on both UP', async () => {
         const arrayLengthUP1 = await context.lsp9Vault1.getData(
-          ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+          ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
         );
 
         const arrayLengthUP2 = await context.lsp9Vault2.getData(
-          ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
+          ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
         );
 
         expect(arrayLengthUP1).to.equal(ARRAY_LENGTH.ZERO);
@@ -809,7 +809,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
     });
   });
 
-  describe("testing values set under `LSP5ReceivedAssets[]`", () => {
+  describe('testing values set under `LSP5ReceivedAssets[]`', () => {
     let context: LSP1TestContext;
     let token: LSP7Tester;
     let arrayKey: BytesLike;
@@ -821,28 +821,28 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       context = await buildContext();
 
       token = await new LSP7Tester__factory(context.accounts.random).deploy(
-        "Example LSP7 token",
-        "EL7T",
+        'Example LSP7 token',
+        'EL7T',
         context.accounts.random.address,
       );
 
-      arrayKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
-      arrayIndexKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "0".repeat(32);
+      arrayKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
+      arrayIndexKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '0'.repeat(32);
       assetMapKey = ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2);
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is less than 20 bytes", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is less than 20 bytes', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.lsp9Vault1.address, 100, true, "0x");
+          .mint(context.lsp9Vault1.address, 100, true, '0x');
 
-        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData("setData", [
+        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData('setData', [
           ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
 
         await context.universalProfile
@@ -852,23 +852,23 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
 
         balance = await token.balanceOf(context.lsp9Vault1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.lsp9Vault1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         const vaultTokenTransferCalldata = context.lsp9Vault1.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata],
         );
 
@@ -877,11 +877,11 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           .execute(OPERATION_TYPES.CALL, context.lsp9Vault1.address, 0, vaultTokenTransferCalldata);
       });
 
-      it("it should pass", async () => {
+      it('it should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("it should emit UniversalReceiver event", async () => {
+      it('it should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -891,12 +891,12 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.lsp9Vault1, "UniversalReceiver")
+          .to.emit(context.lsp9Vault1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -910,25 +910,25 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
       });
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is bigger than 20 bytes, (valid `(byte4,uint128)` tuple  + extra bytes)', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.lsp9Vault1.address, 100, true, "0x");
+          .mint(context.lsp9Vault1.address, 100, true, '0x');
 
-        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData("setData", [
+        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData('setData', [
           ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-          "0xda1f85e400000000000000000000000000000000cafecafe",
+          '0xda1f85e400000000000000000000000000000000cafecafe',
         ]);
 
         await context.universalProfile
@@ -938,23 +938,23 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xda1f85e400000000000000000000000000000000cafecafe",
+          '0xda1f85e400000000000000000000000000000000cafecafe',
         ]);
 
         balance = await token.balanceOf(context.lsp9Vault1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.lsp9Vault1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         const vaultTokenTransferCalldata = context.lsp9Vault1.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata],
         );
 
@@ -963,11 +963,11 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           .execute(OPERATION_TYPES.CALL, context.lsp9Vault1.address, 0, vaultTokenTransferCalldata);
       });
 
-      it("should pass", async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -977,12 +977,12 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["bytes", "bytes"],
-          ["0x", "0x"],
+          ['bytes', 'bytes'],
+          ['0x', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.lsp9Vault1, "UniversalReceiver")
+          .to.emit(context.lsp9Vault1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -992,25 +992,25 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           );
       });
 
-      it("should de-register the asset properly", async () => {
+      it('should de-register the asset properly', async () => {
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
-        ).to.deep.equal(["0x" + "00".repeat(16), "0x", "0x"]);
+        ).to.deep.equal(['0x' + '00'.repeat(16), '0x', '0x']);
       });
     });
 
-    describe("when the Map value of LSP5ReceivedAssetsMap is 20 random bytes", () => {
+    describe('when the Map value of LSP5ReceivedAssetsMap is 20 random bytes', () => {
       let tokenTransferTx: Transaction;
       let balance: BigNumber;
 
       before(async () => {
         await token
           .connect(context.accounts.owner1)
-          .mint(context.lsp9Vault1.address, 100, true, "0x");
+          .mint(context.lsp9Vault1.address, 100, true, '0x');
 
-        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData("setData", [
+        const vaultSetDataCalldata = context.lsp9Vault1.interface.encodeFunctionData('setData', [
           ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + token.address.substring(2),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
 
         await context.universalProfile
@@ -1020,23 +1020,23 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
 
         balance = await token.balanceOf(context.lsp9Vault1.address);
 
-        const tokenTransferCalldata = token.interface.encodeFunctionData("transfer", [
+        const tokenTransferCalldata = token.interface.encodeFunctionData('transfer', [
           context.lsp9Vault1.address,
           context.accounts.owner1.address,
           balance,
           true,
-          "0x",
+          '0x',
         ]);
 
         const vaultTokenTransferCalldata = context.lsp9Vault1.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, token.address, 0, tokenTransferCalldata],
         );
 
@@ -1045,11 +1045,11 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           .execute(OPERATION_TYPES.CALL, context.lsp9Vault1.address, 0, vaultTokenTransferCalldata);
       });
 
-      it("should pass", async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = (
@@ -1059,12 +1059,12 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         ).toLowerCase();
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
-          ["string", "bytes"],
-          ["LSP1: asset data corrupted", "0x"],
+          ['string', 'bytes'],
+          ['LSP1: asset data corrupted', '0x'],
         );
 
         await expect(tokenTransferTx)
-          .to.emit(context.lsp9Vault1, "UniversalReceiver")
+          .to.emit(context.lsp9Vault1, 'UniversalReceiver')
           .withArgs(
             token.address,
             0,
@@ -1078,44 +1078,44 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(
           await context.lsp9Vault1.getDataBatch([arrayKey, arrayIndexKey, assetMapKey]),
         ).to.deep.equal([
-          "0x" + "00".repeat(15) + "01",
+          '0x' + '00'.repeat(15) + '01',
           token.address.toLowerCase(),
-          "0xcafecafecafecafecafecafecafecafecafecafe",
+          '0xcafecafecafecafecafecafecafecafecafecafe',
         ]);
       });
     });
   });
 
-  describe("when testing LSP8-IdentifiableDigitalAsset", () => {
+  describe('when testing LSP8-IdentifiableDigitalAsset', () => {
     let lsp8TokenA: LSP8Tester, lsp8TokenB: LSP8Tester, lsp8TokenC: LSP8Tester;
     before(async () => {
       lsp8TokenA = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenAlpha",
-        "TA",
+        'TokenAlpha',
+        'TA',
         context.accounts.random.address,
       );
 
       lsp8TokenB = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenBeta",
-        "TB",
+        'TokenBeta',
+        'TB',
         context.accounts.random.address,
       );
 
       lsp8TokenC = await new LSP8Tester__factory(context.accounts.random).deploy(
-        "TokenGamma",
-        "TA",
+        'TokenGamma',
+        'TA',
         context.accounts.random.address,
       );
     });
 
-    describe("when minting tokens", () => {
-      describe("when minting tokenId 1 of tokenA to lsp9Vault1", () => {
+    describe('when minting tokens', () => {
+      describe('when minting tokenId 1 of tokenA to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenA.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1127,7 +1127,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenA.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenA);
           expect(indexInMap).to.equal(0);
@@ -1137,13 +1137,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting tokenId 1 of tokenB to lsp9Vault1", () => {
+      describe('when minting tokenId 1 of tokenB to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1155,7 +1155,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenB.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1165,13 +1165,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting tokenId 2 of tokenB (another) to lsp9Vault1", () => {
+      describe('when minting tokenId 2 of tokenB (another) to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
             TOKEN_ID.TWO,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1183,7 +1183,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenB.address, abi),
             );
         });
-        it("should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys: arrayLength 2, index 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1193,13 +1193,13 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when minting tokenId 1 of tokenC to lsp9Vault1", () => {
+      describe('when minting tokenId 1 of tokenC to lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("mint", [
+          const abi = lsp8TokenC.interface.encodeFunctionData('mint', [
             context.lsp9Vault1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1211,7 +1211,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenC.address, abi),
             );
         });
-        it("should register lsp5keys: arrayLength 3, index 2, tokenC address in Vault1", async () => {
+        it('should register lsp5keys: arrayLength 3, index 2, tokenC address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenC);
           expect(indexInMap).to.equal(2);
@@ -1222,10 +1222,10 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       });
     });
 
-    describe("when burning tokens", () => {
-      describe("when burning tokenId 1 (all balance) of tokenC (last token) from lsp9Vault1", () => {
+    describe('when burning tokens', () => {
+      describe('when burning tokenId 1 (all balance) of tokenC (last token) from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenC.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.universalProfile
             .connect(context.accounts.owner1)
@@ -1236,22 +1236,22 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenC.address, abi),
             );
         });
-        it("should update lsp5keys: arrayLength 2, no map, no tokenC address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenC address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenC.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000002",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000002',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning tokenId 1 (all balance) of tokenA (first token) from lsp9Vault1", () => {
+      describe('when burning tokenId 1 (all balance) of tokenA (first token) from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenA.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.universalProfile
             .connect(context.accounts.owner1)
@@ -1263,7 +1263,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in Vault1", async () => {
+        it('should pop and swap TokenA with TokenB, lsp5keys (tokenB should become first token) : arrayLength 1, index = 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(0);
@@ -1272,22 +1272,22 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should update lsp5keys: arrayLength 1, no map, no tokenA address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 1, no map, no tokenA address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenA.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
 
-      describe("when burning 1 tokenId (not all balance) of tokenB from lsp9Vault1", () => {
+      describe('when burning 1 tokenId (not all balance) of tokenB from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("burn", [TOKEN_ID.ONE, "0x"]);
+          const abi = lsp8TokenB.interface.encodeFunctionData('burn', [TOKEN_ID.ONE, '0x']);
 
           await context.universalProfile
             .connect(context.accounts.owner1)
@@ -1298,7 +1298,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenB.address, abi),
             );
         });
-        it("should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys: arrayLength 1, index 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(0);
@@ -1308,9 +1308,9 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("when burning all tokenB from lsp9Vault1", () => {
+      describe('when burning all tokenB from lsp9Vault1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("burn", [TOKEN_ID.TWO, "0x"]);
+          const abi = lsp8TokenB.interface.encodeFunctionData('burn', [TOKEN_ID.TWO, '0x']);
 
           await context.universalProfile
             .connect(context.accounts.owner1)
@@ -1321,45 +1321,45 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
               callPayload(context.lsp9Vault1, lsp8TokenB.address, abi),
             );
         });
-        it("should update lsp5keys: arrayLength 0, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 0, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000000",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000000',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
       });
     });
 
-    describe("when transferring tokens", () => {
-      it("should fund the universalProfle with tokens to test token transfers (TokenA, TokenB, TokenC)", async () => {
+    describe('when transferring tokens', () => {
+      it('should fund the universalProfle with tokens to test token transfers (TokenA, TokenB, TokenC)', async () => {
         // 1 tokenId of TokenA
         await lsp8TokenA
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, '0x');
 
         // 3 tokenIds of TokenB
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, '0x');
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, TOKEN_ID.TWO, false, "0x");
+          .mint(context.lsp9Vault1.address, TOKEN_ID.TWO, false, '0x');
         await lsp8TokenB
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, TOKEN_ID.THREE, false, "0x");
+          .mint(context.lsp9Vault1.address, TOKEN_ID.THREE, false, '0x');
 
         // 1 tokenId of TokenC
         await lsp8TokenC
           .connect(context.accounts.random)
-          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, "0x");
+          .mint(context.lsp9Vault1.address, TOKEN_ID.ONE, false, '0x');
       });
 
-      it("should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in Vault1 ", async () => {
+      it('should register lsp5keys: arrayLength 3, index [1,2,3], [tokenA, tokenB, tokenC] addresses in Vault1 ', async () => {
         const [indexInMapTokenA, interfaceIdTokenA, arrayLength, elementAddressTokenA] =
           await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenA);
 
@@ -1381,14 +1381,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         expect(elementAddressTokenC).to.equal(lsp8TokenC.address);
       });
 
-      describe("When transferring tokenId 1 (all) of token A from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (all) of token A from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenA.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenA.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1401,7 +1401,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in Vault1", async () => {
+        it('should pop and swap TokenA with TokenC, lsp5keys (tokenC should become first token) : arrayLength 1, index = 0, tokenC address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenC);
           expect(indexInMap).to.equal(0);
@@ -1410,19 +1410,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp8TokenC.address);
         });
 
-        it("should update lsp5keys: arrayLength 2, no map, no tokenA address in Vault1", async () => {
+        it('should update lsp5keys: arrayLength 2, no map, no tokenA address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenA.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000002",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000002',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.TWO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault2", async () => {
+        it('should register lsp5keys: arrayLength 1, index 0, tokenA address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp8TokenA);
           expect(indexInMap).to.equal(0);
@@ -1432,14 +1432,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring tokenId 1 (not all balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (not all balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1452,7 +1452,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1461,7 +1461,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault2", async () => {
+        it('should register lsp5keys: arrayLength 2, index 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1471,14 +1471,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring tokenId 2 (not all balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 2 (not all balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
             TOKEN_ID.TWO,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1491,7 +1491,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1500,7 +1500,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           expect(elementAddress).to.equal(lsp8TokenB.address);
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1510,14 +1510,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring tokenId 3 (remaining balance) of token B from UP1 to UP2", () => {
+      describe('When transferring tokenId 3 (remaining balance) of token B from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
             TOKEN_ID.THREE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1530,19 +1530,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenB has the last index): arrayLength 1, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2", async () => {
+        it('should keep the same lsp5keys : arrayLength 2, index = 1, tokenB address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp8TokenB);
           expect(indexInMap).to.equal(1);
@@ -1552,14 +1552,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring tokenId 1 (all balance) of token C from UP1 to UP2", () => {
+      describe('When transferring tokenId 1 (all balance) of token C from UP1 to UP2', () => {
         before(async () => {
-          const abi = lsp8TokenC.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenC.interface.encodeFunctionData('transfer', [
             context.lsp9Vault1.address,
             context.lsp9Vault2.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1572,19 +1572,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in Vault1", async () => {
+        it('should update lsp5keys (no pop and swap as TokenC has the last index): arrayLength 0, no map, no tokenB address in Vault1', async () => {
           const [mapValue, arrayLength, elementAddress] = await context.lsp9Vault1.getDataBatch([
             ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap + lsp8TokenB.address.substr(2),
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length,
-            ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index + "00000000000000000000000000000001",
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length,
+            ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index + '00000000000000000000000000000001',
           ]);
 
-          expect(mapValue).to.equal("0x");
+          expect(mapValue).to.equal('0x');
           expect(arrayLength).to.equal(ARRAY_LENGTH.ZERO);
-          expect(elementAddress).to.equal("0x");
+          expect(elementAddress).to.equal('0x');
         });
 
-        it("should register lsp5keys : arrayLength 3, index = 2, tokenC address in Vault2", async () => {
+        it('should register lsp5keys : arrayLength 3, index = 2, tokenC address in Vault2', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault2, lsp8TokenC);
           expect(indexInMap).to.equal(2);
@@ -1594,14 +1594,14 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         });
       });
 
-      describe("When transferring 1 tokenId (not all balance) of token B from UP2 to UP1", () => {
+      describe('When transferring 1 tokenId (not all balance) of token B from UP2 to UP1', () => {
         before(async () => {
-          const abi = lsp8TokenB.interface.encodeFunctionData("transfer", [
+          const abi = lsp8TokenB.interface.encodeFunctionData('transfer', [
             context.lsp9Vault2.address,
             context.lsp9Vault1.address,
             TOKEN_ID.ONE,
             false,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -1614,7 +1614,7 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
             );
         });
 
-        it("should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in Vault1", async () => {
+        it('should register lsp5keys (UP1 able to re-register keys) : arrayLength 1, index = 0, tokenB address in Vault1', async () => {
           const [indexInMap, interfaceId, arrayLength, elementAddress] =
             await getLSP5MapAndArrayKeysValue(context.lsp9Vault1, lsp8TokenB);
           expect(indexInMap).to.equal(0);

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.test.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.test.ts
@@ -1,18 +1,18 @@
-import { ERC725YDataKeys, OPERATION_TYPES } from "../../constants";
+import { ERC725YDataKeys, OPERATION_TYPES } from '../../constants';
 import {
   LSP1UniversalReceiverDelegateVault__factory,
   UniversalProfile__factory,
   LSP9Vault__factory,
-} from "../../types";
+} from '../../types';
 
 import {
   LSP1TestContext,
   getNamedAccounts,
   shouldBehaveLikeLSP1Delegate,
-} from "./LSP1UniversalReceiverDelegateVault.behaviour";
+} from './LSP1UniversalReceiverDelegateVault.behaviour';
 
-describe("LSP1UniversalReceiverDelegateVault", () => {
-  describe("when testing deployed contract", () => {
+describe('LSP1UniversalReceiverDelegateVault', () => {
+  describe('when testing deployed contract', () => {
     const buildLSP1TestContext = async (): Promise<LSP1TestContext> => {
       const accounts = await getNamedAccounts();
 
@@ -35,7 +35,7 @@ describe("LSP1UniversalReceiverDelegateVault", () => {
 
       // Setting lsp1UniversalReceiverDelegateVault as URD for the Vault
 
-      const abi = lsp9Vault1.interface.encodeFunctionData("setData", [
+      const abi = lsp9Vault1.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
         lsp1universalReceiverDelegateVault.address,
       ]);

--- a/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers, network } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { FakeContract, smock } from "@defi-wonderland/smock";
+import { expect } from 'chai';
+import { ethers, network } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { FakeContract, smock } from '@defi-wonderland/smock';
 
 // types
 import {
@@ -20,10 +20,10 @@ import {
   LSP0ERC725Account,
   ILSP20CallVerification,
   ILSP20CallVerification__factory,
-} from "../../types";
+} from '../../types';
 
 // constants
-import { LSP20_MAGIC_VALUES, OPERATION_TYPES } from "../../constants";
+import { LSP20_MAGIC_VALUES, OPERATION_TYPES } from '../../constants';
 
 export type LSP20TestContext = {
   accounts: SignerWithAddress[];
@@ -38,13 +38,13 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
     context = await buildContext();
   });
 
-  describe("when testing lsp20 integration", () => {
-    describe("when owner is an EOA", () => {
-      describe("when calling `setData(bytes32,bytes)`", () => {
-        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+  describe('when testing lsp20 integration', () => {
+    describe('when owner is an EOA', () => {
+      describe('when calling `setData(bytes32,bytes)`', () => {
+        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
         const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
-        it("should pass when owner calls", async () => {
+        it('should pass when owner calls', async () => {
           await context.universalProfile
             .connect(context.deployParams.owner)
             .setData(dataKey, dataValue);
@@ -52,20 +52,20 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           expect(await context.universalProfile.getData(dataKey)).to.equal(dataValue);
         });
 
-        it("should revert when non-owner calls", async () => {
+        it('should revert when non-owner calls', async () => {
           await expect(
             context.universalProfile.connect(context.accounts[1]).setData(dataKey, dataValue),
           )
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("when calling `setData(bytes32[],bytes[])` array", () => {
-        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey2"));
+      describe('when calling `setData(bytes32[],bytes[])` array', () => {
+        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey2'));
         const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
-        it("should pass when owner calls", async () => {
+        it('should pass when owner calls', async () => {
           await context.universalProfile
             .connect(context.deployParams.owner)
             .setDataBatch([dataKey], [dataValue]);
@@ -73,24 +73,24 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           expect(await context.universalProfile.getDataBatch([dataKey])).to.deep.equal([dataValue]);
         });
 
-        it("should revert when non-owner calls", async () => {
+        it('should revert when non-owner calls', async () => {
           await expect(
             context.universalProfile
               .connect(context.accounts[1])
               .setDataBatch([dataKey], [dataValue]),
           )
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("when calling `execute(...)`", () => {
-        it("should pass when owner calls", async () => {
+      describe('when calling `execute(...)`', () => {
+        it('should pass when owner calls', async () => {
           const executeParams = {
             operation: OPERATION_TYPES.CALL,
             address: context.accounts[1].address,
             value: 0,
-            data: "0x",
+            data: '0x',
           };
 
           await expect(
@@ -103,16 +103,16 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
                 executeParams.data,
               ),
           )
-            .to.emit(context.universalProfile, "Executed")
-            .withArgs(OPERATION_TYPES.CALL, context.accounts[1].address, 0, "0x00000000");
+            .to.emit(context.universalProfile, 'Executed')
+            .withArgs(OPERATION_TYPES.CALL, context.accounts[1].address, 0, '0x00000000');
         });
 
-        it("when calling should revert when non-owner calls", async () => {
+        it('when calling should revert when non-owner calls', async () => {
           const executeParams = {
             operation: OPERATION_TYPES.CALL,
             address: context.accounts[1].address,
             value: 0,
-            data: "0x",
+            data: '0x',
           };
 
           await expect(
@@ -125,89 +125,89 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
                 executeParams.data,
               ),
           )
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("when calling `execute([],[],[],[])` Array", () => {
-        it("should pass when the owner is calling", async () => {
+      describe('when calling `execute([],[],[],[])` Array', () => {
+        it('should pass when the owner is calling', async () => {
           const operationsType = [OPERATION_TYPES.CALL];
           const recipients = [context.accounts[1].address];
           const values = [0];
-          const datas = ["0x"];
+          const datas = ['0x'];
 
           const tx = await context.universalProfile
             .connect(context.deployParams.owner)
             .executeBatch(operationsType, recipients, values, datas);
 
           await expect(tx)
-            .to.emit(context.universalProfile, "Executed")
-            .withArgs(OPERATION_TYPES.CALL, context.accounts[1].address, 0, "0x00000000");
+            .to.emit(context.universalProfile, 'Executed')
+            .withArgs(OPERATION_TYPES.CALL, context.accounts[1].address, 0, '0x00000000');
         });
 
-        it("should revert when the non-owner is calling", async () => {
+        it('should revert when the non-owner is calling', async () => {
           const operationsType = [OPERATION_TYPES.CALL];
           const recipients = [context.accounts[1].address];
-          const values = [ethers.BigNumber.from("0")];
-          const datas = ["0x"];
+          const values = [ethers.BigNumber.from('0')];
+          const datas = ['0x'];
 
           await expect(
             context.universalProfile
               .connect(context.accounts[3])
               .executeBatch(operationsType, recipients, values, datas),
           )
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("when calling `transferOwnership(...)`", () => {
-        it("should pass when the owner is calling", async () => {
+      describe('when calling `transferOwnership(...)`', () => {
+        it('should pass when the owner is calling', async () => {
           const newOwner = context.accounts[1].address;
 
           await expect(
             context.universalProfile
               .connect(context.deployParams.owner)
               .transferOwnership(newOwner),
-          ).to.emit(context.universalProfile, "OwnershipTransferStarted");
+          ).to.emit(context.universalProfile, 'OwnershipTransferStarted');
         });
 
-        it("should revert when the non-owner is calling", async () => {
+        it('should revert when the non-owner is calling', async () => {
           const newOwner = context.accounts[1].address;
 
           await expect(
             context.universalProfile.connect(context.accounts[3]).transferOwnership(newOwner),
           )
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("when calling `renounceOwnership`", () => {
-        it("should pass when the owner is calling", async () => {
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(500)]);
+      describe('when calling `renounceOwnership`', () => {
+        it('should pass when the owner is calling', async () => {
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(500)]);
 
           await expect(
             context.universalProfile.connect(context.deployParams.owner).renounceOwnership(),
-          ).to.emit(context.universalProfile, "RenounceOwnershipStarted");
+          ).to.emit(context.universalProfile, 'RenounceOwnershipStarted');
         });
 
-        it("should revert when the non-owner is calling", async () => {
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(100)]);
+        it('should revert when the non-owner is calling', async () => {
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(100)]);
 
           await expect(context.universalProfile.connect(context.accounts[3]).renounceOwnership())
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
     });
 
-    describe("when the owner is a contract", () => {
+    describe('when the owner is a contract', () => {
       describe("that doesn't implement the verifyCall function", () => {
         let ownerContract: NotImplementingVerifyCall;
 
-        before("deploying a new owner", async () => {
+        before('deploying a new owner', async () => {
           ownerContract = await new NotImplementingVerifyCall__factory(
             context.deployParams.owner,
           ).deploy();
@@ -221,7 +221,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
             .acceptOwnership(context.universalProfile.address);
         });
 
-        after("reverting to previous owner", async () => {
+        after('reverting to previous owner', async () => {
           await ownerContract
             .connect(context.deployParams.owner)
             .transferOwnership(context.deployParams.owner.address);
@@ -229,12 +229,12 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await context.universalProfile.connect(context.deployParams.owner).acceptOwnership();
         });
 
-        it("should revert when calling LSP0 function", async () => {
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+        it('should revert when calling LSP0 function', async () => {
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
           await expect(context.universalProfile.setData(dataKey, dataValue))
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20CallingVerifierFailed")
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20CallingVerifierFailed')
             .withArgs(false);
         });
       });
@@ -242,7 +242,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
       describe("that implement the fallback function that doesn't return anything", () => {
         let ownerContract: ImplementingFallback;
 
-        before("deploying a new owner", async () => {
+        before('deploying a new owner', async () => {
           ownerContract = await new ImplementingFallback__factory(
             context.deployParams.owner,
           ).deploy();
@@ -254,7 +254,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await ownerContract.acceptOwnership(context.universalProfile.address);
         });
 
-        after("reverting to previous owner", async () => {
+        after('reverting to previous owner', async () => {
           await ownerContract
             .connect(context.deployParams.owner)
             .transferOwnership(context.deployParams.owner.address);
@@ -262,20 +262,20 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await context.universalProfile.connect(context.deployParams.owner).acceptOwnership();
         });
 
-        it("should revert when calling LSP0 function", async () => {
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+        it('should revert when calling LSP0 function', async () => {
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
           await expect(context.universalProfile.setData(dataKey, dataValue))
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("that implement the fallback that return the magicValue", () => {
+      describe('that implement the fallback that return the magicValue', () => {
         let ownerContract: FallbackReturnMagicValue;
 
-        before("deploying a new owner", async () => {
+        before('deploying a new owner', async () => {
           ownerContract = await new FallbackReturnMagicValue__factory(
             context.deployParams.owner,
           ).deploy();
@@ -287,7 +287,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await ownerContract.acceptOwnership(context.universalProfile.address);
         });
 
-        after("reverting to previous owner", async () => {
+        after('reverting to previous owner', async () => {
           await ownerContract
             .connect(context.deployParams.owner)
             .transferOwnership(context.deployParams.owner.address);
@@ -295,21 +295,21 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await context.universalProfile.connect(context.deployParams.owner).acceptOwnership();
         });
 
-        it("should pass when calling LSP0 function", async () => {
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+        it('should pass when calling LSP0 function', async () => {
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
           await expect(context.universalProfile.setData(dataKey, dataValue)).to.emit(
             ownerContract,
-            "FallbackCalled",
+            'FallbackCalled',
           );
         });
       });
 
-      describe("that implements verifyCall but return an expanded bytes32 value", () => {
+      describe('that implements verifyCall but return an expanded bytes32 value', () => {
         let ownerContract: FirstCallReturnExpandedInvalidValue;
 
-        before("deploying a new owner", async () => {
+        before('deploying a new owner', async () => {
           ownerContract = await new FirstCallReturnExpandedInvalidValue__factory(
             context.deployParams.owner,
           ).deploy();
@@ -321,7 +321,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await ownerContract.acceptOwnership(context.universalProfile.address);
         });
 
-        after("reverting to previous owner", async () => {
+        after('reverting to previous owner', async () => {
           await ownerContract
             .connect(context.deployParams.owner)
             .transferOwnership(context.deployParams.owner.address);
@@ -329,20 +329,20 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await context.universalProfile.connect(context.deployParams.owner).acceptOwnership();
         });
 
-        it("should revert when calling `setData(bytes32,bytes)`", async () => {
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+        it('should revert when calling `setData(bytes32,bytes)`', async () => {
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
           await expect(
             context.universalProfile.setData(dataKey, dataValue),
-          ).to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue");
+          ).to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue');
         });
       });
 
       describe("that implements verifyCall but doesn't return magic value", () => {
         let ownerContract: FirstCallReturnInvalidMagicValue;
 
-        before("deploying a new owner", async () => {
+        before('deploying a new owner', async () => {
           ownerContract = await new FirstCallReturnInvalidMagicValue__factory(
             context.deployParams.owner,
           ).deploy();
@@ -354,7 +354,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await ownerContract.acceptOwnership(context.universalProfile.address);
         });
 
-        after("reverting to previous owner", async () => {
+        after('reverting to previous owner', async () => {
           await ownerContract
             .connect(context.deployParams.owner)
             .transferOwnership(context.deployParams.owner.address);
@@ -362,13 +362,13 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           await context.universalProfile.connect(context.deployParams.owner).acceptOwnership();
         });
 
-        it("should revert when calling `setData(bytes32,bytes)`", async () => {
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomKey1"));
+        it('should revert when calling `setData(bytes32,bytes)`', async () => {
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
           await expect(context.universalProfile.setData(dataKey, dataValue))
-            .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-            .withArgs(false, "0xaabbccdd" + "0".repeat(56));
+            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0xaabbccdd' + '0'.repeat(56));
         });
       });
 
@@ -387,12 +387,12 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
         });
 
-        it("should pass when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should pass when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(newUniversalProfile.connect(context.accounts[3]).setData(key, value))
-            .to.emit(newUniversalProfile, "DataChanged")
+            .to.emit(newUniversalProfile, 'DataChanged')
             .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
           const result = await newUniversalProfile.getData(key);
@@ -400,7 +400,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
         });
       });
 
-      describe("that implements verifyCall that returns a valid magicValue with additional data after the first 32 bytes", () => {
+      describe('that implements verifyCall that returns a valid magicValue with additional data after the first 32 bytes', () => {
         let firstCallReturnMagicValueContract: FakeContract;
         let newUniversalProfile: UniversalProfile;
 
@@ -408,9 +408,9 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           firstCallReturnMagicValueContract = await smock.fake(ILSP20CallVerification__factory.abi);
           firstCallReturnMagicValueContract.lsp20VerifyCall.returns(
             LSP20_MAGIC_VALUES.VERIFY_CALL.NO_POST_VERIFICATION +
-              "0".repeat(56) +
-              "0xcafecafecafecafecafecafecafecafecafecafe" +
-              "0".repeat(24),
+              '0'.repeat(56) +
+              '0xcafecafecafecafecafecafecafecafecafecafe' +
+              '0'.repeat(24),
           );
 
           newUniversalProfile = await new UniversalProfile__factory(context.accounts[0]).deploy(
@@ -418,22 +418,22 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
         });
 
-        it("should pass when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should pass when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(
-            newUniversalProfile.connect(context.accounts[3])["setData(bytes32,bytes)"](key, value),
+            newUniversalProfile.connect(context.accounts[3])['setData(bytes32,bytes)'](key, value),
           )
-            .to.emit(newUniversalProfile, "DataChanged")
+            .to.emit(newUniversalProfile, 'DataChanged')
             .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
-          const result = await newUniversalProfile["getData(bytes32)"](key);
+          const result = await newUniversalProfile['getData(bytes32)'](key);
           expect(result).to.equal(value);
         });
       });
 
-      describe("that implements verifyCall and verifyCallResult and both return magic value", () => {
+      describe('that implements verifyCall and verifyCallResult and both return magic value', () => {
         let bothCallReturnMagicValueContract: FakeContract<ILSP20CallVerification>;
         let newUniversalProfile: UniversalProfile;
 
@@ -451,12 +451,12 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
         });
 
-        it("should pass when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should pass when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(newUniversalProfile.connect(context.accounts[3]).setData(key, value))
-            .to.emit(newUniversalProfile, "DataChanged")
+            .to.emit(newUniversalProfile, 'DataChanged')
             .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
           const result = await newUniversalProfile.getData(key);
@@ -464,7 +464,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
         });
       });
 
-      describe("that implements verifyCall and verifyCallResult and both return magic value plus additional data", () => {
+      describe('that implements verifyCall and verifyCallResult and both return magic value plus additional data', () => {
         let bothCallReturnMagicValueContract: FakeContract<ILSP20CallVerification>;
         let newUniversalProfile: UniversalProfile;
 
@@ -472,15 +472,15 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           bothCallReturnMagicValueContract = await smock.fake(ILSP20CallVerification__factory.abi);
           bothCallReturnMagicValueContract.lsp20VerifyCall.returns(
             LSP20_MAGIC_VALUES.VERIFY_CALL.WITH_POST_VERIFICATION +
-              "0".repeat(56) +
-              "0xcafecafecafecafecafecafecafecafecafecafe" +
-              "0".repeat(24),
+              '0'.repeat(56) +
+              '0xcafecafecafecafecafecafecafecafecafecafe' +
+              '0'.repeat(24),
           );
           bothCallReturnMagicValueContract.lsp20VerifyCallResult.returns(
             LSP20_MAGIC_VALUES.VERIFY_CALL_RESULT +
-              "0".repeat(56) +
-              "0xcafecafecafecafecafecafecafecafecafecafe" +
-              "0".repeat(24),
+              '0'.repeat(56) +
+              '0xcafecafecafecafecafecafecafecafecafecafe' +
+              '0'.repeat(24),
           );
 
           newUniversalProfile = await new UniversalProfile__factory(context.accounts[0]).deploy(
@@ -488,22 +488,22 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
         });
 
-        it("should pass when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should pass when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(
-            newUniversalProfile.connect(context.accounts[3])["setData(bytes32,bytes)"](key, value),
+            newUniversalProfile.connect(context.accounts[3])['setData(bytes32,bytes)'](key, value),
           )
-            .to.emit(newUniversalProfile, "DataChanged")
+            .to.emit(newUniversalProfile, 'DataChanged')
             .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
-          const result = await newUniversalProfile["getData(bytes32)"](key);
+          const result = await newUniversalProfile['getData(bytes32)'](key);
           expect(result).to.equal(value);
         });
       });
 
-      describe("that implements verifyCallResult but return invalid magicValue", () => {
+      describe('that implements verifyCallResult but return invalid magicValue', () => {
         let secondCallReturnFailureContract: FakeContract<ILSP20CallVerification>;
         let newUniversalProfile: UniversalProfile;
 
@@ -512,24 +512,24 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           secondCallReturnFailureContract.lsp20VerifyCall.returns(
             LSP20_MAGIC_VALUES.VERIFY_CALL.WITH_POST_VERIFICATION,
           );
-          secondCallReturnFailureContract.lsp20VerifyCallResult.returns("0x00000000");
+          secondCallReturnFailureContract.lsp20VerifyCallResult.returns('0x00000000');
 
           newUniversalProfile = await new UniversalProfile__factory(context.accounts[0]).deploy(
             secondCallReturnFailureContract.address,
           );
         });
 
-        it("should revert when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should revert when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(
             newUniversalProfile.connect(context.accounts[3]).setData(key, value),
-          ).to.be.revertedWithCustomError(newUniversalProfile, "LSP20InvalidMagicValue");
+          ).to.be.revertedWithCustomError(newUniversalProfile, 'LSP20InvalidMagicValue');
         });
       });
 
-      describe("that implements verifyCallResult but return an expanded magic value", () => {
+      describe('that implements verifyCallResult but return an expanded magic value', () => {
         let secondCallReturnExpandedValueContract: FakeContract<ILSP20CallVerification>;
         let newUniversalProfile: UniversalProfile;
 
@@ -542,8 +542,8 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
           secondCallReturnExpandedValueContract.lsp20VerifyCallResult.returns(
             ethers.utils.solidityPack(
-              ["bytes4", "bytes28"],
-              [LSP20_MAGIC_VALUES.VERIFY_CALL_RESULT, "0x" + "0".repeat(56)],
+              ['bytes4', 'bytes28'],
+              [LSP20_MAGIC_VALUES.VERIFY_CALL_RESULT, '0x' + '0'.repeat(56)],
             ),
           );
 
@@ -552,12 +552,12 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           );
         });
 
-        it("should pass when calling `setData(bytes32,bytes)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+        it('should pass when calling `setData(bytes32,bytes)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
           await expect(newUniversalProfile.connect(context.accounts[3]).setData(key, value))
-            .to.emit(newUniversalProfile, "DataChanged")
+            .to.emit(newUniversalProfile, 'DataChanged')
             .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
           const result = await newUniversalProfile.getData(key);

--- a/tests/LSP20CallVerification/LSP20WithLSP14.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP20WithLSP14.behaviour.ts
@@ -1,19 +1,19 @@
-import { expect } from "chai";
-import { ethers, network, artifacts } from "hardhat";
+import { expect } from 'chai';
+import { ethers, network, artifacts } from 'hardhat';
 
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import {
   LSP0ERC725Account,
   UPWithInstantAcceptOwnership__factory,
   UPWithInstantAcceptOwnership,
-} from "../../types";
+} from '../../types';
 
 // constants
-import { OPERATION_TYPES } from "../../constants";
+import { OPERATION_TYPES } from '../../constants';
 
 // helpers
-import { provider } from "../utils/helpers";
-import { BigNumber, ContractTransaction } from "ethers";
+import { provider } from '../utils/helpers';
+import { BigNumber, ContractTransaction } from 'ethers';
 
 export type LSP14CombinedWithLSP20TestContext = {
   accounts: SignerWithAddress[];
@@ -29,23 +29,23 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
   let newOwner: SignerWithAddress;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("50"));
+    context = await buildContext(ethers.utils.parseEther('50'));
     newOwner = context.accounts[1];
   });
 
-  describe("when owner call transferOwnership(...)", () => {
+  describe('when owner call transferOwnership(...)', () => {
     before(async () => {
       await context.contract
         .connect(context.deployParams.owner)
         .transferOwnership(newOwner.address);
     });
 
-    it("should have set the pendingOwner", async () => {
+    it('should have set the pendingOwner', async () => {
       let pendingOwner = await context.contract.pendingOwner();
       expect(pendingOwner).to.equal(newOwner.address);
     });
 
-    it("owner should remain the current owner", async () => {
+    it('owner should remain the current owner', async () => {
       let newOwner = ethers.Wallet.createRandom();
 
       const ownerBefore = await context.contract.owner();
@@ -59,7 +59,7 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
       expect(ownerBefore).to.equal(ownerAfter);
     });
 
-    it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+    it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
       let overridenNewOwner = ethers.Wallet.createRandom();
 
       await context.contract
@@ -70,18 +70,18 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
       expect(pendingOwner).to.equal(overridenNewOwner.address);
     });
 
-    it("should revert when transferring Ownership to the contract itself", async () => {
+    it('should revert when transferring Ownership to the contract itself', async () => {
       await expect(
         context.contract
           .connect(context.deployParams.owner)
           .transferOwnership(context.contract.address),
-      ).to.be.revertedWithCustomError(context.contract, "CannotTransferOwnershipToSelf");
+      ).to.be.revertedWithCustomError(context.contract, 'CannotTransferOwnershipToSelf');
     });
 
-    describe("it should still be allowed to call onlyOwner functions", () => {
-      it("setData(...)", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('it should still be allowed to call onlyOwner functions', () => {
+      it('setData(...)', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
         await context.contract.connect(context.deployParams.owner).setData(key, value);
 
@@ -89,16 +89,16 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         expect(result).to.equal(value);
       });
 
-      it("execute(...) - LYX transfer", async () => {
+      it('execute(...) - LYX transfer', async () => {
         const recipient = context.accounts[3];
-        const amount = ethers.utils.parseEther("3");
+        const amount = ethers.utils.parseEther('3');
 
         const recipientBalanceBefore = await provider.getBalance(recipient.address);
         const accountBalanceBefore = await provider.getBalance(context.contract.address);
 
         await context.contract
           .connect(context.deployParams.owner)
-          .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x");
+          .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x');
 
         const recipientBalanceAfter = await provider.getBalance(recipient.address);
         const accountBalanceAfter = await provider.getBalance(context.contract.address);
@@ -111,7 +111,7 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
       });
     });
 
-    describe("when `acceptOwnership(...)` is called in the same tx as `transferOwnership(...)`", () => {
+    describe('when `acceptOwnership(...)` is called in the same tx as `transferOwnership(...)`', () => {
       let upWithCustomURD: UPWithInstantAcceptOwnership;
 
       before(async () => {
@@ -125,7 +125,7 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
           context.contract
             .connect(context.deployParams.owner)
             .transferOwnership(upWithCustomURD.address),
-        ).to.be.revertedWith("LSP14: newOwner MUST accept ownership in a separate transaction");
+        ).to.be.revertedWith('LSP14: newOwner MUST accept ownership in a separate transaction');
       });
     });
 
@@ -136,24 +136,24 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
     });
   });
 
-  describe("when non-owner call transferOwnership(...)", () => {
-    it("should revert", async () => {
+  describe('when non-owner call transferOwnership(...)', () => {
+    it('should revert', async () => {
       let randomAddress = context.accounts[2];
 
       await expect(context.contract.connect(randomAddress).transferOwnership(randomAddress.address))
-        .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-        .withArgs(false, "0x");
+        .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+        .withArgs(false, '0x');
     });
   });
 
-  describe("when calling acceptOwnership(...)", () => {
-    it("should revert when caller is not the pending owner", async () => {
+  describe('when calling acceptOwnership(...)', () => {
+    it('should revert when caller is not the pending owner', async () => {
       await expect(
         context.contract.connect(context.accounts[2]).acceptOwnership(),
-      ).to.be.revertedWith("LSP14: caller is not the pendingOwner");
+      ).to.be.revertedWith('LSP14: caller is not the pendingOwner');
     });
 
-    describe("when caller is the pending owner", () => {
+    describe('when caller is the pending owner', () => {
       let pendingOwner: string;
       let acceptOwnershipTx: ContractTransaction;
 
@@ -162,65 +162,65 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         acceptOwnershipTx = await context.contract.connect(newOwner).acceptOwnership();
       });
 
-      it("should change the contract owner to the pendingOwner", async () => {
+      it('should change the contract owner to the pendingOwner', async () => {
         let updatedOwner = await context.contract.owner();
         expect(updatedOwner).to.equal(pendingOwner);
       });
 
-      it("should have cleared the pendingOwner after transferring ownership", async () => {
+      it('should have cleared the pendingOwner after transferring ownership', async () => {
         let newPendingOwner = await context.contract.pendingOwner();
         expect(newPendingOwner).to.equal(ethers.constants.AddressZero);
       });
 
-      it("should have emitted a OwnershipTransferred event", async () => {
-        await expect(acceptOwnershipTx).to.emit(context.contract, "OwnershipTransferred").withArgs(
+      it('should have emitted a OwnershipTransferred event', async () => {
+        await expect(acceptOwnershipTx).to.emit(context.contract, 'OwnershipTransferred').withArgs(
           context.deployParams.owner.address, // previous owner
           newOwner.address, // new owner
         );
       });
     });
 
-    describe("after pendingOwner has claimed ownership", () => {
+    describe('after pendingOwner has claimed ownership', () => {
       let previousOwner: SignerWithAddress;
 
       before(async () => {
         previousOwner = context.deployParams.owner;
       });
 
-      describe("previous owner should not be allowed anymore to call onlyOwner functions", () => {
-        it("should revert when calling `setData(...)`", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('previous owner should not be allowed anymore to call onlyOwner functions', () => {
+        it('should revert when calling `setData(...)`', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
           await expect(context.contract.connect(previousOwner).setData(key, value))
-            .to.be.to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
 
-        it("should revert when calling `execute(...)`", async () => {
+        it('should revert when calling `execute(...)`', async () => {
           const recipient = context.accounts[3];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           await expect(
             context.contract
               .connect(previousOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x'),
           )
-            .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
 
-        it("should revert when calling `renounceOwnership(...)`", async () => {
+        it('should revert when calling `renounceOwnership(...)`', async () => {
           await expect(context.contract.connect(previousOwner).renounceOwnership())
-            .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-            .withArgs(false, "0x");
+            .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+            .withArgs(false, '0x');
         });
       });
 
-      describe("new owner should be allowed to call onlyOwner functions", () => {
-        it("setData(...)", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('new owner should be allowed to call onlyOwner functions', () => {
+        it('setData(...)', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
           await context.contract.connect(newOwner).setData(key, value);
 
@@ -228,14 +228,14 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
           expect(result).to.equal(value);
         });
 
-        it("execute(...) - LYX transfer", async () => {
+        it('execute(...) - LYX transfer', async () => {
           const recipient = context.accounts[3];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           await expect(() =>
             context.contract
               .connect(newOwner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x'),
           ).to.changeEtherBalances(
             [context.contract.address, recipient.address],
             [
@@ -248,25 +248,25 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
     });
   });
 
-  describe("renounceOwnership(...)", () => {
-    describe("when calling renounceOwnership() with a non-owner account", () => {
-      it("should revert with custom message", async () => {
+  describe('renounceOwnership(...)', () => {
+    describe('when calling renounceOwnership() with a non-owner account', () => {
+      it('should revert with custom message', async () => {
         const tx = context.contract.connect(context.accounts[5]).renounceOwnership();
 
         await expect(tx)
-          .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-          .withArgs(false, "0x");
+          .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+          .withArgs(false, '0x');
       });
     });
 
-    describe("when calling renounceOwnership() the first time", () => {
+    describe('when calling renounceOwnership() the first time', () => {
       let currentOwner: SignerWithAddress;
       let renounceOwnershipTx: ContractTransaction;
 
       let anotherOwner: string;
 
       before(async () => {
-        context = await buildContext(ethers.utils.parseEther("20"));
+        context = await buildContext(ethers.utils.parseEther('20'));
 
         currentOwner = context.accounts[0];
 
@@ -276,23 +276,23 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         await context.contract.connect(currentOwner).transferOwnership(anotherOwner);
 
         // mine 1,000 blocks
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(1000)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(1000)]);
 
         renounceOwnershipTx = await context.contract.connect(currentOwner).renounceOwnership();
 
         await renounceOwnershipTx.wait();
       });
 
-      it("should instantiate the renounceOwnership process correctly", async () => {
+      it('should instantiate the renounceOwnership process correctly', async () => {
         const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
           (
             await artifacts.getBuildInfo(
-              "contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account",
+              'contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account',
             )
           )?.output.contracts[
-            "contracts/LSP0ERC725Account/LSP0ERC725Account.sol"
+            'contracts/LSP0ERC725Account/LSP0ERC725Account.sol'
           ].LSP0ERC725Account.storageLayout.storage.filter((elem) => {
-            if (elem.label === "_renounceOwnershipStartedAt") return elem;
+            if (elem.label === '_renounceOwnershipStartedAt') return elem;
           })[0].slot,
         );
 
@@ -306,22 +306,22 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         );
       });
 
-      it("should have emitted a RenounceOwnershipStarted event", async () => {
-        await expect(renounceOwnershipTx).to.emit(context.contract, "RenounceOwnershipStarted");
+      it('should have emitted a RenounceOwnershipStarted event', async () => {
+        await expect(renounceOwnershipTx).to.emit(context.contract, 'RenounceOwnershipStarted');
       });
 
-      it("should not change the current owner", async () => {
+      it('should not change the current owner', async () => {
         expect(await context.contract.owner()).to.equal(currentOwner.address);
       });
 
-      it("should reset the pendingOwner", async () => {
+      it('should reset the pendingOwner', async () => {
         expect(await context.contract.pendingOwner()).to.equal(ethers.constants.AddressZero);
       });
 
-      describe("currentOwner should still be able to interact with contract before confirming", () => {
-        it("`setData(...)`", async () => {
-          const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Random Key"));
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Value"));
+      describe('currentOwner should still be able to interact with contract before confirming', () => {
+        it('`setData(...)`', async () => {
+          const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Random Key'));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Value'));
 
           await context.contract.connect(currentOwner).setData(key, value);
 
@@ -330,26 +330,26 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
           expect(result).to.equal(value);
         });
 
-        it("transfer LYX via `execute(...)`", async () => {
+        it('transfer LYX via `execute(...)`', async () => {
           const recipient = context.accounts[3].address;
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           // verify that balances have been updated
           await expect(() =>
             context.contract
               .connect(currentOwner)
-              .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
           ).to.changeEtherBalances([context.contract.address, recipient], [`-${amount}`, amount]);
         });
       });
     });
 
-    describe("when calling renounceOwnership() the second time", () => {
+    describe('when calling renounceOwnership() the second time', () => {
       before(async () => {
-        context = await buildContext(ethers.utils.parseEther("20"));
+        context = await buildContext(ethers.utils.parseEther('20'));
       });
 
-      it("should revert if called in the delay period", async () => {
+      it('should revert if called in the delay period', async () => {
         const renounceOwnershipOnce = await context.contract
           .connect(context.deployParams.owner)
           .renounceOwnership();
@@ -357,10 +357,10 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         const renounceOwnershipOnceReceipt = await renounceOwnershipOnce.wait();
 
         // skip 98 blocks, but not enough to reach the delay period
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(98)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(98)]);
 
         await expect(context.contract.connect(context.deployParams.owner).renounceOwnership())
-          .to.be.revertedWithCustomError(context.contract, "NotInRenounceOwnershipInterval")
+          .to.be.revertedWithCustomError(context.contract, 'NotInRenounceOwnershipInterval')
           .withArgs(
             renounceOwnershipOnceReceipt.blockNumber + 200,
             renounceOwnershipOnceReceipt.blockNumber + 400,
@@ -369,25 +369,25 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         expect(await context.contract.owner()).to.equal(context.deployParams.owner.address);
 
         // skip 500 blocks for the next test
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(500)]);
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(500)]);
       });
 
-      it("should initialize again if the confirmation period passed", async () => {
+      it('should initialize again if the confirmation period passed', async () => {
         const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
           (
             await artifacts.getBuildInfo(
-              "contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account",
+              'contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account',
             )
           )?.output.contracts[
-            "contracts/LSP0ERC725Account/LSP0ERC725Account.sol"
+            'contracts/LSP0ERC725Account/LSP0ERC725Account.sol'
           ].LSP0ERC725Account.storageLayout.storage.filter((elem) => {
-            if (elem.label === "_renounceOwnershipStartedAt") return elem;
+            if (elem.label === '_renounceOwnershipStartedAt') return elem;
           })[0].slot,
         );
 
         await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
-        await network.provider.send("hardhat_mine", [ethers.utils.hexValue(400)]); // skip 400 blocks
+        await network.provider.send('hardhat_mine', [ethers.utils.hexValue(400)]); // skip 400 blocks
 
         let tx = await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
@@ -403,12 +403,12 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
         );
       });
 
-      describe("when called after the delay and before the confirmation period end", () => {
+      describe('when called after the delay and before the confirmation period end', () => {
         let renounceOwnershipFirstTx: ContractTransaction;
         let renounceOwnershipSecondTx: ContractTransaction;
 
         before(async () => {
-          context = await buildContext(ethers.utils.parseEther("20"));
+          context = await buildContext(ethers.utils.parseEther('20'));
 
           // Call renounceOwnership for the first time
           renounceOwnershipFirstTx = await context.contract
@@ -416,41 +416,41 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
             .renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(199)]);
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(199)]);
 
           renounceOwnershipSecondTx = await context.contract
             .connect(context.deployParams.owner)
             .renounceOwnership();
         });
 
-        it("should have emitted a OwnershipTransferred event", async () => {
+        it('should have emitted a OwnershipTransferred event', async () => {
           await expect(renounceOwnershipSecondTx)
-            .to.emit(context.contract, "OwnershipTransferred")
+            .to.emit(context.contract, 'OwnershipTransferred')
             .withArgs(context.deployParams.owner.address, ethers.constants.AddressZero);
 
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("should have emitted a OwnershipRenounced event", async () => {
-          await expect(renounceOwnershipSecondTx).to.emit(context.contract, "OwnershipRenounced");
+        it('should have emitted a OwnershipRenounced event', async () => {
+          await expect(renounceOwnershipSecondTx).to.emit(context.contract, 'OwnershipRenounced');
 
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("owner should now be address(0)", async () => {
+        it('owner should now be address(0)', async () => {
           expect(await context.contract.owner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("should have reset the `_renounceOwnershipStartedAt` state variable to zero", async () => {
+        it('should have reset the `_renounceOwnershipStartedAt` state variable to zero', async () => {
           const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
             (
               await artifacts.getBuildInfo(
-                "contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account",
+                'contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account',
               )
             )?.output.contracts[
-              "contracts/LSP0ERC725Account/LSP0ERC725Account.sol"
+              'contracts/LSP0ERC725Account/LSP0ERC725Account.sol'
             ].LSP0ERC725Account.storageLayout.storage.filter((elem) => {
-              if (elem.label === "_renounceOwnershipStartedAt") return elem;
+              if (elem.label === '_renounceOwnershipStartedAt') return elem;
             })[0].slot,
           );
 
@@ -462,36 +462,36 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
           expect(ethers.BigNumber.from(_renounceOwnershipStartedAtAfter).toNumber()).to.equal(0);
         });
 
-        describe("currentOwner should not be able to interact with contract anymore after confirming", () => {
-          it("`setData(...)`", async () => {
-            const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Random Key"));
-            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Value"));
+        describe('currentOwner should not be able to interact with contract anymore after confirming', () => {
+          it('`setData(...)`', async () => {
+            const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Random Key'));
+            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Value'));
 
             await expect(context.contract.connect(context.deployParams.owner).setData(key, value))
-              .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-              .withArgs(false, "0x");
+              .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+              .withArgs(false, '0x');
           });
 
-          it("transfer LYX via `execute(...)`", async () => {
+          it('transfer LYX via `execute(...)`', async () => {
             const recipient = context.accounts[3].address;
-            const amount = ethers.utils.parseEther("3");
+            const amount = ethers.utils.parseEther('3');
 
             await expect(
               context.contract
                 .connect(context.deployParams.owner)
-                .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+                .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
             )
-              .to.be.revertedWithCustomError(context.contract, "LSP20InvalidMagicValue")
-              .withArgs(false, "0x");
+              .to.be.revertedWithCustomError(context.contract, 'LSP20InvalidMagicValue')
+              .withArgs(false, '0x');
           });
         });
       });
 
-      describe("if there was a pendingOwner set before confirming `renounceOwnership(...)", () => {
+      describe('if there was a pendingOwner set before confirming `renounceOwnership(...)', () => {
         let newOwner: SignerWithAddress;
 
         before(async () => {
-          context = await buildContext(ethers.utils.parseEther("20"));
+          context = await buildContext(ethers.utils.parseEther('20'));
 
           // transferOwnership to a new owner
           newOwner = context.accounts[3];
@@ -504,44 +504,44 @@ export const shouldBehaveLikeLSP14WithLSP20 = (
           await context.contract.connect(context.deployParams.owner).renounceOwnership();
 
           // Skip 199 block to reach the time where renouncing ownership can happen
-          await network.provider.send("hardhat_mine", [ethers.utils.hexValue(199)]);
+          await network.provider.send('hardhat_mine', [ethers.utils.hexValue(199)]);
 
           // Call renounceOwnership for the second time
           await context.contract.connect(context.deployParams.owner).renounceOwnership();
         });
 
-        it("should reset the pendingOwner whenever renounceOwnership(..) is confirmed", async () => {
+        it('should reset the pendingOwner whenever renounceOwnership(..) is confirmed', async () => {
           expect(await context.contract.pendingOwner()).to.equal(ethers.constants.AddressZero);
         });
 
-        it("previous pendingOwner should not be able to call acceptOwnership(...) anymore", async () => {
+        it('previous pendingOwner should not be able to call acceptOwnership(...) anymore', async () => {
           await expect(context.contract.connect(newOwner).acceptOwnership()).to.be.revertedWith(
-            "LSP14: caller is not the pendingOwner",
+            'LSP14: caller is not the pendingOwner',
           );
         });
       });
     });
   });
 
-  describe("when calling `renounceOwnership()` when `block.number` is less than 400 blocks (RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY + RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD)`", () => {
+  describe('when calling `renounceOwnership()` when `block.number` is less than 400 blocks (RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY + RENOUNCE_OWNERSHIP_CONFIRMATION_PERIOD)`', () => {
     before(async () => {
       context = await buildContext();
 
       // Simulate a scenario where we are at just few hundred blocks after the blockchain started
       // (few hundred blocks after genesis)
-      await network.provider.send("hardhat_mine", [ethers.utils.hexValue(138)]);
+      await network.provider.send('hardhat_mine', [ethers.utils.hexValue(138)]);
     });
 
-    it("should instantiate the renounceOwnership process in 2 steps correctly", async () => {
+    it('should instantiate the renounceOwnership process in 2 steps correctly', async () => {
       const _renounceOwnershipStartedAtAfterSlotNumber = Number.parseInt(
         (
           await artifacts.getBuildInfo(
-            "contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account",
+            'contracts/LSP0ERC725Account/LSP0ERC725Account.sol:LSP0ERC725Account',
           )
         )?.output.contracts[
-          "contracts/LSP0ERC725Account/LSP0ERC725Account.sol"
+          'contracts/LSP0ERC725Account/LSP0ERC725Account.sol'
         ].LSP0ERC725Account.storageLayout.storage.filter((elem) => {
-          if (elem.label === "_renounceOwnershipStartedAt") return elem;
+          if (elem.label === '_renounceOwnershipStartedAt') return elem;
         })[0].slot,
       );
 

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
@@ -1,27 +1,27 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
   combinePermissions,
   encodeCompactBytesArray,
   getRandomAddresses,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOrAddExtensions = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting Extension Handler keys (CHANGE vs ADD)", () => {
+  describe('setting Extension Handler keys (CHANGE vs ADD)', () => {
     let canAddAndChangeExtensions: SignerWithAddress,
       canOnlyAddExtensions: SignerWithAddress,
       canOnlyChangeExtensions: SignerWithAddress,
@@ -48,27 +48,27 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       extensionHandlerKey1 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey2 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey3 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey4 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey5 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       [extensionA, extensionB, extensionC, extensionD] = getRandomAddresses(4);
 
@@ -80,20 +80,20 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyChangeExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySuperSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canOnlyCall.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
       let permissionValues = [
@@ -106,22 +106,22 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         encodeCompactBytesArray([
           // Adding the Extension Handler Keys as AllowedERC725YDataKey to test if it break the behavior
           ERC725YDataKeys.LSP17.LSP17ExtensionPrefix,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
         ]),
         PERMISSIONS.CALL,
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006',
       ];
 
       permissionArrayValues = [
@@ -141,9 +141,9 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when setting one ExtensionHandler key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+    describe('when setting one ExtensionHandler key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
@@ -157,7 +157,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a ExtensionHandler key", async () => {
+        it('should be allowed to edit a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionB,
@@ -171,10 +171,10 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a ExtensionHandler key set", async () => {
+        it('should be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -186,8 +186,8 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE Extensions permission", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+      describe('when caller is an address with ADD/CHANGE Extensions permission', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
@@ -201,7 +201,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a ExtensionHandler key", async () => {
+        it('should be allowed to edit a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionB,
@@ -215,10 +215,10 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a ExtensionHandler key set", async () => {
+        it('should be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -230,8 +230,8 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADDExtensions permission", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+      describe('when caller is an address with ADDExtensions permission', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
@@ -256,11 +256,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyAddExtensions)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionB,
@@ -271,14 +271,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyAddExtensions)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove a ExtensionHandler key set", async () => {
+        it('should NOT be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -286,13 +286,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyAddExtensions)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with CHANGEExtensions permission", () => {
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+      describe('when caller is an address with CHANGEExtensions permission', () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
@@ -303,11 +303,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyChangeExtensions)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
         });
 
-        it("should be allowed to edit the ExtensionHandler key set", async () => {
+        it('should be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionD,
@@ -322,10 +322,10 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove the ExtensionHandler key set", async () => {
+        it('should be allowed to remove the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -338,7 +338,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with SUPER_SETDATA permission", () => {
+      describe('when caller is an address with SUPER_SETDATA permission', () => {
         before(async () => {
           // Adding am extensionHandler data key by the owner to test if address with SUPER_SETDATA
           // can CHANGE its content
@@ -351,7 +351,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             .connect(context.owner)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
@@ -362,11 +362,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionB,
@@ -377,14 +377,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -392,12 +392,12 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with SETDATA permission with LSP0_EXTENSIONSHANDLER_Prefix as allowedKey", () => {
+      describe('when caller is an address with SETDATA permission with LSP0_EXTENSIONSHANDLER_Prefix as allowedKey', () => {
         before(async () => {
           // Adding an extensionHandler data key by the owner to test if address with SETDATA
           // can CHANGE its content
@@ -411,7 +411,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
-        it("should NOT be allowed to ADD another ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
@@ -422,11 +422,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionA,
@@ -437,14 +437,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -452,12 +452,12 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with CALL permission (Without SETDATA)", () => {
+      describe('when caller is an address with CALL permission (Without SETDATA)', () => {
         before(async () => {
           // Adding an extensionHandler data key by the owner to test if address with CALL
           // can CHANGE its content
@@ -471,7 +471,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
@@ -482,11 +482,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionA,
@@ -497,14 +497,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -512,25 +512,25 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEEXTENSIONS');
         });
       });
     });
 
-    describe("when setting mixed keys (ExtensionHandler + AddressPermission + ERC725Y Data Key)", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a ExtensionHandler, AddressPermission and ERC725Y Data Key", async () => {
+    describe('when setting mixed keys (ExtensionHandler + AddressPermission + ERC725Y Data Key)', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a ExtensionHandler, AddressPermission and ERC725Y Data Key', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
             ],
             dataValues: [
               extensionA,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-              "0xaabbccdd",
+              '0xaabbccdd',
             ],
           };
 
@@ -543,21 +543,21 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to edit a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to edit a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
             dataValues: [
               extensionB,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 32),
-              "0xaabb",
+              '0xaabb',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -571,14 +571,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to remove a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to remove a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
-            dataValues: ["0x", ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), "0x"],
+            dataValues: ['0x', ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), '0x'],
           };
 
           await context.universalProfile
@@ -591,19 +591,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE Extensions permission ", () => {
-        describe("when adding a ExtensionHandler, AddressPermission and ERC725Y Data Key", () => {
+      describe('when caller is an address with ADD/CHANGE Extensions permission ', () => {
+        describe('when adding a ExtensionHandler, AddressPermission and ERC725Y Data Key', () => {
           it("should revert because of caller don't have EDITPERMISSIONS Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey5,
-                ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 extensionA,
                 ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
@@ -612,19 +612,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canAddAndChangeExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeExtensions.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeExtensions.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey5,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
             await expect(
@@ -632,13 +632,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canAddAndChangeExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeExtensions.address, 'SETDATA');
           });
         });
 
-        describe("when adding and changing in same tx ExtensionHandler", () => {
-          it("should pass", async () => {
+        describe('when adding and changing in same tx ExtensionHandler', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey5, extensionHandlerKey5],
               dataValues: [extensionA, extensionB],
@@ -657,15 +657,15 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD Extensions permission ", () => {
+      describe('when caller is an address with ADD Extensions permission ', () => {
         before(async () => {
           // Nullfying the value of ExtensionHandler keys to test that we cannot add them
           const payloadParam = {
             dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
-            dataValues: ["0x", "0x"],
+            dataValues: ['0x', '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -674,8 +674,8 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             .connect(context.owner)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
         });
-        describe("when adding multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+        describe('when adding multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
               dataValues: [extensionA, extensionB],
@@ -691,7 +691,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when adding and changing ExtensionHandler keys in 1 tx ", () => {
+        describe('when adding and changing ExtensionHandler keys in 1 tx ', () => {
           it("should revert because caller don't have CHANGE Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey3, extensionHandlerKey1],
@@ -703,19 +703,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyAddExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
             await expect(
@@ -723,15 +723,15 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyAddExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with CHANGE Extensions permission ", () => {
-        describe("when changing multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+      describe('when caller is an address with CHANGE Extensions permission ', () => {
+        describe('when changing multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -752,7 +752,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when changing multiple ExtensionHandler keys with adding ERC725Y Data Key", () => {
+        describe('when changing multiple ExtensionHandler keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have SETDATA permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -760,9 +760,9 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 extensionHandlerKey5,
                 extensionHandlerKey1,
                 extensionHandlerKey2,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, extensionB, extensionC, "0xaabbccdd"],
+              dataValues: [extensionA, extensionB, extensionC, '0xaabbccdd'],
             };
 
             await expect(
@@ -770,12 +770,12 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyChangeExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'SETDATA');
           });
         });
 
-        describe("when changing multiple ExtensionHandler keys with adding a ExtensionHandler key", () => {
+        describe('when changing multiple ExtensionHandler keys with adding a ExtensionHandler key', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -794,13 +794,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyChangeExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when changing (removing) multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+        describe('when changing (removing) multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -808,7 +808,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 extensionHandlerKey1,
                 extensionHandlerKey2,
               ],
-              dataValues: ["0x", "0x", "0x"],
+              dataValues: ['0x', '0x', '0x'],
             };
 
             await context.universalProfile
@@ -821,7 +821,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when adding ExtensionHandler keys ", () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
@@ -833,19 +833,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyChangeExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
             await expect(
@@ -853,14 +853,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlyAddExtensions)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with SUPER SETDATA permission ", () => {
-        describe("when adding ExtensionHandler keys ", () => {
+      describe('when caller is an address with SUPER SETDATA permission ', () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
@@ -872,18 +872,18 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlySuperSetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
           });
         });
-        describe("when Adding multiple ExtensionHandler keys with adding ERC725Y Data Key", () => {
+        describe('when Adding multiple ExtensionHandler keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
             await expect(
@@ -891,14 +891,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlySuperSetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
           });
         });
       });
 
-      describe("when caller is an address with SETDATA permission with ExtensionHandler keys as AllowedERC725YDataKeys ", () => {
-        describe("when adding ExtensionHandler keys ", () => {
+      describe('when caller is an address with SETDATA permission with ExtensionHandler keys as AllowedERC725YDataKeys ', () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission and ExtensionHandler keys are not part of AllowedERC725YDataKeys", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey5, extensionHandlerKey2],
@@ -910,19 +910,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlySetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when Adding multiple ExtensionHandler keys with adding other allowedERC725YDataKey", () => {
+        describe('when Adding multiple ExtensionHandler keys with adding other allowedERC725YDataKey', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
             await expect(
@@ -930,16 +930,16 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 .connect(canOnlySetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("When granting the caller ADDExtensions permission", () => {
+        describe('When granting the caller ADDExtensions permission', () => {
           before(async () => {
             const payloadParam = {
               dataKeys: [
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                   canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
@@ -949,17 +949,17 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .connect(context.owner)
               .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
           });
-          describe("When adding ExtensionHandler key and one of his allowedERC725Y Data Key", () => {
-            it("should pass", async () => {
+          describe('When adding ExtensionHandler key and one of his allowedERC725Y Data Key', () => {
+            it('should pass', async () => {
               const payloadParam = {
                 dataKeys: [
                   extensionHandlerKey4,
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
+                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
                 ],
-                dataValues: [extensionA, "0xaabbccdd"],
+                dataValues: [extensionA, '0xaabbccdd'],
               };
 
-              let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+              let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
                 payloadParam.dataKeys,
                 payloadParam.dataValues,
               ]);

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddURD.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddURD.test.ts
@@ -1,27 +1,27 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
   combinePermissions,
   encodeCompactBytesArray,
   getRandomAddresses,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOrAddURD = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting UniversalReceiverDelegate keys (CHANGE vs ADD)", () => {
+  describe('setting UniversalReceiverDelegate keys (CHANGE vs ADD)', () => {
     let canAddAndChangeUniversalReceiverDelegate: SignerWithAddress,
       canOnlyAddUniversalReceiverDelegate: SignerWithAddress,
       canOnlyChangeUniversalReceiverDelegate: SignerWithAddress,
@@ -78,20 +78,20 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyChangeUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySuperSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canOnlyCall.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
       let permissionValues = [
@@ -108,22 +108,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           // Adding the LSP1 Keys as AllowedERC725YDataKey to test if it break the behavior
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix,
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
         ]),
         PERMISSIONS.CALL,
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006',
       ];
 
       permissionArrayValues = [
@@ -143,9 +143,9 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when setting one UniversalReceiverDelegate key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+    describe('when setting one UniversalReceiverDelegate key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
@@ -159,7 +159,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate key", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateB,
@@ -173,10 +173,10 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -188,8 +188,8 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
@@ -203,7 +203,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate key", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateB,
@@ -217,10 +217,10 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -232,8 +232,8 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADDUniversalReceiverDelegate permission", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with ADDUniversalReceiverDelegate permission', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
@@ -258,14 +258,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyAddUniversalReceiverDelegate)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should NOT be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateB,
@@ -276,17 +276,17 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyAddUniversalReceiverDelegate)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should NOT be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -294,16 +294,16 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyAddUniversalReceiverDelegate)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
       });
 
-      describe("when caller is an address with CHANGEUniversalReceiverDelegate permission", () => {
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with CHANGEUniversalReceiverDelegate permission', () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
@@ -314,14 +314,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyChangeUniversalReceiverDelegate)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyChangeUniversalReceiverDelegate.address,
-              "ADDUNIVERSALRECEIVERDELEGATE",
+              'ADDUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateD,
@@ -336,10 +336,10 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove the UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await context.universalProfile
@@ -352,7 +352,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with SUPER_SETDATA permission", () => {
+      describe('when caller is an address with SUPER_SETDATA permission', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with SUPER_SETDATA
           // can CHANGE its content
@@ -365,7 +365,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             .connect(context.owner)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
@@ -376,11 +376,11 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateB,
@@ -391,14 +391,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -406,12 +406,12 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySuperSetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
 
-      describe("when caller is an address with SETDATA permission with LSP1URDPrefix as allowedKey", () => {
+      describe('when caller is an address with SETDATA permission with LSP1URDPrefix as allowedKey', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with SETDATA
           // can CHANGE its content
@@ -425,7 +425,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
@@ -436,11 +436,11 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateA,
@@ -451,14 +451,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -466,12 +466,12 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlySetData)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
 
-      describe("when caller is an address with CALL permission (Without SETDATA)", () => {
+      describe('when caller is an address with CALL permission (Without SETDATA)', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with CALL
           // can CHANGE its content
@@ -485,7 +485,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
@@ -496,11 +496,11 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateA,
@@ -511,14 +511,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
           await expect(
@@ -526,29 +526,29 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(canOnlyCall)
               .setData(payloadParam.dataKey, payloadParam.dataValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
     });
 
-    describe("when setting mixed keys (UniversalReceiverDelegate + AddressPermission + ERC725Y Data Key)", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key", async () => {
+    describe('when setting mixed keys (UniversalReceiverDelegate + AddressPermission + ERC725Y Data Key)', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
             ],
             dataValues: [
               universalReceiverDelegateA,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-              "0xaabbccdd",
+              '0xaabbccdd',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -562,21 +562,21 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
             dataValues: [
               universalReceiverDelegateB,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 16),
-              "0xaabb",
+              '0xaabb',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -590,17 +590,17 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
-            dataValues: ["0x", ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), "0x"],
+            dataValues: ['0x', ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -615,19 +615,19 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission ", () => {
-        describe("when adding a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key", () => {
+      describe('when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission ', () => {
+        describe('when adding a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key', () => {
           it("should revert because of caller don't have EDITPERMISSIONS Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-                ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 universalReceiverDelegateA,
                 ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
@@ -636,19 +636,19 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canAddAndChangeUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
             await expect(
@@ -656,13 +656,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canAddAndChangeUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
 
-        describe("when adding and changing in same tx UniversalReceiverDelegate", () => {
-          it("should pass", async () => {
+        describe('when adding and changing in same tx UniversalReceiverDelegate', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
@@ -684,15 +684,15 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD UniversalReceiverDelegate permission ", () => {
+      describe('when caller is an address with ADD UniversalReceiverDelegate permission ', () => {
         before(async () => {
           // Nullfying the value of UniversalReceiverDelegate keys to test that we cannot add them
           const payloadParam = {
             dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
-            dataValues: ["0x", "0x"],
+            dataValues: ['0x', '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -701,8 +701,8 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             .connect(context.owner)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
         });
-        describe("when adding multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+        describe('when adding multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
               dataValues: [universalReceiverDelegateA, universalReceiverDelegateB],
@@ -718,7 +718,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when adding and changing UniversalReceiverDelegate keys in 1 tx ", () => {
+        describe('when adding and changing UniversalReceiverDelegate keys in 1 tx ', () => {
           it("should revert because caller don't have CHANGE UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey3, universalReceiverDelegateKey1],
@@ -730,22 +730,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyAddUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyAddUniversalReceiverDelegate.address,
-                "CHANGEUNIVERSALRECEIVERDELEGATE",
+                'CHANGEUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
             await expect(
@@ -753,15 +753,15 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyAddUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with CHANGE UniversalReceiverDelegate permission ", () => {
-        describe("when changing multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+      describe('when caller is an address with CHANGE UniversalReceiverDelegate permission ', () => {
+        describe('when changing multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -786,7 +786,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when changing multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key", () => {
+        describe('when changing multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have SETDATA permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -794,13 +794,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
                 universalReceiverDelegateKey1,
                 universalReceiverDelegateKey2,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 universalReceiverDelegateA,
                 universalReceiverDelegateB,
                 universalReceiverDelegateC,
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
@@ -809,12 +809,12 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyChangeUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
 
-        describe("when changing multiple UniversalReceiverDelegate keys with adding a UniversalReceiverDelegate Key", () => {
+        describe('when changing multiple UniversalReceiverDelegate keys with adding a UniversalReceiverDelegate Key', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -838,16 +838,16 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyChangeUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyChangeUniversalReceiverDelegate.address,
-                "ADDUNIVERSALRECEIVERDELEGATE",
+                'ADDUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when changing (removing) multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+        describe('when changing (removing) multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -855,7 +855,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 universalReceiverDelegateKey1,
                 universalReceiverDelegateKey2,
               ],
-              dataValues: ["0x", "0x", "0x"],
+              dataValues: ['0x', '0x', '0x'],
             };
 
             await context.universalProfile
@@ -868,7 +868,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
@@ -880,22 +880,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyChangeUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyChangeUniversalReceiverDelegate.address,
-                "ADDUNIVERSALRECEIVERDELEGATE",
+                'ADDUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
             await expect(
@@ -903,14 +903,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlyAddUniversalReceiverDelegate)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with SUPER SETDATA permission ", () => {
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+      describe('when caller is an address with SUPER SETDATA permission ', () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
@@ -922,18 +922,18 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlySuperSetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
-        describe("when Adding multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key", () => {
+        describe('when Adding multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
             await expect(
@@ -941,14 +941,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlySuperSetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
       });
 
-      describe("when caller is an address with SETDATA permission with UniversalReceiverDelegate keys as AllowedERC725YDataKeys ", () => {
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+      describe('when caller is an address with SETDATA permission with UniversalReceiverDelegate keys as AllowedERC725YDataKeys ', () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission and UniversalReceiverDelegate keys are not part of AllowedERC725YDataKeys", async () => {
             const payloadParam = {
               dataKeys: [
@@ -963,19 +963,19 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlySetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
 
-        describe("when Adding multiple UniversalReceiverDelegate keys with adding other allowedERC725YDataKey", () => {
+        describe('when Adding multiple UniversalReceiverDelegate keys with adding other allowedERC725YDataKey', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
             await expect(
@@ -983,16 +983,16 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 .connect(canOnlySetData)
                 .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
 
-        describe("When granting the caller ADDUniversalReceiverDelegate permission", () => {
+        describe('When granting the caller ADDUniversalReceiverDelegate permission', () => {
           before(async () => {
             const payloadParam = {
               dataKeys: [
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                   canOnlySetData.address.substring(2),
               ],
               dataValues: [
@@ -1004,17 +1004,17 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               .connect(context.owner)
               .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
           });
-          describe("When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key", () => {
-            it("should pass", async () => {
+          describe('When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key', () => {
+            it('should pass', async () => {
               const payloadParam = {
                 dataKeys: [
                   universalReceiverDelegateKey4,
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
+                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
                 ],
-                dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+                dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
               };
 
-              let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+              let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
                 payloadParam.dataKeys,
                 payloadParam.dataValues,
               ]);

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeOwner.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeOwner.test.ts
@@ -1,19 +1,19 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES } from "../../../../constants";
+import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES } from '../../../../constants';
 
-import { LSP6KeyManager, LSP6KeyManager__factory } from "../../../../types";
+import { LSP6KeyManager, LSP6KeyManager__factory } from '../../../../types';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { provider } from "../../../utils/helpers";
+import { provider } from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOwner = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -28,7 +28,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
   let permissionsValues: string[];
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
 
     canChangeOwner = context.accounts[1];
     cannotChangeOwner = context.accounts[2];
@@ -38,8 +38,8 @@ export const shouldBehaveLikePermissionChangeOwner = (
     );
 
     permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canChangeOwner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canChangeOwner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         cannotChangeOwner.address.substring(2),
     ];
 
@@ -48,48 +48,48 @@ export const shouldBehaveLikePermissionChangeOwner = (
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("when calling `transferOwnership(...)` with the target address as parameter", () => {
-    it("should revert", async () => {
+  describe('when calling `transferOwnership(...)` with the target address as parameter', () => {
+    it('should revert', async () => {
       await expect(
         context.universalProfile
           .connect(canChangeOwner)
           .transferOwnership(context.universalProfile.address),
-      ).to.be.revertedWithCustomError(context.universalProfile, "CannotTransferOwnershipToSelf");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'CannotTransferOwnershipToSelf');
     });
   });
 
-  describe("when calling `transferOwnership(...)` with a new KeyManager address as parameter", () => {
-    describe("when caller does not have have CHANGEOWNER permission", () => {
-      it("should revert", async () => {
+  describe('when calling `transferOwnership(...)` with a new KeyManager address as parameter', () => {
+    describe('when caller does not have have CHANGEOWNER permission', () => {
+      it('should revert', async () => {
         await expect(
           context.universalProfile
             .connect(cannotChangeOwner)
             .transferOwnership(newKeyManager.address),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(cannotChangeOwner.address, "TRANSFEROWNERSHIP");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(cannotChangeOwner.address, 'TRANSFEROWNERSHIP');
       });
     });
 
-    describe("when caller has ALL PERMISSIONS", () => {
-      before("`transferOwnership(...)` to new Key Manager", async () => {
+    describe('when caller has ALL PERMISSIONS', () => {
+      before('`transferOwnership(...)` to new Key Manager', async () => {
         await context.universalProfile
           .connect(context.owner)
           .transferOwnership(newKeyManager.address);
       });
 
-      after("reset ownership", async () => {
+      after('reset ownership', async () => {
         await context.universalProfile
           .connect(context.owner)
           .transferOwnership(ethers.constants.AddressZero);
       });
 
-      it("should have set newKeyManager as pendingOwner", async () => {
+      it('should have set newKeyManager as pendingOwner', async () => {
         let pendingOwner = await context.universalProfile.pendingOwner();
         expect(pendingOwner).to.equal(newKeyManager.address);
       });
 
-      it("owner should remain the current KeyManager", async () => {
+      it('owner should remain the current KeyManager', async () => {
         const ownerBefore = await context.universalProfile.owner();
 
         await context.universalProfile
@@ -102,10 +102,10 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(ownerAfter).to.equal(context.keyManager.address);
       });
 
-      describe("it should still be possible to call onlyOwner functions via the old KeyManager", () => {
-        it("setData(...)", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('it should still be possible to call onlyOwner functions via the old KeyManager', () => {
+        it('setData(...)', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
           await context.universalProfile.connect(context.owner).setData(key, value);
 
@@ -113,16 +113,16 @@ export const shouldBehaveLikePermissionChangeOwner = (
           expect(result).to.equal(value);
         });
 
-        it("execute(...) - LYX transfer", async () => {
+        it('execute(...) - LYX transfer', async () => {
           const recipient = context.accounts[8];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           const recipientBalanceBefore = await provider.getBalance(recipient.address);
           const accountBalanceBefore = await provider.getBalance(context.universalProfile.address);
 
           await context.universalProfile
             .connect(context.owner)
-            .execute(OPERATION_TYPES.CALL, recipient.address, amount, "0x");
+            .execute(OPERATION_TYPES.CALL, recipient.address, amount, '0x');
 
           const recipientBalanceAfter = await provider.getBalance(recipient.address);
           const accountBalanceAfter = await provider.getBalance(context.universalProfile.address);
@@ -135,7 +135,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         });
       });
 
-      it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+      it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
         let overridenPendingOwner = ethers.Wallet.createRandom().address;
 
         await context.universalProfile
@@ -147,25 +147,25 @@ export const shouldBehaveLikePermissionChangeOwner = (
       });
     });
 
-    describe("when caller has only CHANGE0OWNER permission", () => {
-      before("`transferOwnership(...)` to new KeyManager", async () => {
+    describe('when caller has only CHANGE0OWNER permission', () => {
+      before('`transferOwnership(...)` to new KeyManager', async () => {
         await context.universalProfile
           .connect(canChangeOwner)
           .transferOwnership(newKeyManager.address);
       });
 
-      after("reset ownership", async () => {
+      after('reset ownership', async () => {
         await context.universalProfile
           .connect(context.owner)
           .transferOwnership(ethers.constants.AddressZero);
       });
 
-      it("should have set newKeyManager as pendingOwner", async () => {
+      it('should have set newKeyManager as pendingOwner', async () => {
         let pendingOwner = await context.universalProfile.pendingOwner();
         expect(pendingOwner).to.equal(newKeyManager.address);
       });
 
-      it("owner should remain the current KeyManager", async () => {
+      it('owner should remain the current KeyManager', async () => {
         const ownerBefore = await context.universalProfile.owner();
 
         await context.universalProfile
@@ -178,7 +178,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(ownerAfter).to.equal(context.keyManager.address);
       });
 
-      it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+      it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
         let overridenPendingOwner = await new LSP6KeyManager__factory(context.owner).deploy(
           context.universalProfile.address,
         );
@@ -193,21 +193,21 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
   });
 
-  describe("when calling acceptOwnership(...) from a KeyManager that is not the pendingOwner", () => {
-    it("should revert", async () => {
+  describe('when calling acceptOwnership(...) from a KeyManager that is not the pendingOwner', () => {
+    it('should revert', async () => {
       let notPendingKeyManager = await new LSP6KeyManager__factory(context.accounts[5]).deploy(
         context.universalProfile.address,
       );
 
-      let payload = context.universalProfile.interface.getSighash("acceptOwnership");
+      let payload = context.universalProfile.interface.getSighash('acceptOwnership');
 
       await expect(notPendingKeyManager.connect(context.owner).execute(payload)).to.be.revertedWith(
-        "LSP14: caller is not the pendingOwner",
+        'LSP14: caller is not the pendingOwner',
       );
     });
   });
 
-  describe("when calling acceptOwnership(...) via the pending new KeyManager", () => {
+  describe('when calling acceptOwnership(...) via the pending new KeyManager', () => {
     let pendingOwner: string;
 
     before(async () => {
@@ -217,7 +217,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
       pendingOwner = await context.universalProfile.pendingOwner();
 
-      let acceptOwnershipPayload = context.universalProfile.interface.getSighash("acceptOwnership");
+      let acceptOwnershipPayload = context.universalProfile.interface.getSighash('acceptOwnership');
 
       await newKeyManager.connect(context.owner).execute(acceptOwnershipPayload);
     });
@@ -227,57 +227,57 @@ export const shouldBehaveLikePermissionChangeOwner = (
       expect(updatedOwner).to.equal(pendingOwner);
     });
 
-    it("should have cleared the pendingOwner after transfering ownership", async () => {
+    it('should have cleared the pendingOwner after transfering ownership', async () => {
       let newPendingOwner = await context.universalProfile.pendingOwner();
       expect(newPendingOwner).to.equal(ethers.constants.AddressZero);
     });
   });
 
-  describe("after KeyManager has been upgraded via acceptOwnership(...)", () => {
+  describe('after KeyManager has been upgraded via acceptOwnership(...)', () => {
     let oldKeyManager: LSP6KeyManager;
 
     before(async () => {
       oldKeyManager = context.keyManager;
     });
 
-    describe("old KeyManager should not be allowed to call onlyOwner functions anymore", () => {
-      it("should revert with error `NoPermissionsSet` when calling `setData(...)`", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('old KeyManager should not be allowed to call onlyOwner functions anymore', () => {
+      it('should revert with error `NoPermissionsSet` when calling `setData(...)`', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(oldKeyManager.connect(context.owner).execute(payload))
-          .to.be.revertedWithCustomError(newKeyManager, "NoPermissionsSet")
+          .to.be.revertedWithCustomError(newKeyManager, 'NoPermissionsSet')
           .withArgs(oldKeyManager.address);
       });
 
-      it("should revert with error `NoPermissionsSet` when calling `execute(...)`", async () => {
+      it('should revert with error `NoPermissionsSet` when calling `execute(...)`', async () => {
         let recipient = context.accounts[3];
-        let amount = ethers.utils.parseEther("3");
+        let amount = ethers.utils.parseEther('3');
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient.address,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await expect(oldKeyManager.connect(context.owner).execute(payload))
-          .to.be.revertedWithCustomError(newKeyManager, "NoPermissionsSet")
+          .to.be.revertedWithCustomError(newKeyManager, 'NoPermissionsSet')
           .withArgs(oldKeyManager.address);
       });
     });
 
-    describe("new Key Manager should be allowed to call onlyOwner functions", () => {
-      it("setData(...)", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('new Key Manager should be allowed to call onlyOwner functions', () => {
+      it('setData(...)', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -288,18 +288,18 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(result).to.equal(value);
       });
 
-      it("execute(...) - LYX transfer", async () => {
+      it('execute(...) - LYX transfer', async () => {
         const recipient = context.accounts[3];
-        const amount = ethers.utils.parseEther("3");
+        const amount = ethers.utils.parseEther('3');
 
         const recipientBalanceBefore = await provider.getBalance(recipient.address);
         const accountBalanceBefore = await provider.getBalance(context.universalProfile.address);
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient.address,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await newKeyManager.connect(context.owner).execute(payload);
@@ -316,12 +316,12 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
   });
 
-  describe("when calling `renounceOwnership(...)`", () => {
-    it("should revert even if caller has ALL PERMISSIONS`", async () => {
-      let payload = context.universalProfile.interface.getSighash("renounceOwnership");
+  describe('when calling `renounceOwnership(...)`', () => {
+    it('should revert even if caller has ALL PERMISSIONS`', async () => {
+      let payload = context.universalProfile.interface.getSighash('renounceOwnership');
 
       await expect(context.universalProfile.connect(context.owner).renounceOwnership())
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(payload);
     });
   });

--- a/tests/LSP20CallVerification/LSP6/Interactions/AllowedAddresses.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/AllowedAddresses.test.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract, TargetContract__factory } from "../../../../types";
+import { TargetContract, TargetContract__factory } from '../../../../types';
 
 // constants
 import {
@@ -11,11 +11,11 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -36,7 +36,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     notAllowedEOA: SignerWithAddress,
     allowedTargetContract: TargetContract,
     notAllowedTargetContract: TargetContract;
-  const invalidEncodedAllowedCallsValue = "0xbadbadbadbad";
+  const invalidEncodedAllowedCallsValue = '0xbadbadbadbad';
 
   before(async () => {
     context = await buildContext();
@@ -52,14 +52,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     notAllowedTargetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         canCallOnlyTwoAddresses.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         canCallOnlyTwoAddresses.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         invalidEncodedAllowedCalls.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         invalidEncodedAllowedCalls.address.substring(2),
     ];
 
@@ -69,8 +69,8 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
         combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
       ],
       [allowedEOA.address, allowedTargetContract.address],
-      ["0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff'],
     );
 
     let permissionsValues = [
@@ -85,12 +85,12 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
 
     await context.owner.sendTransaction({
       to: context.universalProfile.address,
-      value: ethers.utils.parseEther("10"),
+      value: ethers.utils.parseEther('10'),
     });
   });
 
-  describe("when caller has ALL_DEFAULT_PERMISSIONS + no ALLOWED ADDRESSES set", () => {
-    describe("it should be allowed to interact with any address", () => {
+  describe('when caller has ALL_DEFAULT_PERMISSIONS + no ALLOWED ADDRESSES set', () => {
+    describe('it should be allowed to interact with any address', () => {
       const randomAddresses = getRandomAddresses(5);
 
       randomAddresses.forEach((recipient) => {
@@ -98,7 +98,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
           let initialBalanceEOA = await provider.getBalance(recipient);
 
-          let amount = ethers.utils.parseEther("1");
+          let amount = ethers.utils.parseEther('1');
 
           await context.universalProfile
             .connect(context.owner)
@@ -114,12 +114,12 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     });
   });
 
-  describe("when caller has 2 x addresses set under `AllowedCalls`", () => {
-    it("should be allowed to send LYX to an allowed address (= EOA)", async () => {
+  describe('when caller has 2 x addresses set under `AllowedCalls`', () => {
+    it('should be allowed to send LYX to an allowed address (= EOA)', async () => {
       let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
       let initialBalanceEOA = await provider.getBalance(allowedEOA.address);
 
-      let amount = ethers.utils.parseEther("1");
+      let amount = ethers.utils.parseEther('1');
 
       await context.universalProfile
         .connect(canCallOnlyTwoAddresses)
@@ -132,10 +132,10 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(newBalanceEOA).to.be.gt(initialBalanceEOA);
     });
 
-    it("should be allowed to interact with an allowed address (= contract)", async () => {
-      const argument = "new name";
+    it('should be allowed to interact with an allowed address (= contract)', async () => {
+      const argument = 'new name';
 
-      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData("setName", [
+      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData('setName', [
         argument,
       ]);
 
@@ -147,7 +147,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(result).to.equal(argument);
     });
 
-    it("should revert when sending LYX to a non-allowed address (= EOA)", async () => {
+    it('should revert when sending LYX to a non-allowed address (= EOA)', async () => {
       let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
       let initialBalanceRecipient = await provider.getBalance(notAllowedEOA.address);
 
@@ -157,12 +157,12 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           .execute(
             OPERATION_TYPES.CALL,
             notAllowedEOA.address,
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
             EMPTY_PAYLOAD,
           ),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-        .withArgs(canCallOnlyTwoAddresses.address, notAllowedEOA.address, "0x00000000");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+        .withArgs(canCallOnlyTwoAddresses.address, notAllowedEOA.address, '0x00000000');
 
       let newBalanceUP = await provider.getBalance(context.universalProfile.address);
       let newBalanceRecipient = await provider.getBalance(notAllowedEOA.address);
@@ -171,10 +171,10 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
     });
 
-    it("should revert when interacting with an non-allowed address (= contract)", async () => {
-      const argument = "new name";
+    it('should revert when interacting with an non-allowed address (= contract)', async () => {
+      const argument = 'new name';
 
-      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData("setName", [
+      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData('setName', [
         argument,
       ]);
 
@@ -188,17 +188,17 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
             targetContractPayload,
           ),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
         .withArgs(
           canCallOnlyTwoAddresses.address,
           notAllowedTargetContract.address,
-          notAllowedTargetContract.interface.getSighash("setName"),
+          notAllowedTargetContract.interface.getSighash('setName'),
         );
     });
   });
 
-  describe("when caller has an invalid abi-encoded array set for ALLOWED ADDRESSES", () => {
-    describe("it should not allow to interact with any address", () => {
+  describe('when caller has an invalid abi-encoded array set for ALLOWED ADDRESSES', () => {
+    describe('it should not allow to interact with any address', () => {
       const randomAddresses = getRandomAddresses(5);
 
       randomAddresses.forEach((recipient) => {
@@ -206,14 +206,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           await provider.getBalance(context.universalProfile.address);
           await provider.getBalance(recipient);
 
-          let amount = ethers.utils.parseEther("1");
+          let amount = ethers.utils.parseEther('1');
 
           await expect(
             context.universalProfile
               .connect(invalidEncodedAllowedCalls)
               .execute(OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(invalidEncodedAllowedCallsValue);
         });
       });

--- a/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   LSP7Mintable,
@@ -10,7 +10,7 @@ import {
   LSP8Mintable__factory,
   TargetContract,
   TargetContract__factory,
-} from "../../../../types";
+} from '../../../../types';
 
 // constants
 import {
@@ -20,14 +20,14 @@ import {
   PERMISSIONS,
   INTERFACE_IDS,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from "../../../utils/helpers";
+import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from '../../../utils/helpers';
 
 export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -46,11 +46,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressWithNoAllowedFunctions.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanCallOnlyOneFunction.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanCallOnlyOneFunction.address.substring(2),
     ];
 
@@ -59,23 +59,23 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
       PERMISSIONS.CALL,
       combineAllowedCalls(
         [CALLTYPE.CALL],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
-        ["0xffffffff"],
-        [targetContract.interface.getSighash("setName")],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
+        ['0xffffffff'],
+        [targetContract.interface.getSighash('setName')],
       ),
     ];
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("when interacting via `execute(...)`", () => {
-    describe("when caller has nothing listed under allowedCalls", () => {
-      describe("when calling a contract", () => {
-        it("should revert when calling any function (eg: `setName(...)`)", async () => {
+  describe('when interacting via `execute(...)`', () => {
+    describe('when caller has nothing listed under allowedCalls', () => {
+      describe('when calling a contract', () => {
+        it('should revert when calling any function (eg: `setName(...)`)', async () => {
           let initialName = await targetContract.callStatic.getName();
-          let newName = "Updated Name";
+          let newName = 'Updated Name';
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
             newName,
           ]);
 
@@ -84,14 +84,14 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressWithNoAllowedFunctions)
               .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
             .withArgs(addressWithNoAllowedFunctions.address);
         });
 
-        it("should revert when calling any function (eg: `setNumber(...)`)", async () => {
+        it('should revert when calling any function (eg: `setNumber(...)`)', async () => {
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setNumber", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setNumber', [
             newNumber,
           ]);
 
@@ -100,19 +100,19 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressWithNoAllowedFunctions)
               .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
             .withArgs(addressWithNoAllowedFunctions.address);
         });
       });
     });
 
-    describe("when caller has 1 x bytes4 function selector listed under AllowedFunctions", () => {
-      describe("when calling a contract", () => {
-        it("should pass when the bytes4 selector of the function called is listed in its AllowedFunctions", async () => {
+    describe('when caller has 1 x bytes4 function selector listed under AllowedFunctions', () => {
+      describe('when calling a contract', () => {
+        it('should pass when the bytes4 selector of the function called is listed in its AllowedFunctions', async () => {
           let initialName = await targetContract.callStatic.getName();
-          let newName = "Updated Name";
+          let newName = 'Updated Name';
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
             newName,
           ]);
 
@@ -125,11 +125,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(result).to.equal(newName);
         });
 
-        it("should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions", async () => {
+        it('should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions', async () => {
           let initialNumber = await targetContract.callStatic.getNumber();
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setNumber", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setNumber', [
             newNumber,
           ]);
 
@@ -138,11 +138,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressCanCallOnlyOneFunction)
               .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallOnlyOneFunction.address,
               targetContract.address,
-              targetContract.interface.getSighash("setNumber"),
+              targetContract.interface.getSighash('setNumber'),
             );
 
           let result = await targetContract.callStatic.getNumber();
@@ -151,16 +151,16 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         });
       });
 
-      it("should revert when passing a random bytes payload with a random function selector", async () => {
+      it('should revert when passing a random bytes payload with a random function selector', async () => {
         const randomPayload =
-          "0xbaadca110000000000000000000000000000000000000000000000000000000123456789";
+          '0xbaadca110000000000000000000000000000000000000000000000000000000123456789';
 
         await expect(
           context.universalProfile
             .connect(addressCanCallOnlyOneFunction)
             .execute(OPERATION_TYPES.CALL, targetContract.address, 0, randomPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanCallOnlyOneFunction.address,
             targetContract.address,
@@ -170,16 +170,16 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
     });
   });
 
-  describe("allowed to call only `transfer(...)` function on LSP8 contracts", () => {
+  describe('allowed to call only `transfer(...)` function on LSP8 contracts', () => {
     let addressCanCallOnlyTransferOnLSP8: SignerWithAddress;
     let addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8: SignerWithAddress;
 
     let lsp7Contract: LSP7Mintable;
     let lsp8Contract: LSP8Mintable;
 
-    const tokenIdToTransfer = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+    const tokenIdToTransfer = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
-    const tokenIdToApprove = "0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d";
+    const tokenIdToApprove = '0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d';
 
     before(async () => {
       context = await buildContext();
@@ -188,27 +188,27 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
       addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8 = context.accounts[2];
 
       lsp7Contract = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-        "LSP7 Token",
-        "TKN",
+        'LSP7 Token',
+        'TKN',
         context.accounts[0].address,
         false,
       );
 
       lsp8Contract = await new LSP8Mintable__factory(context.accounts[0]).deploy(
-        "LSP8 NFT",
-        "NFT",
+        'LSP8 NFT',
+        'NFT',
         context.accounts[0].address,
       );
 
       await lsp7Contract
         .connect(context.accounts[0])
-        .mint(context.universalProfile.address, 100, false, "0x");
+        .mint(context.universalProfile.address, 100, false, '0x');
 
       // mint some NFTs for the UP
       [tokenIdToTransfer, tokenIdToApprove].forEach(async (tokenId) => {
         await lsp8Contract
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, tokenId, true, "0x");
+          .mint(context.universalProfile.address, tokenId, true, '0x');
       });
 
       await lsp7Contract
@@ -216,13 +216,13 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         .transferOwnership(context.universalProfile.address);
 
       let permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanCallOnlyTransferOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanCallOnlyTransferOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address.substring(2),
       ];
 
@@ -231,36 +231,36 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         // LSP8:ANY:transfer(…)
         combineAllowedCalls(
           [CALLTYPE.CALL],
-          ["0xffffffffffffffffffffffffffffffffffffffff"],
+          ['0xffffffffffffffffffffffffffffffffffffffff'],
           [INTERFACE_IDS.LSP8IdentifiableDigitalAsset],
-          [lsp8Contract.interface.getSighash("transfer")],
+          [lsp8Contract.interface.getSighash('transfer')],
         ),
         PERMISSIONS.CALL,
         // LSP7:ANY:ANY + LSP8:ANY: authorizeOperator(…)
         combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.LSP8IdentifiableDigitalAsset],
-          ["0xffffffff", lsp8Contract.interface.getSighash("authorizeOperator")],
+          ['0xffffffff', lsp8Contract.interface.getSighash('authorizeOperator')],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when caller can only call `transfer(...)` on LSP8 contracts only", () => {
-      it("should pass when calling `transfer(...)` on LSP8 contract", async () => {
+    describe('when caller can only call `transfer(...)` on LSP8 contracts only', () => {
+      it('should pass when calling `transfer(...)` on LSP8 contract', async () => {
         const recipient = context.accounts[5].address;
 
-        let transferPayload = lsp8Contract.interface.encodeFunctionData("transfer", [
+        let transferPayload = lsp8Contract.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           tokenIdToTransfer,
           true,
-          "0x",
+          '0x',
         ]);
 
         await context.universalProfile
@@ -270,11 +270,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         expect(await lsp8Contract.tokenOwnerOf(tokenIdToTransfer)).to.equal(recipient);
       });
 
-      it("should revert when calling `authorizeOperator(...)` on LSP8 contract", async () => {
+      it('should revert when calling `authorizeOperator(...)` on LSP8 contract', async () => {
         const operator = context.accounts[8].address;
 
         const authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-          "authorizeOperator",
+          'authorizeOperator',
           [operator, tokenIdToApprove],
         );
 
@@ -283,26 +283,26 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
             .connect(addressCanCallOnlyTransferOnLSP8)
             .execute(OPERATION_TYPES.CALL, lsp8Contract.address, 0, authorizeOperatorPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanCallOnlyTransferOnLSP8.address,
             lsp8Contract.address,
-            lsp8Contract.interface.getSighash("authorizeOperator"),
+            lsp8Contract.interface.getSighash('authorizeOperator'),
           );
       });
     });
 
-    describe("when caller can all any functions on LSP7 contracts, but only `authorizeOperator(...)` on LSP8 contracts", () => {
-      describe("when interacting with LSP7 contract", () => {
-        it("should pass when calling `mint(...)`", async () => {
+    describe('when caller can all any functions on LSP7 contracts, but only `authorizeOperator(...)` on LSP8 contracts', () => {
+      describe('when interacting with LSP7 contract', () => {
+        it('should pass when calling `mint(...)`', async () => {
           let recipient = context.accounts[4].address;
           const amount = 10;
 
-          let mintPayload = lsp7Contract.interface.encodeFunctionData("mint", [
+          let mintPayload = lsp7Contract.interface.encodeFunctionData('mint', [
             recipient,
             amount,
             true,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -312,7 +312,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(await lsp7Contract.balanceOf(recipient)).to.equal(amount);
         });
 
-        it("should pass when calling `transfer(...)`", async () => {
+        it('should pass when calling `transfer(...)`', async () => {
           let recipient = context.accounts[4].address;
 
           const previousUPTokenBalance = await lsp7Contract.balanceOf(
@@ -323,12 +323,12 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
 
           const amount = 10;
 
-          let transferPayload = lsp7Contract.interface.encodeFunctionData("transfer", [
+          let transferPayload = lsp7Contract.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             recipient,
             amount,
             true,
-            "0x",
+            '0x',
           ]);
 
           await context.universalProfile
@@ -346,12 +346,12 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           );
         });
 
-        it("should pass when calling `authorizeOperator(...)`", async () => {
+        it('should pass when calling `authorizeOperator(...)`', async () => {
           let operator = context.accounts[6].address;
           const amount = 10;
 
           let authorizeOperatorPayload = lsp7Contract.interface.encodeFunctionData(
-            "authorizeOperator",
+            'authorizeOperator',
             [operator, amount],
           );
 
@@ -364,12 +364,12 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           ).to.equal(amount);
         });
 
-        it("should pass when calling `setData(...)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Token Icon"));
+        it('should pass when calling `setData(...)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Token Icon'));
 
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(":)"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(':)'));
 
-          let setDataPayload = lsp7Contract.interface.encodeFunctionData("setData", [key, value]);
+          let setDataPayload = lsp7Contract.interface.encodeFunctionData('setData', [key, value]);
 
           await context.universalProfile
             .connect(addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8)
@@ -379,12 +379,12 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         });
       });
 
-      describe("when interacting lsp8 contract", async () => {
-        it("should pass when calling `authorizeOperator(...)`", async () => {
+      describe('when interacting lsp8 contract', async () => {
+        it('should pass when calling `authorizeOperator(...)`', async () => {
           let recipient = context.accounts[4].address;
 
           let authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-            "authorizeOperator",
+            'authorizeOperator',
             [recipient, tokenIdToApprove],
           );
 
@@ -395,15 +395,15 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(await lsp8Contract.isOperatorFor(recipient, tokenIdToApprove)).to.be.true;
         });
 
-        it("should revert when calling `transfer(...)`", async () => {
+        it('should revert when calling `transfer(...)`', async () => {
           let recipient = context.accounts[4].address;
 
-          let transferPayload = lsp8Contract.interface.encodeFunctionData("transfer", [
+          let transferPayload = lsp8Contract.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             recipient,
             tokenIdToTransfer,
             true,
-            "0x",
+            '0x',
           ]);
 
           await expect(
@@ -411,23 +411,23 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8)
               .execute(OPERATION_TYPES.CALL, lsp8Contract.address, 0, transferPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address,
               lsp8Contract.address,
-              lsp8Contract.interface.getSighash("transfer"),
+              lsp8Contract.interface.getSighash('transfer'),
             );
         });
 
-        it("should revert when calling `mint(...)`", async () => {
+        it('should revert when calling `mint(...)`', async () => {
           const randomTokenId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
           let recipient = context.accounts[4].address;
-          let mintPayload = lsp8Contract.interface.encodeFunctionData("mint", [
+          let mintPayload = lsp8Contract.interface.encodeFunctionData('mint', [
             recipient,
             randomTokenId,
             true,
-            "0x",
+            '0x',
           ]);
 
           await expect(
@@ -435,11 +435,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8)
               .execute(OPERATION_TYPES.CALL, lsp8Contract.address, 0, mintPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address,
               lsp8Contract.address,
-              lsp8Contract.interface.getSighash("mint"),
+              lsp8Contract.interface.getSighash('mint'),
             );
         });
       });

--- a/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
@@ -1,6 +1,6 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   SignatureValidator,
@@ -11,7 +11,7 @@ import {
   UniversalProfile__factory,
   LSP7Mintable,
   LSP7Mintable__factory,
-} from "../../../../types";
+} from '../../../../types';
 
 // constants
 import {
@@ -22,11 +22,11 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
@@ -35,7 +35,7 @@ import {
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -64,14 +64,14 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     );
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithLSP7.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanInteractOnlyWithLSP7.address.substring(2),
     ];
 
@@ -81,15 +81,15 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
       combineAllowedCalls(
         [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
         [INTERFACE_IDS.ERC1271],
-        ["0xffffffff"],
+        ['0xffffffff'],
       ),
       combineAllowedCalls(
         [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
         [INTERFACE_IDS.LSP7DigitalAsset],
-        ["0xffffffff"],
+        ['0xffffffff'],
       ),
     ];
 
@@ -97,14 +97,14 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
 
     await context.owner.sendTransaction({
       to: context.universalProfile.address,
-      value: ethers.utils.parseEther("10"),
+      value: ethers.utils.parseEther('10'),
     });
   });
 
-  describe("when caller has no value set for ALLOWEDSTANDARDS (= all interfaces whitelisted)", () => {
-    it("should allow to interact with contract that does not implement any interface", async () => {
-      let newName = "Some Name";
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", [newName]);
+  describe('when caller has no value set for ALLOWEDSTANDARDS (= all interfaces whitelisted)', () => {
+    it('should allow to interact with contract that does not implement any interface', async () => {
+      let newName = 'Some Name';
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', [newName]);
 
       await context.universalProfile
         .connect(context.owner)
@@ -114,12 +114,12 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       expect(result).to.equal(newName);
     });
 
-    describe("should allow to interact with a contract that implement (+ register) any interface", () => {
-      it("ERC1271", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await context.owner.signMessage("Sample Message");
+    describe('should allow to interact with a contract that implement (+ register) any interface', () => {
+      it('ERC1271', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await context.owner.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
@@ -128,29 +128,29 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           .connect(context.owner)
           .callStatic.execute(OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload);
 
-        let [result] = abiCoder.decode(["bytes4"], data);
+        let [result] = abiCoder.decode(['bytes4'], data);
         expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
 
-      it("LSP0 (ERC725Account)", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key"));
-        let value = "0xcafecafecafecafe";
+      it('LSP0 (ERC725Account)', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key'));
+        let value = '0xcafecafecafecafe';
 
         await context.universalProfile.connect(context.owner).setData(key, value);
 
-        const result = await context.universalProfile.callStatic["getData(bytes32)"](key);
+        const result = await context.universalProfile.callStatic['getData(bytes32)'](key);
         expect(result).to.equal(value);
       });
     });
   });
 
-  describe("when caller has only ERC1271 interface ID set for ALLOWED STANDARDS", () => {
-    describe("when interacting with a contract that implements + register ERC1271 interface", () => {
-      it("should pass", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await addressCanInteractOnlyWithERC1271.signMessage("Sample Message");
+  describe('when caller has only ERC1271 interface ID set for ALLOWED STANDARDS', () => {
+    describe('when interacting with a contract that implements + register ERC1271 interface', () => {
+      it('should pass', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await addressCanInteractOnlyWithERC1271.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
@@ -159,13 +159,13 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           .connect(addressCanInteractOnlyWithERC1271)
           .callStatic.execute(OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload);
 
-        let [result] = abiCoder.decode(["bytes4"], data);
+        let [result] = abiCoder.decode(['bytes4'], data);
         expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
     });
 
-    describe("when trying to interact an ERC725Account (LSP0)", () => {
-      it("should allow to transfer LYX", async () => {
+    describe('when trying to interact an ERC725Account (LSP0)', () => {
+      it('should allow to transfer LYX', async () => {
         let initialAccountBalance = await provider.getBalance(otherUniversalProfile.address);
 
         await context.universalProfile
@@ -173,8 +173,8 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           .execute(
             OPERATION_TYPES.CALL,
             otherUniversalProfile.address,
-            ethers.utils.parseEther("1"),
-            "0x",
+            ethers.utils.parseEther('1'),
+            '0x',
           );
 
         let newAccountBalance = await provider.getBalance(otherUniversalProfile.address);
@@ -182,32 +182,32 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       });
     });
 
-    describe("when interacting with contract that does not implement ERC1271", () => {
-      it("should fail", async () => {
-        let targetPayload = targetContract.interface.encodeFunctionData("setName", ["New Name"]);
+    describe('when interacting with contract that does not implement ERC1271', () => {
+      it('should fail', async () => {
+        let targetPayload = targetContract.interface.encodeFunctionData('setName', ['New Name']);
 
         await expect(
           context.universalProfile
             .connect(addressCanInteractOnlyWithERC1271)
             .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithERC1271.address,
             targetContract.address,
-            targetContract.interface.getSighash("setName"),
+            targetContract.interface.getSighash('setName'),
           );
       });
     });
   });
 
-  describe("when caller has only LSP7 interface ID set for ALLOWED STANDARDS", () => {
-    describe("when interacting with a contract that implements + register ERC1271 interface", () => {
-      it("should fail", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await addressCanInteractOnlyWithLSP7.signMessage("Sample Message");
+  describe('when caller has only LSP7 interface ID set for ALLOWED STANDARDS', () => {
+    describe('when interacting with a contract that implements + register ERC1271 interface', () => {
+      it('should fail', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await addressCanInteractOnlyWithLSP7.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
@@ -217,86 +217,86 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
             .connect(addressCanInteractOnlyWithLSP7)
             .execute(OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithLSP7.address,
             signatureValidatorContract.address,
-            signatureValidatorContract.interface.getSighash("isValidSignature"),
+            signatureValidatorContract.interface.getSighash('isValidSignature'),
           );
       });
     });
 
-    describe("when interacting with an ERC725Account (LSP0)", () => {
-      it("should fail when trying to transfer LYX", async () => {
+    describe('when interacting with an ERC725Account (LSP0)', () => {
+      it('should fail when trying to transfer LYX', async () => {
         await expect(
           context.universalProfile
             .connect(addressCanInteractOnlyWithLSP7)
             .execute(
               OPERATION_TYPES.CALL,
               otherUniversalProfile.address,
-              ethers.utils.parseEther("1"),
-              "0x",
+              ethers.utils.parseEther('1'),
+              '0x',
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithLSP7.address,
             otherUniversalProfile.address,
-            "0x00000000",
+            '0x00000000',
           );
       });
     });
 
-    describe("should be allowed to interact with any LSP7 token contracts", () => {
+    describe('should be allowed to interact with any LSP7 token contracts', () => {
       let lsp7TokenA: LSP7Mintable;
       let lsp7TokenB: LSP7Mintable;
       let lsp7TokenC: LSP7Mintable;
 
       before(async () => {
         lsp7TokenA = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token A",
-          "TKNA",
+          'LSP7 Token A',
+          'TKNA',
           context.accounts[0].address,
           false,
         );
 
         lsp7TokenB = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token B",
-          "TKNB",
+          'LSP7 Token B',
+          'TKNB',
           context.accounts[0].address,
           false,
         );
 
         lsp7TokenC = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token C",
-          "TKNC",
+          'LSP7 Token C',
+          'TKNC',
           context.accounts[0].address,
           false,
         );
 
         await lsp7TokenA
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
 
         await lsp7TokenB
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
 
         await lsp7TokenC
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
       });
 
-      it("-> interacting with lsp7TokenA", async () => {
+      it('-> interacting with lsp7TokenA', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenA.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenA.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
         await context.universalProfile
@@ -307,16 +307,16 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         expect(await lsp7TokenA.balanceOf(context.universalProfile.address)).to.equal(90);
       });
 
-      it("-> interacting with lsp7TokenB", async () => {
+      it('-> interacting with lsp7TokenB', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenB.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenB.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
         await context.universalProfile
@@ -327,16 +327,16 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         expect(await lsp7TokenB.balanceOf(context.universalProfile.address)).to.equal(90);
       });
 
-      it("-> interacting with lsp7TokenC", async () => {
+      it('-> interacting with lsp7TokenC', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenC.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenC.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
         await context.universalProfile

--- a/tests/LSP20CallVerification/LSP6/Interactions/OtherScenarios.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/OtherScenarios.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract__factory, TargetContract } from "../../../../types";
+import { TargetContract__factory, TargetContract } from '../../../../types';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from "../../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -24,8 +24,8 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeCall.address.substring(2),
     ];
 
@@ -34,9 +34,9 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("wrong operation type", () => {
-    it("Should revert because of wrong operation type when caller has ALL PERMISSIONS", async () => {
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+  describe('wrong operation type', () => {
+    it('Should revert because of wrong operation type when caller has ALL PERMISSIONS', async () => {
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
       const INVALID_OPERATION_TYPE = 8;
 
@@ -44,11 +44,11 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
         context.universalProfile
           .connect(context.owner)
           .execute(INVALID_OPERATION_TYPE, targetContract.address, 0, targetPayload),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_UnknownOperationType");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });
 
-    it("Should revert because of wrong operation type when caller has not ALL PERMISSIONS", async () => {
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+    it('Should revert because of wrong operation type when caller has not ALL PERMISSIONS', async () => {
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
       const INVALID_OPERATION_TYPE = 8;
 
@@ -56,7 +56,7 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
         context.universalProfile
           .connect(addressCanMakeCall)
           .execute(INVALID_OPERATION_TYPE, targetContract.address, 0, targetPayload),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_UnknownOperationType");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });
   });
 };

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   FallbackInitializer,
@@ -10,7 +10,7 @@ import {
   FallbackRevert__factory,
   TargetContract,
   TargetContract__factory,
-} from "../../../../types";
+} from '../../../../types';
 
 // constants
 import {
@@ -20,19 +20,19 @@ import {
   LSP6_VERSION,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { abiCoder, combineAllowedCalls } from "../../../utils/helpers";
+import { abiCoder, combineAllowedCalls } from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
-  describe("when making an empty call via `ERC25X.execute(...)` -> (`data` = `0x`, `value` = 0)", () => {
+  describe('when making an empty call via `ERC25X.execute(...)` -> (`data` = `0x`, `value` = 0)', () => {
     let addressCanMakeCallNoAllowedCalls: SignerWithAddress,
       addressCanMakeCallWithAllowedCalls: SignerWithAddress,
       addressCannotMakeCallNoAllowedCalls: SignerWithAddress,
@@ -64,19 +64,19 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       ).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithSuperCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCannotMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
       ];
 
@@ -87,8 +87,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           allowedContractWithFallback.address,
           allowedContractWithFallbackRevert.address,
         ],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
       );
 
       const permissionsValues = [
@@ -104,147 +104,147 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    describe("when caller does not have permission CALL and no Allowed Calls", () => {
-      it("should fail with `NotAuthorised` error when `to` is an EOA", async () => {
+    describe('when caller does not have permission CALL and no Allowed Calls', () => {
+      it('should fail with `NotAuthorised` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
         await expect(
           context.universalProfile
             .connect(addressCannotMakeCallNoAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetEOA, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetEOA, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallNoAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallNoAllowedCalls.address, 'CALL');
       });
 
-      it("should fail with `NotAuthorised` error when `to` is a contract", async () => {
+      it('should fail with `NotAuthorised` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(
           context.universalProfile
             .connect(addressCannotMakeCallNoAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallNoAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallNoAllowedCalls.address, 'CALL');
       });
     });
 
-    describe("when caller does not have permission CALL but have some Allowed Calls", () => {
-      it("should fail with `NotAuthorised` error when `to` is an EOA", async () => {
+    describe('when caller does not have permission CALL but have some Allowed Calls', () => {
+      it('should fail with `NotAuthorised` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
         await expect(
           context.universalProfile
             .connect(addressCannotMakeCallWithAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetEOA, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetEOA, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallWithAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallWithAllowedCalls.address, 'CALL');
       });
 
-      it("should fail with `NotAuthorised` error when `to` is a contract", async () => {
+      it('should fail with `NotAuthorised` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
         await expect(
           context.universalProfile
             .connect(addressCannotMakeCallWithAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallWithAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallWithAllowedCalls.address, 'CALL');
       });
     });
 
-    describe("when caller has permission CALL, but no Allowed Calls", () => {
-      it("should fail with `NoCallsAllowed` error when `to` is an EOA", async () => {
+    describe('when caller has permission CALL, but no Allowed Calls', () => {
+      it('should fail with `NoCallsAllowed` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
         await expect(
           context.universalProfile
             .connect(addressCanMakeCallNoAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetEOA, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetEOA, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
           .withArgs(addressCanMakeCallNoAllowedCalls.address);
       });
 
-      it("should fail with `NoCallsAllowed` error when `to` is a contract", async () => {
+      it('should fail with `NoCallsAllowed` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
         await expect(
           context.universalProfile
             .connect(addressCanMakeCallNoAllowedCalls)
-            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, "0x"),
+            .execute(OPERATION_TYPES.CALL, targetContract.address, 0, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
           .withArgs(addressCanMakeCallNoAllowedCalls.address);
       });
     });
 
-    describe("when caller has permission CALL with some Allowed Calls", () => {
-      describe("when `to` is an EOA", () => {
-        describe("when `to` is NOT in the list of Allowed Calls", () => {
-          it("should fail with `NotAllowedCall` error", async () => {
+    describe('when caller has permission CALL with some Allowed Calls', () => {
+      describe('when `to` is an EOA', () => {
+        describe('when `to` is NOT in the list of Allowed Calls', () => {
+          it('should fail with `NotAllowedCall` error', async () => {
             const targetEOA = ethers.Wallet.createRandom().address;
 
             await expect(
               context.universalProfile
                 .connect(addressCanMakeCallWithAllowedCalls)
-                .execute(OPERATION_TYPES.CALL, targetEOA, 0, "0x"),
+                .execute(OPERATION_TYPES.CALL, targetEOA, 0, '0x'),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-              .withArgs(addressCanMakeCallWithAllowedCalls.address, targetEOA, "0x00000000");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+              .withArgs(addressCanMakeCallWithAllowedCalls.address, targetEOA, '0x00000000');
           });
         });
 
-        describe("when `to` is in the list of Allowed Calls", () => {
-          it("should pass", async () => {
+        describe('when `to` is in the list of Allowed Calls', () => {
+          it('should pass', async () => {
             const tx = context.universalProfile
               .connect(addressCanMakeCallWithAllowedCalls)
-              .execute(OPERATION_TYPES.CALL, allowedEOA, 0, "0x");
+              .execute(OPERATION_TYPES.CALL, allowedEOA, 0, '0x');
 
             await expect(tx).to.not.be.reverted;
 
             expect(tx)
-              .to.emit(context.keyManager, "VerifiedCall")
-              .withArgs(addressCanMakeCallWithAllowedCalls.address, 0, "0x00000000");
+              .to.emit(context.keyManager, 'VerifiedCall')
+              .withArgs(addressCanMakeCallWithAllowedCalls.address, 0, '0x00000000');
           });
         });
       });
 
-      describe("when `to` is a contract", () => {
-        describe("when `to` is NOT in the list of Allowed Calls", () => {
-          it("should fail with `NotAllowedCall` error", async () => {
+      describe('when `to` is a contract', () => {
+        describe('when `to` is NOT in the list of Allowed Calls', () => {
+          it('should fail with `NotAllowedCall` error', async () => {
             const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
             await expect(
               context.universalProfile
                 .connect(addressCanMakeCallWithAllowedCalls)
-                .execute(OPERATION_TYPES.CALL, targetContract.address, 0, "0x"),
+                .execute(OPERATION_TYPES.CALL, targetContract.address, 0, '0x'),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
               .withArgs(
                 addressCanMakeCallWithAllowedCalls.address,
                 targetContract.address,
-                "0x00000000",
+                '0x00000000',
               );
           });
         });
 
-        describe("when `to` is in the list of Allowed Calls", () => {
-          describe("if the `fallback()` function of `to` update some state", () => {
+        describe('when `to` is in the list of Allowed Calls', () => {
+          describe('if the `fallback()` function of `to` update some state', () => {
             it("should pass and update `to` contract's storage", async () => {
               await context.universalProfile
                 .connect(addressCanMakeCallWithAllowedCalls)
-                .execute(OPERATION_TYPES.CALL, allowedContractWithFallback.address, 0, "0x");
+                .execute(OPERATION_TYPES.CALL, allowedContractWithFallback.address, 0, '0x');
 
               expect(await allowedContractWithFallback.caller()).to.equal(
                 context.universalProfile.address,
@@ -252,8 +252,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             });
           });
 
-          describe("if the `fallback()` function of `to` reverts", () => {
-            it("should fail and bubble the error back to the Key Manager", async () => {
+          describe('if the `fallback()` function of `to` reverts', () => {
+            it('should fail and bubble the error back to the Key Manager', async () => {
               await expect(
                 context.universalProfile
                   .connect(addressCanMakeCallWithAllowedCalls)
@@ -261,26 +261,26 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                     OPERATION_TYPES.CALL,
                     allowedContractWithFallbackRevert.address,
                     0,
-                    "0x",
+                    '0x',
                   ),
-              ).to.be.revertedWith("fallback reverted");
+              ).to.be.revertedWith('fallback reverted');
             });
           });
         });
       });
     });
 
-    describe("when caller has permission SUPER_CALL", () => {
-      it("should pass and allow to call an EOA", async () => {
+    describe('when caller has permission SUPER_CALL', () => {
+      it('should pass and allow to call an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
         await context.universalProfile
           .connect(addressWithSuperCall)
-          .execute(OPERATION_TYPES.CALL, targetEOA, 0, "0x");
+          .execute(OPERATION_TYPES.CALL, targetEOA, 0, '0x');
       });
 
-      describe("when `to` is a contract", () => {
-        describe("if the `fallback()` function of `to` update some state", () => {
+      describe('when `to` is a contract', () => {
+        describe('if the `fallback()` function of `to` update some state', () => {
           it("should pass and update `to` contract's storage", async () => {
             const targetContractWithFallback = await new FallbackInitializer__factory(
               context.accounts[0],
@@ -288,7 +288,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
 
             await context.universalProfile
               .connect(addressWithSuperCall)
-              .execute(OPERATION_TYPES.CALL, targetContractWithFallback.address, 0, "0x");
+              .execute(OPERATION_TYPES.CALL, targetContractWithFallback.address, 0, '0x');
 
             expect(await targetContractWithFallback.caller()).to.equal(
               context.universalProfile.address,
@@ -296,8 +296,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           });
         });
 
-        describe("if the `fallback()` function of `to` reverts", () => {
-          it("should fail and bubble the error back to the Key Manager", async () => {
+        describe('if the `fallback()` function of `to` reverts', () => {
+          it('should fail and bubble the error back to the Key Manager', async () => {
             const targetContractWithFallbackRevert = await new FallbackRevert__factory(
               context.accounts[0],
             ).deploy();
@@ -305,15 +305,15 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             await expect(
               context.universalProfile
                 .connect(addressWithSuperCall)
-                .execute(OPERATION_TYPES.CALL, targetContractWithFallbackRevert.address, 0, "0x"),
-            ).to.be.revertedWith("fallback reverted");
+                .execute(OPERATION_TYPES.CALL, targetContractWithFallbackRevert.address, 0, '0x'),
+            ).to.be.revertedWith('fallback reverted');
           });
         });
       });
     });
   });
 
-  describe("when making a ERC25X.execute(...) call with some `data` payload", () => {
+  describe('when making a ERC25X.execute(...) call with some `data` payload', () => {
     let addressCanMakeCallNoAllowedCalls: SignerWithAddress,
       addressCanMakeCallWithAllowedCalls: SignerWithAddress,
       addressCannotMakeCall: SignerWithAddress;
@@ -330,14 +330,14 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
       ];
 
@@ -349,8 +349,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
         combineAllowedCalls(
           [CALLTYPE.CALL],
           [targetContract.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
@@ -358,18 +358,18 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
     });
 
     describe("when the 'offset' of the `data` payload is not `0x00...80`", () => {
-      it("should revert", async () => {
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should revert', async () => {
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0xcafecafe",
+          '0xcafecafe',
         ]);
 
         // edit the `data` offset
         payload = payload.replace(
-          "0000000000000000000000000000000000000000000000000000000000000080",
-          "0000000000000000000000000000000000000000000000000000000000000040",
+          '0000000000000000000000000000000000000000000000000000000000000080',
+          '0000000000000000000000000000000000000000000000000000000000000040',
         );
 
         await expect(
@@ -378,17 +378,17 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             data: payload,
           }),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
           .withArgs(payload);
       });
     });
 
-    describe("when interacting via `execute(...)`", () => {
-      describe("when caller has ALL PERMISSIONS", () => {
-        it("should pass and change state at the target contract", async () => {
-          let argument = "new name";
+    describe('when interacting via `execute(...)`', () => {
+      describe('when caller has ALL PERMISSIONS', () => {
+        it('should pass and change state at the target contract', async () => {
+          let argument = 'new name';
 
-          let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+          let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
           await context.universalProfile
             .connect(context.owner)
@@ -398,11 +398,11 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           expect(result).to.equal(argument);
         });
 
-        describe("when calling a function that returns some value", () => {
-          it("should return the value to the Key Manager <- UP <- targetContract.getName()", async () => {
+        describe('when calling a function that returns some value', () => {
+          it('should return the value to the Key Manager <- UP <- targetContract.getName()', async () => {
             let expectedName = await targetContract.callStatic.getName();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+            let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
             let result = await context.universalProfile
               .connect(context.owner)
@@ -413,14 +413,14 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 targetContractPayload,
               );
 
-            let [decodedResult] = abiCoder.decode(["string"], result);
+            let [decodedResult] = abiCoder.decode(['string'], result);
             expect(decodedResult).to.equal(expectedName);
           });
 
-          it("Should return the value to the Key Manager <- UP <- targetContract.getNumber()", async () => {
+          it('Should return the value to the Key Manager <- UP <- targetContract.getNumber()', async () => {
             let expectedNumber = await targetContract.callStatic.getNumber();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("getNumber");
+            let targetContractPayload = targetContract.interface.encodeFunctionData('getNumber');
 
             let result = await context.universalProfile
               .connect(context.owner)
@@ -431,14 +431,14 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 targetContractPayload,
               );
 
-            let [decodedResult] = abiCoder.decode(["uint256"], result);
+            let [decodedResult] = abiCoder.decode(['uint256'], result);
             expect(decodedResult).to.equal(expectedNumber);
           });
         });
 
-        describe("when calling a function that reverts", () => {
-          it("should revert", async () => {
-            let targetContractPayload = targetContract.interface.encodeFunctionData("revertCall");
+        describe('when calling a function that reverts', () => {
+          it('should revert', async () => {
+            let targetContractPayload = targetContract.interface.encodeFunctionData('revertCall');
 
             await expect(
               context.universalProfile.execute(
@@ -447,33 +447,33 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 0,
                 targetContractPayload,
               ),
-            ).to.be.revertedWith("TargetContract:revertCall: this function has reverted!");
+            ).to.be.revertedWith('TargetContract:revertCall: this function has reverted!');
           });
         });
       });
 
-      describe("when caller has permission CALL", () => {
-        describe("when caller has no allowed calls set", () => {
-          it("should revert with `NotAllowedCall(...)` error", async () => {
-            let argument = "another name";
+      describe('when caller has permission CALL', () => {
+        describe('when caller has no allowed calls set', () => {
+          it('should revert with `NotAllowedCall(...)` error', async () => {
+            let argument = 'another name';
 
-            let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+            let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
             await expect(
               context.universalProfile
                 .connect(addressCanMakeCallNoAllowedCalls)
                 .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
               .withArgs(addressCanMakeCallNoAllowedCalls.address);
           });
         });
 
-        describe("when caller has some allowed calls set", () => {
-          it("should pass and change state at the target contract", async () => {
-            let argument = "another name";
+        describe('when caller has some allowed calls set', () => {
+          it('should pass and change state at the target contract', async () => {
+            let argument = 'another name';
 
-            let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+            let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
             await context.universalProfile
               .connect(addressCanMakeCallWithAllowedCalls)
@@ -485,19 +485,19 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
         });
       });
 
-      describe("when caller does not have permission CALL", () => {
-        it("should revert", async () => {
-          let argument = "another name";
+      describe('when caller does not have permission CALL', () => {
+        it('should revert', async () => {
+          let argument = 'another name';
 
-          let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+          let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
           await expect(
             context.universalProfile
               .connect(addressCannotMakeCall)
               .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(addressCannotMakeCall.address, "CALL");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(addressCannotMakeCall.address, 'CALL');
         });
       });
     });

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionDelegateCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionDelegateCall.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { ERC725YDelegateCall, ERC725YDelegateCall__factory } from "../../../../types";
+import { ERC725YDelegateCall, ERC725YDelegateCall__factory } from '../../../../types';
 
 // constants
 import {
@@ -10,21 +10,21 @@ import {
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { combineAllowedCalls } from "../../../utils/helpers";
+import { combineAllowedCalls } from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionDelegateCall = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed", () => {
+  describe('when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed', () => {
     let addressCanDelegateCall: SignerWithAddress, addressCannotDelegateCall: SignerWithAddress;
 
     let erc725YDelegateCallContract: ERC725YDelegateCall;
@@ -40,10 +40,10 @@ export const shouldBehaveLikePermissionDelegateCall = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanDelegateCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotDelegateCall.address.substring(2),
       ];
 
@@ -52,19 +52,19 @@ export const shouldBehaveLikePermissionDelegateCall = (
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    it("should revert even if caller has ALL PERMISSIONS", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert even if caller has ALL PERMISSIONS', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
+        'updateStorage',
         [key, value],
       );
 
@@ -77,22 +77,22 @@ export const shouldBehaveLikePermissionDelegateCall = (
             0,
             delegateCallPayload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
 
-    it("should revert even if caller has permission DELEGATECALL", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert even if caller has permission DELEGATECALL', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
+        'updateStorage',
         [key, value],
       );
 
@@ -105,22 +105,22 @@ export const shouldBehaveLikePermissionDelegateCall = (
             0,
             delegateCallPayload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
 
-    it("should revert with operation disallowed, even if caller does not have permission DELEGATECALL", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert with operation disallowed, even if caller does not have permission DELEGATECALL', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "setDataBatch",
+        'setDataBatch',
         [[key], [value]],
       );
 
@@ -133,11 +133,11 @@ export const shouldBehaveLikePermissionDelegateCall = (
             0,
             delegateCallPayload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
   });
 
-  describe("when caller has permission SUPER_DELEGATECALL + 2 x allowed addresses", () => {
+  describe('when caller has permission SUPER_DELEGATECALL + 2 x allowed addresses', () => {
     let caller: SignerWithAddress;
 
     let allowedDelegateCallContracts: [ERC725YDelegateCall, ERC725YDelegateCall];
@@ -157,8 +157,8 @@ export const shouldBehaveLikePermissionDelegateCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionValues = [
@@ -166,15 +166,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
         combineAllowedCalls(
           [CALLTYPE.DELEGATECALL, CALLTYPE.DELEGATECALL],
           [allowedDelegateCallContracts[0].address, allowedDelegateCallContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when calling a disallowed contract", () => {
+    describe('when calling a disallowed contract', () => {
       let randomContracts: ERC725YDelegateCall[];
 
       before(async () => {
@@ -197,14 +197,14 @@ export const shouldBehaveLikePermissionDelegateCall = (
         ];
       });
 
-      describe("it should revert since DELEGATECALL is disallowed", () => {
+      describe('it should revert since DELEGATECALL is disallowed', () => {
         for (let ii = 0; ii < 5; ii++) {
           it(`delegate call to contract nb ${ii}`, async () => {
-            const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-            const value = "0xbbbbbbbbbbbbbbbb";
+            const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+            const value = '0xbbbbbbbbbbbbbbbb';
 
-            const currentStorage = await context.universalProfile["getData(bytes32)"](key);
-            expect(currentStorage).to.equal("0x");
+            const currentStorage = await context.universalProfile['getData(bytes32)'](key);
+            expect(currentStorage).to.equal('0x');
 
             // prettier-ignore
             let delegateCallPayload = randomContracts[ii].interface.encodeFunctionData(
@@ -224,25 +224,25 @@ export const shouldBehaveLikePermissionDelegateCall = (
                 ),
             ).to.be.revertedWithCustomError(
               context.keyManager,
-              "DelegateCallDisallowedViaKeyManager",
+              'DelegateCallDisallowedViaKeyManager',
             );
 
             // storage should remain unchanged and not set
-            const newStorage = await context.universalProfile["getData(bytes32)"](key);
-            expect(newStorage).to.equal("0x");
+            const newStorage = await context.universalProfile['getData(bytes32)'](key);
+            expect(newStorage).to.equal('0x');
           });
         }
       });
     });
 
-    describe("when calling an allowed contract", () => {
-      it("should revert with DELEGATECALL disallowed when trying to interact with the 1st allowed contract", async () => {
-        const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        const value = "0xbbbbbbbbbbbbbbbb";
+    describe('when calling an allowed contract', () => {
+      it('should revert with DELEGATECALL disallowed when trying to interact with the 1st allowed contract', async () => {
+        const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const value = '0xbbbbbbbbbbbbbbbb';
 
         // prettier-ignore
         const currentStorage = await context.universalProfile.getData(key);
-        expect(currentStorage).to.equal("0x");
+        expect(currentStorage).to.equal('0x');
 
         // prettier-ignore
         let delegateCallPayload = allowedDelegateCallContracts[0].interface.encodeFunctionData(
@@ -260,20 +260,20 @@ export const shouldBehaveLikePermissionDelegateCall = (
               0,
               delegateCallPayload,
             ),
-        ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+        ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
 
         // prettier-ignore
         const newStorage = await context.universalProfile.getData(key);
-        expect(newStorage).to.equal("0x");
+        expect(newStorage).to.equal('0x');
       });
 
-      it("should revert with DELEGATECALL disallowed when trying to interact with the 2nd allowed contract", async () => {
-        const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        const value = "0xbbbbbbbbbbbbbbbb";
+      it('should revert with DELEGATECALL disallowed when trying to interact with the 2nd allowed contract', async () => {
+        const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const value = '0xbbbbbbbbbbbbbbbb';
 
         // prettier-ignore
         const currentStorage = await context.universalProfile.getData(key);
-        expect(currentStorage).to.equal("0x");
+        expect(currentStorage).to.equal('0x');
 
         // prettier-ignore
         let delegateCallPayload = allowedDelegateCallContracts[1].interface.encodeFunctionData(
@@ -291,11 +291,11 @@ export const shouldBehaveLikePermissionDelegateCall = (
               0,
               delegateCallPayload,
             ),
-        ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+        ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
 
         // prettier-ignore
         const newStorage = await context.universalProfile.getData(key);
-        expect(newStorage).to.equal("0x");
+        expect(newStorage).to.equal('0x');
       });
     });
   });

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionDeploy.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionDeploy.test.ts
@@ -1,9 +1,9 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { calculateCreate2 } from "eth-create2-calculator";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { calculateCreate2 } from 'eth-create2-calculator';
 
-import { TargetContract__factory } from "../../../../types";
+import { TargetContract__factory } from '../../../../types';
 
 // constants
 import {
@@ -12,13 +12,13 @@ import {
   LSP6_VERSION,
   PERMISSIONS,
   OPERATION_TYPES,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
-import { LOCAL_PRIVATE_KEYS } from "../../../utils/helpers";
+import { LOCAL_PRIVATE_KEYS } from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -32,10 +32,10 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
     addressCannotDeploy = context.accounts[2];
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeploy.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCannotDeploy.address.substring(2),
     ];
 
@@ -44,11 +44,11 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when caller has ALL PERMISSIONS", () => {
-    it("should be allowed to deploy a contract TargetContract via CREATE", async () => {
+  describe('when caller has ALL PERMISSIONS', () => {
+    it('should be allowed to deploy a contract TargetContract via CREATE', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      const expectedContractAddress = await context.universalProfile.callStatic["execute"](
+      const expectedContractAddress = await context.universalProfile.callStatic['execute'](
         OPERATION_TYPES.CREATE, // operation type
         ethers.constants.AddressZero, // recipient
         0, // value
@@ -63,16 +63,16 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
           contractBytecodeToDeploy,
         ),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should be allowed to deploy a contract TargetContract via CREATE2", async () => {
+    it('should be allowed to deploy a contract TargetContract via CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
@@ -92,13 +92,13 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
             contractBytecodeToDeploy + salt.substring(2),
           ),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
   });
 
-  describe("when caller is an address with permission DEPLOY", () => {
-    it("should be allowed to deploy a contract TargetContract via CREATE", async () => {
+  describe('when caller is an address with permission DEPLOY', () => {
+    it('should be allowed to deploy a contract TargetContract via CREATE', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
       const expectedContractAddress = await context.universalProfile
@@ -120,18 +120,18 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
             contractBytecodeToDeploy,
           ),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should be allowed to deploy a contract TargetContract via CREATE2", async () => {
+    it('should be allowed to deploy a contract TargetContract via CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
-      let salt = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+      let salt = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
 
       let preComputedAddress = calculateCreate2(
         context.universalProfile.address,
@@ -149,14 +149,14 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
             contractBytecodeToDeploy + salt.substring(2),
           ),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
   });
 
-  describe("when caller is an address that does not have the permission DEPLOY", () => {
-    describe("-> interacting via execute(...)", () => {
-      it("should revert when trying to deploy a contract via CREATE", async () => {
+  describe('when caller is an address that does not have the permission DEPLOY', () => {
+    describe('-> interacting via execute(...)', () => {
+      it('should revert when trying to deploy a contract via CREATE', async () => {
         let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
         await expect(
@@ -169,13 +169,13 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
               contractBytecodeToDeploy,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "DEPLOY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotDeploy.address, 'DEPLOY');
       });
 
-      it("should revert when trying to deploy a contract via CREATE2", async () => {
+      it('should revert when trying to deploy a contract via CREATE2', async () => {
         let contractBytecodeToDeploy = TargetContract__factory.bytecode;
-        let salt = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
+        let salt = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
 
         await expect(
           context.universalProfile
@@ -187,8 +187,8 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
               contractBytecodeToDeploy + salt.substring(2),
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "DEPLOY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotDeploy.address, 'DEPLOY');
       });
     });
   });

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionStaticCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionStaticCall.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract, TargetContract__factory } from "../../../../types";
+import { TargetContract, TargetContract__factory } from '../../../../types';
 
 // constants
 import {
@@ -10,14 +10,14 @@ import {
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { abiCoder, combineAllowedCalls, combineCallTypes } from "../../../utils/helpers";
+import { abiCoder, combineAllowedCalls, combineCallTypes } from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionStaticCall = (
   buildContext: () => Promise<LSP6TestContext>,
@@ -40,14 +40,14 @@ export const shouldBehaveLikePermissionStaticCall = (
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCannotMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCallNoAllowedCalls.address.substring(2),
     ];
 
@@ -57,8 +57,8 @@ export const shouldBehaveLikePermissionStaticCall = (
       combineAllowedCalls(
         [combineCallTypes(CALLTYPE.STATICCALL, CALLTYPE.VALUE)],
         [targetContract.address],
-        ["0xffffffff"],
-        ["0xffffffff"],
+        ['0xffffffff'],
+        ['0xffffffff'],
       ),
       PERMISSIONS.SETDATA,
       PERMISSIONS.STATICCALL,
@@ -67,11 +67,11 @@ export const shouldBehaveLikePermissionStaticCall = (
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when caller has ALL PERMISSIONS", () => {
-    it("should pass and return data", async () => {
+  describe('when caller has ALL PERMISSIONS', () => {
+    it('should pass and return data', async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
       let result = await context.universalProfile
         .connect(context.owner)
@@ -82,16 +82,16 @@ export const shouldBehaveLikePermissionStaticCall = (
           targetContractPayload,
         );
 
-      let [decodedResult] = abiCoder.decode(["string"], result);
+      let [decodedResult] = abiCoder.decode(['string'], result);
       expect(decodedResult).to.equal(expectedName);
     });
   });
 
-  describe("when caller has permission STATICCALL + some allowed calls", () => {
-    it("should pass and return data", async () => {
+  describe('when caller has permission STATICCALL + some allowed calls', () => {
+    it('should pass and return data', async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
       let result = await context.universalProfile
         .connect(addressCanMakeStaticCall)
@@ -102,15 +102,15 @@ export const shouldBehaveLikePermissionStaticCall = (
           targetContractPayload,
         );
 
-      let [decodedResult] = abiCoder.decode(["string"], result);
+      let [decodedResult] = abiCoder.decode(['string'], result);
       expect(decodedResult).to.equal(expectedName);
     });
 
-    it("should revert when trying to change state at the target contract", async () => {
+    it('should revert when trying to change state at the target contract', async () => {
       let initialValue = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-        "modified name",
+      let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+        'modified name',
       ]);
 
       await expect(
@@ -124,9 +124,9 @@ export const shouldBehaveLikePermissionStaticCall = (
       expect(initialValue).to.equal(newValue);
     });
 
-    it("should revert when caller try to make a CALL", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-        "modified name",
+    it('should revert when caller try to make a CALL', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+        'modified name',
       ]);
 
       await expect(
@@ -134,14 +134,14 @@ export const shouldBehaveLikePermissionStaticCall = (
           .connect(addressCanMakeStaticCall)
           .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCanMakeStaticCall.address, "CALL");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCanMakeStaticCall.address, 'CALL');
     });
   });
 
-  describe("when caller has permission STATICCALL + no allowed calls", () => {
-    it("should revert with `NotAllowedCall` error", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+  describe('when caller has permission STATICCALL + no allowed calls', () => {
+    it('should revert with `NotAllowedCall` error', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
       await expect(
         context.universalProfile
@@ -153,26 +153,26 @@ export const shouldBehaveLikePermissionStaticCall = (
             targetContractPayload,
           ),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+        .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
         .withArgs(addressCanMakeStaticCallNoAllowedCalls.address);
     });
   });
 
-  describe("when caller does not have permission STATICCALL", () => {
-    it("should revert", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+  describe('when caller does not have permission STATICCALL', () => {
+    it('should revert', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
       await expect(
         context.universalProfile
           .connect(addressCannotMakeStaticCall)
           .execute(OPERATION_TYPES.STATICCALL, targetContract.address, 0, targetContractPayload),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCannotMakeStaticCall.address, "STATICCALL");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCannotMakeStaticCall.address, 'STATICCALL');
     });
   });
 
-  describe("when caller has permission STATICCALL + 2 x allowed addresses", () => {
+  describe('when caller has permission STATICCALL + 2 x allowed addresses', () => {
     let caller: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -187,8 +187,8 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionValues = [
@@ -196,15 +196,15 @@ export const shouldBehaveLikePermissionStaticCall = (
         combineAllowedCalls(
           [CALLTYPE.STATICCALL, CALLTYPE.STATICCALL],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    it("should revert when trying to interact with a non-allowed address", async () => {
+    it('should revert when trying to interact with a non-allowed address', async () => {
       let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       await expect(
@@ -214,19 +214,19 @@ export const shouldBehaveLikePermissionStaticCall = (
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
-            targetContract.interface.getSighash("getName"),
+            targetContract.interface.getSighash('getName'),
           ),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
         .withArgs(
           caller.address,
           targetContract.address,
-          targetContract.interface.getSighash("getName"),
+          targetContract.interface.getSighash('getName'),
         );
     });
 
-    describe("when interacting with 1st allowed contract", () => {
-      it("should allow to call view function -> getName()", async () => {
+    describe('when interacting with 1st allowed contract', () => {
+      it('should allow to call view function -> getName()', async () => {
         let targetContract = allowedTargetContracts[0];
 
         const name = await targetContract.getName();
@@ -237,14 +237,14 @@ export const shouldBehaveLikePermissionStaticCall = (
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
-            targetContract.interface.getSighash("getName"),
+            targetContract.interface.getSighash('getName'),
           );
 
-        const [decodedResult] = abiCoder.decode(["string"], result);
+        const [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(name);
       });
 
-      it("should allow to call view function -> getNumber()", async () => {
+      it('should allow to call view function -> getNumber()', async () => {
         let targetContract = allowedTargetContracts[0];
 
         const number = await targetContract.getNumber();
@@ -255,17 +255,17 @@ export const shouldBehaveLikePermissionStaticCall = (
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
-            targetContract.interface.getSighash("getNumber"),
+            targetContract.interface.getSighash('getNumber'),
           );
 
-        const [decodedResult] = abiCoder.decode(["uint256"], result);
+        const [decodedResult] = abiCoder.decode(['uint256'], result);
         expect(decodedResult).to.equal(number);
       });
 
-      it("should revert when calling state changing function -> setName(string)", async () => {
+      it('should revert when calling state changing function -> setName(string)', async () => {
         let targetContract = allowedTargetContracts[0];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
         await expect(
           context.universalProfile
@@ -279,10 +279,10 @@ export const shouldBehaveLikePermissionStaticCall = (
         ).to.be.reverted;
       });
 
-      it("should revert when calling state changing function -> setNumber(uint256)", async () => {
+      it('should revert when calling state changing function -> setNumber(uint256)', async () => {
         let targetContract = allowedTargetContracts[0];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setNumber", [12345]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setNumber', [12345]);
 
         await expect(
           context.universalProfile
@@ -297,8 +297,8 @@ export const shouldBehaveLikePermissionStaticCall = (
       });
     });
 
-    describe("when interacting with 2nd allowed contract", () => {
-      it("should allow to interact with 2nd allowed contract - getName()", async () => {
+    describe('when interacting with 2nd allowed contract', () => {
+      it('should allow to interact with 2nd allowed contract - getName()', async () => {
         let targetContract = allowedTargetContracts[1];
 
         const name = await targetContract.getName();
@@ -309,14 +309,14 @@ export const shouldBehaveLikePermissionStaticCall = (
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
-            targetContract.interface.getSighash("getName"),
+            targetContract.interface.getSighash('getName'),
           );
 
-        const [decodedResult] = abiCoder.decode(["string"], result);
+        const [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(name);
       });
 
-      it("should allow to interact with 2nd allowed contract - getNumber()", async () => {
+      it('should allow to interact with 2nd allowed contract - getNumber()', async () => {
         let targetContract = allowedTargetContracts[1];
 
         const number = await targetContract.getNumber();
@@ -327,17 +327,17 @@ export const shouldBehaveLikePermissionStaticCall = (
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
-            targetContract.interface.getSighash("getNumber"),
+            targetContract.interface.getSighash('getNumber'),
           );
 
-        const [decodedResult] = abiCoder.decode(["uint256"], result);
+        const [decodedResult] = abiCoder.decode(['uint256'], result);
         expect(decodedResult).to.equal(number);
       });
 
-      it("should revert when calling state changing function -> setName(string)", async () => {
+      it('should revert when calling state changing function -> setName(string)', async () => {
         let targetContract = allowedTargetContracts[1];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
         await expect(
           context.universalProfile
@@ -351,10 +351,10 @@ export const shouldBehaveLikePermissionStaticCall = (
         ).to.be.reverted;
       });
 
-      it("should revert when calling state changing function -> setNumber(uint256)", async () => {
+      it('should revert when calling state changing function -> setNumber(uint256)', async () => {
         let targetContract = allowedTargetContracts[1];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setNumber", [12345]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setNumber', [12345]);
 
         await expect(
           context.universalProfile
@@ -370,7 +370,7 @@ export const shouldBehaveLikePermissionStaticCall = (
     });
   });
 
-  describe("when caller has permission SUPER_STATICCALL + 2 allowed addresses", () => {
+  describe('when caller has permission SUPER_STATICCALL + 2 allowed addresses', () => {
     let caller: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -385,24 +385,24 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionValues = [
         PERMISSIONS.SUPER_STATICCALL,
         combineAllowedCalls(
-          ["00000004", "00000004"],
+          ['00000004', '00000004'],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("it should bypass allowed addresses check + allow to interact with any contract", () => {
+    describe('it should bypass allowed addresses check + allow to interact with any contract', () => {
       for (let ii = 1; ii <= 5; ii++) {
         it(`e.g: Target Contract nb ${ii}`, async () => {
           let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
@@ -415,10 +415,10 @@ export const shouldBehaveLikePermissionStaticCall = (
               OPERATION_TYPES.STATICCALL,
               targetContract.address,
               0,
-              targetContract.interface.getSighash("getName"),
+              targetContract.interface.getSighash('getName'),
             );
 
-          const [decodedResult] = abiCoder.decode(["string"], result);
+          const [decodedResult] = abiCoder.decode(['string'], result);
           expect(decodedResult).to.equal(name);
         });
       }

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber } from "ethers";
-import { FakeContract, smock } from "@defi-wonderland/smock";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { BigNumber } from 'ethers';
+import { FakeContract, smock } from '@defi-wonderland/smock';
 
 import {
   ExecutorLSP20,
@@ -16,7 +16,7 @@ import {
   UniversalProfile,
   GraffitiEventExtension__factory,
   GraffitiEventExtension,
-} from "../../../../types";
+} from '../../../../types';
 
 // constants
 import {
@@ -25,11 +25,11 @@ import {
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
@@ -37,14 +37,14 @@ import {
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const shouldBehaveLikePermissionTransferValue = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("when caller = EOA", () => {
+  describe('when caller = EOA', () => {
     let canTransferValue: SignerWithAddress,
       canTransferValueAndCall: SignerWithAddress,
       cannotTransferValue: SignerWithAddress;
@@ -57,7 +57,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     let graffitiExtension: GraffitiEventExtension;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       canTransferValue = context.accounts[1];
       canTransferValueAndCall = context.accounts[2];
@@ -71,9 +71,9 @@ export const shouldBehaveLikePermissionTransferValue = (
       graffitiExtension = await new GraffitiEventExtension__factory(context.accounts[0]).deploy();
 
       const lsp17ExtensionDataKeyForGraffiti =
-        ERC725YDataKeys.LSP17["LSP17ExtensionPrefix"] +
-        "00000000" + // selector for graffiti data,
-        "00000000000000000000000000000000"; // zero padded
+        ERC725YDataKeys.LSP17['LSP17ExtensionPrefix'] +
+        '00000000' + // selector for graffiti data,
+        '00000000000000000000000000000000'; // zero padded
 
       await recipientUP
         .connect(context.accounts[0])
@@ -86,16 +86,16 @@ export const shouldBehaveLikePermissionTransferValue = (
       ).to.equal(graffitiExtension.address);
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           canTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValueAndCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           canTransferValueAndCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           cannotTransferValue.address.substring(2),
       ];
 
@@ -105,8 +105,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [recipient.address, recipientUP.address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
         combinePermissions(PERMISSIONS.TRANSFERVALUE, PERMISSIONS.CALL),
         combineAllowedCalls(
@@ -115,8 +115,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
           ],
           [recipient.address, recipientUP.address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
         PERMISSIONS.CALL,
       ];
@@ -124,13 +124,13 @@ export const shouldBehaveLikePermissionTransferValue = (
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when recipient = EOA", () => {
-      describe("when transferring value via `execute(...)`", () => {
-        describe("when transferring value without bytes `_data`", () => {
-          const data = "0x";
+    describe('when recipient = EOA', () => {
+      describe('when transferring value via `execute(...)`', () => {
+        describe('when transferring value without bytes `_data`', () => {
+          const data = '0x';
 
-          it("should pass when caller has ALL PERMISSIONS", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has ALL PERMISSIONS', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             /**
              * verify that balances have been updated
@@ -146,8 +146,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should pass when caller has permission TRANSFERVALUE only", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE only', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             await expect(() =>
               context.universalProfile
@@ -159,8 +159,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             await expect(() =>
               context.universalProfile
@@ -172,7 +172,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should fail when caller does not have permission TRANSFERVALUE", async () => {
+          it('should fail when caller does not have permission TRANSFERVALUE', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
@@ -182,12 +182,12 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .execute(
                   OPERATION_TYPES.CALL,
                   recipient.address,
-                  ethers.utils.parseEther("3"),
+                  ethers.utils.parseEther('3'),
                   data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(cannotTransferValue.address, "TRANSFERVALUE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(cannotTransferValue.address, 'TRANSFERVALUE');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -198,17 +198,17 @@ export const shouldBehaveLikePermissionTransferValue = (
           });
         });
 
-        describe("when transferring value with bytes `_data`", () => {
-          const data = "0xaabbccdd";
+        describe('when transferring value with bytes `_data`', () => {
+          const data = '0xaabbccdd';
 
-          it("should pass when caller has ALL PERMISSIONS", async () => {
+          it('should pass when caller has ALL PERMISSIONS', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
 
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
             await context.universalProfile
               .connect(context.owner)
-              .execute(OPERATION_TYPES.CALL, recipient.address, ethers.utils.parseEther("3"), data);
+              .execute(OPERATION_TYPES.CALL, recipient.address, ethers.utils.parseEther('3'), data);
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             expect(newBalanceUP).to.be.lt(initialBalanceUP);
@@ -217,8 +217,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(newBalanceRecipient).to.be.gt(initialBalanceRecipient);
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             await expect(() =>
               context.universalProfile
@@ -230,7 +230,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should fail when caller has permission TRANSFERVALUE only", async () => {
+          it('should fail when caller has permission TRANSFERVALUE only', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
@@ -240,12 +240,12 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .execute(
                   OPERATION_TYPES.CALL,
                   recipient.address,
-                  ethers.utils.parseEther("3"),
+                  ethers.utils.parseEther('3'),
                   data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canTransferValue.address, "CALL");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canTransferValue.address, 'CALL');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -255,7 +255,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
           });
 
-          it("should fail when caller does not have permission TRANSFERVALUE", async () => {
+          it('should fail when caller does not have permission TRANSFERVALUE', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
@@ -265,12 +265,12 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .execute(
                   OPERATION_TYPES.CALL,
                   recipient.address,
-                  ethers.utils.parseEther("3"),
+                  ethers.utils.parseEther('3'),
                   data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(cannotTransferValue.address, "TRANSFERVALUE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(cannotTransferValue.address, 'TRANSFERVALUE');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -281,10 +281,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           });
         });
 
-        describe("when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)", () => {
-          const data = "0x00000000aabbccdd";
+        describe('when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)', () => {
+          const data = '0x00000000aabbccdd';
 
-          it("should fail when caller has permission TRANSFERVALUE only", async () => {
+          it('should fail when caller has permission TRANSFERVALUE only', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
@@ -294,12 +294,12 @@ export const shouldBehaveLikePermissionTransferValue = (
                 .execute(
                   OPERATION_TYPES.CALL,
                   recipient.address,
-                  ethers.utils.parseEther("3"),
+                  ethers.utils.parseEther('3'),
                   data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canTransferValue.address, "CALL");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canTransferValue.address, 'CALL');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -309,8 +309,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             await expect(() =>
               context.universalProfile
@@ -325,11 +325,11 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when recipient is a UP", () => {
-      describe("when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)", () => {
-        const data = "0x00000000aabbccdd";
+    describe('when recipient is a UP', () => {
+      describe('when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)', () => {
+        const data = '0x00000000aabbccdd';
 
-        it("should fail when caller has permission TRANSFERVALUE only", async () => {
+        it('should fail when caller has permission TRANSFERVALUE only', async () => {
           let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
           let initialBalanceRecipient = await provider.getBalance(recipientUP.address);
 
@@ -339,12 +339,12 @@ export const shouldBehaveLikePermissionTransferValue = (
               .execute(
                 OPERATION_TYPES.CALL,
                 recipientUP.address,
-                ethers.utils.parseEther("3"),
+                ethers.utils.parseEther('3'),
                 data,
               ),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canTransferValue.address, "CALL");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canTransferValue.address, 'CALL');
 
           let newBalanceUP = await provider.getBalance(context.universalProfile.address);
           let newBalanceRecipient = await provider.getBalance(recipientUP.address);
@@ -354,8 +354,8 @@ export const shouldBehaveLikePermissionTransferValue = (
           expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
         });
 
-        it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-          const amount = ethers.utils.parseEther("3");
+        it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+          const amount = ethers.utils.parseEther('3');
 
           const tx = await context.universalProfile
             .connect(canTransferValueAndCall)
@@ -366,18 +366,18 @@ export const shouldBehaveLikePermissionTransferValue = (
             [`-${amount}`, amount],
           );
 
-          expect(tx).to.emit(graffitiExtension, "EventEmittedInExtension");
+          expect(tx).to.emit(graffitiExtension, 'EventEmittedInExtension');
         });
       });
     });
   });
 
-  describe("when caller = contract", () => {
+  describe('when caller = contract', () => {
     let contractCanTransferValue: ExecutorLSP20;
 
     let recipient: string;
 
-    const hardcodedRecipient: string = "0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe";
+    const hardcodedRecipient: string = '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe';
 
     /**
      * @dev this is necessary when the function being called in the contract
@@ -387,7 +387,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     const GAS_PROVIDED = 200_000;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       recipient = context.accounts[1].address;
 
@@ -396,10 +396,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           contractCanTransferValue.address.substring(2),
       ];
 
@@ -409,17 +409,17 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [hardcodedRecipient, recipient],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("> Contract calls", () => {
-      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcoded`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+    describe('> Contract calls', () => {
+      it('Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcoded`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxHardcoded({
@@ -434,8 +434,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxToRecipient(recipient, {
@@ -448,9 +448,9 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("> Low-level calls", () => {
-      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcodedRawCall`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+    describe('> Low-level calls', () => {
+      it('Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcodedRawCall`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxHardcodedRawCall({
@@ -462,8 +462,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxToRecipientRawCall(recipient, {
@@ -477,7 +477,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller is another UP (with a KeyManager as owner)", () => {
+  describe('when caller is another UP (with a KeyManager as owner)', () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -487,22 +487,22 @@ export const shouldBehaveLikePermissionTransferValue = (
     let bobContext: LSP6TestContext;
 
     before(async () => {
-      aliceContext = await buildContext(ethers.utils.parseEther("50"));
+      aliceContext = await buildContext(ethers.utils.parseEther('50'));
       alice = aliceContext.accounts[0];
 
-      bobContext = await buildContext(ethers.utils.parseEther("50"));
+      bobContext = await buildContext(ethers.utils.parseEther('50'));
       bob = bobContext.accounts[1];
 
       const alicePermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2),
       ];
       const alicePermissionValues = [ALL_PERMISSIONS];
 
       const bobPermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           aliceContext.universalProfile.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           aliceContext.universalProfile.address.substring(2),
       ];
 
@@ -512,8 +512,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE],
           [aliceContext.universalProfile.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
@@ -521,16 +521,16 @@ export const shouldBehaveLikePermissionTransferValue = (
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
     });
 
-    it("Alice should have ALL PERMISSIONS in her UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2);
+    it('Alice should have ALL PERMISSIONS in her UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2);
 
       // prettier-ignore
       const result = await aliceContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
     });
 
-    it("Bob should have ALL PERMISSIONS in his UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2);
+    it('Bob should have ALL PERMISSIONS in his UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
@@ -538,7 +538,7 @@ export const shouldBehaveLikePermissionTransferValue = (
 
     it("Alice's UP should have permission TRANSFERVALUE on Bob's UP", async () => {
       let key =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         aliceContext.universalProfile.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
@@ -546,11 +546,11 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
 
     it("Alice should be able to send 5 LYX from Bob's UP to her UP", async () => {
-      const amount = ethers.utils.parseEther("5");
+      const amount = ethers.utils.parseEther('5');
 
       let finalTransferLyxPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, aliceContext.universalProfile.address, amount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, aliceContext.universalProfile.address, amount, '0x'],
       );
 
       await expect(() =>
@@ -569,7 +569,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller has SUPER_TRANSFERVALUE + CALL", () => {
+  describe('when caller has SUPER_TRANSFERVALUE + CALL', () => {
     let caller: SignerWithAddress;
     let lsp7Token: LSP7Mintable;
     let targetContract: TargetPayableContract;
@@ -588,13 +588,13 @@ export const shouldBehaveLikePermissionTransferValue = (
     let recipientUPs: string[] = [];
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
 
       lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-        "LSP7 Token",
-        "LSP7",
+        'LSP7 Token',
+        'LSP7',
         context.accounts[0].address,
         false,
       );
@@ -606,19 +606,19 @@ export const shouldBehaveLikePermissionTransferValue = (
       // this contract has a payable fallback function and can receive native tokens
       lyxRecipientContract = await smock.fake([
         {
-          stateMutability: "payable",
-          type: "fallback",
+          stateMutability: 'payable',
+          type: 'fallback',
         },
       ]);
       lyxRecipientContract.fallback.returns();
 
       await lsp7Token
         .connect(context.accounts[0])
-        .mint(context.universalProfile.address, 100, false, "0x");
+        .mint(context.universalProfile.address, 100, false, '0x');
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -639,8 +639,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             lyxRecipientEOA,
             lyxRecipientContract.address,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         ),
       ];
 
@@ -654,15 +654,15 @@ export const shouldBehaveLikePermissionTransferValue = (
       }
     });
 
-    describe("when sending native tokens without `data`", () => {
+    describe('when sending native tokens without `data`', () => {
       recipientsEOA.forEach((recipient) => {
         it(`should allow to send LYX to any EOA (e.g; at address -> ${recipient})`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
           await expect(() =>
             context.universalProfile
               .connect(caller)
-              .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
           ).to.changeEtherBalances(
             [context.universalProfile.address, recipient],
             [`-${amount}`, amount],
@@ -672,12 +672,12 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       recipientUPs.forEach((recipientUP) => {
         it(`should allow to send LYX to any UP contract (e.g: at address -> ${recipientUP})`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
           await expect(() =>
             context.universalProfile
               .connect(caller)
-              .execute(OPERATION_TYPES.CALL, recipientUP, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipientUP, amount, '0x'),
           ).to.changeEtherBalances(
             [context.universalProfile.address, recipientUP],
             [`-${amount}`, amount],
@@ -686,40 +686,40 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when sending native tokens with `data`", () => {
+    describe('when sending native tokens with `data`', () => {
       recipientsEOA.forEach((recipient) => {
         it(`should not allow to send LYX with some \`data\` to a random EOA (e.g: at address -> ${recipient})`, async () => {
-          const amount = ethers.utils.parseEther("1");
-          const data = "0x12345678";
+          const amount = ethers.utils.parseEther('1');
+          const data = '0x12345678';
 
           await expect(
             context.universalProfile
               .connect(caller)
               .execute(OPERATION_TYPES.CALL, recipient, amount, data),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(caller.address, recipient, data);
         });
       });
 
       recipientUPs.forEach((recipientUP) => {
         it(`should not allow to send LYX with some \`data\` to a random UP (e.g: at address -> ${recipientUP})`, async () => {
-          const amount = ethers.utils.parseEther("1");
-          const data = "0x12345678";
+          const amount = ethers.utils.parseEther('1');
+          const data = '0x12345678';
 
           await expect(
             context.universalProfile
               .connect(caller)
               .execute(OPERATION_TYPES.CALL, recipientUP, amount, data),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(caller.address, recipientUP, data);
         });
       });
 
-      it("should allow to send LYX with some `data` to an EOA listed in the AllowedCalls", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+      it('should allow to send LYX with some `data` to an EOA listed in the AllowedCalls', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
         await expect(
           context.universalProfile
@@ -731,9 +731,9 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("should allow to send LYX with some `data` to a contract listed in the AllowedCalls", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+      it('should allow to send LYX with some `data` to a contract listed in the AllowedCalls', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
         await expect(
           context.universalProfile
@@ -746,21 +746,21 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when interacting with some contracts", () => {
-      it("should not be allowed to interact with a disallowed LSP7 contract", async () => {
+    describe('when interacting with some contracts', () => {
+      it('should not be allowed to interact with a disallowed LSP7 contract', async () => {
         let newLSP7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "New LSP7 Token",
-          "LSP7TKN",
+          'New LSP7 Token',
+          'LSP7TKN',
           context.accounts[0].address,
           false,
         );
 
-        let lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData("transfer", [
+        let lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           context.accounts[5].address,
           10,
           true, // sending to an EOA
-          "0x",
+          '0x',
         ]);
 
         await expect(
@@ -768,15 +768,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             .connect(caller)
             .execute(OPERATION_TYPES.CALL, newLSP7Token.address, 5, lsp7TransferPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             caller.address,
             newLSP7Token.address,
-            newLSP7Token.interface.getSighash("transfer"),
+            newLSP7Token.interface.getSighash('transfer'),
           );
       });
 
-      it("should be allowed to interact with an allowed LSP7 contract", async () => {
+      it('should be allowed to interact with an allowed LSP7 contract', async () => {
         let recipient = context.accounts[5].address;
         let tokenAmount = ethers.BigNumber.from(10);
 
@@ -784,12 +784,12 @@ export const shouldBehaveLikePermissionTransferValue = (
 
         let lsp7RecipientBalanceBefore = await lsp7Token.balanceOf(recipient);
 
-        let lsp7TransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+        let lsp7TransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           tokenAmount,
           true, // sending to an EOA
-          "0x",
+          '0x',
         ]);
 
         await context.universalProfile
@@ -805,10 +805,10 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(lsp7RecipientBalanceAfter).to.equal(lsp7RecipientBalanceBefore.add(tokenAmount));
       });
 
-      it("should be allowed to interact with an allowed contract", async () => {
+      it('should be allowed to interact with an allowed contract', async () => {
         let newValue = 35;
 
-        let targetPayload = targetContract.interface.encodeFunctionData("updateState", [newValue]);
+        let targetPayload = targetContract.interface.encodeFunctionData('updateState', [newValue]);
 
         await context.universalProfile
           .connect(caller)
@@ -818,11 +818,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(result).to.equal(newValue);
       });
 
-      it("should be allowed to interact with an allowed contract + send some LYX while calling the function", async () => {
+      it('should be allowed to interact with an allowed contract + send some LYX while calling the function', async () => {
         const newValue = 358;
-        const lyxAmount = ethers.utils.parseEther("3");
+        const lyxAmount = ethers.utils.parseEther('3');
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("updateState", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('updateState', [
           newValue,
         ]);
 
@@ -844,16 +844,16 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(result).to.equal(newValue);
       });
 
-      it("should not be allowed to interact with a not allowed contract + send some LYX while calling the function", async () => {
+      it('should not be allowed to interact with a not allowed contract + send some LYX while calling the function', async () => {
         const newValue = 8910;
-        const lyxAmount = ethers.utils.parseEther("3");
+        const lyxAmount = ethers.utils.parseEther('3');
 
         const randomTargetContract = await new TargetPayableContract__factory(
           context.accounts[0],
         ).deploy();
 
         let targetContractPayload = randomTargetContract.interface.encodeFunctionData(
-          "updateState",
+          'updateState',
           [newValue],
         );
 
@@ -867,29 +867,29 @@ export const shouldBehaveLikePermissionTransferValue = (
               targetContractPayload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             caller.address,
             randomTargetContract.address,
-            randomTargetContract.interface.getSighash("updateState"),
+            randomTargetContract.interface.getSighash('updateState'),
           );
       });
     });
   });
 
-  describe("when caller has TRANSFERVALUE + SUPER_CALL", () => {
+  describe('when caller has TRANSFERVALUE + SUPER_CALL', () => {
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -899,18 +899,18 @@ export const shouldBehaveLikePermissionTransferValue = (
           // is the bit for CALL required as well? (since the controller has SUPER_CALL)
           [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
           [allowedAddress.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when transferring LYX without `data`", () => {
-      it("should not be allowed to transfer LYX to a non-allowed address", async () => {
+    describe('when transferring LYX without `data`', () => {
+      it('should not be allowed to transfer LYX to a non-allowed address', async () => {
         const recipient = context.accounts[3].address;
-        const amount = ethers.utils.parseEther("1");
+        const amount = ethers.utils.parseEther('1');
 
         let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
 
@@ -919,10 +919,10 @@ export const shouldBehaveLikePermissionTransferValue = (
         await expect(
           context.universalProfile
             .connect(caller)
-            .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+            .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-          .withArgs(caller.address, recipient, "0x00000000");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+          .withArgs(caller.address, recipient, '0x00000000');
 
         let newBalanceUP = await provider.getBalance(context.universalProfile.address);
         expect(newBalanceUP).to.equal(initialBalanceUP);
@@ -931,13 +931,13 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(newBalanceRecipient).to.equal(initialBalanceRecipient);
       });
 
-      it("should be allowed to transfer LYX to an allowed address", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('should be allowed to transfer LYX to an allowed address', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           context.universalProfile
             .connect(caller)
-            .execute(OPERATION_TYPES.CALL, allowedAddress.address, amount, "0x"),
+            .execute(OPERATION_TYPES.CALL, allowedAddress.address, amount, '0x'),
         ).to.changeEtherBalances(
           [context.universalProfile.address, allowedAddress.address],
           [`-${amount}`, amount],
@@ -946,10 +946,10 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
 
     // TODO: this test overlaps with the one above and pass, but the expected behaviour is not clear
-    describe("when transferring LYX with `data`", () => {
-      it("should be allowed to transfer LYX to an allowed address while sending some `data`", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+    describe('when transferring LYX with `data`', () => {
+      it('should be allowed to transfer LYX to an allowed address while sending some `data`', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
         await expect(() =>
           context.universalProfile
@@ -962,15 +962,15 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should be allowed to interact with any contract", () => {
-      describe("eg: any TargetContract", () => {
+    describe('should be allowed to interact with any contract', () => {
+      describe('eg: any TargetContract', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`TargetContract nb ${ii}`, async () => {
             let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
             let newValue = 12345;
 
-            let payload = targetContract.interface.encodeFunctionData("setNumber", [newValue]);
+            let payload = targetContract.interface.encodeFunctionData('setNumber', [newValue]);
 
             await context.universalProfile
               .connect(caller)
@@ -982,18 +982,18 @@ export const shouldBehaveLikePermissionTransferValue = (
         }
       });
 
-      describe("eg: any LSP7 Token owned by the UP", () => {
+      describe('eg: any LSP7 Token owned by the UP', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`LSP7DigitalAsset nb ${ii}`, async () => {
             let lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-              "LSP7 Token",
-              "LSP7",
+              'LSP7 Token',
+              'LSP7',
               context.accounts[0].address,
               false,
             );
 
             // give some tokens to the UP
-            await lsp7Token.mint(context.universalProfile.address, 100, false, "0x");
+            await lsp7Token.mint(context.universalProfile.address, 100, false, '0x');
 
             const tokenRecipient = context.accounts[5].address;
             const tokenAmount = 10;
@@ -1005,12 +1005,12 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(senderTokenBalanceBefore).to.equal(100);
             expect(recipientTokenBalanceBefore).to.equal(0);
 
-            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
               context.universalProfile.address,
               tokenRecipient,
               tokenAmount,
               true,
-              "0x",
+              '0x',
             ]);
 
             await context.universalProfile
@@ -1030,8 +1030,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should not be allowed to interact with any contract if sending LYX along the call", () => {
-      const lyxAmount = ethers.utils.parseEther("1");
+    describe('should not be allowed to interact with any contract if sending LYX along the call', () => {
+      const lyxAmount = ethers.utils.parseEther('1');
 
       for (let ii = 1; ii <= 5; ii++) {
         it(`Target Payable Contract nb ${ii}`, async () => {
@@ -1043,18 +1043,18 @@ export const shouldBehaveLikePermissionTransferValue = (
           let targetContractLyxBalanceBefore = await provider.getBalance(targetContract.address);
           expect(targetContractLyxBalanceBefore).to.equal(0);
 
-          let targetPayload = targetContract.interface.encodeFunctionData("updateState", [35]);
+          let targetPayload = targetContract.interface.encodeFunctionData('updateState', [35]);
 
           await expect(
             context.universalProfile
               .connect(caller)
               .execute(OPERATION_TYPES.CALL, targetContract.address, lyxAmount, targetPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               caller.address,
               targetContract.address,
-              targetContract.interface.getSighash("updateState"),
+              targetContract.interface.getSighash('updateState'),
             );
 
           // verify LYX (native tokens) balances have not changed
@@ -1068,19 +1068,19 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller has SUPER_TRANSFERVALUE + SUPER_CALL", () => {
+  describe('when caller has SUPER_TRANSFERVALUE + SUPER_CALL', () => {
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -1091,15 +1091,15 @@ export const shouldBehaveLikePermissionTransferValue = (
           // since the controller already has permissions SUPER_TRANSFERVALUE + SUPER_CALL
           [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
           [allowedAddress.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("should be allowed to send LYX to any address", () => {
+    describe('should be allowed to send LYX to any address', () => {
       const recipients: string[] = [
         ethers.Wallet.createRandom().address,
         ethers.Wallet.createRandom().address,
@@ -1110,12 +1110,12 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       recipients.forEach((recipient) => {
         it(`should send LYX to EOA -> ${recipient}`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
           await expect(() =>
             context.universalProfile
               .connect(caller)
-              .execute(OPERATION_TYPES.CALL, recipient, amount, "0x"),
+              .execute(OPERATION_TYPES.CALL, recipient, amount, '0x'),
           ).to.changeEtherBalances(
             [context.universalProfile.address, recipient],
             [`-${amount}`, amount],
@@ -1124,15 +1124,15 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should be allowed to interact with any contract", () => {
-      describe("eg: any TargetContract", () => {
+    describe('should be allowed to interact with any contract', () => {
+      describe('eg: any TargetContract', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`TargetContract nb ${ii}`, async () => {
             let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
             let newValue = 12345;
 
-            let payload = targetContract.interface.encodeFunctionData("setNumber", [newValue]);
+            let payload = targetContract.interface.encodeFunctionData('setNumber', [newValue]);
 
             await context.universalProfile
               .connect(caller)
@@ -1144,18 +1144,18 @@ export const shouldBehaveLikePermissionTransferValue = (
         }
       });
 
-      describe("eg: any LSP7 Token owned by the UP", () => {
+      describe('eg: any LSP7 Token owned by the UP', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`LSP7DigitalAsset nb ${ii}`, async () => {
             let lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-              "LSP7 Token",
-              "LSP7",
+              'LSP7 Token',
+              'LSP7',
               context.accounts[0].address,
               false,
             );
 
             // give some tokens to the UP
-            await lsp7Token.mint(context.universalProfile.address, 100, false, "0x");
+            await lsp7Token.mint(context.universalProfile.address, 100, false, '0x');
 
             const tokenRecipient = context.accounts[5].address;
             const tokenAmount = 10;
@@ -1167,12 +1167,12 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(senderTokenBalanceBefore).to.equal(100);
             expect(recipientTokenBalanceBefore).to.equal(0);
 
-            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
               context.universalProfile.address,
               tokenRecipient,
               tokenAmount,
               true,
-              "0x",
+              '0x',
             ]);
 
             await context.universalProfile

--- a/tests/LSP20CallVerification/LSP6/Interactions/Security.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/Security.test.ts
@@ -1,6 +1,6 @@
-import { expect } from "chai";
-import { ethers, artifacts } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers, artifacts } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   FirstToCallLSP20,
@@ -12,7 +12,7 @@ import {
   TargetContract,
   TargetContract__factory,
   UniversalReceiverDelegateDataUpdater__factory,
-} from "../../../../types";
+} from '../../../../types';
 
 // constants
 import {
@@ -22,11 +22,11 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
@@ -36,7 +36,7 @@ import {
   combineAllowedCalls,
   combineCallTypes,
   encodeCompactBytesArray,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -60,9 +60,9 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
     maliciousContract = await new Reentrancy__factory(attacker).deploy(context.keyManager.address);
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
     ];
 
     const permissionValues = [
@@ -75,8 +75,8 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
           combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
         ],
         [signer.address, ethers.constants.AddressZero],
-        ["0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff'],
       ),
     ];
 
@@ -85,13 +85,13 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
     // Fund Universal Profile with some LYXe
     await context.owner.sendTransaction({
       to: context.universalProfile.address,
-      value: ethers.utils.parseEther("10"),
+      value: ethers.utils.parseEther('10'),
     });
   });
 
-  it("Should revert when caller has no permissions set", async () => {
-    let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-      "New Contract Name",
+  it('Should revert when caller has no permissions set', async () => {
+    let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+      'New Contract Name',
     ]);
 
     await expect(
@@ -99,36 +99,36 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
         .connect(addressWithNoPermissions)
         .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload),
     )
-      .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+      .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
       .withArgs(addressWithNoPermissions.address);
   });
 
-  it("Should revert when caller calls the KeyManager through `ERC725X.execute`", async () => {
+  it('Should revert when caller calls the KeyManager through `ERC725X.execute`', async () => {
     let lsp20VerifyCallPayload = context.keyManager.interface.encodeFunctionData(
-      "lsp20VerifyCall",
-      [context.accounts[2].address, 0, "0xaabbccdd"], // random arguments
+      'lsp20VerifyCall',
+      [context.accounts[2].address, 0, '0xaabbccdd'], // random arguments
     );
 
     await expect(
       context.universalProfile
         .connect(context.owner)
         .execute(OPERATION_TYPES.CALL, context.keyManager.address, 0, lsp20VerifyCallPayload),
-    ).to.be.revertedWithCustomError(context.keyManager, "CallingKeyManagerNotAllowed");
+    ).to.be.revertedWithCustomError(context.keyManager, 'CallingKeyManagerNotAllowed');
   });
 
-  describe("when sending LYX to a contract", () => {
-    it("Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant receive() function.", async () => {
+  describe('when sending LYX to a contract', () => {
+    it('Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant receive() function.', async () => {
       // the Universal Profile wants to send 1 x LYX from its UP to another smart contract
       // we assume the UP owner is not aware that some malicious code is present
       // in the fallback function of the target (= recipient) contract
-      let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         maliciousContract.address,
-        ethers.utils.parseEther("1"),
+        ethers.utils.parseEther('1'),
         EMPTY_PAYLOAD,
       ]);
 
-      let executePayload = context.keyManager.interface.encodeFunctionData("execute", [
+      let executePayload = context.keyManager.interface.encodeFunctionData('execute', [
         transferPayload,
       ]);
       // load the malicious payload, that will be executed in the receive function
@@ -142,8 +142,8 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
       // at this point, the malicious contract receive function try to drain funds by re-entering the KeyManager
       // this should not be possible since it does not have the permission `REENTRANCY`
       await expect(context.keyManager.connect(context.owner).execute(transferPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(maliciousContract.address, "REENTRANCY");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(maliciousContract.address, 'REENTRANCY');
 
       let newAccountBalance = await provider.getBalance(context.universalProfile.address);
       let newAttackerContractBalance = await provider.getBalance(maliciousContract.address);
@@ -153,24 +153,24 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
     });
   });
 
-  describe("when reentering execute function", () => {
-    it("should allow the URD to use `setData(..)` through the LSP6", async () => {
+  describe('when reentering execute function', () => {
+    it('should allow the URD to use `setData(..)` through the LSP6', async () => {
       const universalReceiverDelegateDataUpdater =
         await new UniversalReceiverDelegateDataUpdater__factory(context.owner).deploy();
 
       const randomHardcodedKey = ethers.utils.keccak256(
-        ethers.utils.toUtf8Bytes("some random data key"),
+        ethers.utils.toUtf8Bytes('some random data key'),
       );
       const randomHardcodedValue = ethers.utils.hexlify(
-        ethers.utils.toUtf8Bytes("some random text for the data value"),
+        ethers.utils.toUtf8Bytes('some random text for the data value'),
       );
 
-      const setDataPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+      const setDataPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
         [
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             universalReceiverDelegateDataUpdater.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             universalReceiverDelegateDataUpdater.address.substring(2),
         ],
         [
@@ -183,15 +183,15 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
       await context.keyManager.connect(context.owner).execute(setDataPayload);
 
       const universalReceiverDelegatePayload =
-        universalReceiverDelegateDataUpdater.interface.encodeFunctionData("universalReceiver", [
+        universalReceiverDelegateDataUpdater.interface.encodeFunctionData('universalReceiver', [
           LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
-          "0xcafecafecafecafe",
+          '0xcafecafecafecafe',
         ]);
 
-      const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         universalReceiverDelegateDataUpdater.address,
-        ethers.utils.parseEther("0"),
+        ethers.utils.parseEther('0'),
         universalReceiverDelegatePayload,
       ]);
 
@@ -203,7 +203,7 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
     });
   });
 
-  describe("when chaining reentrancy", () => {
+  describe('when chaining reentrancy', () => {
     let firstReentrant: FirstToCallLSP20;
     let secondReentrant: SecondToCallLSP20;
 
@@ -217,10 +217,10 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           firstReentrant.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           secondReentrant.address.substring(2),
       ];
 
@@ -233,26 +233,26 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when executing reentrant calls from two different contracts", () => {
-      describe("when the firstReentrant execute its first reentrant call to the UniversalProfile successfully", () => {
-        describe("when the secondReentrant is not granted REENTRANCY Permission", () => {
-          it("shoul fail stating that the caller (secondReentrant) is not authorised (no reentrancy permission)", async () => {
-            let firstTargetSelector = firstReentrant.interface.encodeFunctionData("firstTarget");
+    describe('when executing reentrant calls from two different contracts', () => {
+      describe('when the firstReentrant execute its first reentrant call to the UniversalProfile successfully', () => {
+        describe('when the secondReentrant is not granted REENTRANCY Permission', () => {
+          it('shoul fail stating that the caller (secondReentrant) is not authorised (no reentrancy permission)', async () => {
+            let firstTargetSelector = firstReentrant.interface.encodeFunctionData('firstTarget');
 
             await expect(
               context.universalProfile
                 .connect(context.owner)
                 .execute(OPERATION_TYPES.CALL, firstReentrant.address, 0, firstTargetSelector),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(secondReentrant.address, "REENTRANCY");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(secondReentrant.address, 'REENTRANCY');
           });
         });
 
-        describe("when the secondReentrant is granted REENTRANCY Permission", () => {
+        describe('when the secondReentrant is granted REENTRANCY Permission', () => {
           before(async () => {
             const permissionKeys = [
-              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                 secondReentrant.address.substring(2),
             ];
 
@@ -263,26 +263,26 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
             await setupKeyManager(context, permissionKeys, permissionValues);
           });
 
-          it("should pass and setData from the second reentrantCall on the UniversalProfile correctly", async () => {
-            let firstTargetSelector = firstReentrant.interface.encodeFunctionData("firstTarget");
+          it('should pass and setData from the second reentrantCall on the UniversalProfile correctly', async () => {
+            let firstTargetSelector = firstReentrant.interface.encodeFunctionData('firstTarget');
 
             await context.universalProfile
               .connect(context.owner)
               .execute(OPERATION_TYPES.CALL, firstReentrant.address, 0, firstTargetSelector);
 
-            let result = await context.universalProfile["getData(bytes32)"](
+            let result = await context.universalProfile['getData(bytes32)'](
               ethers.constants.HashZero,
             );
 
-            expect(result).to.equal("0xaabbccdd");
+            expect(result).to.equal('0xaabbccdd');
           });
         });
       });
     });
 
-    describe("when calling the lsp20 functions by an address other than the target", () => {
-      it("should pass and not modify _reentrancyStatus when verfying that the owner have permission to execute a payload, ", async () => {
-        let emptyCallPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+    describe('when calling the lsp20 functions by an address other than the target', () => {
+      it('should pass and not modify _reentrancyStatus when verfying that the owner have permission to execute a payload, ', async () => {
+        let emptyCallPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           context.accounts[5].address,
           0,
@@ -300,12 +300,12 @@ export const testSecurityScenarios = (buildContext: () => Promise<LSP6TestContex
         const _reentrancyStatusSlotNumber = Number.parseInt(
           (
             await artifacts.getBuildInfo(
-              "contracts/LSP6KeyManager/LSP6KeyManager.sol:LSP6KeyManager",
+              'contracts/LSP6KeyManager/LSP6KeyManager.sol:LSP6KeyManager',
             )
           )?.output.contracts[
-            "contracts/LSP6KeyManager/LSP6KeyManager.sol"
+            'contracts/LSP6KeyManager/LSP6KeyManager.sol'
           ].LSP6KeyManager.storageLayout.storage.filter((elem) => {
-            if (elem.label === "_reentrancyStatus") return elem;
+            if (elem.label === '_reentrancyStatus') return elem;
           })[0].slot,
         );
 

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.behaviour.ts
@@ -1,5 +1,5 @@
-import { BigNumber } from "ethers";
-import { LSP6TestContext } from "../../utils/context";
+import { BigNumber } from 'ethers';
+import { LSP6TestContext } from '../../utils/context';
 
 import {
   // Admin
@@ -29,68 +29,68 @@ import {
   // other scenarios
   testSecurityScenarios,
   otherTestScenarios,
-} from "./index";
+} from './index';
 
 export const shouldBehaveLikeLSP6 = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
-  describe("CHANGEOWNER", () => {
+  describe('CHANGEOWNER', () => {
     shouldBehaveLikePermissionChangeOwner(buildContext);
   });
 
-  describe("Set Permissions", () => {
+  describe('Set Permissions', () => {
     shouldBehaveLikePermissionChangeOrAddController(buildContext);
     shouldBehaveLikeSetAllowedCalls(buildContext);
     shouldBehaveLikeSetAllowedERC725YDataKeys(buildContext);
   });
 
-  describe("CHANGE / ADD extensions", () => {
+  describe('CHANGE / ADD extensions', () => {
     shouldBehaveLikePermissionChangeOrAddExtensions(buildContext);
   });
 
-  describe("CHANGE / ADD UniversalReceiverDelegate", () => {
+  describe('CHANGE / ADD UniversalReceiverDelegate', () => {
     shouldBehaveLikePermissionChangeOrAddURD(buildContext);
   });
 
-  describe("SETDATA", () => {
+  describe('SETDATA', () => {
     shouldBehaveLikePermissionSetData(buildContext);
   });
 
-  describe("AllowedERC725YDataKeys", () => {
+  describe('AllowedERC725YDataKeys', () => {
     shouldBehaveLikeAllowedERC725YDataKeys(buildContext);
   });
 
-  describe("CALL", () => {
+  describe('CALL', () => {
     shouldBehaveLikePermissionCall(buildContext);
   });
 
-  describe("STATICCALL", () => {
+  describe('STATICCALL', () => {
     shouldBehaveLikePermissionStaticCall(buildContext);
   });
 
-  describe("DELEGATECALL", () => {
+  describe('DELEGATECALL', () => {
     shouldBehaveLikePermissionDelegateCall(buildContext);
   });
 
-  describe("DEPLOY", () => {
+  describe('DEPLOY', () => {
     shouldBehaveLikePermissionDeploy(buildContext);
   });
 
-  describe("TRANSFERVALUE", () => {
+  describe('TRANSFERVALUE', () => {
     shouldBehaveLikePermissionTransferValue(buildContext);
   });
 
-  describe("ALLOWED CALLS", () => {
+  describe('ALLOWED CALLS', () => {
     shouldBehaveLikeAllowedAddresses(buildContext);
     shouldBehaveLikeAllowedFunctions(buildContext);
     shouldBehaveLikeAllowedStandards(buildContext);
   });
 
-  describe("miscellaneous", () => {
+  describe('miscellaneous', () => {
     otherTestScenarios(buildContext);
   });
 
-  describe("Security", () => {
+  describe('Security', () => {
     testSecurityScenarios(buildContext);
   });
 };

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
@@ -1,13 +1,13 @@
-import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
 
-import { UniversalProfile__factory, LSP6KeyManager__factory } from "../../../types";
+import { UniversalProfile__factory, LSP6KeyManager__factory } from '../../../types';
 
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
-import { shouldBehaveLikeLSP6 } from "./LSP20WithLSP6.behaviour";
+import { shouldBehaveLikeLSP6 } from './LSP20WithLSP6.behaviour';
 
-describe("LSP20 + LSP6 with constructor", () => {
+describe('LSP20 + LSP6 with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
     const owner = accounts[0];
@@ -21,12 +21,12 @@ describe("LSP20 + LSP6 with constructor", () => {
     return { accounts, owner, universalProfile, keyManager, initialFunding };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     // TODO: add tests to ensure LSP20 interface is registered.
     // on LSP6 or LSP0?
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP6(buildTestContext);
   });
 });

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6Init.test.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6Init.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
 
-import { UniversalProfileInit__factory, LSP6KeyManagerInit__factory } from "../../../types";
+import { UniversalProfileInit__factory, LSP6KeyManagerInit__factory } from '../../../types';
 
-import { LSP6TestContext } from "../../utils/context";
-import { deployProxy } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { deployProxy } from '../../utils/fixtures';
 
-import { shouldBehaveLikeLSP6 } from "./LSP20WithLSP6.behaviour";
+import { shouldBehaveLikeLSP6 } from './LSP20WithLSP6.behaviour';
 
-describe("LSP20 Init + LSP6 Init with proxy", () => {
+describe('LSP20 Init + LSP6 Init with proxy', () => {
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
     const owner = accounts[0];
@@ -26,43 +26,43 @@ describe("LSP20 Init + LSP6 Init with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP6TestContext) => {
-    await context.universalProfile["initialize(address)"](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.owner.address, {
       value: context.initialFunding,
     });
 
-    await context.keyManager["initialize(address)"](context.universalProfile.address);
+    await context.keyManager['initialize(address)'](context.universalProfile.address);
 
     return context;
   };
 
-  describe("when deploying the base contract implementation", () => {
-    it("should prevent any address from calling the `initialize(...)` function on the base contract", async () => {
+  describe('when deploying the base contract implementation', () => {
+    it('should prevent any address from calling the `initialize(...)` function on the base contract', async () => {
       let context = await buildProxyTestContext();
 
       const baseKM = await new LSP6KeyManagerInit__factory(context.accounts[0]).deploy();
 
       await expect(baseKM.initialize(context.accounts[0].address)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP6TestContext;
 
-    describe("when calling `initialize(...) more than once`", () => {
-      it("should revert", async () => {
+    describe('when calling `initialize(...) more than once`', () => {
+      it('should revert', async () => {
         context = await buildProxyTestContext();
         await initializeProxy(context);
 
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP6(async (initialFunding?: BigNumber) => {
       let context = await buildProxyTestContext(initialFunding);
       await initializeProxy(context);

--- a/tests/LSP20CallVerification/LSP6/SetData/AllowedERC725YDataKeys.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetData/AllowedERC725YDataKeys.test.ts
@@ -1,17 +1,17 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from "../../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { encodeCompactBytesArray, decodeCompactBytes } from "../../../utils/helpers";
-import { BytesLike } from "ethers";
+import { encodeCompactBytesArray, decodeCompactBytes } from '../../../utils/helpers';
+import { BytesLike } from 'ethers';
 
 export type TestCase = {
   datakeyToSet: BytesLike;
@@ -23,13 +23,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 ) => {
   let context: LSP6TestContext;
 
-  describe("keyType: Singleton", () => {
+  describe('keyType: Singleton', () => {
     let controllerCanSetOneKey: SignerWithAddress, controllerCanSetManyKeys: SignerWithAddress;
 
-    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey1"));
-    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey2"));
-    const customKey3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey3"));
-    const customKey4 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey4"));
+    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey1'));
+    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey2'));
+    const customKey3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey3'));
+    const customKey4 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey4'));
 
     before(async () => {
       context = await buildContext();
@@ -38,14 +38,14 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetManyKeys = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetOneKey.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetManyKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetOneKey.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetManyKeys.address.substring(2),
       ];
 
@@ -60,10 +60,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("verify Allowed ERC725Y data keys set", () => {
-      it("`controllerCanSetOneKey` should have 1 x key in its list of allowed keys", async () => {
+    describe('verify Allowed ERC725Y data keys set', () => {
+      it('`controllerCanSetOneKey` should have 1 x key in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetOneKey.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -71,9 +71,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.have.lengthOf(1);
       });
 
-      it("`controllerCanSetManyKeys` should have 3 x keys in its list of allowed keys", async () => {
+      it('`controllerCanSetManyKeys` should have 3 x keys in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetManyKeys.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -81,9 +81,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.have.lengthOf(3);
       });
 
-      it("`controllerCanSetOneKey` should have the right keys set in its list of allowed keys", async () => {
+      it('`controllerCanSetOneKey` should have the right keys set in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetOneKey.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -91,9 +91,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.include(customKey1);
       });
 
-      it("`controllerCanSetManyKeys` should have the right keys set in its list of allowed keys", async () => {
+      it('`controllerCanSetManyKeys` should have the right keys set in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetManyKeys.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -104,11 +104,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       });
     });
 
-    describe("when address can set only one key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting the right key", async () => {
+    describe('when address can set only one key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting the right key', async () => {
           let key = customKey1;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await context.universalProfile.connect(controllerCanSetOneKey).setData(key, newValue);
 
@@ -116,66 +116,66 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should fail when setting the wrong key", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NotAllowedKey"));
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+        it('should fail when setting the wrong key', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NotAllowedKey'));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await expect(
             context.universalProfile.connect(controllerCanSetOneKey).setData(key, newValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, key);
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should fail when the list contains none of the allowed keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should fail when the list contains none of the allowed keys', async () => {
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
           ];
 
           await expect(
             context.universalProfile.connect(controllerCanSetOneKey).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, keys[0]);
         });
 
-        it("should fail, even if the list contains the allowed key", async () => {
+        it('should fail, even if the list contains the allowed key', async () => {
           let keys = [
             customKey1,
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
           ];
 
           await expect(
             context.universalProfile.connect(controllerCanSetOneKey).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, keys[1]);
         });
       });
     });
 
-    describe("when address can set multiple keys", () => {
-      it("should pass when the input is all the allowed keys", async () => {
+    describe('when address can set multiple keys', () => {
+      it('should pass when the input is all the allowed keys', async () => {
         let keys = [customKey2, customKey3, customKey4];
         let values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 3")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 3')),
         ];
 
         await context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values);
@@ -185,29 +185,29 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.deep.equal(values);
       });
 
-      it("should fail when the input contains none of the allowed keys", async () => {
+      it('should fail when the input contains none of the allowed keys', async () => {
         let keys = [
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
         ];
         let values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
         ];
 
         await expect(
           context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetManyKeys.address, keys[0]);
       });
 
-      describe("when setting one key", () => {
-        it("should pass when trying to set the 1st allowed key", async () => {
+      describe('when setting one key', () => {
+        it('should pass when trying to set the 1st allowed key', async () => {
           let key = customKey2;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await context.universalProfile.connect(controllerCanSetManyKeys).setData(key, newValue);
 
@@ -215,9 +215,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should pass when trying to set the 2nd allowed key", async () => {
+        it('should pass when trying to set the 2nd allowed key', async () => {
           let key = customKey3;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await context.universalProfile.connect(controllerCanSetManyKeys).setData(key, newValue);
 
@@ -225,9 +225,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should pass when trying to set the 3rd allowed key", async () => {
+        it('should pass when trying to set the 3rd allowed key', async () => {
           let key = customKey4;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await context.universalProfile.connect(controllerCanSetManyKeys).setData(key, newValue);
 
@@ -235,25 +235,25 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should fail when setting a not-allowed Singleton key", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NotAllowedKey"));
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+        it('should fail when setting a not-allowed Singleton key', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NotAllowedKey'));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await expect(
             context.universalProfile.connect(controllerCanSetManyKeys).setData(key, newValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetManyKeys.address, key);
         });
       });
 
-      describe("when setting 2 x keys", () => {
-        describe("should pass when", () => {
-          it("the input is the first two (subset) allowed keys", async () => {
+      describe('when setting 2 x keys', () => {
+        describe('should pass when', () => {
+          it('the input is the first two (subset) allowed keys', async () => {
             let keys = [customKey2, customKey3];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             await context.universalProfile
@@ -264,11 +264,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             expect(result).to.deep.equal(values);
           });
 
-          it("the input is the last two (subset) allowed keys", async () => {
+          it('the input is the last two (subset) allowed keys', async () => {
             let keys = [customKey3, customKey4];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             await context.universalProfile
@@ -279,11 +279,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             expect(result).to.deep.equal(values);
           });
 
-          it("the input is the first + last (subset) allowed keys", async () => {
+          it('the input is the first + last (subset) allowed keys', async () => {
             let keys = [customKey2, customKey4];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             await context.universalProfile
@@ -296,255 +296,255 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting 3 x keys", () => {
-        describe("should fail when", () => {
-          it("1st key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+      describe('when setting 3 x keys', () => {
+        describe('should fail when', () => {
+          it('1st key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey2,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('1st key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey3,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('1st key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey4,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey4,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey4,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('1st key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey2,
               customKey3,
             ];
 
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("2nd key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('2nd key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey3,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("3rd key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('3rd key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
               customKey2,
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
             ];
 
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
             ];
 
             await expect(
               context.universalProfile.connect(controllerCanSetManyKeys).setDataBatch(keys, values),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[2]);
           });
         });
       });
 
-      describe("when setting multiple keys", () => {
-        describe("when input is bigger than the number of allowed keys", () => {
-          describe("should fail when", () => {
-            it("input = all the allowed keys + 1 x not-allowed key", async () => {
+      describe('when setting multiple keys', () => {
+        describe('when input is bigger than the number of allowed keys', () => {
+          describe('should fail when', () => {
+            it('input = all the allowed keys + 1 x not-allowed key', async () => {
               let keys = [
                 customKey2,
                 customKey3,
                 customKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey3")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey3')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
               ];
 
               await expect(
@@ -552,30 +552,30 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
                   .connect(controllerCanSetManyKeys)
                   .setDataBatch(keys, values),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
                 .withArgs(controllerCanSetManyKeys.address, keys[3]);
             });
 
-            it("input = all the allowed keys + 5 x not-allowed key", async () => {
+            it('input = all the allowed keys + 5 x not-allowed key', async () => {
               let keys = [
                 customKey2,
                 customKey3,
                 customKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("AAAAAAAAAA")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("BBBBBBBBBB")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('AAAAAAAAAA')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('BBBBBBBBBB')),
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value AAAAAAAA")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value BBBBBBBB")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value AAAAAAAA')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value BBBBBBBB')),
               ];
 
               await expect(
@@ -583,13 +583,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
                   .connect(controllerCanSetManyKeys)
                   .setDataBatch(keys, values),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
                 .withArgs(controllerCanSetManyKeys.address, keys[3]);
             });
           });
 
-          describe("should pass when", () => {
-            it("input contains all the allowed keys as DUPLICATE", async () => {
+          describe('should pass when', () => {
+            it('input contains all the allowed keys as DUPLICATE', async () => {
               let keys = [
                 customKey2,
                 customKey4,
@@ -602,26 +602,26 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
                 customKey4,
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey3")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey3')),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey2"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey2'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey3"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey3'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey2"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey2'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey4"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey4'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey3"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey3'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey4"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey4'),
                 ),
               ];
 
@@ -647,11 +647,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       });
     });
 
-    describe("when address can set any key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting any random key", async () => {
+    describe('when address can set any key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting any random key', async () => {
           let key = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
           await context.universalProfile.connect(context.owner).setData(key, value);
 
@@ -660,17 +660,17 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when setting any multiple keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when setting any multiple keys', async () => {
           let keys = [
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 3')),
           ];
 
           await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
@@ -683,20 +683,20 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
   });
 
-  describe("keyType: Mapping", () => {
+  describe('keyType: Mapping', () => {
     let controllerCanSetMappingKeys: SignerWithAddress;
 
     // all mapping keys starting with: SupportedStandards:...
-    const supportedStandardKey = "0xeafec4d89fa9619884b6b89135626455";
+    const supportedStandardKey = '0xeafec4d89fa9619884b6b89135626455';
 
     // SupportedStandards:LSPX
-    const LSPXKey = "0xeafec4d89fa9619884b6b8913562645500000000000000000000000024ae6f23";
+    const LSPXKey = '0xeafec4d89fa9619884b6b8913562645500000000000000000000000024ae6f23';
 
     // SupportedStandards:LSPY
-    const LSPYKey = "0xeafec4d89fa9619884b6b891356264550000000000000000000000005e8d18c5";
+    const LSPYKey = '0xeafec4d89fa9619884b6b891356264550000000000000000000000005e8d18c5';
 
     // SupportedStandards:LSPZ
-    const LSPZKey = "0xeafec4d89fa9619884b6b8913562645500000000000000000000000025b71a36";
+    const LSPZKey = '0xeafec4d89fa9619884b6b8913562645500000000000000000000000025b71a36';
 
     before(async () => {
       context = await buildContext();
@@ -704,10 +704,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetMappingKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetMappingKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetMappingKeys.address.substring(2),
       ];
 
@@ -721,10 +721,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
 
     describe("when address can set Mapping keys starting with a 'SupportedStandards:...'", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting SupportedStandards:LSPX", async () => {
+      describe('when setting one key', () => {
+        it('should pass when setting SupportedStandards:LSPX', async () => {
           let mappingKey = LSPXKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x24ae6f23"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x24ae6f23'));
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -734,9 +734,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when overriding SupportedStandards:LSPX", async () => {
+        it('should pass when overriding SupportedStandards:LSPX', async () => {
           let mappingKey = LSPXKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x24ae6f23"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x24ae6f23'));
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -746,9 +746,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when setting SupportedStandards:LSPY", async () => {
+        it('should pass when setting SupportedStandards:LSPY', async () => {
           let mappingKey = LSPYKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x5e8d18c5"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x5e8d18c5'));
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -758,9 +758,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when setting SupportedStandards:LSPZ", async () => {
+        it('should pass when setting SupportedStandards:LSPZ', async () => {
           let mappingKey = LSPZKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x25b71a36"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x25b71a36'));
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -770,26 +770,26 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should fail when setting any other not-allowed Mapping key", async () => {
+        it('should fail when setting any other not-allowed Mapping key', async () => {
           // CustomMapping:...
           let notAllowedMappingKey =
-            "0xb8a73e856fea3d5a518029e588a713f300000000000000000000000000000000";
-          let notAllowedMappingValue = "0xbeefbeef";
+            '0xb8a73e856fea3d5a518029e588a713f300000000000000000000000000000000';
+          let notAllowedMappingValue = '0xbeefbeef';
 
           await expect(
             context.universalProfile
               .connect(controllerCanSetMappingKeys)
               .setData(notAllowedMappingKey, notAllowedMappingValue),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, notAllowedMappingKey);
         });
       });
 
-      describe("when setting multiple keys", () => {
+      describe('when setting multiple keys', () => {
         it('(2 x keys) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [LSPYKey, LSPZKey];
-          let mappingValues = ["0x5e8d18c5", "0x5e8d18c5"];
+          let mappingValues = ['0x5e8d18c5', '0x5e8d18c5'];
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -801,7 +801,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(2 x keys) (override) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [LSPYKey, LSPZKey];
-          let mappingValues = ["0x5e8d18c5", "0x5e8d18c5"];
+          let mappingValues = ['0x5e8d18c5', '0x5e8d18c5'];
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -813,11 +813,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(3 x keys) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc",
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc',
           ];
-          let mappingValues = ["0xaaaaaaaa", "0xbbbbbbbb", "0xcccccccc"];
+          let mappingValues = ['0xaaaaaaaa', '0xbbbbbbbb', '0xcccccccc'];
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -829,11 +829,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(3 x keys) (override) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc",
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc',
           ];
-          let mappingValues = ["0xaaaaaaaa", "0xbbbbbbbb", "0xcccccccc"];
+          let mappingValues = ['0xaaaaaaaa', '0xbbbbbbbb', '0xcccccccc'];
 
           await context.universalProfile
             .connect(controllerCanSetMappingKeys)
@@ -843,16 +843,16 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.deep.equal(mappingValues);
         });
 
-        it("should fail when the list contains none of the allowed Mapping keys", async () => {
+        it('should fail when the list contains none of the allowed Mapping keys', async () => {
           let randomMappingKeys = [
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111",
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111',
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let randomMappingValues = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 3')),
           ];
 
           await expect(
@@ -860,20 +860,20 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
               .connect(controllerCanSetMappingKeys)
               .setDataBatch(randomMappingKeys, randomMappingValues),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, randomMappingKeys[0]);
         });
 
-        it("should fail, even if the list contains some keys starting with `SupportedStandards`", async () => {
+        it('should fail, even if the list contains some keys starting with `SupportedStandards`', async () => {
           let mappingKeys = [
             LSPXKey,
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let mappingValues = [
-            "0x24ae6f23",
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
+            '0x24ae6f23',
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
           ];
 
           await expect(
@@ -881,19 +881,19 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
               .connect(controllerCanSetMappingKeys)
               .setDataBatch(mappingKeys, mappingValues),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, mappingKeys[1]);
         });
       });
     });
 
-    describe("when address can set any key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting any random Mapping key", async () => {
+    describe('when address can set any key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting any random Mapping key', async () => {
           let randomMappingKey =
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111";
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111';
           let randomMappingValue = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("Random Mapping Value"),
+            ethers.utils.toUtf8Bytes('Random Mapping Value'),
           );
 
           await context.universalProfile
@@ -905,17 +905,17 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when setting any random set of Mapping keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when setting any random set of Mapping keys', async () => {
           let randomMappingKeys = [
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111",
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111',
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let randomMappingValues = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 3')),
           ];
 
           await context.universalProfile
@@ -930,32 +930,32 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
   });
 
-  describe("keyType: Array", () => {
+  describe('keyType: Array', () => {
     let controllerCanSetArrayKeys: SignerWithAddress;
 
-    const allowedArrayKey = "0x868affce801d08a5948eebc349a5c8ff";
+    const allowedArrayKey = '0x868affce801d08a5948eebc349a5c8ff';
 
     // keccak256("MyArray[]")
-    const arrayKeyLength = "0x868affce801d08a5948eebc349a5c8ff18e4c7076d14879dd5d19180dff1f547";
+    const arrayKeyLength = '0x868affce801d08a5948eebc349a5c8ff18e4c7076d14879dd5d19180dff1f547';
 
     // MyArray[0]
-    const arrayKeyElement1 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000000";
+    const arrayKeyElement1 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000000';
 
     // MyArray[1]
-    const arrayKeyElement2 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000001";
+    const arrayKeyElement2 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000001';
 
     // MyArray[2]
-    const arrayKeyElement3 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000002";
+    const arrayKeyElement3 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000002';
 
     before(async () => {
       context = await buildContext();
       controllerCanSetArrayKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetArrayKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetArrayKeys.address.substring(2),
       ];
 
@@ -969,11 +969,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
 
     describe("when address can set Array element in 'MyArray[]", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting array key length MyArray[]", async () => {
+      describe('when setting one key', () => {
+        it('should pass when setting array key length MyArray[]', async () => {
           let key = arrayKeyLength;
           // eg: MyArray[].length = 10 elements
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x0a"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x0a'));
 
           await context.universalProfile.connect(controllerCanSetArrayKeys).setData(key, value);
 
@@ -981,9 +981,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 1st array element MyArray[0]", async () => {
+        it('should pass when setting 1st array element MyArray[0]', async () => {
           let key = arrayKeyElement1;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xaaaaaaaa"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xaaaaaaaa'));
 
           await context.universalProfile.connect(controllerCanSetArrayKeys).setData(key, value);
 
@@ -991,9 +991,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 2nd array element MyArray[1]", async () => {
+        it('should pass when setting 2nd array element MyArray[1]', async () => {
           let key = arrayKeyElement2;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xbbbbbbbb"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xbbbbbbbb'));
 
           await context.universalProfile.connect(controllerCanSetArrayKeys).setData(key, value);
 
@@ -1001,9 +1001,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 3rd array element MyArray[3]", async () => {
+        it('should pass when setting 3rd array element MyArray[3]', async () => {
           let key = arrayKeyElement3;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xcccccccc"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xcccccccc'));
 
           await context.universalProfile.connect(controllerCanSetArrayKeys).setData(key, value);
 
@@ -1011,23 +1011,23 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting elements of a not-allowed Array (eg: LSP5ReceivedAssets)", async () => {
-          let notAllowedArrayKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
+        it('should fail when setting elements of a not-allowed Array (eg: LSP5ReceivedAssets)', async () => {
+          let notAllowedArrayKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
 
           await expect(
             context.universalProfile
               .connect(controllerCanSetArrayKeys)
-              .setData(notAllowedArrayKey, "0x00"),
+              .setData(notAllowedArrayKey, '0x00'),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, notAllowedArrayKey);
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when all the keys in the list are from the allowed array MyArray[]", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when all the keys in the list are from the allowed array MyArray[]', async () => {
           let keys = [arrayKeyElement1, arrayKeyElement2];
-          let values = ["0xaaaaaaaa", "0xbbbbbbbb"];
+          let values = ['0xaaaaaaaa', '0xbbbbbbbb'];
 
           await context.universalProfile
             .connect(controllerCanSetArrayKeys)
@@ -1037,74 +1037,74 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.deep.equal(values);
         });
 
-        it("should fail when the list contains elements keys of a non-allowed Array (RandomArray[])", async () => {
+        it('should fail when the list contains elements keys of a non-allowed Array (RandomArray[])', async () => {
           let randomArrayKeys = [
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000002",
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000002',
           ];
 
           await expect(
             context.universalProfile
               .connect(controllerCanSetArrayKeys)
-              .setDataBatch(randomArrayKeys, ["0xdeadbeef", "0xdeadbeef", "0xdeadbeef"]),
+              .setDataBatch(randomArrayKeys, ['0xdeadbeef', '0xdeadbeef', '0xdeadbeef']),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, randomArrayKeys[0]);
         });
 
-        it("should fail, even if the list contains a mix of allowed + not-allowed array element keys (MyArray[] + RandomArray[])", async () => {
+        it('should fail, even if the list contains a mix of allowed + not-allowed array element keys (MyArray[] + RandomArray[])', async () => {
           let keys = [
             arrayKeyElement1,
             arrayKeyElement2,
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001",
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001',
           ];
-          let values = ["0xaaaaaaaa", "0xbbbbbbbb", "0xdeadbeef", "0xdeadbeef"];
+          let values = ['0xaaaaaaaa', '0xbbbbbbbb', '0xdeadbeef', '0xdeadbeef'];
 
           await expect(
             context.universalProfile.connect(controllerCanSetArrayKeys).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, keys[2]);
         });
       });
     });
   });
 
-  describe("Testing bytes32(0) (= zero key) edge cases", () => {
+  describe('Testing bytes32(0) (= zero key) edge cases', () => {
     let controllerCanSetSomeKeys: SignerWithAddress;
 
-    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey1"));
-    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey2"));
+    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey1'));
+    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey2'));
 
-    const zeroKey = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    const zeroKey = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
     const bytes31DynamicKeyPrefix =
-      "0x00000000000000000000000000000000000000000000000000000000000000";
+      '0x00000000000000000000000000000000000000000000000000000000000000';
 
-    const bytes31DynamicKey = "0x00000000000000000000000000000000000000000000000000000000000000ca";
+    const bytes31DynamicKey = '0x00000000000000000000000000000000000000000000000000000000000000ca';
 
-    const bytes20DynamicKeyPrefix = "0x0000000000000000000000000000000000000000";
+    const bytes20DynamicKeyPrefix = '0x0000000000000000000000000000000000000000';
 
-    const bytes20DynamicKey = "0x0000000000000000000000000000000000000000cafecafecafecafecafecafe";
+    const bytes20DynamicKey = '0x0000000000000000000000000000000000000000cafecafecafecafecafecafe';
 
-    const bytes24DynamicKey = "0x000000000000000000000000000000000000000000000000cafecafecafecafe";
+    const bytes24DynamicKey = '0x000000000000000000000000000000000000000000000000cafecafecafecafe';
 
-    const bytes19DynamicKey = "0x00000000000000000000000000000000000000cafecafecafecafecafecafeca";
+    const bytes19DynamicKey = '0x00000000000000000000000000000000000000cafecafecafecafecafecafeca';
 
-    describe("When bytes32(0) key is part of the AllowedERC725YDataKeys", () => {
+    describe('When bytes32(0) key is part of the AllowedERC725YDataKeys', () => {
       before(async () => {
         context = await buildContext();
 
         controllerCanSetSomeKeys = context.accounts[1];
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetSomeKeys.address.substring(2),
         ];
 
@@ -1120,7 +1120,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       [{ allowedDataKey: customKey1 }, { allowedDataKey: customKey2 }].forEach((testCase) => {
         it(`should pass when setting a data key listed in the allowed ERC725Y data keys: ${testCase.allowedDataKey}`, async () => {
           const key = testCase.allowedDataKey;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
           await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
@@ -1131,57 +1131,57 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
       [
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 1")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 1')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 2")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 2')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 3")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 3')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 4")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 4')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 5")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 5')),
         },
       ].forEach((testCase) => {
         it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
           await expect(
             context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
         });
       });
 
-      it("should revert when trying to set bytes31(0) dynamic key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set bytes31(0) dynamic key, not in AllowedERC725YDataKeys', async () => {
         const key = bytes31DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
         await expect(context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, key);
       });
 
-      it("should pass and allow to set the bytes32(0) data key", async () => {
+      it('should pass and allow to set the bytes32(0) data key', async () => {
         const key = zeroKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
         expect(await context.universalProfile.getData(key)).to.equal(value);
       });
 
-      it("should pass when trying to set an array of data keys that includes bytes32(0) (= zero data key)", async () => {
+      it('should pass when trying to set an array of data keys that includes bytes32(0) (= zero data key)', async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values);
@@ -1189,49 +1189,49 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes31(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes31(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes31DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await expect(
           context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes20(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes20(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes20DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await expect(
           context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
     });
 
-    describe("When bytes32(0) key is not part of the AllowedERC725YDataKeys", () => {
+    describe('When bytes32(0) key is not part of the AllowedERC725YDataKeys', () => {
       before(async () => {
         context = await buildContext();
 
         controllerCanSetSomeKeys = context.accounts[1];
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetSomeKeys.address.substring(2),
         ];
 
@@ -1252,7 +1252,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       [{ allowedDataKey: customKey1 }, { allowedDataKey: customKey2 }].forEach((testCase) => {
         it(`should pass when setting a data key listed in the allowed ERC725Y data keys: ${testCase.allowedDataKey}`, async () => {
           const key = testCase.allowedDataKey;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
           await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
@@ -1263,36 +1263,36 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
       [
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 1")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 1')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 2")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 2')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 3")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 3')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 4")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 4')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 5")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 5')),
         },
       ].forEach((testCase) => {
         it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
           await expect(
             context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
         });
       });
 
-      it("should allow setting up a key with a prefix of 31 null bytes, as bytes31(0) is part of AllowedERC725YDataKeys", async () => {
+      it('should allow setting up a key with a prefix of 31 null bytes, as bytes31(0) is part of AllowedERC725YDataKeys', async () => {
         const key = bytes31DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
@@ -1300,9 +1300,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.equal(value);
       });
 
-      it("should allow setting up a key with a prefix of 20 null bytes, as bytes20(0) is part of AllowedERC725YDataKeys", async () => {
+      it('should allow setting up a key with a prefix of 20 null bytes, as bytes20(0) is part of AllowedERC725YDataKeys', async () => {
         const key = bytes20DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
         const tx = await context.universalProfile
           .connect(controllerCanSetSomeKeys)
@@ -1312,21 +1312,21 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.equal(value);
       });
 
-      it("should pass and allow to set the bytes32(0) data key", async () => {
+      it('should pass and allow to set the bytes32(0) data key', async () => {
         const key = zeroKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
         expect(await context.universalProfile.getData(key)).to.equal(value);
       });
 
-      it("should pass when setting an array of data keys that includes bytes32(0) (= zero data key)", async () => {
+      it('should pass when setting an array of data keys that includes bytes32(0) (= zero data key)', async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values);
@@ -1334,12 +1334,12 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should pass when trying to set an array of data keys including a dynamic bytes24(0) data key, because bytes20(0) dynamic data ke is in AllowedERC725YDataKeys", async () => {
+      it('should pass when trying to set an array of data keys including a dynamic bytes24(0) data key, because bytes20(0) dynamic data ke is in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes24DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values);
@@ -1347,27 +1347,27 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes19(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes19(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes19DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         await expect(
           context.universalProfile.connect(controllerCanSetSomeKeys).setDataBatch(keys, values),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
     });
   });
 
-  describe("one single byte as an allowed data key (e.g: 0xaa0000...0000", () => {
+  describe('one single byte as an allowed data key (e.g: 0xaa0000...0000', () => {
     let controllerCanSetSomeKeys: SignerWithAddress;
 
-    const allowedDataKey = "0xaa";
+    const allowedDataKey = '0xaa';
 
     before(async () => {
       context = await buildContext();
@@ -1375,10 +1375,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetSomeKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetSomeKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetSomeKeys.address.substring(2),
       ];
 
@@ -1391,21 +1391,21 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("should pass when setting a data key that starts with `0xaa`", () => {
+    describe('should pass when setting a data key that starts with `0xaa`', () => {
       [
         {
-          datakeyToSet: "0xaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          datakeyToSet: '0xaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         },
         {
-          datakeyToSet: "0xaacccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          datakeyToSet: '0xaacccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
         },
         {
-          datakeyToSet: "0xaadddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          datakeyToSet: '0xaadddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
         },
       ].forEach((testCase) => {
         it(`e.g: ${testCase.datakeyToSet}`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
           await context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value);
 
@@ -1415,35 +1415,35 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when trying to set a data key that does not start with `0xaa`", () => {
+      describe('when trying to set a data key that does not start with `0xaa`', () => {
         [
           {
-            datakeyToSet: "0xbb00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xbb00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xcc00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xcc00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xdd00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xdd00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xbb12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xbb12345678000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xcc12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xcc12345678000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xdd12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xdd12345678000000000000000000000000000000000000000000000000000000',
           },
         ].forEach((testCase) => {
           it(`should revert (e.g: ${testCase.datakeyToSet})`, async () => {
             const key = testCase.datakeyToSet;
-            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
             await expect(
               context.universalProfile.connect(controllerCanSetSomeKeys).setData(key, value),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetSomeKeys.address, key);
           });
         });

--- a/tests/LSP20CallVerification/LSP6/SetData/PermissionSetData.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetData/PermissionSetData.test.ts
@@ -1,9 +1,9 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { encodeData, ERC725JSONSchema } from "@erc725/erc725.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { encodeData, ERC725JSONSchema } from '@erc725/erc725.js';
 
-import { ExecutorLSP20, ExecutorLSP20__factory } from "../../../../types";
+import { ExecutorLSP20, ExecutorLSP20__factory } from '../../../../types';
 
 // constants
 import {
@@ -11,47 +11,47 @@ import {
   ALL_PERMISSIONS,
   PERMISSIONS,
   OPERATION_TYPES,
-} from "../../../../constants";
+} from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
 import {
   getRandomAddresses,
   combinePermissions,
   encodeCompactBytesArray,
-} from "../../../utils/helpers";
+} from '../../../utils/helpers';
 
 const BasicUPSetup_Schema: ERC725JSONSchema[] = [
   {
-    name: "LSP3Profile",
-    key: ERC725YDataKeys.LSP3["LSP3Profile"],
-    keyType: "Singleton",
-    valueContent: "JSONURL",
-    valueType: "bytes",
+    name: 'LSP3Profile',
+    key: ERC725YDataKeys.LSP3['LSP3Profile'],
+    keyType: 'Singleton',
+    valueContent: 'JSONURL',
+    valueType: 'bytes',
   },
   {
-    name: "LSP1UniversalReceiverDelegate",
+    name: 'LSP1UniversalReceiverDelegate',
     key: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-    keyType: "Singleton",
-    valueContent: "Address",
-    valueType: "address",
+    keyType: 'Singleton',
+    valueContent: 'Address',
+    valueType: 'address',
   },
   {
-    name: "LSP12IssuedAssets[]",
-    key: ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length,
-    keyType: "Array",
-    valueContent: "Number",
-    valueType: "uint256",
+    name: 'LSP12IssuedAssets[]',
+    key: ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].length,
+    keyType: 'Array',
+    valueContent: 'Number',
+    valueType: 'uint256',
   },
 ];
 
 export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
-  describe("when caller is an EOA", () => {
+  describe('when caller is an EOA', () => {
     let canSetDataWithAllowedERC725YDataKeys: SignerWithAddress,
       canSetDataWithoutAllowedERC725YDataKeys: SignerWithAddress,
       cannotSetData: SignerWithAddress;
@@ -64,14 +64,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       cannotSetData = context.accounts[3];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithoutAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + cannotSetData.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + cannotSetData.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -80,13 +80,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         encodeCompactBytesArray([
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
           ERC725YDataKeys.LSP3.LSP3Profile,
-          ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+          ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index,
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
         ]),
         combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.CALL),
         PERMISSIONS.CALL,
@@ -95,76 +95,76 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when setting one key", () => {
-      describe("For UP owner", () => {
-        it("should pass", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+    describe('when setting one key', () => {
+      describe('For UP owner', () => {
+        it('should pass', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
           await context.universalProfile.connect(context.owner).setData(key, value);
 
-          const fetchedResult = await context.universalProfile.callStatic["getData(bytes32)"](key);
+          const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
         });
       });
 
-      describe("For address that has permission SETDATA with AllowedERC725YDataKeys", () => {
-        it("should pass", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+      describe('For address that has permission SETDATA with AllowedERC725YDataKeys', () => {
+        it('should pass', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
           await context.universalProfile
             .connect(canSetDataWithAllowedERC725YDataKeys)
             .setData(key, value);
-          const fetchedResult = await context.universalProfile.callStatic["getData(bytes32)"](key);
+          const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
         });
       });
 
-      describe("For address that has permission SETDATA without any AllowedERC725YDataKeys", () => {
-        it("should revert", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+      describe('For address that has permission SETDATA without any AllowedERC725YDataKeys', () => {
+        it('should revert', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
           await expect(
             context.universalProfile
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .setData(key, value),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
       describe("For address that doesn't have permission SETDATA", () => {
-        it("should not allow", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+        it('should not allow', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
           await expect(context.universalProfile.connect(cannotSetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
       });
     });
 
-    describe("when setting multiple keys", () => {
-      describe("For UP owner", () => {
-        it("(should pass): adding 5 singleton keys", async () => {
+    describe('when setting multiple keys', () => {
+      describe('For UP owner', () => {
+        it('(should pass): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
           await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
@@ -174,10 +174,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+        it('(should pass): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
@@ -187,26 +187,26 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
+        it('(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
             {
-              keyName: "LSP1UniversalReceiverDelegate",
-              value: "0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb",
+              keyName: 'LSP1UniversalReceiverDelegate',
+              value: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
             },
           ];
 
@@ -219,22 +219,22 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
       });
 
-      describe("For address that has permission SETDATA with AllowedERC725YDataKeys", () => {
-        it("(should pass): adding 5 singleton keys", async () => {
+      describe('For address that has permission SETDATA with AllowedERC725YDataKeys', () => {
+        it('(should pass): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
           await context.universalProfile
@@ -246,10 +246,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+        it('(should pass): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
@@ -261,21 +261,21 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
@@ -291,22 +291,22 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
       });
 
-      describe("For address that has permission SETDATA without AllowedERC725YDataKeys", () => {
-        it("(should revert): adding 5 singleton keys", async () => {
+      describe('For address that has permission SETDATA without AllowedERC725YDataKeys', () => {
+        it('(should revert): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
           await expect(
@@ -314,14 +314,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
-        it("(should revert): adding 10 LSP12IssuedAssets", async () => {
+        it('(should revert): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
@@ -330,25 +330,25 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
-        it("(should revert): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should revert): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
@@ -360,79 +360,79 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
               .connect(canSetDataWithoutAllowedERC725YDataKeys)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
       describe("For address that doesn't have permission SETDATA", () => {
-        it("(should fail): adding 5 singleton keys", async () => {
+        it('(should fail): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
           await expect(context.universalProfile.connect(cannotSetData).setDataBatch(keys, values))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
 
-        it("(should fail): adding 10 LSP12IssuedAssets", async () => {
+        it('(should fail): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
           await expect(context.universalProfile.connect(cannotSetData).setDataBatch(keys, values))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
 
-        it("(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
 
           let { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
           await expect(context.universalProfile.connect(cannotSetData).setDataBatch(keys, values))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
       });
     });
   });
 
-  describe("when caller is a contract", () => {
+  describe('when caller is a contract', () => {
     let contractCanSetData: ExecutorLSP20;
 
-    const hardcodedDataKey = "0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1";
-    const hardcodedDataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some value"));
+    const hardcodedDataKey = '0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1';
+    const hardcodedDataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some value'));
 
     /**
      * @dev this is necessary when the function being called in the contract
@@ -449,10 +449,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           contractCanSetData.address.substring(2),
       ];
 
@@ -472,69 +472,69 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
     afterEach(async () => {
       // teardown to start always with empty storage under the hardcoded data key
-      await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, "0x");
+      await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, '0x');
     });
 
-    describe("> contract calls", () => {
-      it("should allow to set a key hardcoded inside a function of the calling contract", async () => {
+    describe('> contract calls', () => {
+      it('should allow to set a key hardcoded inside a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setHardcodedKey();
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to set a key computed inside a function of the calling contract", async () => {
+      it('Should allow to set a key computed inside a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKey();
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to set a key computed from parameters given to a function of the calling contract", async () => {
+      it('Should allow to set a key computed from parameters given to a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, hardcodedDataValue);
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
     });
 
-    describe("> Low-level calls", () => {
-      it("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
+    describe('> Low-level calls', () => {
+      it('Should allow to `setHardcodedKeyRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // check if low-level call succeeded
         let result = await contractCanSetData.callStatic.setHardcodedKeyRawCall({
@@ -548,18 +548,18 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to `setComputedKeyRawCall` on UP", async () => {
+      it('Should allow to `setComputedKeyRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyRawCall({
@@ -567,18 +567,18 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to `setComputedKeyFromParamsRawCall` on UP", async () => {
+      it('Should allow to `setComputedKeyFromParamsRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        let initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        let initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyFromParamsRawCall(
@@ -590,7 +590,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         );
 
         // check that store[key] is now set to value
-        let newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        let newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
@@ -598,7 +598,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     });
   });
 
-  describe("when caller is another UniversalProfile (with a KeyManager attached as owner)", () => {
+  describe('when caller is another UniversalProfile (with a KeyManager attached as owner)', () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -615,13 +615,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       bob = bobContext.accounts[1];
 
       const alicePermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2),
       ];
       const alicePermissionValues = [ALL_PERMISSIONS];
 
       const bobPermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           aliceContext.universalProfile.address.substring(2),
       ];
 
@@ -632,15 +632,15 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
     });
 
-    it("Alice should have ALL PERMISSIONS in her UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2);
+    it('Alice should have ALL PERMISSIONS in her UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2);
 
       const result = await aliceContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
     });
 
-    it("Bob should have ALL PERMISSIONS in his UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2);
+    it('Bob should have ALL PERMISSIONS in his UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
@@ -648,7 +648,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
     it("Alice's UP should have permission SETDATA on Bob's UP", async () => {
       let key =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         aliceContext.universalProfile.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
@@ -660,7 +660,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Alice's Value"));
 
       let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "setData",
+        'setData',
         [key, value],
       );
 
@@ -674,7 +674,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             finalSetDataPayload,
           ),
       )
-        .to.be.revertedWithCustomError(bobContext.keyManager, "NoERC725YDataKeysAllowed")
+        .to.be.revertedWithCustomError(bobContext.keyManager, 'NoERC725YDataKeysAllowed')
         .withArgs(aliceContext.universalProfile.address);
     });
 
@@ -686,13 +686,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await bobContext.universalProfile
         .connect(bob)
         .setData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             aliceContext.universalProfile.address.substring(2),
           encodeCompactBytesArray([key]),
         );
 
       let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "setData",
+        'setData',
         [key, value],
       );
 
@@ -705,13 +705,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     });
   });
 
-  describe("when caller has SUPER_SETDATA + some allowed ERC725YDataKeys", () => {
+  describe('when caller has SUPER_SETDATA + some allowed ERC725YDataKeys', () => {
     let caller: SignerWithAddress;
 
     const AllowedERC725YDataKeys = [
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 1st allowed key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 2nd allowed key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 3rd allowed key")),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 1st allowed key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 2nd allowed key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 3rd allowed key')),
     ];
 
     before(async () => {
@@ -720,8 +720,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       caller = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           caller.address.substring(2),
       ];
 
@@ -733,7 +733,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when trying to set a disallowed key", () => {
+    describe('when trying to set a disallowed key', () => {
       for (let ii = 1; ii <= 5; ii++) {
         let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`dissallowed key ${ii}`));
         let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(`some value ${ii}`));
@@ -747,9 +747,9 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       }
     });
 
-    describe("when trying to set an allowed key", () => {
-      it("should be allowed to set the 1st allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 1"));
+    describe('when trying to set an allowed key', () => {
+      it('should be allowed to set the 1st allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 1'));
 
         await context.universalProfile.connect(caller).setData(AllowedERC725YDataKeys[0], value);
 
@@ -757,8 +757,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         expect(result).to.equal(value);
       });
 
-      it("should be allowed to set the 2nd allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 2"));
+      it('should be allowed to set the 2nd allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 2'));
 
         await context.universalProfile.connect(caller).setData(AllowedERC725YDataKeys[1], value);
 
@@ -766,8 +766,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         expect(result).to.equal(value);
       });
 
-      it("should be allowed to set the 3rd allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 3"));
+      it('should be allowed to set the 3rd allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 3'));
 
         await context.universalProfile.connect(caller).setData(AllowedERC725YDataKeys[2], value);
 

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
@@ -1,16 +1,16 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { combinePermissions, encodeCompactBytesArray } from "../../../utils/helpers";
+import { combinePermissions, encodeCompactBytesArray } from '../../../utils/helpers';
 
 async function setupPermissions(
   context: LSP6TestContext,
@@ -28,7 +28,7 @@ async function setupPermissions(
 async function resetPermissions(context: LSP6TestContext, permissionsKeys: string[]) {
   await context.universalProfile
     .connect(context.owner)
-    .setDataBatch(permissionsKeys, Array(permissionsKeys.length).fill("0x"));
+    .setDataBatch(permissionsKeys, Array(permissionsKeys.length).fill('0x'));
 }
 
 export const shouldBehaveLikePermissionChangeOrAddController = (
@@ -42,24 +42,24 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
   let permissionArrayKeys: string[] = [];
   let permissionArrayValues: string[] = [];
 
-  before("setup", async () => {
+  before('setup', async () => {
     context = await buildContext();
 
     await setupKeyManager(
       context,
-      [ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2)],
+      [ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2)],
       [ALL_PERMISSIONS],
     );
   });
 
-  describe("setting permissions keys (EDIT vs ADD Permissions)", () => {
+  describe('setting permissions keys (EDIT vs ADD Permissions)', () => {
     // this data key is hardcoded to be removed in teardown
     const permissionArrayIndexToAdd =
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006";
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006';
 
     // this data key is hardcoded for readability
     const permissionArrayIndexToEdit =
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004";
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004';
 
     let canOnlyAddController: SignerWithAddress,
       canOnlyEditPermissions: SignerWithAddress,
@@ -68,7 +68,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressToEditPermissions: SignerWithAddress,
       addressWithZeroHexPermissions: SignerWithAddress;
 
-    before("prepare permissions data keys", async () => {
+    before('prepare permissions data keys', async () => {
       canOnlyAddController = context.accounts[1];
       canOnlyEditPermissions = context.accounts[2];
       canOnlySetData = context.accounts[3];
@@ -76,15 +76,15 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressWithZeroHexPermissions = context.accounts[5];
 
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressToEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithZeroHexPermissions.address.substring(2),
       ];
 
@@ -95,17 +95,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         // placeholder permission
         PERMISSIONS.TRANSFERVALUE,
         // 0x0000... = similar to empty, or 'no permissions set'
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
       ];
 
       permissionArrayValues = [
@@ -119,20 +119,20 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       ];
     });
 
-    describe("when setting one permission key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
+    describe('when setting one permission key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
 
           // setup AddressPermissions[]
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -140,11 +140,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should be allowed to ADD a permission", async () => {
+        it('should be allowed to ADD a permission', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
           await context.universalProfile.connect(context.owner).setData(key, PERMISSIONS.SETDATA);
@@ -154,9 +154,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(PERMISSIONS.SETDATA);
         });
 
-        it("should be allowed to CHANGE a permission", async () => {
+        it('should be allowed to CHANGE a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
@@ -168,11 +168,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
@@ -185,10 +185,10 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should be allowed to decrement the length", async () => {
-            let key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should be allowed to decrement the length', async () => {
+            let key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            let currentLength = await context.universalProfile["getData(bytes32)"](key);
+            let currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
@@ -202,11 +202,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should be allowed to set a 20 bytes long address", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should be allowed to set a 20 bytes long address', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
             await context.universalProfile.connect(context.owner).setData(key, value);
@@ -215,46 +215,46 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
-            let randomValue = "0xcafecafecafecafecafe";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should be allowed to set a new 20 bytes long address", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should be allowed to set a new 20 bytes long address', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
             let value = randomWallet.address;
 
@@ -265,46 +265,46 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(ethers.utils.getAddress(result)).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
-            let randomValue = "0xcafecafecafecafecafe";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should pass", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should pass', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
-            let value = "0x";
+            let value = '0x';
 
             await context.universalProfile.connect(context.owner).setData(key, value);
 
@@ -315,29 +315,29 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
 
         // this include any permission data key that start with bytes6(keccak256('AddressPermissions'))
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert', async () => {
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
             await expect(context.universalProfile.connect(context.owner).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission ADDCONTROLLER", () => {
+      describe('when caller is an address with permission ADDCONTROLLER', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -345,7 +345,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           // teardown in one batch `setData(bytes32[])` for efficiency
           await resetPermissions(context, [
             ...permissionKeys,
@@ -354,11 +354,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should be allowed to ADD a new controller", async () => {
+        it('should be allowed to ADD a new controller', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
@@ -370,23 +370,23 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        it("should not be allowed to EDIT a permission", async () => {
+        it('should not be allowed to EDIT a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
@@ -399,26 +399,26 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should not be allowed to decrement the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should not be allowed to decrement the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             let value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
             await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should be allowed to set a new 20 bytes long address", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should be allowed to set a new 20 bytes long address', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
             await context.universalProfile.connect(canOnlyAddController).setData(key, value);
@@ -427,11 +427,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
-            let randomValue = "0xcafecafecafecafecafe";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
 
@@ -440,82 +440,82 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             await expect(
               context.universalProfile.connect(canOnlyAddController).setData(key, randomValue),
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should not be allowed to set an address", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should not be allowed to set an address', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
             let value = randomWallet.address;
 
             await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should not be allowed to remove an address", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should not be allowed to remove an address', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
-            let value = "0x";
+            let value = '0x';
 
             await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
             await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission EDITPERMISSIONS", () => {
+      describe('when caller is an address with permission EDITPERMISSIONS', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -523,7 +523,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -531,34 +531,34 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should not be allowed to ADD a new controller", async () => {
+        it('should not be allowed to ADD a new controller', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it('should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should be allowed to CHANGE a permission", async () => {
+        it('should be allowed to CHANGE a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
@@ -570,11 +570,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
+        describe('when editing `AddressPermissions[]` array length', () => {
           it("should not be allowed to increment the 'AddressPermissions[]' key (length)", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
@@ -583,14 +583,14 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(
               context.universalProfile.connect(canOnlyEditPermissions).setData(key, value),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
           });
 
           it("should be allowed to decrement the 'AddressPermissions[]' key (length)", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
@@ -604,28 +604,28 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should not be allowed", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should not be allowed', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000006";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000006';
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
             await expect(
               context.universalProfile.connect(canOnlyEditPermissions).setData(key, value),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should be allowed", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should be allowed', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
             let value = randomWallet.address;
 
@@ -636,11 +636,11 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(ethers.utils.getAddress(result)).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
-            let randomValue = "0xcafecafecafecafecafe";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
 
@@ -649,16 +649,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
 
@@ -667,19 +667,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should pass", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should pass', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
-            let value = "0x";
+            let value = '0x';
 
             await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
@@ -689,32 +689,32 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
             await expect(
               context.universalProfile.connect(canOnlyEditPermissions).setData(key, value),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission SETDATA", () => {
+      describe('when caller is an address with permission SETDATA', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -722,7 +722,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -730,123 +730,123 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should not be allowed to ADD a permission", async () => {
+        it('should not be allowed to ADD a permission', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it('should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to CHANGE a permission", async () => {
+        it('should not be allowed to CHANGE a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
           await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should not be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should not be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
             await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
           });
 
-          it("should not be allowed to decrement the length", async () => {
-            let key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should not be allowed to decrement the length', async () => {
+            let key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             let value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
             await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should revert", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should revert', async () => {
             let key =
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].index +
-              "00000000000000000000000000000004";
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].index +
+              '00000000000000000000000000000004';
 
-            let value = "0x";
+            let value = '0x';
 
             await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
           });
         });
 
-        it("should not be allowed to add a new address at index -> AddressPermissions[6]", async () => {
+        it('should not be allowed to add a new address at index -> AddressPermissions[6]', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006";
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006';
           let value = ethers.Wallet.createRandom().address.toLowerCase();
 
           await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to edit key at index -> AddressPermissions[4]", async () => {
+        it('should not be allowed to edit key at index -> AddressPermissions[4]', async () => {
           let randomWallet = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004";
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004';
 
           let value = randomWallet.address;
 
           await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
             await expect(context.universalProfile.connect(canOnlySetData).setData(key, value))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
@@ -854,16 +854,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
     });
   });
 
-  describe("setting mixed keys (SETDATA, CHANGE & ADD Permissions)", () => {
+  describe('setting mixed keys (SETDATA, CHANGE & ADD Permissions)', () => {
     let canSetDataAndAddController: SignerWithAddress,
       canSetDataAndEditPermissions: SignerWithAddress;
     // addresses being used to CHANGE (= edit) permissions
     let addressesToEditPermissions: [SignerWithAddress, SignerWithAddress];
 
     const allowedERC725YDataKeys = [
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Third Key")),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Third Key')),
     ];
 
     let permissionKeys: string[];
@@ -876,19 +876,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressesToEditPermissions = [context.accounts[3], context.accounts[4]];
 
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataAndAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataAndAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataAndEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataAndEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressesToEditPermissions[0].address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressesToEditPermissions[1].address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
       ];
 
       permissionValues = [
@@ -904,32 +904,32 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       ];
     });
 
-    describe("when setting multiple keys", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        before("setup permissions", async () => {
+    describe('when setting multiple keys', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should pass): 2 x keys + add 2 x new permissions", async () => {
+        it('(should pass): 2 x keys + add 2 x new permissions', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
@@ -941,19 +941,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
+        it('(should pass): 2 x keys + change 2 x existing permissions', async () => {
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 1st Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 2nd Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 1st Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 2nd Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -965,21 +965,21 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
+        it('(should pass): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -992,32 +992,32 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
       });
 
-      describe("when caller is an address with permission SETDATA + ADDCONTROLLER + 3x Allowed ERC725Y data keys", () => {
-        before("setup permissions", async () => {
+      describe('when caller is an address with permission SETDATA + ADDCONTROLLER + 3x Allowed ERC725Y data keys', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should fail): 2 x allowed data keys + add 2 x new controllers + decrement AddressPermissions[].length by -1", async () => {
+        it('(should fail): 2 x allowed data keys + add 2 x new controllers + decrement AddressPermissions[].length by -1', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
             ethers.utils.hexZeroPad(ethers.utils.hexlify(5), 16),
@@ -1026,23 +1026,23 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await expect(
             context.universalProfile.connect(canSetDataAndAddController).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 2 x allowed data keys + edit permissions of 2 x existing controllers", async () => {
+        it('(should fail): 2 x allowed data keys + edit permissions of 2 x existing controllers', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -1050,25 +1050,25 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await expect(
             context.universalProfile.connect(canSetDataAndAddController).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 2 x allowed data keys + (add 1 x new controller) + (edit permission of 1 x existing controller)", async () => {
+        it('(should fail): 2 x allowed data keys + (add 1 x new controller) + (edit permission of 1 x existing controller)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -1076,16 +1076,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await expect(
             context.universalProfile.connect(canSetDataAndAddController).setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 1 x allowed data key + 1 x NOT allowed data key + 2 x new controllers", async () => {
+        it('(should fail): 1 x allowed data key + 1 x NOT allowed data key + 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           const NotAllowedERC725YDataKey = ethers.utils.keccak256(
-            ethers.utils.toUtf8Bytes("Not Allowed Data Key"),
+            ethers.utils.toUtf8Bytes('Not Allowed Data Key'),
           );
 
           // prettier-ignore
@@ -1111,26 +1111,26 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               .connect(canSetDataAndAddController)
               .setDataBatch(dataKeys, dataValues),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(canSetDataAndAddController.address, NotAllowedERC725YDataKey);
         });
 
-        it("(should pass): 2 x allowed data keys + add 2 x new controllers", async () => {
+        it('(should pass): 2 x allowed data keys + add 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
@@ -1142,9 +1142,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x allowed data keys + add 2 x new controllers + increment AddressPermissions[].length by +2", async () => {
-          const currentPermissionsArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        it('(should pass): 2 x allowed data keys + add 2 x new controllers + increment AddressPermissions[].length by +2', async () => {
+          const currentPermissionsArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           const newPermissionsArrayLength = ethers.BigNumber.from(currentPermissionsArrayLength)
@@ -1157,16 +1157,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
             ethers.utils.hexZeroPad(ethers.utils.hexlify(newPermissionsArrayLength), 16),
@@ -1180,31 +1180,31 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
       });
 
-      describe("when caller is an address with permission SETDATA + EDITPERMISSIONS + 3x Allowed ERC725Y data keys", () => {
-        before("setup permissions", async () => {
+      describe('when caller is an address with permission SETDATA + EDITPERMISSIONS + 3x Allowed ERC725Y data keys', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should fail): 2 x allowed data keys + add 2 x new controllers", async () => {
+        it('(should fail): 2 x allowed data keys + add 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
@@ -1214,13 +1214,13 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               .connect(canSetDataAndEditPermissions)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): 2 x allowed data keys + increment AddressPermissions[].length by +1", async () => {
-          const currentArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        it('(should fail): 2 x allowed data keys + increment AddressPermissions[].length by +1', async () => {
+          const currentArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           const newArrayLength = ethers.BigNumber.from(currentArrayLength).add(1).toNumber();
@@ -1228,12 +1228,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             ethers.utils.hexZeroPad(ethers.utils.hexlify(newArrayLength), 16),
           ];
 
@@ -1242,25 +1242,25 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               .connect(canSetDataAndEditPermissions)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): 2 x allowed data keys + (add 1 x new permission) + (edit permission of 1 x existing controller)", async () => {
+        it('(should fail): 2 x allowed data keys + (add 1 x new permission) + (edit permission of 1 x existing controller)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -1270,19 +1270,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               .connect(canSetDataAndEditPermissions)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): edit permissions of 2 x existing controllers + (set 1 x allowed data key) + (set 1 x NOT allowed data key)", async () => {
+        it('(should fail): edit permissions of 2 x existing controllers + (set 1 x allowed data key) + (set 1 x NOT allowed data key)', async () => {
           const NotAllowedERC725YDataKey = ethers.utils.keccak256(
-            ethers.utils.toUtf8Bytes("Not Allowed Data Key"),
+            ethers.utils.toUtf8Bytes('Not Allowed Data Key'),
           );
 
           let keys = [
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
             allowedERC725YDataKeys[0],
             NotAllowedERC725YDataKey,
@@ -1291,8 +1291,8 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let values = [
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random data for not allowed value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random data for not allowed value')),
           ];
 
           await expect(
@@ -1300,23 +1300,23 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               .connect(canSetDataAndEditPermissions)
               .setDataBatch(keys, values),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(canSetDataAndEditPermissions.address, NotAllowedERC725YDataKey);
         });
 
-        it("(should pass): 2 x allowed data keys + edit permissions of 2 x existing controllers", async () => {
+        it('(should pass): 2 x allowed data keys + edit permissions of 2 x existing controllers', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
@@ -1328,22 +1328,22 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x allowed data keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
+        it('(should pass): 2 x allowed data keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
             ethers.utils.hexZeroPad(ethers.utils.hexlify(4), 16),
           ];
 

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedCalls.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedCalls.test.ts
@@ -1,21 +1,21 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS, INTERFACE_IDS, CALLTYPE } from "../../../../constants";
+import { ERC725YDataKeys, PERMISSIONS, INTERFACE_IDS, CALLTYPE } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { combineAllowedCalls } from "../../../utils/helpers";
+import { combineAllowedCalls } from '../../../utils/helpers';
 
 export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
-  describe("deleting AllowedCalls", () => {
+  describe('deleting AllowedCalls', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress;
@@ -33,15 +33,15 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       noBytes = context.accounts[5];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + invalidBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + noBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + invalidBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + noBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + invalidBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + noBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + invalidBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + noBytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -53,40 +53,40 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           // allow the beneficiary to transfer value to addresses 0xcafe... and 0xbeef...
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0xbadbadbadbad",
-        "0x",
+        '0xbadbadbadbad',
+        '0x',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADD permission", () => {
-      it("should revert and not be allowed to clear the list of allowed calls for an address", async () => {
+    describe('when caller has ADD permission', () => {
+      it('should revert and not be allowed to clear the list of allowed calls for an address', async () => {
         const dataKey =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
-        const dataValue = "0x";
+        const dataValue = '0x';
 
         await expect(
           context.universalProfile.connect(canOnlyAddController).setData(dataKey, dataValue),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
     });
 
-    describe("when caller has CHANGE permission", () => {
-      it("should allow to clear the list of allowed calls for an address", async () => {
+    describe('when caller has CHANGE permission', () => {
+      it('should allow to clear the list of allowed calls for an address', async () => {
         const dataKey =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
-        const dataValue = "0x";
+        const dataValue = '0x';
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(dataKey, dataValue);
 
@@ -96,7 +96,7 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
     });
   });
 
-  describe("setting Allowed Calls -> Addresses", () => {
+  describe('setting Allowed Calls -> Addresses', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -116,15 +116,15 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -134,44 +134,44 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           // allow the beneficiary to transfer value to addresses 0xcafe... and 0xbeef...
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has permission ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed addresses for an address", async () => {
+    describe('when caller has permission ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed addresses for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xca11ca11ca11ca11ca11ca11ca11ca11ca11ca11",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xca11ca11ca11ca11ca11ca11ca11ca11ca11ca11',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompatBytesArray]", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompatBytesArray]', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         // try to set for the invalidBeneficiary some allowed calls
@@ -179,80 +179,80 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         // set for the newController some allowed calls
         // that allow it to transfer value to addresses 0xcafe... and 0xbeef...
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyAddController).setData(key, value);
@@ -262,64 +262,64 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] for a new beneficiary", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] for a new beneficiary', () => {
+        it('should revert with error when value = random bytes', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length bytes)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xffffffffcafecafecafecafecafecafecafecafecafecafeffffffff";
+          let value = '0xffffffffcafecafecafecafecafecafecafecafecafecafeffffffff';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has permission EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has permission EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         // try to set for the newController some allowed calls
         // that allow it to transfer value to addresses 0xcafe... and 0xbeef...
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed addresses for an address", async () => {
+      it('should pass when trying to edit existing allowed addresses for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         // edit the allowed calls of the beneficiary
@@ -328,11 +328,11 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xf00df00df00df00df00df00df00df00df00df00d",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xf00df00df00df00df00df00df00df00df00df00d',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -342,20 +342,20 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         // set some allowed calls for the beneficiary
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -368,19 +368,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -393,19 +393,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed addresses", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed addresses', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -415,35 +415,35 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of allowed calls from existing ANY:<address>:ANY to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of allowed calls from existing ANY:<address>:ANY to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xffffffffcafecafecafecafecafecafecafecafecafecafeffffffff";
+          let value = '0xffffffffcafecafecafecafecafecafecafecafecafecafeffffffff';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
   });
 
-  describe("setting Allowed Calls -> Functions", () => {
+  describe('setting Allowed Calls -> Functions', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -463,15 +463,15 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -480,124 +480,124 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has permission ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed functions for an address", async () => {
+    describe('when caller has permission ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed functions for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to make a CALL to only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to make a CALL to only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xca11ca11"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xca11ca11'],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xca11ca11"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xca11ca11'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
         await context.universalProfile.connect(canOnlyAddController).setData(key, value);
@@ -607,74 +607,74 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] for a new beneficiary", () => {
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (= random bytes)", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] for a new beneficiary', () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (= random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
         await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed bytes4 selectors under ANY:ANY:<selector>", async () => {
+      it('should pass when trying to edit existing allowed bytes4 selectors under ANY:ANY:<selector>', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -684,20 +684,20 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -710,19 +710,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -735,19 +735,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed functions", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed functions', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -757,35 +757,35 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of selectors in allowed calls from existing ANY:ANY:<selector> to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of selectors in allowed calls from existing ANY:ANY:<selector> to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
   });
 
-  describe("setting Allowed Calls -> Standards", () => {
+  describe('setting Allowed Calls -> Standards', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -805,15 +805,15 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -824,33 +824,33 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           // on any LSP7 or ERC20 contracts
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed standards for an address", async () => {
+    describe('when caller has ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed standards for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -861,26 +861,26 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -891,29 +891,29 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -921,29 +921,29 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -951,27 +951,27 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -982,7 +982,7 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyAddController).setData(key, value);
@@ -992,74 +992,74 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] of allowed calls for a new beneficiary", () => {
-        it("should fail when setting an bytes28[CompactBytesArray] (= random bytes)", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] of allowed calls for a new beneficiary', () => {
+        it('should fail when setting an bytes28[CompactBytesArray] (= random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           // try to add in the list of allowed calls for the beneficiary controller
           // the rights to CALL any LSP7 or ERC20 token contract
           // (NB: just the AllowedCalls, not the permission CALL)
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed standards for an address", async () => {
+      it('should pass when trying to edit existing allowed standards for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1070,7 +1070,7 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -1080,19 +1080,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -1105,19 +1105,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -1130,19 +1130,19 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
         await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
@@ -1152,28 +1152,28 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of interface IDs in allowed calls <standard>:ANY:ANY to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of interface IDs in allowed calls <standard>:ANY:ANY to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0xffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedERC725YDataKeys.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedERC725YDataKeys.test.ts
@@ -1,23 +1,23 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS } from "../../../../constants";
+import { ERC725YDataKeys, PERMISSIONS } from '../../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../../utils/context";
-import { setupKeyManager } from "../../../utils/fixtures";
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { encodeCompactBytesArray } from "../../../utils/helpers";
+import { encodeCompactBytesArray } from '../../../utils/helpers';
 
 export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting Allowed ERC725YDataKeys", () => {
+  describe('setting Allowed ERC725YDataKeys', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -37,17 +37,17 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           zero40Bytes.address.substring(2),
       ];
 
@@ -55,27 +55,27 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
         PERMISSIONS.ADDCONTROLLER,
         PERMISSIONS.EDITPERMISSIONS,
         encodeCompactBytesArray([
-          ERC725YDataKeys.LSP3["LSP3Profile"],
+          ERC725YDataKeys.LSP3['LSP3Profile'],
           // prettier-ignore
           ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
         ]),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADDCONTROLLER", () => {
-      describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should fail when adding an extra allowed ERC725Y data key", async () => {
+    describe('when caller has ADDCONTROLLER', () => {
+      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should fail when adding an extra allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
           let value = encodeCompactBytesArray([
-            ERC725YDataKeys.LSP3["LSP3Profile"],
+            ERC725YDataKeys.LSP3['LSP3Profile'],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
@@ -83,56 +83,56 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           ]);
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when removing an allowed ERC725Y data key", async () => {
+        it('should fail when removing an allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when trying to clear the CompactedBytesArray completely", async () => {
+        it('should fail when trying to clear the CompactedBytesArray completely', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0x";
+          let value = '0x';
 
           await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(
             context.universalProfile.connect(canOnlyAddController).setData(key, value),
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidEncodedAllowedERC725YDataKeys",
+            'InvalidEncodedAllowedERC725YDataKeys',
           );
         });
       });
 
-      describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should pass when setting a valid CompactedBytesArray", async () => {
+      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should pass when setting a valid CompactedBytesArray', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
           let value = encodeCompactBytesArray([
@@ -149,34 +149,34 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid CompactedBytesArray (random bytes)", async () => {
+        it('should fail when setting an invalid CompactedBytesArray (random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(
             context.universalProfile.connect(canOnlyAddController).setData(key, value),
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidEncodedAllowedERC725YDataKeys",
+            'InvalidEncodedAllowedERC725YDataKeys',
           );
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should pass when adding an extra allowed ERC725Y data key", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should pass when adding an extra allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
           let value = encodeCompactBytesArray([
-            ERC725YDataKeys.LSP3["LSP3Profile"],
+            ERC725YDataKeys.LSP3['LSP3Profile'],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
@@ -190,12 +190,12 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when removing an allowed ERC725Y data key", async () => {
+        it('should pass when removing an allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
 
           await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
@@ -204,12 +204,12 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when trying to clear the CompactedBytesArray completely", async () => {
+        it('should pass when trying to clear the CompactedBytesArray completely', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0x";
+          let value = '0x';
 
           await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
@@ -218,54 +218,54 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(
             context.universalProfile.connect(canOnlyEditPermissions).setData(key, value),
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidEncodedAllowedERC725YDataKeys",
+            'InvalidEncodedAllowedERC725YDataKeys',
           );
         });
       });
 
-      describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)", async () => {
+      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
           let value = encodeCompactBytesArray([
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 1")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 2")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 1')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 2')),
           ]);
 
           await expect(context.universalProfile.connect(canOnlyEditPermissions).setData(key, value))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
           await expect(
             context.universalProfile.connect(canOnlyEditPermissions).setData(key, value),
           ).to.be.revertedWithCustomError(
             context.keyManager,
-            "InvalidEncodedAllowedERC725YDataKeys",
+            'InvalidEncodedAllowedERC725YDataKeys',
           );
         });
       });

--- a/tests/LSP20CallVerification/LSP6/index.ts
+++ b/tests/LSP20CallVerification/LSP6/index.ts
@@ -1,25 +1,25 @@
 // Admin
-export * from "./Admin/PermissionChangeOwner.test";
-export * from "./Admin/PermissionChangeAddExtensions.test";
-export * from "./Admin/PermissionChangeAddURD.test";
+export * from './Admin/PermissionChangeOwner.test';
+export * from './Admin/PermissionChangeAddExtensions.test';
+export * from './Admin/PermissionChangeAddURD.test';
 
 // Set Permissions
-export * from "./SetPermissions/PermissionChangeAddController.test";
-export * from "./SetPermissions/SetAllowedCalls.test";
-export * from "./SetPermissions/SetAllowedERC725YDataKeys.test";
+export * from './SetPermissions/PermissionChangeAddController.test';
+export * from './SetPermissions/SetAllowedCalls.test';
+export * from './SetPermissions/SetAllowedERC725YDataKeys.test';
 
 // Interactions
-export * from "./Interactions/PermissionCall.test";
-export * from "./Interactions/PermissionStaticCall.test";
-export * from "./Interactions/PermissionDelegateCall.test";
-export * from "./Interactions/PermissionDeploy.test";
-export * from "./Interactions/PermissionTransferValue.test";
-export * from "./Interactions/AllowedAddresses.test";
-export * from "./Interactions/AllowedFunctions.test";
-export * from "./Interactions/AllowedStandards.test";
-export * from "./Interactions/OtherScenarios.test";
-export * from "./Interactions/Security.test";
+export * from './Interactions/PermissionCall.test';
+export * from './Interactions/PermissionStaticCall.test';
+export * from './Interactions/PermissionDelegateCall.test';
+export * from './Interactions/PermissionDeploy.test';
+export * from './Interactions/PermissionTransferValue.test';
+export * from './Interactions/AllowedAddresses.test';
+export * from './Interactions/AllowedFunctions.test';
+export * from './Interactions/AllowedStandards.test';
+export * from './Interactions/OtherScenarios.test';
+export * from './Interactions/Security.test';
 
 // SetData
-export * from "./SetData/PermissionSetData.test";
-export * from "./SetData/AllowedERC725YDataKeys.test";
+export * from './SetData/PermissionSetData.test';
+export * from './SetData/AllowedERC725YDataKeys.test';

--- a/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
+++ b/tests/LSP2ERC725YJSONSchema/LSP2UtilsLibrary.test.ts
@@ -1,11 +1,11 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { LSP2UtilsLibraryTester, LSP2UtilsLibraryTester__factory } from "../../types";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { LSP2UtilsLibraryTester, LSP2UtilsLibraryTester__factory } from '../../types';
 
-import { abiCoder, encodeCompactBytesArray } from "../utils/helpers";
+import { abiCoder, encodeCompactBytesArray } from '../utils/helpers';
 
-describe("LSP2Utils", () => {
+describe('LSP2Utils', () => {
   let accounts: SignerWithAddress[];
   let lsp2Utils: LSP2UtilsLibraryTester;
 
@@ -14,162 +14,162 @@ describe("LSP2Utils", () => {
     lsp2Utils = await new LSP2UtilsLibraryTester__factory(accounts[0]).deploy();
   });
 
-  describe("isEncodedArray(...)", () => {
-    describe("testing different zero bytes 00 of various length", () => {
-      it("should return false for 1 x empty zero bytes", async () => {
-        const data = "0x00";
+  describe('isEncodedArray(...)', () => {
+    describe('testing different zero bytes 00 of various length', () => {
+      it('should return false for 1 x empty zero bytes', async () => {
+        const data = '0x00';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.false;
       });
 
-      it("should return false for 10 x empty zero bytes", async () => {
-        const data = "0x00000000000000000000";
+      it('should return false for 10 x empty zero bytes', async () => {
+        const data = '0x00000000000000000000';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.false;
       });
 
-      it("should return false for 20 x empty zero bytes", async () => {
-        const data = "0x0000000000000000000000000000000000000000";
+      it('should return false for 20 x empty zero bytes', async () => {
+        const data = '0x0000000000000000000000000000000000000000';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.false;
       });
 
-      it("should return false for 30 x empty zero bytes", async () => {
-        const data = "0x000000000000000000000000000000000000000000000000000000000000";
+      it('should return false for 30 x empty zero bytes', async () => {
+        const data = '0x000000000000000000000000000000000000000000000000000000000000';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.false;
       });
 
-      it("should return true for 32 x empty zero bytes", async () => {
-        const data = "0x0000000000000000000000000000000000000000000000000000000000000000";
+      it('should return true for 32 x empty zero bytes', async () => {
+        const data = '0x0000000000000000000000000000000000000000000000000000000000000000';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true for 40 x empty zero bytes", async () => {
+      it('should return true for 40 x empty zero bytes', async () => {
         const data =
-          "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000";
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000';
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true for 64 x empty zero bytes", async () => {
-        const data = "0x" + "00".repeat(64);
+      it('should return true for 64 x empty zero bytes', async () => {
+        const data = '0x' + '00'.repeat(64);
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true for 100 x empty zero bytes", async () => {
-        const data = "0x" + "00".repeat(100);
+      it('should return true for 100 x empty zero bytes', async () => {
+        const data = '0x' + '00'.repeat(100);
         const result = await lsp2Utils.isEncodedArray(data);
         expect(result).to.be.true;
       });
     });
 
-    describe("testing various non-zero bytes input", () => {
-      describe("when 32 bytes", () => {
-        it("should return false (`uint256` data = 32)", async () => {
-          const data = abiCoder.encode(["uint256"], [32]);
+    describe('testing various non-zero bytes input', () => {
+      describe('when 32 bytes', () => {
+        it('should return false (`uint256` data = 32)', async () => {
+          const data = abiCoder.encode(['uint256'], [32]);
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
 
-        it("should return false (`uint256` data = 12345)", async () => {
-          const data = abiCoder.encode(["uint256"], [12345]);
+        it('should return false (`uint256` data = 12345)', async () => {
+          const data = abiCoder.encode(['uint256'], [12345]);
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
 
-        it("should return false (`bytes32` data = 0xcafecafecafecafe...)", async () => {
+        it('should return false (`bytes32` data = 0xcafecafecafecafe...)', async () => {
           const data = abiCoder.encode(
-            ["bytes32"],
-            ["0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe"],
+            ['bytes32'],
+            ['0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe'],
           );
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
       });
 
-      describe("when less than 32 bytes", () => {
-        it("should return false with 4x random bytes", async () => {
-          const data = "0xaabbccdd";
+      describe('when less than 32 bytes', () => {
+        it('should return false with 4x random bytes', async () => {
+          const data = '0xaabbccdd';
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
 
-        it("should return false with 16x random bytes", async () => {
-          const data = "0x1234567890abcdef1234567890abcdef";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.false;
-        });
-      });
-
-      describe("when abi-encoded array, with length = 0", () => {
-        it("should return true with 64 bytes -> offset = 0x20, length = 0 (null)", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-
-        it("should return true with 64 bytes -> offset = 0x20, length = 0 (null) + 10x extra zero bytes", async () => {
-          const data =
-            "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-
-        it("should return true with 64 bytes -> offset = 0x20, length = 0 (null) + 10x extra random bytes", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000aaaabbbbccccddddeeee";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-      });
-
-      describe("when abi-encoded array, with length = 1", () => {
-        it("should return true with 1x array element - offset = 0x20, length = 1", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-
-        it("should return true with 1x array element - offset = 0x20, length = 1, +5 custom bytes in the end", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720ffffffffff";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-
-        it("should return true with 1x array element - offset = 0x25 (+ 5 custom bytes in between), length = 1", async () => {
-          const data =
-            "0x0000000000000000000000000000000000000000000000000000000000000025ffffffffff0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.true;
-        });
-      });
-
-      describe("when not correctly abi-encoded array, with length = 1", () => {
-        it("should return false with 1x array element - offset = 0x20, length = 1, but 31 bytes only", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a797";
-          const result = await lsp2Utils.isEncodedArray(data);
-          expect(result).to.be.false;
-        });
-
-        it("should return false with 1x array element - offset = 0x20, length = 1, but 30 bytes only", async () => {
-          const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a7";
+        it('should return false with 16x random bytes', async () => {
+          const data = '0x1234567890abcdef1234567890abcdef';
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
       });
 
-      describe("when correctly abi-encoded array, but the length does not match the number of elements", () => {
-        it("should return false when 1x array element, but length = 2", async () => {
+      describe('when abi-encoded array, with length = 0', () => {
+        it('should return true with 64 bytes -> offset = 0x20, length = 0 (null)', async () => {
           const data =
-            "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000cafecafecafecafecafecafecafecafecafecafe";
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+
+        it('should return true with 64 bytes -> offset = 0x20, length = 0 (null) + 10x extra zero bytes', async () => {
+          const data =
+            '0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+
+        it('should return true with 64 bytes -> offset = 0x20, length = 0 (null) + 10x extra random bytes', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000aaaabbbbccccddddeeee';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+      });
+
+      describe('when abi-encoded array, with length = 1', () => {
+        it('should return true with 1x array element - offset = 0x20, length = 1', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+
+        it('should return true with 1x array element - offset = 0x20, length = 1, +5 custom bytes in the end', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720ffffffffff';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+
+        it('should return true with 1x array element - offset = 0x25 (+ 5 custom bytes in between), length = 1', async () => {
+          const data =
+            '0x0000000000000000000000000000000000000000000000000000000000000025ffffffffff0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a79720';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.true;
+        });
+      });
+
+      describe('when not correctly abi-encoded array, with length = 1', () => {
+        it('should return false with 1x array element - offset = 0x20, length = 1, but 31 bytes only', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a797';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.false;
+        });
+
+        it('should return false with 1x array element - offset = 0x20, length = 1, but 30 bytes only', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a0Ee7A142d267C1f36714E4a8F75612F20a7';
+          const result = await lsp2Utils.isEncodedArray(data);
+          expect(result).to.be.false;
+        });
+      });
+
+      describe('when correctly abi-encoded array, but the length does not match the number of elements', () => {
+        it('should return false when 1x array element, but length = 2', async () => {
+          const data =
+            '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000cafecafecafecafecafecafecafecafecafecafe';
           const result = await lsp2Utils.isEncodedArray(data);
           expect(result).to.be.false;
         });
@@ -177,73 +177,73 @@ describe("LSP2Utils", () => {
     });
   });
 
-  describe("`isCompactBytesArray(...)`", () => {
-    it("should return true with `0x` (equivalent to `[]`)", async () => {
-      const data = "0x";
+  describe('`isCompactBytesArray(...)`', () => {
+    it('should return true with `0x` (equivalent to `[]`)', async () => {
+      const data = '0x';
       const result = await lsp2Utils.isCompactBytesArray(data);
       expect(result).to.be.true;
     });
 
-    describe("when pass a CompactBytesArray with one element", () => {
-      it("should return true when the first length byte is 0", async () => {
-        const data = encodeCompactBytesArray(["0x"]);
+    describe('when pass a CompactBytesArray with one element', () => {
+      it('should return true when the first length byte is 0', async () => {
+        const data = encodeCompactBytesArray(['0x']);
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true when the first length byte matches the following number of bytes", async () => {
-        const data = encodeCompactBytesArray(["0xaabbccddee"]);
+      it('should return true when the first length byte matches the following number of bytes', async () => {
+        const data = encodeCompactBytesArray(['0xaabbccddee']);
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return false when the first length does not matches the following number of bytes", async () => {
-        let data = encodeCompactBytesArray(["0xaabbccddee"]);
+      it('should return false when the first length does not matches the following number of bytes', async () => {
+        let data = encodeCompactBytesArray(['0xaabbccddee']);
 
         // replace the first length byte of 0xaabbccddee with an invalid length value
-        data = String(data).replace(/05/g, "10");
+        data = String(data).replace(/05/g, '10');
 
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });
     });
 
-    describe("when passing a CompactBytesArray with 3 x elements", () => {
-      it("should return true when all the length bytes match the number of bytes of each elements", async () => {
-        const data = encodeCompactBytesArray(["0xaabbccddee", "0xaabbccddee", "0xaabbccddee"]);
+    describe('when passing a CompactBytesArray with 3 x elements', () => {
+      it('should return true when all the length bytes match the number of bytes of each elements', async () => {
+        const data = encodeCompactBytesArray(['0xaabbccddee', '0xaabbccddee', '0xaabbccddee']);
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true even if one of the element is an empty byte", async () => {
-        const data = encodeCompactBytesArray(["0xaabbccddee", "0x", "0x1122334455"]);
+      it('should return true even if one of the element is an empty byte', async () => {
+        const data = encodeCompactBytesArray(['0xaabbccddee', '0x', '0x1122334455']);
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return true if all the elements are empty bytes", async () => {
-        const data = encodeCompactBytesArray(["0x", "0x", "0x"]);
+      it('should return true if all the elements are empty bytes', async () => {
+        const data = encodeCompactBytesArray(['0x', '0x', '0x']);
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.true;
       });
 
-      it("should return false if one of the byte length of an element has an incorrect length", async () => {
-        let data = encodeCompactBytesArray(["0xaabbccddee", "0xcafecafecafecafe", "0x112233"]);
+      it('should return false if one of the byte length of an element has an incorrect length', async () => {
+        let data = encodeCompactBytesArray(['0xaabbccddee', '0xcafecafecafecafe', '0x112233']);
 
         // replace the first length byte of 0xaabbccddee with an invalid length value
-        data = String(data).replace(/05/g, "10");
+        data = String(data).replace(/05/g, '10');
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });
 
       it("should return false if the byte length of the last element is invalid and points 'too far'", async () => {
-        let data = "0x02aabb05112233445520cafecafe";
+        let data = '0x02aabb05112233445520cafecafe';
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });
 
-      it("should return false for 0x000000", async () => {
-        const data = "0x000000";
+      it('should return false for 0x000000', async () => {
+        const data = '0x000000';
         const result = await lsp2Utils.isCompactBytesArray(data);
         expect(result).to.be.false;
       });

--- a/tests/LSP4DigitalAssetMetadata/LSP4Compatibility.test.ts
+++ b/tests/LSP4DigitalAssetMetadata/LSP4Compatibility.test.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { LSP4CompatibilityTester, LSP4CompatibilityTester__factory } from "../../types";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { LSP4CompatibilityTester, LSP4CompatibilityTester__factory } from '../../types';
 
-import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 type LSP4CompatibilityTestAccounts = {
   owner: SignerWithAddress;
@@ -23,12 +23,12 @@ type LSP4CompatibilityTestContext = {
   };
 };
 
-describe("LSP4Compatibility", () => {
+describe('LSP4Compatibility', () => {
   const buildTestContext = async (): Promise<LSP4CompatibilityTestContext> => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "Much compat",
-      symbol: "WOW",
+      name: 'Much compat',
+      symbol: 'WOW',
       newOwner: accounts.owner.address,
     };
 
@@ -41,34 +41,34 @@ describe("LSP4Compatibility", () => {
     return { accounts, lsp4Compatibility, deployParams };
   };
 
-  describe("when using LSP4Compatibility", () => {
+  describe('when using LSP4Compatibility', () => {
     let context: LSP4CompatibilityTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    it("should allow reading name", async () => {
+    it('should allow reading name', async () => {
       // using compatibility getter -> returns(string)
       const nameAsString = await context.lsp4Compatibility.name();
       expect(nameAsString).to.equal(context.deployParams.name);
 
       // using getData -> returns(bytes)
       const nameAsBytes = await context.lsp4Compatibility.getData(
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("LSP4TokenName")),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('LSP4TokenName')),
       );
 
       expect(ethers.utils.toUtf8String(nameAsBytes)).to.equal(context.deployParams.name);
     });
 
-    it("should allow reading symbol", async () => {
+    it('should allow reading symbol', async () => {
       // using compatibility getter -> returns(string)
       const symbolAsString = await context.lsp4Compatibility.symbol();
       expect(symbolAsString).to.equal(context.deployParams.symbol);
 
       // using getData -> returns(bytes)
       const symbolAsBytes = await context.lsp4Compatibility.getData(
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("LSP4TokenSymbol")),
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('LSP4TokenSymbol')),
       );
 
       expect(ethers.utils.toUtf8String(symbolAsBytes)).to.equal(context.deployParams.symbol);

--- a/tests/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour.ts
+++ b/tests/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour.ts
@@ -1,12 +1,12 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 // LSP7 + LSP8
-import { LSP7DigitalAsset, LSP8IdentifiableDigitalAsset, LSP9Vault } from "../../types";
+import { LSP7DigitalAsset, LSP8IdentifiableDigitalAsset, LSP9Vault } from '../../types';
 
 // constants
-import { ERC725YDataKeys } from "../../constants";
+import { ERC725YDataKeys } from '../../constants';
 
 export type LS4DigitalAssetMetadataTestContext = {
   accounts: SignerWithAddress[];
@@ -23,32 +23,32 @@ export const shouldBehaveLikeLSP4DigitalAssetMetadata = (
     context = await buildContext();
   });
 
-  describe("when setting data on ERC725Y storage", () => {
-    it("should revert when trying to edit Token Name", async () => {
-      const key = ERC725YDataKeys.LSP4["LSP4TokenName"];
-      const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Overriden Token Name"));
+  describe('when setting data on ERC725Y storage', () => {
+    it('should revert when trying to edit Token Name', async () => {
+      const key = ERC725YDataKeys.LSP4['LSP4TokenName'];
+      const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Overriden Token Name'));
 
       expect(
         context.contract.connect(context.deployParams.owner).setData(key, value),
-      ).to.be.revertedWithCustomError(context.contract, "LSP4TokenNameNotEditable");
+      ).to.be.revertedWithCustomError(context.contract, 'LSP4TokenNameNotEditable');
     });
 
-    it("should revert when trying to edit Token Symbol", async () => {
-      const key = ERC725YDataKeys.LSP4["LSP4TokenSymbol"];
-      const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("BAD"));
+    it('should revert when trying to edit Token Symbol', async () => {
+      const key = ERC725YDataKeys.LSP4['LSP4TokenSymbol'];
+      const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('BAD'));
 
       expect(
         context.contract.connect(context.deployParams.owner).setData(key, value),
-      ).to.be.revertedWithCustomError(context.contract, "LSP4TokenSymbolNotEditable");
+      ).to.be.revertedWithCustomError(context.contract, 'LSP4TokenSymbolNotEditable');
     });
 
-    describe("when setting a data key with a value less than 256 bytes", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value less than 256 bytes', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(200));
 
         await expect(context.contract.connect(context.deployParams.owner).setData(key, value))
-          .to.emit(context.contract, "DataChanged")
+          .to.emit(context.contract, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.contract.getData(key);
@@ -56,13 +56,13 @@ export const shouldBehaveLikeLSP4DigitalAssetMetadata = (
       });
     });
 
-    describe("when setting a data key with a value more than 256 bytes", () => {
-      it("should emit DataChanged event with only the first 256 bytes of the value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value more than 256 bytes', () => {
+      it('should emit DataChanged event with only the first 256 bytes of the value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
         await expect(context.contract.connect(context.deployParams.owner).setData(key, value))
-          .to.emit(context.contract, "DataChanged")
+          .to.emit(context.contract, 'DataChanged')
           .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
         const result = await context.contract.getData(key);
@@ -70,13 +70,13 @@ export const shouldBehaveLikeLSP4DigitalAssetMetadata = (
       });
     });
 
-    describe("when setting a data key with a value exactly 256 bytes long", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value exactly 256 bytes long', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(256));
 
         await expect(context.contract.connect(context.deployParams.owner).setData(key, value))
-          .to.emit(context.contract, "DataChanged")
+          .to.emit(context.contract, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.contract.getData(key);

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -1,27 +1,27 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
   combinePermissions,
   encodeCompactBytesArray,
   getRandomAddresses,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOrAddExtensions = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting Extension Handler keys (CHANGE vs ADD)", () => {
+  describe('setting Extension Handler keys (CHANGE vs ADD)', () => {
     let canAddAndChangeExtensions: SignerWithAddress,
       canOnlyAddExtensions: SignerWithAddress,
       canOnlyChangeExtensions: SignerWithAddress,
@@ -48,27 +48,27 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       extensionHandlerKey1 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey2 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey3 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey4 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       extensionHandlerKey5 =
         ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
         ethers.utils.hexlify(ethers.utils.randomBytes(4)).substring(2) + // function selector
-        "00000000000000000000000000000000"; // zero padded
+        '00000000000000000000000000000000'; // zero padded
 
       [extensionA, extensionB, extensionC, extensionD] = getRandomAddresses(4);
 
@@ -80,20 +80,20 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyChangeExtensions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySuperSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canOnlyCall.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
       let permissionValues = [
@@ -106,22 +106,22 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         encodeCompactBytesArray([
           // Adding the Extension Handler Keys as AllowedERC725YDataKey to test if it break the behavior
           ERC725YDataKeys.LSP17.LSP17ExtensionPrefix,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
         ]),
         PERMISSIONS.CALL,
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006',
       ];
 
       permissionArrayValues = [
@@ -141,15 +141,15 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when setting one ExtensionHandler key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+    describe('when setting one ExtensionHandler key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -160,13 +160,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a ExtensionHandler key", async () => {
+        it('should be allowed to edit a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -177,13 +177,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a ExtensionHandler key set", async () => {
+        it('should be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -195,14 +195,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE Extensions permission", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+      describe('when caller is an address with ADD/CHANGE Extensions permission', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -213,13 +213,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a ExtensionHandler key", async () => {
+        it('should be allowed to edit a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -230,13 +230,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a ExtensionHandler key set", async () => {
+        it('should be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -248,14 +248,14 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADDExtensions permission", () => {
-        it("should be allowed to ADD a ExtensionHandler key", async () => {
+      describe('when caller is an address with ADDExtensions permission', () => {
+        it('should be allowed to ADD a ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -272,73 +272,73 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove a ExtensionHandler key set", async () => {
+        it('should NOT be allowed to remove a ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with CHANGEExtensions permission", () => {
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+      describe('when caller is an address with CHANGEExtensions permission', () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
         });
 
-        it("should be allowed to edit the ExtensionHandler key set", async () => {
+        it('should be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionD,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -350,13 +350,13 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove the ExtensionHandler key set", async () => {
+        it('should be allowed to remove the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -369,7 +369,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with SUPER_SETDATA permission", () => {
+      describe('when caller is an address with SUPER_SETDATA permission', () => {
         before(async () => {
           // Adding am extensionHandler data key by the owner to test if address with SUPER_SETDATA
           // can CHANGE its content
@@ -378,63 +378,63 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await context.keyManager.connect(context.owner).execute(payload);
         });
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to edit the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with SETDATA permission with LSP0_EXTENSIONSHANDLER_Prefix as allowedKey", () => {
+      describe('when caller is an address with SETDATA permission with LSP0_EXTENSIONSHANDLER_Prefix as allowedKey', () => {
         before(async () => {
           // Adding an extensionHandler data key by the owner to test if address with SETDATA
           // can CHANGE its content
@@ -443,7 +443,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -451,56 +451,56 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           await context.keyManager.connect(context.owner).execute(payload);
         });
 
-        it("should NOT be allowed to ADD another ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEEXTENSIONS');
         });
       });
 
-      describe("when caller is an address with CALL permission (Without SETDATA)", () => {
+      describe('when caller is an address with CALL permission (Without SETDATA)', () => {
         before(async () => {
           // Adding an extensionHandler data key by the owner to test if address with CALL
           // can CHANGE its content
@@ -509,7 +509,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             dataValue: extensionB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -517,73 +517,73 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           await context.keyManager.connect(context.owner).execute(payload);
         });
 
-        it("should NOT be allowed to ADD another ExtensionHandler key", async () => {
+        it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "ADDEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'ADDEXTENSIONS');
         });
 
-        it("should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
             dataValue: extensionA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEEXTENSIONS');
         });
 
-        it("should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the ExtensionHandler key set even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEEXTENSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEEXTENSIONS');
         });
       });
     });
 
-    describe("when setting mixed keys (ExtensionHandler + AddressPermission + ERC725Y Data Key)", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a ExtensionHandler, AddressPermission and ERC725Y Data Key", async () => {
+    describe('when setting mixed keys (ExtensionHandler + AddressPermission + ERC725Y Data Key)', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a ExtensionHandler, AddressPermission and ERC725Y Data Key', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
             ],
             dataValues: [
               extensionA,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-              "0xaabbccdd",
+              '0xaabbccdd',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -595,21 +595,21 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to edit a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to edit a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
             dataValues: [
               extensionB,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 32),
-              "0xaabb",
+              '0xaabb',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -621,17 +621,17 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to remove a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to remove a ExtensionHandler key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               extensionHandlerKey5,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
-            dataValues: ["0x", ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), "0x"],
+            dataValues: ['0x', ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -644,62 +644,62 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE Extensions permission ", () => {
-        describe("when adding a ExtensionHandler, AddressPermission and ERC725Y Data Key", () => {
+      describe('when caller is an address with ADD/CHANGE Extensions permission ', () => {
+        describe('when adding a ExtensionHandler, AddressPermission and ERC725Y Data Key', () => {
           it("should revert because of caller don't have EDITPERMISSIONS Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey5,
-                ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 extensionA,
                 ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canAddAndChangeExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeExtensions.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeExtensions.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey5,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canAddAndChangeExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeExtensions.address, 'SETDATA');
           });
         });
 
-        describe("when adding and changing in same tx ExtensionHandler", () => {
-          it("should pass", async () => {
+        describe('when adding and changing in same tx ExtensionHandler', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey5, extensionHandlerKey5],
               dataValues: [extensionA, extensionB],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -715,29 +715,29 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
         });
       });
 
-      describe("when caller is an address with ADD Extensions permission ", () => {
+      describe('when caller is an address with ADD Extensions permission ', () => {
         before(async () => {
           // Nullfying the value of ExtensionHandler keys to test that we cannot add them
           const payloadParam = {
             dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
-            dataValues: ["0x", "0x"],
+            dataValues: ['0x', '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
 
           await context.keyManager.connect(context.owner).execute(payload);
         });
-        describe("when adding multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+        describe('when adding multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
               dataValues: [extensionA, extensionB],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -750,49 +750,49 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when adding and changing ExtensionHandler keys in 1 tx ", () => {
+        describe('when adding and changing ExtensionHandler keys in 1 tx ', () => {
           it("should revert because caller don't have CHANGE Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey3, extensionHandlerKey1],
               dataValues: [extensionC, extensionD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "CHANGEEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with CHANGE Extensions permission ", () => {
-        describe("when changing multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+      describe('when caller is an address with CHANGE Extensions permission ', () => {
+        describe('when changing multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -803,7 +803,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               dataValues: [extensionA, extensionB, extensionC],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -816,7 +816,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when changing multiple ExtensionHandler keys with adding ERC725Y Data Key", () => {
+        describe('when changing multiple ExtensionHandler keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have SETDATA permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -824,23 +824,23 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 extensionHandlerKey5,
                 extensionHandlerKey1,
                 extensionHandlerKey2,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, extensionB, extensionC, "0xaabbccdd"],
+              dataValues: [extensionA, extensionB, extensionC, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'SETDATA');
           });
         });
 
-        describe("when changing multiple ExtensionHandler keys with adding a ExtensionHandler key", () => {
+        describe('when changing multiple ExtensionHandler keys with adding a ExtensionHandler key', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -854,19 +854,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               dataValues: [extensionA, extensionB, extensionC, extensionD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when changing (removing) multiple ExtensionHandler keys", () => {
-          it("should pass", async () => {
+        describe('when changing (removing) multiple ExtensionHandler keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -874,10 +874,10 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
                 extensionHandlerKey1,
                 extensionHandlerKey2,
               ],
-              dataValues: ["0x", "0x", "0x"],
+              dataValues: ['0x', '0x', '0x'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -890,154 +890,154 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           });
         });
 
-        describe("when adding ExtensionHandler keys ", () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
               dataValues: [extensionC, extensionD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeExtensions.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when adding a ExtensionHandler and ERC725Y Data Key", () => {
+        describe('when adding a ExtensionHandler and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddExtensions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddExtensions.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddExtensions.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with SUPER SETDATA permission ", () => {
-        describe("when adding ExtensionHandler keys ", () => {
+      describe('when caller is an address with SUPER SETDATA permission ', () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey1, extensionHandlerKey2],
               dataValues: [extensionC, extensionD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
           });
         });
-        describe("when Adding multiple ExtensionHandler keys with adding ERC725Y Data Key", () => {
+        describe('when Adding multiple ExtensionHandler keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
           });
         });
       });
 
-      describe("when caller is an address with SETDATA permission with ExtensionHandler keys as AllowedERC725YDataKeys ", () => {
-        describe("when adding ExtensionHandler keys ", () => {
+      describe('when caller is an address with SETDATA permission with ExtensionHandler keys as AllowedERC725YDataKeys ', () => {
+        describe('when adding ExtensionHandler keys ', () => {
           it("should revert because caller don't have ADD Extensions permission and ExtensionHandler keys are not part of AllowedERC725YDataKeys", async () => {
             const payloadParam = {
               dataKeys: [extensionHandlerKey5, extensionHandlerKey2],
               dataValues: [extensionC, extensionD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("when Adding multiple ExtensionHandler keys with adding other allowedERC725YDataKey", () => {
+        describe('when Adding multiple ExtensionHandler keys with adding other allowedERC725YDataKey', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
               dataKeys: [
                 extensionHandlerKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [extensionA, "0xaabbccdd"],
+              dataValues: [extensionA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDEXTENSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDEXTENSIONS');
           });
         });
 
-        describe("When granting the caller ADDExtensions permission", () => {
+        describe('When granting the caller ADDExtensions permission', () => {
           before(async () => {
             const payloadParam = {
               dataKeys: [
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                   canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await context.keyManager.connect(context.owner).execute(payload);
           });
-          describe("When adding ExtensionHandler key and one of his allowedERC725Y Data Key", () => {
-            it("should pass", async () => {
+          describe('When adding ExtensionHandler key and one of his allowedERC725Y Data Key', () => {
+            it('should pass', async () => {
               const payloadParam = {
                 dataKeys: [
                   extensionHandlerKey4,
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
+                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
                 ],
-                dataValues: [extensionA, "0xaabbccdd"],
+                dataValues: [extensionA, '0xaabbccdd'],
               };
 
-              let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+              let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
                 payloadParam.dataKeys,
                 payloadParam.dataValues,
               ]);

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddURD.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddURD.test.ts
@@ -1,27 +1,27 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
   combinePermissions,
   encodeCompactBytesArray,
   getRandomAddresses,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOrAddURD = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting UniversalReceiverDelegate keys (CHANGE vs ADD)", () => {
+  describe('setting UniversalReceiverDelegate keys (CHANGE vs ADD)', () => {
     let canAddAndChangeUniversalReceiverDelegate: SignerWithAddress,
       canOnlyAddUniversalReceiverDelegate: SignerWithAddress,
       canOnlyChangeUniversalReceiverDelegate: SignerWithAddress,
@@ -78,20 +78,20 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyChangeUniversalReceiverDelegate.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySuperSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canOnlyCall.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
       let permissionValues = [
@@ -108,22 +108,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           // Adding the LSP1 Keys as AllowedERC725YDataKey to test if it break the behavior
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix,
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
         ]),
         PERMISSIONS.CALL,
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006',
       ];
 
       permissionArrayValues = [
@@ -143,15 +143,15 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when setting one UniversalReceiverDelegate key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+    describe('when setting one UniversalReceiverDelegate key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -162,13 +162,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate key", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -179,13 +179,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -197,14 +197,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -217,13 +217,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate key", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -236,13 +236,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -256,14 +256,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADDUniversalReceiverDelegate permission", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with ADDUniversalReceiverDelegate permission', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -280,7 +280,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -288,20 +288,20 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await expect(
             context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should NOT be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -309,20 +309,20 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await expect(
             context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should NOT be allowed to remove a UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to remove a UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -330,22 +330,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await expect(
             context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyAddUniversalReceiverDelegate.address,
-              "CHANGEUNIVERSALRECEIVERDELEGATE",
+              'CHANGEUNIVERSALRECEIVERDELEGATE',
             );
         });
       });
 
-      describe("when caller is an address with CHANGEUniversalReceiverDelegate permission", () => {
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+      describe('when caller is an address with CHANGEUniversalReceiverDelegate permission', () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -353,20 +353,20 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await expect(
             context.keyManager.connect(canOnlyChangeUniversalReceiverDelegate).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(
               canOnlyChangeUniversalReceiverDelegate.address,
-              "ADDUNIVERSALRECEIVERDELEGATE",
+              'ADDUNIVERSALRECEIVERDELEGATE',
             );
         });
 
-        it("should be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateD,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -378,13 +378,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.equal(payloadParam.dataValue);
         });
 
-        it("should be allowed to remove the UniversalReceiverDelegate key set", async () => {
+        it('should be allowed to remove the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -397,7 +397,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with SUPER_SETDATA permission", () => {
+      describe('when caller is an address with SUPER_SETDATA permission', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with SUPER_SETDATA
           // can CHANGE its content
@@ -406,63 +406,63 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await context.keyManager.connect(context.owner).execute(payload);
         });
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey1,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to edit the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySuperSetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySuperSetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
 
-      describe("when caller is an address with SETDATA permission with LSP1URDPrefix as allowedKey", () => {
+      describe('when caller is an address with SETDATA permission with LSP1URDPrefix as allowedKey', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with SETDATA
           // can CHANGE its content
@@ -471,7 +471,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -479,56 +479,56 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await context.keyManager.connect(context.owner).execute(payload);
         });
 
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
 
-      describe("when caller is an address with CALL permission (Without SETDATA)", () => {
+      describe('when caller is an address with CALL permission (Without SETDATA)', () => {
         before(async () => {
           // Adding a LSP1 data key by the owner to test if address with CALL
           // can CHANGE its content
@@ -537,7 +537,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             dataValue: universalReceiverDelegateB,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
@@ -545,73 +545,73 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           await context.keyManager.connect(context.owner).execute(payload);
         });
 
-        it("should NOT be allowed to ADD another UniversalReceiverDelegate key", async () => {
+        it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
             dataKey: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "ADDUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'ADDUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to edit UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
             dataValue: universalReceiverDelegateA,
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
 
-        it("should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey", async () => {
+        it('should NOT be allowed to remove the UniversalReceiverDelegate key set even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
           const payloadParam = {
             dataKey: universalReceiverDelegateKey2,
-            dataValue: "0x",
+            dataValue: '0x',
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             payloadParam.dataKey,
             payloadParam.dataValue,
           ]);
 
           await expect(context.keyManager.connect(canOnlyCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyCall.address, "CHANGEUNIVERSALRECEIVERDELEGATE");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyCall.address, 'CHANGEUNIVERSALRECEIVERDELEGATE');
         });
       });
     });
 
-    describe("when setting mixed keys (UniversalReceiverDelegate + AddressPermission + ERC725Y Data Key)", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        it("should be allowed to ADD a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key", async () => {
+    describe('when setting mixed keys (UniversalReceiverDelegate + AddressPermission + ERC725Y Data Key)', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        it('should be allowed to ADD a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
             ],
             dataValues: [
               universalReceiverDelegateA,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-              "0xaabbccdd",
+              '0xaabbccdd',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -623,21 +623,21 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to edit a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to edit a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
             dataValues: [
               universalReceiverDelegateB,
               ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 16),
-              "0xaabb",
+              '0xaabb',
             ],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -649,17 +649,17 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
 
-        it("should be allowed to remove a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ", async () => {
+        it('should be allowed to remove a UniversalReceiverDelegate Key already set and add new AddressPermission and ERC725Y Data Key ', async () => {
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
+              ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
             ],
-            dataValues: ["0x", ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), "0x"],
+            dataValues: ['0x', ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16), '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
@@ -672,23 +672,23 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission ", () => {
-        describe("when adding a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key", () => {
+      describe('when caller is an address with ADD/CHANGE UniversalReceiverDelegate permission ', () => {
+        describe('when adding a UniversalReceiverDelegate, AddressPermission and ERC725Y Data Key', () => {
           it("should revert because of caller don't have EDITPERMISSIONS Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-                ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 universalReceiverDelegateA,
                 ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -696,22 +696,22 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canAddAndChangeUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -719,13 +719,13 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canAddAndChangeUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canAddAndChangeUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
 
-        describe("when adding and changing in same tx UniversalReceiverDelegate", () => {
-          it("should pass", async () => {
+        describe('when adding and changing in same tx UniversalReceiverDelegate', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
@@ -734,7 +734,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               dataValues: [universalReceiverDelegateA, universalReceiverDelegateB],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -752,29 +752,29 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
         });
       });
 
-      describe("when caller is an address with ADD UniversalReceiverDelegate permission ", () => {
+      describe('when caller is an address with ADD UniversalReceiverDelegate permission ', () => {
         before(async () => {
           // Nullfying the value of UniversalReceiverDelegate keys to test that we cannot add them
           const payloadParam = {
             dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
-            dataValues: ["0x", "0x"],
+            dataValues: ['0x', '0x'],
           };
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             payloadParam.dataKeys,
             payloadParam.dataValues,
           ]);
 
           await context.keyManager.connect(context.owner).execute(payload);
         });
-        describe("when adding multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+        describe('when adding multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
               dataValues: [universalReceiverDelegateA, universalReceiverDelegateB],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -787,14 +787,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when adding and changing UniversalReceiverDelegate keys in 1 tx ", () => {
+        describe('when adding and changing UniversalReceiverDelegate keys in 1 tx ', () => {
           it("should revert because caller don't have CHANGE UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey3, universalReceiverDelegateKey1],
               dataValues: [universalReceiverDelegateC, universalReceiverDelegateD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -802,25 +802,25 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyAddUniversalReceiverDelegate.address,
-                "CHANGEUNIVERSALRECEIVERDELEGATE",
+                'CHANGEUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -828,15 +828,15 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with CHANGE UniversalReceiverDelegate permission ", () => {
-        describe("when changing multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+      describe('when caller is an address with CHANGE UniversalReceiverDelegate permission ', () => {
+        describe('when changing multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -851,7 +851,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -866,7 +866,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when changing multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key", () => {
+        describe('when changing multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have SETDATA permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -874,17 +874,17 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
                 universalReceiverDelegateKey1,
                 universalReceiverDelegateKey2,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
               dataValues: [
                 universalReceiverDelegateA,
                 universalReceiverDelegateB,
                 universalReceiverDelegateC,
-                "0xaabbccdd",
+                '0xaabbccdd',
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -892,12 +892,12 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyChangeUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyChangeUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyChangeUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
 
-        describe("when changing multiple UniversalReceiverDelegate keys with adding a UniversalReceiverDelegate Key", () => {
+        describe('when changing multiple UniversalReceiverDelegate keys with adding a UniversalReceiverDelegate Key', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
@@ -916,7 +916,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -924,16 +924,16 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyChangeUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyChangeUniversalReceiverDelegate.address,
-                "ADDUNIVERSALRECEIVERDELEGATE",
+                'ADDUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when changing (removing) multiple UniversalReceiverDelegate keys", () => {
-          it("should pass", async () => {
+        describe('when changing (removing) multiple UniversalReceiverDelegate keys', () => {
+          it('should pass', async () => {
             const payloadParam = {
               dataKeys: [
                 // All these keys have their values set in previous tests
@@ -941,10 +941,10 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
                 universalReceiverDelegateKey1,
                 universalReceiverDelegateKey2,
               ],
-              dataValues: ["0x", "0x", "0x"],
+              dataValues: ['0x', '0x', '0x'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -959,14 +959,14 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           });
         });
 
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
               dataValues: [universalReceiverDelegateC, universalReceiverDelegateD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -974,25 +974,25 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyChangeUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
               .withArgs(
                 canOnlyChangeUniversalReceiverDelegate.address,
-                "ADDUNIVERSALRECEIVERDELEGATE",
+                'ADDUNIVERSALRECEIVERDELEGATE',
               );
           });
         });
 
-        describe("when adding a UniversalReceiverDelegate and ERC725Y Data Key", () => {
+        describe('when adding a UniversalReceiverDelegate and ERC725Y Data Key', () => {
           it("should revert because of caller don't have SETDATA Permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
@@ -1000,54 +1000,54 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             await expect(
               context.keyManager.connect(canOnlyAddUniversalReceiverDelegate).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddUniversalReceiverDelegate.address, "SETDATA");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddUniversalReceiverDelegate.address, 'SETDATA');
           });
         });
       });
 
-      describe("when caller is an address with SUPER SETDATA permission ", () => {
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+      describe('when caller is an address with SUPER SETDATA permission ', () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [universalReceiverDelegateKey1, universalReceiverDelegateKey2],
               dataValues: [universalReceiverDelegateC, universalReceiverDelegateD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
-        describe("when Adding multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key", () => {
+        describe('when Adding multiple UniversalReceiverDelegate keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySuperSetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySuperSetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySuperSetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
       });
 
-      describe("when caller is an address with SETDATA permission with UniversalReceiverDelegate keys as AllowedERC725YDataKeys ", () => {
-        describe("when adding UniversalReceiverDelegate keys ", () => {
+      describe('when caller is an address with SETDATA permission with UniversalReceiverDelegate keys as AllowedERC725YDataKeys ', () => {
+        describe('when adding UniversalReceiverDelegate keys ', () => {
           it("should revert because caller don't have ADD UniversalReceiverDelegate permission and UniversalReceiverDelegate keys are not part of AllowedERC725YDataKeys", async () => {
             const payloadParam = {
               dataKeys: [
@@ -1057,43 +1057,43 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               dataValues: [universalReceiverDelegateC, universalReceiverDelegateD],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
 
-        describe("when Adding multiple UniversalReceiverDelegate keys with adding other allowedERC725YDataKey", () => {
+        describe('when Adding multiple UniversalReceiverDelegate keys with adding other allowedERC725YDataKey', () => {
           it("should revert because caller don't have ADDUniversalReceiverDelegate permission", async () => {
             const payloadParam = {
               dataKeys: [
                 universalReceiverDelegateKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyKey")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyKey')),
               ],
-              dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+              dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDUNIVERSALRECEIVERDELEGATE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDUNIVERSALRECEIVERDELEGATE');
           });
         });
 
-        describe("When granting the caller ADDUniversalReceiverDelegate permission", () => {
+        describe('When granting the caller ADDUniversalReceiverDelegate permission', () => {
           before(async () => {
             const payloadParam = {
               dataKeys: [
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                   canOnlySetData.address.substring(2),
               ],
               dataValues: [
@@ -1101,24 +1101,24 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               ],
             };
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
               payloadParam.dataKeys,
               payloadParam.dataValues,
             ]);
 
             await context.keyManager.connect(context.owner).execute(payload);
           });
-          describe("When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key", () => {
-            it("should pass", async () => {
+          describe('When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key', () => {
+            it('should pass', async () => {
               const payloadParam = {
                 dataKeys: [
                   universalReceiverDelegateKey4,
-                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
+                  ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
                 ],
-                dataValues: [universalReceiverDelegateA, "0xaabbccdd"],
+                dataValues: [universalReceiverDelegateA, '0xaabbccdd'],
               };
 
-              let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+              let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
                 payloadParam.dataKeys,
                 payloadParam.dataValues,
               ]);

--- a/tests/LSP6KeyManager/Admin/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeOwner.test.ts
@@ -1,18 +1,18 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES, LSP6_VERSION } from "../../../constants";
+import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES, LSP6_VERSION } from '../../../constants';
 
-import { LSP6KeyManager, LSP6KeyManager__factory } from "../../../types";
+import { LSP6KeyManager, LSP6KeyManager__factory } from '../../../types';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
-import { LOCAL_PRIVATE_KEYS } from "../../utils/helpers";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
+import { LOCAL_PRIVATE_KEYS } from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionChangeOwner = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -30,7 +30,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
   let permissionsValues: string[];
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("20"));
+    context = await buildContext(ethers.utils.parseEther('20'));
 
     canChangeOwner = context.accounts[1];
     cannotChangeOwner = context.accounts[2];
@@ -40,18 +40,18 @@ export const shouldBehaveLikePermissionChangeOwner = (
     );
 
     transferOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-      "transferOwnership",
+      'transferOwnership',
       [newKeyManager.address],
     );
 
     resetOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-      "transferOwnership",
+      'transferOwnership',
       [ethers.constants.AddressZero],
     );
 
     permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + canChangeOwner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canChangeOwner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         cannotChangeOwner.address.substring(2),
     ];
 
@@ -60,49 +60,49 @@ export const shouldBehaveLikePermissionChangeOwner = (
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("when calling `transferOwnership(...)` with the target address as parameter", () => {
-    it("should revert", async () => {
+  describe('when calling `transferOwnership(...)` with the target address as parameter', () => {
+    it('should revert', async () => {
       const transferOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-        "transferOwnership",
+        'transferOwnership',
         [context.universalProfile.address],
       );
 
       await expect(
         context.keyManager.connect(canChangeOwner).execute(transferOwnershipPayload),
-      ).to.be.revertedWithCustomError(context.universalProfile, "CannotTransferOwnershipToSelf");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'CannotTransferOwnershipToSelf');
     });
   });
 
-  describe("when calling `transferOwnership(...)` with a new KeyManager address as parameter", () => {
-    describe("when caller does not have permissions CHANGEOWNER", () => {
-      it("should revert", async () => {
+  describe('when calling `transferOwnership(...)` with a new KeyManager address as parameter', () => {
+    describe('when caller does not have permissions CHANGEOWNER', () => {
+      it('should revert', async () => {
         await expect(
           context.keyManager.connect(cannotChangeOwner).execute(transferOwnershipPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(cannotChangeOwner.address, "TRANSFEROWNERSHIP");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(cannotChangeOwner.address, 'TRANSFEROWNERSHIP');
       });
     });
 
-    describe("when caller has ALL PERMISSIONS", () => {
-      before("`transferOwnership(...)` to new Key Manager", async () => {
+    describe('when caller has ALL PERMISSIONS', () => {
+      before('`transferOwnership(...)` to new Key Manager', async () => {
         await context.keyManager.connect(context.owner).execute(transferOwnershipPayload);
       });
 
-      after("reset ownership", async () => {
+      after('reset ownership', async () => {
         await context.keyManager.connect(context.owner).execute(resetOwnershipPayload);
       });
 
-      it("should have set newKeyManager as pendingOwner", async () => {
+      it('should have set newKeyManager as pendingOwner', async () => {
         let pendingOwner = await context.universalProfile.pendingOwner();
         expect(pendingOwner).to.equal(newKeyManager.address);
       });
 
-      it("owner should remain the current KeyManager", async () => {
+      it('owner should remain the current KeyManager', async () => {
         const ownerBefore = await context.universalProfile.owner();
 
         let transferOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-          "transferOwnership",
+          'transferOwnership',
           [newKeyManager.address],
         );
 
@@ -114,12 +114,12 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(ownerAfter).to.equal(context.keyManager.address);
       });
 
-      describe("it should still be possible to call onlyOwner functions via the old KeyManager", () => {
-        it("setData(...)", async () => {
-          const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-          const value = "0xabcd";
+      describe('it should still be possible to call onlyOwner functions via the old KeyManager', () => {
+        it('setData(...)', async () => {
+          const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+          const value = '0xabcd';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -130,15 +130,15 @@ export const shouldBehaveLikePermissionChangeOwner = (
           expect(result).to.equal(value);
         });
 
-        it("execute(...) - LYX transfer", async () => {
+        it('execute(...) - LYX transfer', async () => {
           const recipient = context.accounts[8];
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
-          let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient.address,
             amount,
-            "0x",
+            '0x',
           ]);
 
           await expect(
@@ -147,13 +147,13 @@ export const shouldBehaveLikePermissionChangeOwner = (
         });
       });
 
-      it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+      it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
         let overridenPendingOwner = ethers.Wallet.createRandom().address;
 
         await context.keyManager
           .connect(context.owner)
           .execute(
-            context.universalProfile.interface.encodeFunctionData("transferOwnership", [
+            context.universalProfile.interface.encodeFunctionData('transferOwnership', [
               overridenPendingOwner,
             ]),
           );
@@ -164,25 +164,25 @@ export const shouldBehaveLikePermissionChangeOwner = (
       });
     });
 
-    describe("when caller has only CHANGEOWNER permission", () => {
-      before("`transferOwnership(...)` to new KeyManager", async () => {
+    describe('when caller has only CHANGEOWNER permission', () => {
+      before('`transferOwnership(...)` to new KeyManager', async () => {
         await context.keyManager.connect(canChangeOwner).execute(transferOwnershipPayload);
       });
 
-      after("reset ownership", async () => {
+      after('reset ownership', async () => {
         await context.keyManager.connect(context.owner).execute(resetOwnershipPayload);
       });
 
-      it("should have set newKeyManager as pendingOwner", async () => {
+      it('should have set newKeyManager as pendingOwner', async () => {
         let pendingOwner = await context.universalProfile.pendingOwner();
         expect(pendingOwner).to.equal(newKeyManager.address);
       });
 
-      it("owner should remain the current KeyManager", async () => {
+      it('owner should remain the current KeyManager', async () => {
         const ownerBefore = await context.universalProfile.owner();
 
         let transferOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-          "transferOwnership",
+          'transferOwnership',
           [newKeyManager.address],
         );
 
@@ -194,7 +194,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(ownerAfter).to.equal(context.keyManager.address);
       });
 
-      it("should override the pendingOwner when transferOwnership(...) is called twice", async () => {
+      it('should override the pendingOwner when transferOwnership(...) is called twice', async () => {
         let overridenPendingOwner = await new LSP6KeyManager__factory(context.owner).deploy(
           context.universalProfile.address,
         );
@@ -202,7 +202,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
         await context.keyManager
           .connect(canChangeOwner)
           .execute(
-            context.universalProfile.interface.encodeFunctionData("transferOwnership", [
+            context.universalProfile.interface.encodeFunctionData('transferOwnership', [
               overridenPendingOwner.address,
             ]),
           );
@@ -213,35 +213,35 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
   });
 
-  describe("when calling acceptOwnership(...) from a KeyManager that is not the pendingOwner", () => {
-    before("`transferOwnership(...)` to new Key Manager", async () => {
+  describe('when calling acceptOwnership(...) from a KeyManager that is not the pendingOwner', () => {
+    before('`transferOwnership(...)` to new Key Manager', async () => {
       await context.keyManager.connect(context.owner).execute(transferOwnershipPayload);
     });
 
-    it("should revert", async () => {
+    it('should revert', async () => {
       let notPendingKeyManager = await new LSP6KeyManager__factory(context.accounts[5]).deploy(
         context.universalProfile.address,
       );
 
-      let payload = context.universalProfile.interface.getSighash("acceptOwnership");
+      let payload = context.universalProfile.interface.getSighash('acceptOwnership');
 
       await expect(notPendingKeyManager.connect(context.owner).execute(payload)).to.be.revertedWith(
-        "LSP14: caller is not the pendingOwner",
+        'LSP14: caller is not the pendingOwner',
       );
     });
   });
 
-  describe("when calling acceptOwnership(...) via the pending new KeyManager", () => {
+  describe('when calling acceptOwnership(...) via the pending new KeyManager', () => {
     let pendingOwner: string;
 
-    before("`transferOwnership(...)` to new Key Manager", async () => {
+    before('`transferOwnership(...)` to new Key Manager', async () => {
       await context.universalProfile
         .connect(context.owner)
         .transferOwnership(newKeyManager.address);
 
       pendingOwner = await context.universalProfile.pendingOwner();
 
-      let acceptOwnershipPayload = context.universalProfile.interface.getSighash("acceptOwnership");
+      let acceptOwnershipPayload = context.universalProfile.interface.getSighash('acceptOwnership');
 
       await newKeyManager.connect(context.owner).execute(acceptOwnershipPayload);
     });
@@ -251,13 +251,13 @@ export const shouldBehaveLikePermissionChangeOwner = (
       expect(updatedOwner).to.equal(pendingOwner);
     });
 
-    it("should have cleared the pendingOwner after transfering ownership", async () => {
+    it('should have cleared the pendingOwner after transfering ownership', async () => {
       let newPendingOwner = await context.universalProfile.pendingOwner();
       expect(newPendingOwner).to.equal(ethers.constants.AddressZero);
     });
   });
 
-  describe("after KeyManager has been upgraded via acceptOwnership(...)", () => {
+  describe('after KeyManager has been upgraded via acceptOwnership(...)', () => {
     // to improve readability of tests
     let oldKeyManager: LSP6KeyManager;
 
@@ -265,44 +265,44 @@ export const shouldBehaveLikePermissionChangeOwner = (
       oldKeyManager = context.keyManager;
     });
 
-    describe("old KeyManager should not be allowed to call onlyOwner functions anymore", () => {
-      it("should revert with error `NoPermissionsSet` when calling `setData(...)`", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('old KeyManager should not be allowed to call onlyOwner functions anymore', () => {
+      it('should revert with error `NoPermissionsSet` when calling `setData(...)`', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(oldKeyManager.connect(context.owner).execute(payload))
-          .to.be.revertedWithCustomError(newKeyManager, "NoPermissionsSet")
+          .to.be.revertedWithCustomError(newKeyManager, 'NoPermissionsSet')
           .withArgs(oldKeyManager.address);
       });
 
-      it("should revert with error `NoPermissionsSet` when calling `execute(...)`", async () => {
+      it('should revert with error `NoPermissionsSet` when calling `execute(...)`', async () => {
         let recipient = context.accounts[3];
-        let amount = ethers.utils.parseEther("3");
+        let amount = ethers.utils.parseEther('3');
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient.address,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await expect(oldKeyManager.connect(context.owner).execute(payload))
-          .to.be.revertedWithCustomError(newKeyManager, "NoPermissionsSet")
+          .to.be.revertedWithCustomError(newKeyManager, 'NoPermissionsSet')
           .withArgs(oldKeyManager.address);
       });
     });
 
-    describe("new Key Manager should be allowed to call onlyOwner functions", () => {
-      it("setData(...)", async () => {
-        const key = "0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe";
-        const value = "0xabcd";
+    describe('new Key Manager should be allowed to call onlyOwner functions', () => {
+      it('setData(...)', async () => {
+        const key = '0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe';
+        const value = '0xabcd';
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -313,15 +313,15 @@ export const shouldBehaveLikePermissionChangeOwner = (
         expect(result).to.equal(value);
       });
 
-      it("execute(...) - LYX transfer", async () => {
+      it('execute(...) - LYX transfer', async () => {
         const recipient = context.accounts[3];
-        const amount = ethers.utils.parseEther("3");
+        const amount = ethers.utils.parseEther('3');
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient.address,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await expect(newKeyManager.connect(context.owner).execute(payload)).to.changeEtherBalances(
@@ -332,17 +332,17 @@ export const shouldBehaveLikePermissionChangeOwner = (
     });
   });
 
-  describe("when calling `renounceOwnership(...)` via the KeyManager", () => {
-    describe("when caller has ALL PERMISSIONS", () => {
-      it("should revert via `execute(...)`", async () => {
-        let payload = context.universalProfile.interface.getSighash("renounceOwnership");
+  describe('when calling `renounceOwnership(...)` via the KeyManager', () => {
+    describe('when caller has ALL PERMISSIONS', () => {
+      it('should revert via `execute(...)`', async () => {
+        let payload = context.universalProfile.interface.getSighash('renounceOwnership');
 
         await expect(context.keyManager.connect(context.owner).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
           .withArgs(payload);
       });
 
-      it("should revert via `executeRelayCall()`", async () => {
+      it('should revert via `executeRelayCall()`', async () => {
         const HARDHAT_CHAINID = 31337;
         const valueToSend = 0;
 
@@ -350,10 +350,10 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
         const validityTimestamps = 0;
 
-        const payload = context.universalProfile.interface.getSighash("renounceOwnership");
+        const payload = context.universalProfile.interface.getSighash('renounceOwnership');
 
         const encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
         );
 
@@ -372,7 +372,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
               value: valueToSend,
             }),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
           .withArgs(payload);
       });
     });

--- a/tests/LSP6KeyManager/Admin/PermissionSign.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionSign.test.ts
@@ -1,23 +1,23 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, ERC1271_VALUES } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, ERC1271_VALUES } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
-import { LOCAL_PRIVATE_KEYS } from "../../utils/helpers";
+import { LOCAL_PRIVATE_KEYS } from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
   let signer: SignerWithAddress, nonSigner: SignerWithAddress, noPermissionsSet: SignerWithAddress;
 
-  const dataToSign = "0xcafecafe";
+  const dataToSign = '0xcafecafe';
 
   before(async () => {
     context = await buildContext();
@@ -27,9 +27,9 @@ export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6T
     noPermissionsSet = context.accounts[3];
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + nonSigner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + nonSigner.address.substring(2),
     ];
 
     const permissionsValues = [ALL_PERMISSIONS, PERMISSIONS.SIGN, PERMISSIONS.CALL];
@@ -37,9 +37,9 @@ export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6T
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("when address has ALL PERMISSIONS", () => {
-    describe("should verify the signature, regardless of how it was signed", () => {
-      it("e.g: with Ethereum signed message", async () => {
+  describe('when address has ALL PERMISSIONS', () => {
+    describe('should verify the signature, regardless of how it was signed', () => {
+      it('e.g: with Ethereum signed message', async () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await signer.signMessage(dataToSign);
 
@@ -65,9 +65,9 @@ export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6T
     });
   });
 
-  describe("when address has permission SIGN", () => {
-    describe("should verify the signature, regardless of how it was signed", () => {
-      it("e.g: Ethereum signed message", async () => {
+  describe('when address has permission SIGN', () => {
+    describe('should verify the signature, regardless of how it was signed', () => {
+      it('e.g: Ethereum signed message', async () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await signer.signMessage(dataToSign);
 
@@ -92,9 +92,9 @@ export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6T
     });
   });
 
-  describe("when address does not have permission SIGN", () => {
-    describe("should fail when verifying a signature, regardless of how it was signed", () => {
-      it("e.g: with Ethereum signed message", async () => {
+  describe('when address does not have permission SIGN', () => {
+    describe('should fail when verifying a signature, regardless of how it was signed', () => {
+      it('e.g: with Ethereum signed message', async () => {
         const messageHash = ethers.utils.hashMessage(dataToSign);
         const signature = await nonSigner.signMessage(dataToSign);
 

--- a/tests/LSP6KeyManager/Interactions/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedAddresses.test.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract, TargetContract__factory } from "../../../types";
+import { TargetContract, TargetContract__factory } from '../../../types';
 
 // constants
 import {
@@ -11,11 +11,11 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -37,7 +37,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     allowedTargetContract: TargetContract,
     notAllowedTargetContract: TargetContract;
 
-  const invalidEncodedAllowedCallsValue = "0xbadbadbadbad";
+  const invalidEncodedAllowedCallsValue = '0xbadbadbadbad';
 
   before(async () => {
     context = await buildContext();
@@ -53,14 +53,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     notAllowedTargetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         canCallOnlyTwoAddresses.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         canCallOnlyTwoAddresses.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         invalidEncodedAllowedCalls.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         invalidEncodedAllowedCalls.address.substring(2),
     ];
 
@@ -70,8 +70,8 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
         combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
       ],
       [allowedEOA.address, allowedTargetContract.address],
-      ["0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff'],
     );
 
     let permissionsValues = [
@@ -86,12 +86,12 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
 
     await context.owner.sendTransaction({
       to: context.universalProfile.address,
-      value: ethers.utils.parseEther("10"),
+      value: ethers.utils.parseEther('10'),
     });
   });
 
-  describe("when caller has ALL_DEFAULT_PERMISSIONS + no ALLOWED ADDRESSES set", () => {
-    describe("it should be allowed to interact with any address", () => {
+  describe('when caller has ALL_DEFAULT_PERMISSIONS + no ALLOWED ADDRESSES set', () => {
+    describe('it should be allowed to interact with any address', () => {
       const randomAddresses = getRandomAddresses(5);
 
       randomAddresses.forEach((recipient) => {
@@ -99,9 +99,9 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
           let initialBalanceEOA = await provider.getBalance(recipient);
 
-          let amount = ethers.utils.parseEther("1");
+          let amount = ethers.utils.parseEther('1');
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient,
             amount,
@@ -120,14 +120,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     });
   });
 
-  describe("when caller has 2 x addresses set under `AllowedCalls`", () => {
-    it("should be allowed to send LYX to an allowed address (= EOA)", async () => {
+  describe('when caller has 2 x addresses set under `AllowedCalls`', () => {
+    it('should be allowed to send LYX to an allowed address (= EOA)', async () => {
       let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
       let initialBalanceEOA = await provider.getBalance(allowedEOA.address);
 
-      let amount = ethers.utils.parseEther("1");
+      let amount = ethers.utils.parseEther('1');
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         allowedEOA.address,
         amount,
@@ -143,14 +143,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(newBalanceEOA).to.be.gt(initialBalanceEOA);
     });
 
-    it("should be allowed to interact with an allowed address (= contract)", async () => {
-      const argument = "new name";
+    it('should be allowed to interact with an allowed address (= contract)', async () => {
+      const argument = 'new name';
 
-      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData("setName", [
+      let targetContractPayload = allowedTargetContract.interface.encodeFunctionData('setName', [
         argument,
       ]);
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         allowedTargetContract.address,
         0,
@@ -163,20 +163,20 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(result).to.equal(argument);
     });
 
-    it("should revert when sending LYX to a non-allowed address (= EOA)", async () => {
+    it('should revert when sending LYX to a non-allowed address (= EOA)', async () => {
       let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
       let initialBalanceRecipient = await provider.getBalance(notAllowedEOA.address);
 
-      let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         notAllowedEOA.address,
-        ethers.utils.parseEther("1"),
+        ethers.utils.parseEther('1'),
         EMPTY_PAYLOAD,
       ]);
 
       await expect(context.keyManager.connect(canCallOnlyTwoAddresses).execute(transferPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-        .withArgs(canCallOnlyTwoAddresses.address, notAllowedEOA.address, "0x00000000");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+        .withArgs(canCallOnlyTwoAddresses.address, notAllowedEOA.address, '0x00000000');
 
       let newBalanceUP = await provider.getBalance(context.universalProfile.address);
       let newBalanceRecipient = await provider.getBalance(notAllowedEOA.address);
@@ -185,14 +185,14 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
     });
 
-    it("should revert when interacting with an non-allowed address (= contract)", async () => {
-      const argument = "new name";
+    it('should revert when interacting with an non-allowed address (= contract)', async () => {
+      const argument = 'new name';
 
-      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData("setName", [
+      let targetContractPayload = notAllowedTargetContract.interface.encodeFunctionData('setName', [
         argument,
       ]);
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         notAllowedTargetContract.address,
         0,
@@ -200,17 +200,17 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
       ]);
 
       await expect(context.keyManager.connect(canCallOnlyTwoAddresses).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
         .withArgs(
           canCallOnlyTwoAddresses.address,
           notAllowedTargetContract.address,
-          notAllowedTargetContract.interface.getSighash("setName"),
+          notAllowedTargetContract.interface.getSighash('setName'),
         );
     });
   });
 
-  describe("when caller has an invalid abi-encoded array set for ALLOWED ADDRESSES", () => {
-    describe("it should not allow to interact with any address", () => {
+  describe('when caller has an invalid abi-encoded array set for ALLOWED ADDRESSES', () => {
+    describe('it should not allow to interact with any address', () => {
       const randomAddresses = getRandomAddresses(5);
 
       randomAddresses.forEach((recipient) => {
@@ -218,9 +218,9 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           await provider.getBalance(context.universalProfile.address);
           await provider.getBalance(recipient);
 
-          let amount = ethers.utils.parseEther("1");
+          let amount = ethers.utils.parseEther('1');
 
-          let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient,
             amount,
@@ -230,7 +230,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           await expect(
             context.keyManager.connect(invalidEncodedAllowedCalls).execute(transferPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(invalidEncodedAllowedCallsValue);
         });
       });

--- a/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   LSP7Mintable,
@@ -10,7 +10,7 @@ import {
   LSP8Mintable__factory,
   TargetContract,
   TargetContract__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -20,14 +20,14 @@ import {
   PERMISSIONS,
   INTERFACE_IDS,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
-import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from "../../utils/helpers";
+import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from '../../utils/helpers';
 
 export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -46,11 +46,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressWithNoAllowedFunctions.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanCallOnlyOneFunction.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanCallOnlyOneFunction.address.substring(2),
     ];
 
@@ -59,27 +59,27 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
       PERMISSIONS.CALL,
       combineAllowedCalls(
         [CALLTYPE.CALL],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
-        ["0xffffffff"],
-        [targetContract.interface.getSighash("setName")],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
+        ['0xffffffff'],
+        [targetContract.interface.getSighash('setName')],
       ),
     ];
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("when interacting via `execute(...)`", () => {
-    describe("when caller has nothing listed under allowedCalls", () => {
-      describe("when calling a contract", () => {
-        it("should revert when calling any function (eg: `setName(...)`)", async () => {
+  describe('when interacting via `execute(...)`', () => {
+    describe('when caller has nothing listed under allowedCalls', () => {
+      describe('when calling a contract', () => {
+        it('should revert when calling any function (eg: `setName(...)`)', async () => {
           let initialName = await targetContract.callStatic.getName();
-          let newName = "Updated Name";
+          let newName = 'Updated Name';
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
             newName,
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -89,17 +89,17 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           await expect(
             context.keyManager.connect(addressWithNoAllowedFunctions).execute(executePayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
             .withArgs(addressWithNoAllowedFunctions.address);
         });
 
-        it("should revert when calling any function (eg: `setNumber(...)`)", async () => {
+        it('should revert when calling any function (eg: `setNumber(...)`)', async () => {
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setNumber", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setNumber', [
             newNumber,
           ]);
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -109,23 +109,23 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           await expect(
             context.keyManager.connect(addressWithNoAllowedFunctions).execute(executePayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
             .withArgs(addressWithNoAllowedFunctions.address);
         });
       });
     });
 
-    describe("when caller has 1 x bytes4 function selector listed under AllowedFunctions", () => {
-      describe("when calling a contract", () => {
-        it("should pass when the bytes4 selector of the function called is listed in its AllowedFunctions", async () => {
+    describe('when caller has 1 x bytes4 function selector listed under AllowedFunctions', () => {
+      describe('when calling a contract', () => {
+        it('should pass when the bytes4 selector of the function called is listed in its AllowedFunctions', async () => {
           let initialName = await targetContract.callStatic.getName();
-          let newName = "Updated Name";
+          let newName = 'Updated Name';
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
             newName,
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -139,14 +139,14 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(result).to.equal(newName);
         });
 
-        it("should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions", async () => {
+        it('should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions', async () => {
           let initialNumber = await targetContract.callStatic.getNumber();
           let newNumber = 18;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setNumber", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setNumber', [
             newNumber,
           ]);
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -156,11 +156,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           await expect(
             context.keyManager.connect(addressCanCallOnlyOneFunction).execute(executePayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallOnlyOneFunction.address,
               targetContract.address,
-              targetContract.interface.getSighash("setNumber"),
+              targetContract.interface.getSighash('setNumber'),
             );
 
           let result = await targetContract.callStatic.getNumber();
@@ -169,11 +169,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         });
       });
 
-      it("should revert when passing a random bytes payload with a random function selector", async () => {
+      it('should revert when passing a random bytes payload with a random function selector', async () => {
         const randomPayload =
-          "0xbaadca110000000000000000000000000000000000000000000000000000000123456789";
+          '0xbaadca110000000000000000000000000000000000000000000000000000000123456789';
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
@@ -181,7 +181,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         ]);
 
         await expect(context.keyManager.connect(addressCanCallOnlyOneFunction).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanCallOnlyOneFunction.address,
             targetContract.address,
@@ -191,15 +191,15 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
     });
   });
 
-  describe("when interacting via `executeRelayCall(...)`", () => {
+  describe('when interacting via `executeRelayCall(...)`', () => {
     const channelId = 0;
 
-    describe("when signer has 1 x bytes4 function selector listed under AllowedFunctions", () => {
-      describe("when calling a contract", () => {
-        it("`setName(...)` - should pass when the bytes4 selector of the function called is listed in its AllowedFunctions", async () => {
-          let newName = "Dagobah";
+    describe('when signer has 1 x bytes4 function selector listed under AllowedFunctions', () => {
+      describe('when calling a contract', () => {
+        it('`setName(...)` - should pass when the bytes4 selector of the function called is listed in its AllowedFunctions', async () => {
+          let newName = 'Dagobah';
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
             newName,
           ]);
           let nonce = await context.keyManager.callStatic.getNonce(
@@ -210,7 +210,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           const validityTimestamps = 0;
 
           let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            'execute',
             [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
           );
 
@@ -218,7 +218,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           let valueToSend = 0;
 
           let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
               LSP6_VERSION,
               HARDHAT_CHAINID,
@@ -248,7 +248,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(endResult).to.equal(newName);
         });
 
-        it("`setNumber(...)` - should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions", async () => {
+        it('`setNumber(...)` - should revert when the bytes4 selector of the function called is NOT listed in its AllowedFunctions', async () => {
           let currentNumber = await targetContract.callStatic.getNumber();
 
           let nonce = await context.keyManager.callStatic.getNonce(
@@ -258,12 +258,12 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
 
           const validityTimestamps = 0;
 
-          let targetContractPayload = targetContract.interface.encodeFunctionData("setNumber", [
+          let targetContractPayload = targetContract.interface.encodeFunctionData('setNumber', [
             2354,
           ]);
 
           let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            'execute',
             [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
           );
 
@@ -271,7 +271,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           let valueToSend = 0;
 
           let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
               LSP6_VERSION,
               HARDHAT_CHAINID,
@@ -299,11 +299,11 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               { value: valueToSend },
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallOnlyOneFunction.address,
               targetContract.address,
-              targetContract.interface.getSighash("setNumber"),
+              targetContract.interface.getSighash('setNumber'),
             );
 
           let endResult = await targetContract.callStatic.getNumber();
@@ -313,16 +313,16 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
     });
   });
 
-  describe("allowed to call only `transfer(...)` function on LSP8 contracts", () => {
+  describe('allowed to call only `transfer(...)` function on LSP8 contracts', () => {
     let addressCanCallOnlyTransferOnLSP8: SignerWithAddress;
     let addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8: SignerWithAddress;
 
     let lsp7Contract: LSP7Mintable;
     let lsp8Contract: LSP8Mintable;
 
-    const tokenIdToTransfer = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+    const tokenIdToTransfer = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
-    const tokenIdToApprove = "0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d";
+    const tokenIdToApprove = '0xf00df00df00df00df00df00df00df00df00df00df00df00df00df00df00df00d';
 
     before(async () => {
       context = await buildContext();
@@ -331,27 +331,27 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
       addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8 = context.accounts[2];
 
       lsp7Contract = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-        "LSP7 Token",
-        "TKN",
+        'LSP7 Token',
+        'TKN',
         context.accounts[0].address,
         false,
       );
 
       lsp8Contract = await new LSP8Mintable__factory(context.accounts[0]).deploy(
-        "LSP8 NFT",
-        "NFT",
+        'LSP8 NFT',
+        'NFT',
         context.accounts[0].address,
       );
 
       await lsp7Contract
         .connect(context.accounts[0])
-        .mint(context.universalProfile.address, 100, false, "0x");
+        .mint(context.universalProfile.address, 100, false, '0x');
 
       // mint some NFTs for the UP
       [tokenIdToTransfer, tokenIdToApprove].forEach(async (tokenId) => {
         await lsp8Contract
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, tokenId, true, "0x");
+          .mint(context.universalProfile.address, tokenId, true, '0x');
       });
 
       await lsp7Contract
@@ -359,13 +359,13 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         .transferOwnership(context.universalProfile.address);
 
       let permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanCallOnlyTransferOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanCallOnlyTransferOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address.substring(2),
       ];
 
@@ -374,36 +374,36 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         // LSP8:ANY:transfer(…)
         combineAllowedCalls(
           [CALLTYPE.CALL],
-          ["0xffffffffffffffffffffffffffffffffffffffff"],
+          ['0xffffffffffffffffffffffffffffffffffffffff'],
           [INTERFACE_IDS.LSP8IdentifiableDigitalAsset],
-          [lsp8Contract.interface.getSighash("transfer")],
+          [lsp8Contract.interface.getSighash('transfer')],
         ),
         PERMISSIONS.CALL,
         // LSP7:ANY:ANY + LSP8:ANY: authorizeOperator(…)
         combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.LSP8IdentifiableDigitalAsset],
-          ["0xffffffff", lsp8Contract.interface.getSighash("authorizeOperator")],
+          ['0xffffffff', lsp8Contract.interface.getSighash('authorizeOperator')],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when caller can only call `transfer(...)` on LSP8 contracts only", () => {
-      it("should revert with `NotAllowedCall` when calling `authorizeOperator(...)` on LSP8 contract", async () => {
+    describe('when caller can only call `transfer(...)` on LSP8 contracts only', () => {
+      it('should revert with `NotAllowedCall` when calling `authorizeOperator(...)` on LSP8 contract', async () => {
         const operator = context.accounts[8].address;
 
         const authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-          "authorizeOperator",
+          'authorizeOperator',
           [operator, tokenIdToTransfer],
         );
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp8Contract.address,
           0,
@@ -413,26 +413,26 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         await expect(
           context.keyManager.connect(addressCanCallOnlyTransferOnLSP8).execute(executePayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanCallOnlyTransferOnLSP8.address,
             lsp8Contract.address,
-            lsp8Contract.interface.getSighash("authorizeOperator"),
+            lsp8Contract.interface.getSighash('authorizeOperator'),
           );
       });
 
-      it("should pass when calling `transfer(...)` on LSP8 contract", async () => {
+      it('should pass when calling `transfer(...)` on LSP8 contract', async () => {
         const recipient = context.accounts[5].address;
 
-        let transferPayload = lsp8Contract.interface.encodeFunctionData("transfer", [
+        let transferPayload = lsp8Contract.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           tokenIdToTransfer,
           true,
-          "0x",
+          '0x',
         ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp8Contract.address,
           0,
@@ -445,20 +445,20 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
       });
     });
 
-    describe("when caller can all any functions on LSP7 contracts, but only `authorizeOperator(...)` on LSP8 contracts", () => {
-      describe("when interacting with LSP7 contract", () => {
-        it("should pass when calling `mint(...)`", async () => {
+    describe('when caller can all any functions on LSP7 contracts, but only `authorizeOperator(...)` on LSP8 contracts', () => {
+      describe('when interacting with LSP7 contract', () => {
+        it('should pass when calling `mint(...)`', async () => {
           let recipient = context.accounts[4].address;
           const amount = 10;
 
-          let mintPayload = lsp7Contract.interface.encodeFunctionData("mint", [
+          let mintPayload = lsp7Contract.interface.encodeFunctionData('mint', [
             recipient,
             amount,
             true,
-            "0x",
+            '0x',
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp7Contract.address,
             0,
@@ -472,7 +472,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           expect(await lsp7Contract.balanceOf(recipient)).to.equal(amount);
         });
 
-        it("should pass when calling `transfer(...)`", async () => {
+        it('should pass when calling `transfer(...)`', async () => {
           let recipient = context.accounts[4].address;
 
           const previousUPTokenBalance = await lsp7Contract.balanceOf(
@@ -483,15 +483,15 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
 
           const amount = 10;
 
-          let transferPayload = lsp7Contract.interface.encodeFunctionData("transfer", [
+          let transferPayload = lsp7Contract.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             recipient,
             amount,
             true,
-            "0x",
+            '0x',
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp7Contract.address,
             0,
@@ -513,16 +513,16 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           );
         });
 
-        it("should pass when calling `authorizeOperator(...)`", async () => {
+        it('should pass when calling `authorizeOperator(...)`', async () => {
           let operator = context.accounts[6].address;
           const amount = 10;
 
           let authorizeOperatorPayload = lsp7Contract.interface.encodeFunctionData(
-            "authorizeOperator",
+            'authorizeOperator',
             [operator, amount],
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp7Contract.address,
             0,
@@ -538,14 +538,14 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           ).to.equal(amount);
         });
 
-        it("should pass when calling `setData(...)`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Token Icon"));
+        it('should pass when calling `setData(...)`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Token Icon'));
 
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(":)"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(':)'));
 
-          let setDataPayload = lsp7Contract.interface.encodeFunctionData("setData", [key, value]);
+          let setDataPayload = lsp7Contract.interface.encodeFunctionData('setData', [key, value]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp7Contract.address,
             0,
@@ -560,19 +560,19 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         });
       });
 
-      describe("when interacting lsp8 contract", async () => {
-        it("should revert when calling `transfer(...)`", async () => {
+      describe('when interacting lsp8 contract', async () => {
+        it('should revert when calling `transfer(...)`', async () => {
           let recipient = context.accounts[4].address;
 
-          let transferPayload = lsp8Contract.interface.encodeFunctionData("transfer", [
+          let transferPayload = lsp8Contract.interface.encodeFunctionData('transfer', [
             context.universalProfile.address,
             recipient,
             tokenIdToTransfer,
             true,
-            "0x",
+            '0x',
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp8Contract.address,
             0,
@@ -584,26 +584,26 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8)
               .execute(executePayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address,
               lsp8Contract.address,
-              lsp8Contract.interface.getSighash("transfer"),
+              lsp8Contract.interface.getSighash('transfer'),
             );
         });
 
-        it("should revert when calling `mint(...)`", async () => {
+        it('should revert when calling `mint(...)`', async () => {
           const randomTokenId = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
           let recipient = context.accounts[4].address;
-          let mintPayload = lsp8Contract.interface.encodeFunctionData("mint", [
+          let mintPayload = lsp8Contract.interface.encodeFunctionData('mint', [
             recipient,
             randomTokenId,
             true,
-            "0x",
+            '0x',
           ]);
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp8Contract.address,
             0,
@@ -615,23 +615,23 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
               .connect(addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8)
               .execute(executePayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               addressCanCallAnyLSP7FunctionAndOnlyAuthorizeOperatorOnLSP8.address,
               lsp8Contract.address,
-              lsp8Contract.interface.getSighash("mint"),
+              lsp8Contract.interface.getSighash('mint'),
             );
         });
 
-        it("should pass when calling `authorizeOperator(...)`", async () => {
+        it('should pass when calling `authorizeOperator(...)`', async () => {
           let recipient = context.accounts[4].address;
 
           let authorizeOperatorPayload = lsp8Contract.interface.encodeFunctionData(
-            "authorizeOperator",
+            'authorizeOperator',
             [recipient, tokenIdToApprove],
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             lsp8Contract.address,
             0,

--- a/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
@@ -1,6 +1,6 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   SignatureValidator,
@@ -11,7 +11,7 @@ import {
   UniversalProfile__factory,
   LSP7Mintable,
   LSP7Mintable__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -22,11 +22,11 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
@@ -35,7 +35,7 @@ import {
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -64,14 +64,14 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     );
 
     let permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithLSP7.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanInteractOnlyWithLSP7.address.substring(2),
     ];
 
@@ -81,15 +81,15 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
       combineAllowedCalls(
         [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
         [INTERFACE_IDS.ERC1271],
-        ["0xffffffff"],
+        ['0xffffffff'],
       ),
       combineAllowedCalls(
         [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
-        ["0xffffffffffffffffffffffffffffffffffffffff"],
+        ['0xffffffffffffffffffffffffffffffffffffffff'],
         [INTERFACE_IDS.LSP7DigitalAsset],
-        ["0xffffffff"],
+        ['0xffffffff'],
       ),
     ];
 
@@ -97,16 +97,16 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
 
     await context.owner.sendTransaction({
       to: context.universalProfile.address,
-      value: ethers.utils.parseEther("10"),
+      value: ethers.utils.parseEther('10'),
     });
   });
 
-  describe("when caller has no value set for ALLOWEDSTANDARDS (= all interfaces whitelisted)", () => {
-    it("should allow to interact with contract that does not implement any interface", async () => {
-      let newName = "Some Name";
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", [newName]);
+  describe('when caller has no value set for ALLOWEDSTANDARDS (= all interfaces whitelisted)', () => {
+    it('should allow to interact with contract that does not implement any interface', async () => {
+      let newName = 'Some Name';
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', [newName]);
 
-      let upPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let upPayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         targetContract.address,
         0,
@@ -119,17 +119,17 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       expect(result).to.equal(newName);
     });
 
-    describe("should allow to interact with a contract that implement (+ register) any interface", () => {
-      it("ERC1271", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await context.owner.signMessage("Sample Message");
+    describe('should allow to interact with a contract that implement (+ register) any interface', () => {
+      it('ERC1271', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await context.owner.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
 
-        let upPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let upPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           signatureValidatorContract.address,
           0,
@@ -137,39 +137,39 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         ]);
 
         let data = await context.keyManager.connect(context.owner).callStatic.execute(upPayload);
-        let [result] = abiCoder.decode(["bytes4"], data);
+        let [result] = abiCoder.decode(['bytes4'], data);
         expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
 
-      it("LSP0 (ERC725Account)", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Key"));
-        let value = "0xcafecafecafecafe";
+      it('LSP0 (ERC725Account)', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key'));
+        let value = '0xcafecafecafecafe';
 
-        let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await context.keyManager.connect(context.owner).execute(setDataPayload);
 
-        const result = await context.universalProfile.callStatic["getData(bytes32)"](key);
+        const result = await context.universalProfile.callStatic['getData(bytes32)'](key);
         expect(result).to.equal(value);
       });
     });
   });
 
-  describe("when caller has only ERC1271 interface ID set for ALLOWED STANDARDS", () => {
-    describe("when interacting with a contract that implements + register ERC1271 interface", () => {
-      it("should pass", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await addressCanInteractOnlyWithERC1271.signMessage("Sample Message");
+  describe('when caller has only ERC1271 interface ID set for ALLOWED STANDARDS', () => {
+    describe('when interacting with a contract that implements + register ERC1271 interface', () => {
+      it('should pass', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await addressCanInteractOnlyWithERC1271.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
 
-        let upPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let upPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           signatureValidatorContract.address,
           0,
@@ -179,20 +179,20 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         let data = await context.keyManager
           .connect(addressCanInteractOnlyWithERC1271)
           .callStatic.execute(upPayload);
-        let [result] = abiCoder.decode(["bytes4"], data);
+        let [result] = abiCoder.decode(['bytes4'], data);
         expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
     });
 
-    describe("when trying to interact an ERC725Account (LSP0)", () => {
-      it("should allow to transfer LYX", async () => {
+    describe('when trying to interact an ERC725Account (LSP0)', () => {
+      it('should allow to transfer LYX', async () => {
         let initialAccountBalance = await provider.getBalance(otherUniversalProfile.address);
 
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           otherUniversalProfile.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
         await context.keyManager
@@ -204,11 +204,11 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       });
     });
 
-    describe("when interacting with contract that does not implement ERC1271", () => {
-      it("should fail", async () => {
-        let targetPayload = targetContract.interface.encodeFunctionData("setName", ["New Name"]);
+    describe('when interacting with contract that does not implement ERC1271', () => {
+      it('should fail', async () => {
+        let targetPayload = targetContract.interface.encodeFunctionData('setName', ['New Name']);
 
-        let upPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let upPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
@@ -218,28 +218,28 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         await expect(
           context.keyManager.connect(addressCanInteractOnlyWithERC1271).execute(upPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithERC1271.address,
             targetContract.address,
-            targetContract.interface.getSighash("setName"),
+            targetContract.interface.getSighash('setName'),
           );
       });
     });
   });
 
-  describe("when caller has only LSP7 interface ID set for ALLOWED STANDARDS", () => {
-    describe("when interacting with a contract that implements + register ERC1271 interface", () => {
-      it("should fail", async () => {
-        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Message"));
-        let sampleSignature = await addressCanInteractOnlyWithLSP7.signMessage("Sample Message");
+  describe('when caller has only LSP7 interface ID set for ALLOWED STANDARDS', () => {
+    describe('when interacting with a contract that implements + register ERC1271 interface', () => {
+      it('should fail', async () => {
+        let sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
+        let sampleSignature = await addressCanInteractOnlyWithLSP7.signMessage('Sample Message');
 
-        let payload = signatureValidatorContract.interface.encodeFunctionData("isValidSignature", [
+        let payload = signatureValidatorContract.interface.encodeFunctionData('isValidSignature', [
           sampleHash,
           sampleSignature,
         ]);
 
-        let upPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let upPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           signatureValidatorContract.address,
           0,
@@ -247,89 +247,89 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         ]);
 
         await expect(context.keyManager.connect(addressCanInteractOnlyWithLSP7).execute(upPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithLSP7.address,
             signatureValidatorContract.address,
-            signatureValidatorContract.interface.getSighash("isValidSignature"),
+            signatureValidatorContract.interface.getSighash('isValidSignature'),
           );
       });
     });
 
-    describe("when interacting with an ERC725Account (LSP0)", () => {
-      it("should fail when trying to transfer LYX", async () => {
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+    describe('when interacting with an ERC725Account (LSP0)', () => {
+      it('should fail when trying to transfer LYX', async () => {
+        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           otherUniversalProfile.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
         await expect(
           context.keyManager.connect(addressCanInteractOnlyWithLSP7).execute(transferLyxPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             addressCanInteractOnlyWithLSP7.address,
             otherUniversalProfile.address,
-            "0x00000000",
+            '0x00000000',
           );
       });
     });
 
-    describe("should be allowed to interact with any LSP7 token contracts", () => {
+    describe('should be allowed to interact with any LSP7 token contracts', () => {
       let lsp7TokenA: LSP7Mintable;
       let lsp7TokenB: LSP7Mintable;
       let lsp7TokenC: LSP7Mintable;
 
       before(async () => {
         lsp7TokenA = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token A",
-          "TKNA",
+          'LSP7 Token A',
+          'TKNA',
           context.accounts[0].address,
           false,
         );
 
         lsp7TokenB = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token B",
-          "TKNB",
+          'LSP7 Token B',
+          'TKNB',
           context.accounts[0].address,
           false,
         );
 
         lsp7TokenC = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "LSP7 Token C",
-          "TKNC",
+          'LSP7 Token C',
+          'TKNC',
           context.accounts[0].address,
           false,
         );
 
         await lsp7TokenA
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
 
         await lsp7TokenB
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
 
         await lsp7TokenC
           .connect(context.accounts[0])
-          .mint(context.universalProfile.address, 100, false, "0x");
+          .mint(context.universalProfile.address, 100, false, '0x');
       });
 
-      it("-> interacting with lsp7TokenA", async () => {
+      it('-> interacting with lsp7TokenA', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenA.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenA.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp7TokenA.address,
           0,
@@ -342,19 +342,19 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         expect(await lsp7TokenA.balanceOf(context.universalProfile.address)).to.equal(90);
       });
 
-      it("-> interacting with lsp7TokenB", async () => {
+      it('-> interacting with lsp7TokenB', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenB.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenB.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp7TokenB.address,
           0,
@@ -367,19 +367,19 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         expect(await lsp7TokenB.balanceOf(context.universalProfile.address)).to.equal(90);
       });
 
-      it("-> interacting with lsp7TokenC", async () => {
+      it('-> interacting with lsp7TokenC', async () => {
         const recipient = context.accounts[5].address;
         const amount = 10;
 
-        const transferPayload = lsp7TokenC.interface.encodeFunctionData("transfer", [
+        const transferPayload = lsp7TokenC.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           amount,
           true,
-          "0x",
+          '0x',
         ]);
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp7TokenC.address,
           0,

--- a/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
-import { abiCoder, provider } from "../../utils/helpers";
-import { LSP7Mintable, LSP7MintableInit__factory, LSP7Mintable__factory } from "../../../types";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
+import { abiCoder, provider } from '../../utils/helpers';
+import { LSP7Mintable, LSP7MintableInit__factory, LSP7Mintable__factory } from '../../../types';
 
 export const shouldBehaveLikeBatchExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -25,10 +25,10 @@ export const shouldBehaveLikeBatchExecute = (
     rLyxToken: LSP7Mintable;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("50"));
+    context = await buildContext(ethers.utils.parseEther('50'));
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
     ];
 
     const permissionsValues = [ALL_PERMISSIONS];
@@ -37,33 +37,33 @@ export const shouldBehaveLikeBatchExecute = (
 
     // deploy some sample LSP7 tokens and mint some tokens to the UP
     lyxDaiToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-      "LYX DAI Invented Token",
-      "LYXDAI",
+      'LYX DAI Invented Token',
+      'LYXDAI',
       context.accounts[0].address,
       false,
     );
 
     metaCoin = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-      "Meta Coin",
-      "MTC",
+      'Meta Coin',
+      'MTC',
       context.accounts[0].address,
       false,
     );
 
     rLyxToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-      "LUKSO Relay Token",
-      "rLYX",
+      'LUKSO Relay Token',
+      'rLYX',
       context.accounts[0].address,
       false,
     );
 
-    await lyxDaiToken.mint(context.universalProfile.address, 100, false, "0x");
-    await metaCoin.mint(context.universalProfile.address, 100, false, "0x");
-    await rLyxToken.mint(context.universalProfile.address, 100, false, "0x");
+    await lyxDaiToken.mint(context.universalProfile.address, 100, false, '0x');
+    await metaCoin.mint(context.universalProfile.address, 100, false, '0x');
+    await rLyxToken.mint(context.universalProfile.address, 100, false, '0x');
   });
 
-  describe("example scenarios", () => {
-    it("should send LYX to 3x different addresses", async () => {
+  describe('example scenarios', () => {
+    it('should send LYX to 3x different addresses', async () => {
       const { universalProfile, owner } = context;
 
       const recipients = [
@@ -73,17 +73,17 @@ export const shouldBehaveLikeBatchExecute = (
       ];
 
       const amounts = [
-        ethers.utils.parseEther("1"),
-        ethers.utils.parseEther("2"),
-        ethers.utils.parseEther("3"),
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('2'),
+        ethers.utils.parseEther('3'),
       ];
 
       const batchExecutePayloads = recipients.map((recipient, index) => {
-        return universalProfile.interface.encodeFunctionData("execute", [
+        return universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient,
           amounts[index],
-          "0x",
+          '0x',
         ]);
       });
 
@@ -93,34 +93,34 @@ export const shouldBehaveLikeBatchExecute = (
 
       await expect(tx).to.changeEtherBalance(
         context.universalProfile.address,
-        ethers.utils.parseEther("-6"),
+        ethers.utils.parseEther('-6'),
       );
       await expect(tx).to.changeEtherBalances(recipients, amounts);
     });
 
-    it("should send LYX + some LSP7 tokens to the same address", async () => {
+    it('should send LYX + some LSP7 tokens to the same address', async () => {
       expect(await lyxDaiToken.balanceOf(context.universalProfile.address)).to.equal(100);
 
       const recipient = context.accounts[1].address;
-      const lyxAmount = ethers.utils.parseEther("3");
+      const lyxAmount = ethers.utils.parseEther('3');
       const lyxDaiAmount = 25;
 
-      const lyxDaiTransferPayload = lyxDaiToken.interface.encodeFunctionData("transfer", [
+      const lyxDaiTransferPayload = lyxDaiToken.interface.encodeFunctionData('transfer', [
         context.universalProfile.address,
         recipient,
         lyxDaiAmount,
         true,
-        "0x",
+        '0x',
       ]);
 
       const payloads = [
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient,
           lyxAmount,
-          "0x",
+          '0x',
         ]),
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lyxDaiToken.address,
           0,
@@ -134,7 +134,7 @@ export const shouldBehaveLikeBatchExecute = (
       expect(await lyxDaiToken.balanceOf(recipient)).to.equal(lyxDaiAmount);
     });
 
-    it("should send 3x different tokens to the same recipient", async () => {
+    it('should send 3x different tokens to the same recipient', async () => {
       const recipient = context.accounts[1].address;
 
       const recipientLyxDaiBalanceBefore = await lyxDaiToken.balanceOf(recipient);
@@ -157,26 +157,26 @@ export const shouldBehaveLikeBatchExecute = (
         [context.universalProfile.address, recipient, metaCoinAmount, true, "0x"]
       );
 
-      const rLYXTransferPayload = metaCoin.interface.encodeFunctionData("transfer", [
+      const rLYXTransferPayload = metaCoin.interface.encodeFunctionData('transfer', [
         context.universalProfile.address,
         recipient,
         rLyxAmount,
         true,
-        "0x",
+        '0x',
       ]);
 
       const payloads = [
         context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, lyxDaiToken.address, 0, lyxDaiTransferPayload], // prettier-ignore
         ),
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           metaCoin.address,
           0,
           metaCoinTransferPayload,
         ]),
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           rLyxToken.address,
           0,
@@ -197,15 +197,15 @@ export const shouldBehaveLikeBatchExecute = (
       );
     });
 
-    it("should 1) deploy a LSP7 Token (as minimal proxy), 2) initialize it, and 3) set the token metadata", async () => {
+    it('should 1) deploy a LSP7 Token (as minimal proxy), 2) initialize it, and 3) set the token metadata', async () => {
       const lsp7MintableBase = await new LSP7MintableInit__factory(context.accounts[0]).deploy();
 
       const lsp7TokenProxyBytecode = String(
-        "0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3",
-      ).replace("bebebebebebebebebebebebebebebebebebebebe", lsp7MintableBase.address.substring(2));
+        '0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3',
+      ).replace('bebebebebebebebebebebebebebebebebebebebe', lsp7MintableBase.address.substring(2));
 
       const lsp7ProxyDeploymentPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [OPERATION_TYPES.CREATE, ethers.constants.AddressZero, 0, lsp7TokenProxyBytecode],
       );
 
@@ -216,15 +216,15 @@ export const shouldBehaveLikeBatchExecute = (
         futureTokenAddress,
       );
 
-      const lsp7InitializePayload = futureTokenInstance.interface.encodeFunctionData("initialize", [
-        "My LSP7 UP Token",
-        "UPLSP7",
+      const lsp7InitializePayload = futureTokenInstance.interface.encodeFunctionData('initialize', [
+        'My LSP7 UP Token',
+        'UPLSP7',
         context.universalProfile.address,
         false,
       ]);
 
       // use interface of an existing token contract
-      const initializePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const initializePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         futureTokenAddress,
         0,
@@ -232,14 +232,14 @@ export const shouldBehaveLikeBatchExecute = (
       ]);
 
       const tokenMetadataValue =
-        "0x6f357c6aba20e595da5f38e6c75326802bbf871b4d98b5bfab27812a5456139e3ec087f4697066733a2f2f516d6659696d3146647a645a6747314a50484c46785a3964575a7761616f68596e4b626174797871553144797869";
+        '0x6f357c6aba20e595da5f38e6c75326802bbf871b4d98b5bfab27812a5456139e3ec087f4697066733a2f2f516d6659696d3146647a645a6747314a50484c46785a3964575a7761616f68596e4b626174797871553144797869';
 
-      const lsp7SetDataPayload = futureTokenInstance.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP4["LSP4Metadata"],
+      const lsp7SetDataPayload = futureTokenInstance.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP4['LSP4Metadata'],
         tokenMetadataValue,
       ]);
       const setTokenMetadataPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [OPERATION_TYPES.CALL, futureTokenAddress, 0, lsp7SetDataPayload],
       );
 
@@ -257,39 +257,39 @@ export const shouldBehaveLikeBatchExecute = (
 
       // CHECK that token contract has been deployed
       await expect(tx)
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(futureTokenAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
 
       // CHECK initialize parameters have been set correctly
-      const nameResult = await futureTokenInstance.getData(ERC725YDataKeys.LSP4["LSP4TokenName"]);
+      const nameResult = await futureTokenInstance.getData(ERC725YDataKeys.LSP4['LSP4TokenName']);
       const symbolResult = await futureTokenInstance.getData(
-        ERC725YDataKeys.LSP4["LSP4TokenSymbol"],
+        ERC725YDataKeys.LSP4['LSP4TokenSymbol'],
       );
 
-      expect(ethers.utils.toUtf8String(nameResult)).to.equal("My LSP7 UP Token");
-      expect(ethers.utils.toUtf8String(symbolResult)).to.equal("UPLSP7");
+      expect(ethers.utils.toUtf8String(nameResult)).to.equal('My LSP7 UP Token');
+      expect(ethers.utils.toUtf8String(symbolResult)).to.equal('UPLSP7');
       expect(await futureTokenInstance.owner()).to.equal(context.universalProfile.address);
 
       // CHECK LSP4 token metadata has been set
-      expect(await futureTokenInstance.getData(ERC725YDataKeys.LSP4["LSP4Metadata"])).to.equal(
+      expect(await futureTokenInstance.getData(ERC725YDataKeys.LSP4['LSP4Metadata'])).to.equal(
         tokenMetadataValue,
       );
     });
 
-    it("should 1) deploy a LSP7 token, 2) mint some tokens, 3) `transferBatch(...)` to multiple recipients", async () => {
+    it('should 1) deploy a LSP7 token, 2) mint some tokens, 3) `transferBatch(...)` to multiple recipients', async () => {
       // step 1 - deploy token contract
       const lsp7ConstructorArguments = abiCoder.encode(
-        ["string", "string", "address", "bool"],
-        ["My UP LSP7 Token", "UPLSP7", context.universalProfile.address, false],
+        ['string', 'string', 'address', 'bool'],
+        ['My UP LSP7 Token', 'UPLSP7', context.universalProfile.address, false],
       );
 
       const lsp7DeploymentPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [
           OPERATION_TYPES.CREATE,
           ethers.constants.AddressZero,
@@ -307,11 +307,11 @@ export const shouldBehaveLikeBatchExecute = (
 
       // step 2 - mint some tokens
       // use the interface of an existing token for encoding the function call
-      const lsp7MintingPayload = lyxDaiToken.interface.encodeFunctionData("mint", [
+      const lsp7MintingPayload = lyxDaiToken.interface.encodeFunctionData('mint', [
         context.universalProfile.address,
         3_000,
         false,
-        "0x",
+        '0x',
       ]);
 
       // step 3 - transfer batch to multiple addresses
@@ -323,26 +323,26 @@ export const shouldBehaveLikeBatchExecute = (
       ];
       const amounts = [1_000, 1_000, 1_000];
 
-      const lsp7TransferBatchPayload = lyxDaiToken.interface.encodeFunctionData("transferBatch", [
+      const lsp7TransferBatchPayload = lyxDaiToken.interface.encodeFunctionData('transferBatch', [
         [sender, sender, sender], // address[] memory from,
         recipients, // address[] memory to,
         amounts, // uint256[] memory amount,
         [true, true, true], // bool[] memory allowNonLSP1Recipient,
-        ["0x", "0x", "0x"], // bytes[] memory data
+        ['0x', '0x', '0x'], // bytes[] memory data
       ]);
 
       const payloads = [
         // step 1 - deploy token contract
         lsp7DeploymentPayload,
         // step 2 - mint some tokens for the UP
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           futureTokenAddress,
           0,
           lsp7MintingPayload,
         ]),
         // step 3 - `transferBatch(...)` the tokens to multiple addresses
-        context.universalProfile.interface.encodeFunctionData("execute", [
+        context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           futureTokenAddress,
           0,
@@ -354,12 +354,12 @@ export const shouldBehaveLikeBatchExecute = (
 
       // CHECK for `ContractCreated` event
       await expect(tx)
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(futureTokenAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
 
       // CHECK for tokens balances of recipients
@@ -374,29 +374,29 @@ export const shouldBehaveLikeBatchExecute = (
     });
   });
 
-  describe("when specifying msg.value", () => {
-    describe("when all the payloads are setData(...)", () => {
-      describe("if specifying 0 for each values[index]", () => {
-        it("should revert and not leave any funds locked on the Key Manager", async () => {
-          const amountToFund = ethers.utils.parseEther("5");
+  describe('when specifying msg.value', () => {
+    describe('when all the payloads are setData(...)', () => {
+      describe('if specifying 0 for each values[index]', () => {
+        it('should revert and not leave any funds locked on the Key Manager', async () => {
+          const amountToFund = ethers.utils.parseEther('5');
 
           const dataKeys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key1")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key2")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key1')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key2')),
           ];
-          const dataValues = ["0xaaaaaaaa", "0xbbbbbbbb"];
+          const dataValues = ['0xaaaaaaaa', '0xbbbbbbbb'];
 
           const keyManagerBalanceBefore = await ethers.provider.getBalance(
             context.keyManager.address,
           );
 
           const firstSetDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setData",
+            'setData',
             [dataKeys[0], dataValues[0]],
           );
 
           const secondSetDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setData",
+            'setData',
             [dataKeys[1], dataValues[1]],
           );
 
@@ -409,7 +409,7 @@ export const shouldBehaveLikeBatchExecute = (
                 value: amountToFund,
               }),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "LSP6BatchExcessiveValueSent")
+            .to.be.revertedWithCustomError(context.keyManager, 'LSP6BatchExcessiveValueSent')
             .withArgs(0, amountToFund);
 
           const keyManagerBalanceAfter = await ethers.provider.getBalance(
@@ -424,27 +424,27 @@ export const shouldBehaveLikeBatchExecute = (
         });
       });
 
-      describe("if specifying some value for each values[index]", () => {
-        it("should revert with Key Manager error `CannotSendValueToSetData` when sending value while setting data", async () => {
-          const amountToFund = ethers.utils.parseEther("2");
+      describe('if specifying some value for each values[index]', () => {
+        it('should revert with Key Manager error `CannotSendValueToSetData` when sending value while setting data', async () => {
+          const amountToFund = ethers.utils.parseEther('2');
 
           const dataKeys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key1")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key2")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key1')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key2')),
           ];
-          const dataValues = ["0xaaaaaaaa", "0xbbbbbbbb"];
+          const dataValues = ['0xaaaaaaaa', '0xbbbbbbbb'];
 
           const keyManagerBalanceBefore = await ethers.provider.getBalance(
             context.keyManager.address,
           );
 
           const firstSetDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setData",
+            'setData',
             [dataKeys[0], dataValues[0]],
           );
 
           const secondSetDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setData",
+            'setData',
             [dataKeys[1], dataValues[1]],
           );
 
@@ -456,7 +456,7 @@ export const shouldBehaveLikeBatchExecute = (
               .executeBatch([1, 1], [firstSetDataPayload, secondSetDataPayload], {
                 value: amountToFund,
               }),
-          ).to.be.revertedWithCustomError(context.keyManager, "CannotSendValueToSetData");
+          ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
 
           const keyManagerBalanceAfter = await ethers.provider.getBalance(
             context.keyManager.address,
@@ -471,23 +471,23 @@ export const shouldBehaveLikeBatchExecute = (
       });
     });
 
-    describe("when sending 2x payloads, 1st for `setData`, 2nd for `execute`", () => {
-      describe("when `msgValues[1]` is zero for `setData(...)`", () => {
-        it("should pass", async () => {
+    describe('when sending 2x payloads, 1st for `setData`, 2nd for `execute`', () => {
+      describe('when `msgValues[1]` is zero for `setData(...)`', () => {
+        it('should pass', async () => {
           const recipient = context.accounts[5].address;
 
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Data Key"));
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Data Key'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(10));
 
-          const msgValues = [ethers.BigNumber.from(0), ethers.BigNumber.from("5")];
+          const msgValues = [ethers.BigNumber.from(0), ethers.BigNumber.from('5')];
 
           const payloads = [
-            context.universalProfile.interface.encodeFunctionData("setData", [dataKey, dataValue]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('setData', [dataKey, dataValue]),
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient,
               msgValues[1],
-              "0x",
+              '0x',
             ]),
           ];
 
@@ -507,22 +507,22 @@ export const shouldBehaveLikeBatchExecute = (
         });
       });
 
-      describe("when `msgValues[1]` is NOT zero for `setData(...)`", () => {
-        it("should revert with default LSP6 `executePayload(...)` error message", async () => {
+      describe('when `msgValues[1]` is NOT zero for `setData(...)`', () => {
+        it('should revert with default LSP6 `executePayload(...)` error message', async () => {
           const recipient = context.accounts[5].address;
 
-          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Sample Data Key"));
+          const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Data Key'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(10));
 
-          const msgValues = [ethers.BigNumber.from(5), ethers.BigNumber.from("5")];
+          const msgValues = [ethers.BigNumber.from(5), ethers.BigNumber.from('5')];
 
           const payloads = [
-            context.universalProfile.interface.encodeFunctionData("setData", [dataKey, dataValue]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('setData', [dataKey, dataValue]),
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient,
               msgValues[1],
-              "0x",
+              '0x',
             ]),
           ];
 
@@ -534,28 +534,28 @@ export const shouldBehaveLikeBatchExecute = (
             context.keyManager.connect(context.owner).executeBatch(msgValues, payloads, {
               value: totalValues,
             }),
-          ).to.be.revertedWithCustomError(context.keyManager, "CannotSendValueToSetData");
+          ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
         });
       });
     });
 
-    describe("when sending 3x payloads", () => {
-      describe("when total `values[]` is LESS than `msg.value`", () => {
-        it("should revert because insufficent `msg.value`", async () => {
+    describe('when sending 3x payloads', () => {
+      describe('when total `values[]` is LESS than `msg.value`', () => {
+        it('should revert because insufficent `msg.value`', async () => {
           const firstRecipient = context.accounts[3].address;
           const secondRecipient = context.accounts[4].address;
           const thirdRecipient = context.accounts[5].address;
 
           const amountsToTransfer = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const values = [
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
           ];
 
           const totalValues = values.reduce((accumulator, currentValue) =>
@@ -566,23 +566,23 @@ export const shouldBehaveLikeBatchExecute = (
           const msgValue = totalValues.sub(1);
 
           const payloads = [
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               firstRecipient,
               amountsToTransfer[0],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               secondRecipient,
               amountsToTransfer[1],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               thirdRecipient,
               amountsToTransfer[2],
-              "0x",
+              '0x',
             ]),
           ];
 
@@ -591,27 +591,27 @@ export const shouldBehaveLikeBatchExecute = (
               value: msgValue,
             }),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "LSP6BatchInsufficientValueSent")
+            .to.be.revertedWithCustomError(context.keyManager, 'LSP6BatchInsufficientValueSent')
             .withArgs(totalValues, msgValue);
         });
       });
 
-      describe("when total `values[]` is MORE than `msg.value`", () => {
-        it("should revert to not leave any remaining funds on the Key Manager", async () => {
+      describe('when total `values[]` is MORE than `msg.value`', () => {
+        it('should revert to not leave any remaining funds on the Key Manager', async () => {
           const firstRecipient = context.accounts[3].address;
           const secondRecipient = context.accounts[4].address;
           const thirdRecipient = context.accounts[5].address;
 
           const amountsToTransfer = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const values = [
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
           ];
 
           const totalValues = values.reduce((accumulator, currentValue) =>
@@ -622,23 +622,23 @@ export const shouldBehaveLikeBatchExecute = (
           const msgValue = totalValues.add(1);
 
           const payloads = [
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               firstRecipient,
               amountsToTransfer[0],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               secondRecipient,
               amountsToTransfer[1],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               thirdRecipient,
               amountsToTransfer[2],
-              "0x",
+              '0x',
             ]),
           ];
 
@@ -647,27 +647,27 @@ export const shouldBehaveLikeBatchExecute = (
               value: msgValue,
             }),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "LSP6BatchExcessiveValueSent")
+            .to.be.revertedWithCustomError(context.keyManager, 'LSP6BatchExcessiveValueSent')
             .withArgs(totalValues, msgValue);
         });
       });
 
-      describe("when total `values[]` is EQUAL to `msg.value`", () => {
-        it("should pass", async () => {
+      describe('when total `values[]` is EQUAL to `msg.value`', () => {
+        it('should pass', async () => {
           const firstRecipient = context.accounts[3].address;
           const secondRecipient = context.accounts[4].address;
           const thirdRecipient = context.accounts[5].address;
 
           const amountsToTransfer = [
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
           ];
 
           const values = [
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
-            ethers.utils.parseEther("2"),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
+            ethers.utils.parseEther('2'),
           ];
 
           const totalValues = values.reduce((accumulator, currentValue) =>
@@ -675,23 +675,23 @@ export const shouldBehaveLikeBatchExecute = (
           );
 
           const payloads = [
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               firstRecipient,
               amountsToTransfer[0],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               secondRecipient,
               amountsToTransfer[1],
-              "0x",
+              '0x',
             ]),
-            context.universalProfile.interface.encodeFunctionData("execute", [
+            context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               thirdRecipient,
               amountsToTransfer[2],
-              "0x",
+              '0x',
             ]),
           ];
 
@@ -708,11 +708,11 @@ export const shouldBehaveLikeBatchExecute = (
     });
   });
 
-  describe("when one of the payload reverts", () => {
-    it("should revert the whole transaction if first payload reverts", async () => {
+  describe('when one of the payload reverts', () => {
+    it('should revert the whole transaction if first payload reverts', async () => {
       const upBalance = await provider.getBalance(context.universalProfile.address);
 
-      const validAmount = ethers.utils.parseEther("1");
+      const validAmount = ethers.utils.parseEther('1');
       expect(validAmount).to.be.lt(upBalance); // sanity check
 
       // make it revert by sending too much value than the actual balance
@@ -721,18 +721,18 @@ export const shouldBehaveLikeBatchExecute = (
       const randomRecipient = ethers.Wallet.createRandom().address;
 
       const failingTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, '0x'],
       );
 
       const firstTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
       );
 
       const secondTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
       );
 
       await expect(
@@ -742,13 +742,13 @@ export const shouldBehaveLikeBatchExecute = (
             [0, 0, 0],
             [failingTransferPayload, firstTransferPayload, secondTransferPayload],
           ),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_InsufficientBalance");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
     });
 
-    it("should revert the whole transaction if last payload reverts", async () => {
+    it('should revert the whole transaction if last payload reverts', async () => {
       const upBalance = await provider.getBalance(context.universalProfile.address);
 
-      const validAmount = ethers.utils.parseEther("1");
+      const validAmount = ethers.utils.parseEther('1');
       expect(validAmount).to.be.lt(upBalance); // sanity check
 
       // make it revert by sending too much value than the actual balance
@@ -757,18 +757,18 @@ export const shouldBehaveLikeBatchExecute = (
       const randomRecipient = ethers.Wallet.createRandom().address;
 
       const failingTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, '0x'],
       );
 
       const firstTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
       );
 
       const secondTransferPayload = context.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
       );
 
       await expect(
@@ -778,7 +778,7 @@ export const shouldBehaveLikeBatchExecute = (
             [0, 0, 0],
             [firstTransferPayload, secondTransferPayload, failingTransferPayload],
           ),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_InsufficientBalance");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
     });
   });
 };

--- a/tests/LSP6KeyManager/Interactions/InvalidExecutePayloads.test.ts
+++ b/tests/LSP6KeyManager/Interactions/InvalidExecutePayloads.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract__factory, TargetContract } from "../../../types";
+import { TargetContract__factory, TargetContract } from '../../../types';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -24,8 +24,8 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeCall.address.substring(2),
     ];
 
@@ -34,42 +34,42 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
     await setupKeyManager(context, permissionsKeys, permissionsValues);
   });
 
-  describe("payload", () => {
-    describe("when the payload is smaller than 4 bytes", () => {
-      it("should revert when using `execute(..)` with a payload smaller than 4 bytes", async () => {
-        await expect(context.keyManager.execute("0xaabbcc"))
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
-          .withArgs("0xaabbcc");
+  describe('payload', () => {
+    describe('when the payload is smaller than 4 bytes', () => {
+      it('should revert when using `execute(..)` with a payload smaller than 4 bytes', async () => {
+        await expect(context.keyManager.execute('0xaabbcc'))
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
+          .withArgs('0xaabbcc');
       });
 
-      it("should revert when using `executeRelayCall(..)` with a payload smaller than 4 bytes", async () => {
-        await expect(context.keyManager.executeRelayCall("0x", 0, 0, "0xaabbcc"))
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
-          .withArgs("0xaabbcc");
+      it('should revert when using `executeRelayCall(..)` with a payload smaller than 4 bytes', async () => {
+        await expect(context.keyManager.executeRelayCall('0x', 0, 0, '0xaabbcc'))
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
+          .withArgs('0xaabbcc');
       });
     });
 
     it("should fail when sending an empty payload to `keyManager.execute('0x')`", async () => {
-      await expect(context.keyManager.execute("0x"))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
-        .withArgs("0x");
+      await expect(context.keyManager.execute('0x'))
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
+        .withArgs('0x');
     });
 
-    it("Should revert because calling an unexisting function in ERC725", async () => {
-      const INVALID_PAYLOAD = "0xbad000000000000000000000000bad";
+    it('Should revert because calling an unexisting function in ERC725', async () => {
+      const INVALID_PAYLOAD = '0xbad000000000000000000000000bad';
       await expect(context.keyManager.connect(addressCanMakeCall).execute(INVALID_PAYLOAD))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(INVALID_PAYLOAD.slice(0, 10));
     });
   });
 
-  describe("wrong operation type", () => {
-    it("Should revert because of wrong operation type when caller has ALL PERMISSIONS", async () => {
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+  describe('wrong operation type', () => {
+    it('Should revert because of wrong operation type when caller has ALL PERMISSIONS', async () => {
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
       const INVALID_OPERATION_TYPE = 8;
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         INVALID_OPERATION_TYPE,
         targetContract.address,
         0,
@@ -78,15 +78,15 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
 
       await expect(
         context.keyManager.connect(context.owner).execute(payload),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_UnknownOperationType");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });
 
-    it("Should revert because of wrong operation type when caller has permission CALL", async () => {
-      let targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+    it('Should revert because of wrong operation type when caller has permission CALL', async () => {
+      let targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
       const INVALID_OPERATION_TYPE = 8;
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         INVALID_OPERATION_TYPE,
         targetContract.address,
         0,
@@ -95,7 +95,7 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
 
       await expect(
         context.keyManager.connect(addressCanMakeCall).execute(payload),
-      ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_UnknownOperationType");
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });
   });
 };

--- a/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   FallbackInitializer,
@@ -10,7 +10,7 @@ import {
   FallbackRevert__factory,
   TargetContract,
   TargetContract__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -20,19 +20,19 @@ import {
   LSP6_VERSION,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
-import { abiCoder, combineAllowedCalls, LOCAL_PRIVATE_KEYS } from "../../utils/helpers";
+import { abiCoder, combineAllowedCalls, LOCAL_PRIVATE_KEYS } from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
-  describe("when making an empty call via `ERC25X.execute(...)` -> (`data` = `0x`, `value` = 0)", () => {
+  describe('when making an empty call via `ERC25X.execute(...)` -> (`data` = `0x`, `value` = 0)', () => {
     let addressCanMakeCallNoAllowedCalls: SignerWithAddress,
       addressCanMakeCallWithAllowedCalls: SignerWithAddress,
       addressCannotMakeCallNoAllowedCalls: SignerWithAddress,
@@ -64,19 +64,19 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       ).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithSuperCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCannotMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
       ];
 
@@ -87,8 +87,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           allowedContractWithFallback.address,
           allowedContractWithFallbackRevert.address,
         ],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
       );
 
       const permissionsValues = [
@@ -104,138 +104,138 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    describe("when caller does not have permission CALL and no Allowed Calls", () => {
-      it("should fail with `NotAuthorised` error when `to` is an EOA", async () => {
+    describe('when caller does not have permission CALL and no Allowed Calls', () => {
+      it('should fail with `NotAuthorised` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetEOA,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(
           context.keyManager.connect(addressCannotMakeCallNoAllowedCalls).execute(payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallNoAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallNoAllowedCalls.address, 'CALL');
       });
 
-      it("should fail with `NotAuthorised` error when `to` is a contract", async () => {
+      it('should fail with `NotAuthorised` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(
           context.keyManager.connect(addressCannotMakeCallNoAllowedCalls).execute(payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallNoAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallNoAllowedCalls.address, 'CALL');
       });
     });
 
-    describe("when caller does not have permission CALL but have some Allowed Calls", () => {
-      it("should fail with `NotAuthorised` error when `to` is an EOA", async () => {
+    describe('when caller does not have permission CALL but have some Allowed Calls', () => {
+      it('should fail with `NotAuthorised` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetEOA,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(
           context.keyManager.connect(addressCannotMakeCallWithAllowedCalls).execute(payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallWithAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallWithAllowedCalls.address, 'CALL');
       });
 
-      it("should fail with `NotAuthorised` error when `to` is a contract", async () => {
+      it('should fail with `NotAuthorised` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(
           context.keyManager.connect(addressCannotMakeCallWithAllowedCalls).execute(payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotMakeCallWithAllowedCalls.address, "CALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotMakeCallWithAllowedCalls.address, 'CALL');
       });
     });
 
-    describe("when caller has permission CALL, but no Allowed Calls", () => {
-      it("should fail with `NoCallsAllowed` error when `to` is an EOA", async () => {
+    describe('when caller has permission CALL, but no Allowed Calls', () => {
+      it('should fail with `NoCallsAllowed` error when `to` is an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetEOA,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(context.keyManager.connect(addressCanMakeCallNoAllowedCalls).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
           .withArgs(addressCanMakeCallNoAllowedCalls.address);
       });
 
-      it("should fail with `NoCallsAllowed` error when `to` is a contract", async () => {
+      it('should fail with `NoCallsAllowed` error when `to` is a contract', async () => {
         const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0x",
+          '0x',
         ]);
 
         await expect(context.keyManager.connect(addressCanMakeCallNoAllowedCalls).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
           .withArgs(addressCanMakeCallNoAllowedCalls.address);
       });
     });
 
-    describe("when caller has permission CALL with some Allowed Calls", () => {
-      describe("when `to` is an EOA", () => {
-        describe("when `to` is NOT in the list of Allowed Calls", () => {
-          it("should fail with `NotAllowedCall` error", async () => {
+    describe('when caller has permission CALL with some Allowed Calls', () => {
+      describe('when `to` is an EOA', () => {
+        describe('when `to` is NOT in the list of Allowed Calls', () => {
+          it('should fail with `NotAllowedCall` error', async () => {
             const targetEOA = ethers.Wallet.createRandom().address;
 
-            const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            const payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetEOA,
               0,
-              "0x",
+              '0x',
             ]);
 
             await expect(
               context.keyManager.connect(addressCanMakeCallWithAllowedCalls).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-              .withArgs(addressCanMakeCallWithAllowedCalls.address, targetEOA, "0x00000000");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+              .withArgs(addressCanMakeCallWithAllowedCalls.address, targetEOA, '0x00000000');
           });
         });
 
-        describe("when `to` is in the list of Allowed Calls", () => {
-          it("should pass", async () => {
-            const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        describe('when `to` is in the list of Allowed Calls', () => {
+          it('should pass', async () => {
+            const payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               allowedEOA,
               0,
-              "0x",
+              '0x',
             ]);
 
             await expect(
@@ -245,38 +245,38 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
         });
       });
 
-      describe("when `to` is a contract", () => {
-        describe("when `to` is NOT in the list of Allowed Calls", () => {
-          it("should fail with `NotAllowedCall` error", async () => {
+      describe('when `to` is a contract', () => {
+        describe('when `to` is NOT in the list of Allowed Calls', () => {
+          it('should fail with `NotAllowedCall` error', async () => {
             const targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-            const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            const payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
-              "0x",
+              '0x',
             ]);
 
             await expect(
               context.keyManager.connect(addressCanMakeCallWithAllowedCalls).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
               .withArgs(
                 addressCanMakeCallWithAllowedCalls.address,
                 targetContract.address,
-                "0x00000000",
+                '0x00000000',
               );
           });
         });
 
-        describe("when `to` is in the list of Allowed Calls", () => {
-          describe("if the `fallback()` function of `to` update some state", () => {
+        describe('when `to` is in the list of Allowed Calls', () => {
+          describe('if the `fallback()` function of `to` update some state', () => {
             it("should pass and update `to` contract's storage", async () => {
-              const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+              const payload = context.universalProfile.interface.encodeFunctionData('execute', [
                 OPERATION_TYPES.CALL,
                 allowedContractWithFallback.address,
                 0,
-                "0x",
+                '0x',
               ]);
 
               await context.keyManager.connect(addressCanMakeCallWithAllowedCalls).execute(payload);
@@ -287,50 +287,50 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             });
           });
 
-          describe("if the `fallback()` function of `to` reverts", () => {
-            it("should fail and bubble the error back to the Key Manager", async () => {
-              const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          describe('if the `fallback()` function of `to` reverts', () => {
+            it('should fail and bubble the error back to the Key Manager', async () => {
+              const payload = context.universalProfile.interface.encodeFunctionData('execute', [
                 OPERATION_TYPES.CALL,
                 allowedContractWithFallbackRevert.address,
                 0,
-                "0x",
+                '0x',
               ]);
 
               await expect(
                 context.keyManager.connect(addressCanMakeCallWithAllowedCalls).execute(payload),
-              ).to.be.revertedWith("fallback reverted");
+              ).to.be.revertedWith('fallback reverted');
             });
           });
         });
       });
     });
 
-    describe("when caller has permission SUPER_CALL", () => {
-      it("should pass and allow to call an EOA", async () => {
+    describe('when caller has permission SUPER_CALL', () => {
+      it('should pass and allow to call an EOA', async () => {
         const targetEOA = ethers.Wallet.createRandom().address;
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetEOA,
           0,
-          "0x",
+          '0x',
         ]);
 
         await context.keyManager.connect(addressWithSuperCall).execute(payload);
       });
 
-      describe("when `to` is a contract", () => {
-        describe("if the `fallback()` function of `to` update some state", () => {
+      describe('when `to` is a contract', () => {
+        describe('if the `fallback()` function of `to` update some state', () => {
           it("should pass and update `to` contract's storage", async () => {
             const targetContractWithFallback = await new FallbackInitializer__factory(
               context.accounts[0],
             ).deploy();
 
-            const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            const payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContractWithFallback.address,
               0,
-              "0x",
+              '0x',
             ]);
 
             await context.keyManager.connect(addressWithSuperCall).execute(payload);
@@ -341,29 +341,29 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           });
         });
 
-        describe("if the `fallback()` function of `to` reverts", () => {
-          it("should fail and bubble the error back to the Key Manager", async () => {
+        describe('if the `fallback()` function of `to` reverts', () => {
+          it('should fail and bubble the error back to the Key Manager', async () => {
             const targetContractWithFallbackRevert = await new FallbackRevert__factory(
               context.accounts[0],
             ).deploy();
 
-            const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            const payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContractWithFallbackRevert.address,
               0,
-              "0x",
+              '0x',
             ]);
 
             await expect(
               context.keyManager.connect(addressWithSuperCall).execute(payload),
-            ).to.be.revertedWith("fallback reverted");
+            ).to.be.revertedWith('fallback reverted');
           });
         });
       });
     });
   });
 
-  describe("when making a ERC25X.execute(...) call with some `data` payload", () => {
+  describe('when making a ERC25X.execute(...) call with some `data` payload', () => {
     let addressCanMakeCallNoAllowedCalls: SignerWithAddress,
       addressCanMakeCallWithAllowedCalls: SignerWithAddress,
       addressCannotMakeCall: SignerWithAddress;
@@ -380,14 +380,14 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotMakeCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressCanMakeCallWithAllowedCalls.address.substring(2),
       ];
 
@@ -399,8 +399,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
         combineAllowedCalls(
           [CALLTYPE.CALL],
           [targetContract.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
@@ -408,36 +408,36 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
     });
 
     describe("when the 'offset' of the `data` payload is not `0x00...80`", () => {
-      it("should revert", async () => {
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should revert', async () => {
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
-          "0xcafecafe",
+          '0xcafecafe',
         ]);
 
         // edit the `data` offset
         payload = payload.replace(
-          "0000000000000000000000000000000000000000000000000000000000000080",
-          "0000000000000000000000000000000000000000000000000000000000000040",
+          '0000000000000000000000000000000000000000000000000000000000000080',
+          '0000000000000000000000000000000000000000000000000000000000000040',
         );
 
         await expect(
           context.keyManager.connect(addressCanMakeCallWithAllowedCalls).execute(payload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "InvalidPayload")
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
           .withArgs(payload);
       });
     });
 
-    describe("when interacting via `execute(...)`", () => {
-      describe("when caller has ALL PERMISSIONS", () => {
-        it("should pass and change state at the target contract", async () => {
-          let argument = "new name";
+    describe('when interacting via `execute(...)`', () => {
+      describe('when caller has ALL PERMISSIONS', () => {
+        it('should pass and change state at the target contract', async () => {
+          let argument = 'new name';
 
-          let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+          let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -450,13 +450,13 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           expect(result).to.equal(argument);
         });
 
-        describe("when calling a function that returns some value", () => {
-          it("should return the value to the Key Manager <- UP <- targetContract.getName()", async () => {
+        describe('when calling a function that returns some value', () => {
+          it('should return the value to the Key Manager <- UP <- targetContract.getName()', async () => {
             let expectedName = await targetContract.callStatic.getName();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+            let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -467,16 +467,16 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               .connect(context.owner)
               .callStatic.execute(executePayload);
 
-            let [decodedResult] = abiCoder.decode(["string"], result);
+            let [decodedResult] = abiCoder.decode(['string'], result);
             expect(decodedResult).to.equal(expectedName);
           });
 
-          it("Should return the value to the Key Manager <- UP <- targetContract.getNumber()", async () => {
+          it('Should return the value to the Key Manager <- UP <- targetContract.getNumber()', async () => {
             let expectedNumber = await targetContract.callStatic.getNumber();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("getNumber");
+            let targetContractPayload = targetContract.interface.encodeFunctionData('getNumber');
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -487,16 +487,16 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               .connect(context.owner)
               .callStatic.execute(executePayload);
 
-            let [decodedResult] = abiCoder.decode(["uint256"], result);
+            let [decodedResult] = abiCoder.decode(['uint256'], result);
             expect(decodedResult).to.equal(expectedNumber);
           });
         });
 
-        describe("when calling a function that reverts", () => {
-          it("should revert", async () => {
-            let targetContractPayload = targetContract.interface.encodeFunctionData("revertCall");
+        describe('when calling a function that reverts', () => {
+          it('should revert', async () => {
+            let targetContractPayload = targetContract.interface.encodeFunctionData('revertCall');
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -504,20 +504,20 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             ]);
 
             await expect(context.keyManager.execute(payload)).to.be.revertedWith(
-              "TargetContract:revertCall: this function has reverted!",
+              'TargetContract:revertCall: this function has reverted!',
             );
           });
         });
       });
 
-      describe("when caller has permission CALL", () => {
-        describe("when caller has no allowed calls set", () => {
-          it("should revert with `NotAllowedCall(...)` error", async () => {
-            let argument = "another name";
+      describe('when caller has permission CALL', () => {
+        describe('when caller has no allowed calls set', () => {
+          it('should revert with `NotAllowedCall(...)` error', async () => {
+            let argument = 'another name';
 
-            let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+            let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -527,18 +527,18 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             await expect(
               context.keyManager.connect(addressCanMakeCallNoAllowedCalls).execute(payload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
               .withArgs(addressCanMakeCallNoAllowedCalls.address);
           });
         });
 
-        describe("when caller has some allowed calls set", () => {
-          it("should pass and change state at the target contract", async () => {
-            let argument = "another name";
+        describe('when caller has some allowed calls set', () => {
+          it('should pass and change state at the target contract', async () => {
+            let argument = 'another name';
 
-            let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+            let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -553,13 +553,13 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
         });
       });
 
-      describe("when caller does not have permission CALL", () => {
-        it("should revert", async () => {
-          let argument = "another name";
+      describe('when caller does not have permission CALL', () => {
+        it('should revert', async () => {
+          let argument = 'another name';
 
-          let targetPayload = targetContract.interface.encodeFunctionData("setName", [argument]);
+          let targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             0,
@@ -567,22 +567,22 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           ]);
 
           await expect(context.keyManager.connect(addressCannotMakeCall).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(addressCannotMakeCall.address, "CALL");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(addressCannotMakeCall.address, 'CALL');
         });
       });
     });
 
-    describe("when interacting via `executeRelayCall(...)`", () => {
+    describe('when interacting via `executeRelayCall(...)`', () => {
       // Use channelId = 0 for sequential nonce
       const channelId = 0;
 
-      describe("when signer has ALL PERMISSIONS", () => {
-        describe("when signing tx with EIP191Signer `\\x19\\x00` prefix", () => {
-          it("should execute successfully", async () => {
-            let newName = "New Name";
+      describe('when signer has ALL PERMISSIONS', () => {
+        describe('when signing tx with EIP191Signer `\\x19\\x00` prefix', () => {
+          it('should execute successfully', async () => {
+            let newName = 'New Name';
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+            let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
               newName,
             ]);
             let nonce = await context.keyManager.callStatic.getNonce(
@@ -593,7 +593,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const validityTimestamps = 0;
 
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              'execute',
               [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
             );
 
@@ -601,7 +601,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 LSP6_VERSION,
                 HARDHAT_CHAINID,
@@ -633,11 +633,11 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           });
         });
 
-        describe("when signing with Ethereum Signed Message prefix", () => {
-          it("should retrieve the incorrect signer address and revert with `InvalidRelayNonce` error", async () => {
-            let newName = "New Name";
+        describe('when signing with Ethereum Signed Message prefix', () => {
+          it('should retrieve the incorrect signer address and revert with `InvalidRelayNonce` error', async () => {
+            let newName = 'New Name';
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+            let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
               newName,
             ]);
             let nonce = await context.keyManager.callStatic.getNonce(
@@ -648,7 +648,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const validityTimestamps = 0;
 
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              'execute',
               [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
             );
 
@@ -658,7 +658,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const eip191Signer = new EIP191Signer();
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 LSP6_VERSION,
                 HARDHAT_CHAINID,
@@ -688,19 +688,19 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 { value: valueToSend },
               ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "InvalidRelayNonce")
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidRelayNonce')
               .withArgs(incorrectSignerAddress, nonce, signature);
           });
         });
       });
 
-      describe("when signer has permission CALL", () => {
-        describe("when signing tx with EIP191Signer `\\x19\\x00` prefix", () => {
-          describe("when caller has some allowed calls set", () => {
-            it("should execute successfully", async () => {
-              let newName = "Another name";
+      describe('when signer has permission CALL', () => {
+        describe('when signing tx with EIP191Signer `\\x19\\x00` prefix', () => {
+          describe('when caller has some allowed calls set', () => {
+            it('should execute successfully', async () => {
+              let newName = 'Another name';
 
-              let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+              let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
                 newName,
               ]);
 
@@ -712,7 +712,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               const validityTimestamps = 0;
 
               let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
               );
 
@@ -720,7 +720,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               let valueToSend = 0;
 
               let encodedMessage = ethers.utils.solidityPack(
-                ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+                ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
                   LSP6_VERSION,
                   HARDHAT_CHAINID,
@@ -752,11 +752,11 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             });
           });
 
-          describe("when caller has no allowed calls set", () => {
-            it("should revert with `NotAllowedCall(...)` error", async () => {
-              let newName = "Another name";
+          describe('when caller has no allowed calls set', () => {
+            it('should revert with `NotAllowedCall(...)` error', async () => {
+              let newName = 'Another name';
 
-              let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+              let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
                 newName,
               ]);
               let nonce = await context.keyManager.callStatic.getNonce(
@@ -767,7 +767,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               const validityTimestamps = 0;
 
               let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
               );
 
@@ -775,7 +775,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               let valueToSend = 0;
 
               let encodedMessage = ethers.utils.solidityPack(
-                ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+                ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
                   LSP6_VERSION,
                   HARDHAT_CHAINID,
@@ -803,17 +803,17 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                   { value: valueToSend },
                 ),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+                .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
                 .withArgs(addressCanMakeCallNoAllowedCalls.address);
             });
           });
         });
 
-        describe("when signing tx with Ethereum Signed Message prefix", () => {
-          it("should retrieve the incorrect signer address and revert with `InvalidRelayNonce` error", async () => {
-            let newName = "Another name";
+        describe('when signing tx with Ethereum Signed Message prefix', () => {
+          it('should retrieve the incorrect signer address and revert with `InvalidRelayNonce` error', async () => {
+            let newName = 'Another name';
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+            let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
               newName,
             ]);
             let nonce = await context.keyManager.callStatic.getNonce(
@@ -824,7 +824,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const validityTimestamps = 0;
 
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              'execute',
               [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
             );
 
@@ -832,7 +832,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 LSP6_VERSION,
                 HARDHAT_CHAINID,
@@ -863,19 +863,19 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 { value: valueToSend },
               ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "InvalidRelayNonce")
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidRelayNonce')
               .withArgs(incorrectSignerAddress, nonce, signature);
           });
         });
       });
 
-      describe("when signer does not have permission CALL", () => {
-        describe("when signing tx with EIP191Signer `\\x19\\x00` prefix", () => {
-          it("should revert with `NotAuthorised` and permission CALL error", async () => {
+      describe('when signer does not have permission CALL', () => {
+        describe('when signing tx with EIP191Signer `\\x19\\x00` prefix', () => {
+          it('should revert with `NotAuthorised` and permission CALL error', async () => {
             const initialName = await targetContract.callStatic.getName();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-              "Random name",
+            let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+              'Random name',
             ]);
             let nonce = await context.keyManager.callStatic.getNonce(
               addressCannotMakeCall.address,
@@ -885,7 +885,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const validityTimestamps = 0;
 
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              'execute',
               [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
             );
 
@@ -893,7 +893,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 LSP6_VERSION,
                 HARDHAT_CHAINID,
@@ -921,8 +921,8 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 { value: valueToSend },
               ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(addressCannotMakeCall.address, "CALL");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(addressCannotMakeCall.address, 'CALL');
 
             // ensure no state change at the target contract
             const result = await targetContract.callStatic.getName();
@@ -930,12 +930,12 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           });
         });
 
-        describe("when signing tx with Ethereum Signed Message prefix", () => {
-          it("should retrieve the incorrect signer address and revert with `NoPermissionSet`", async () => {
+        describe('when signing tx with Ethereum Signed Message prefix', () => {
+          it('should retrieve the incorrect signer address and revert with `NoPermissionSet`', async () => {
             const initialName = await targetContract.callStatic.getName();
 
-            let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-              "Random name",
+            let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+              'Random name',
             ]);
             let nonce = await context.keyManager.callStatic.getNonce(
               addressCannotMakeCall.address,
@@ -945,7 +945,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const validityTimestamps = 0;
 
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
+              'execute',
               [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
             );
 
@@ -953,7 +953,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 LSP6_VERSION,
                 HARDHAT_CHAINID,
@@ -985,7 +985,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
                 { value: valueToSend },
               ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
               .withArgs(incorrectSignerAddress);
 
             // ensure state at target contract has not changed
@@ -996,7 +996,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
     });
   });
 
-  describe("`execute(...)` edge cases", async () => {
+  describe('`execute(...)` edge cases', async () => {
     let targetContract: TargetContract;
     let addressWithNoPermissions: SignerWithAddress;
 
@@ -1008,7 +1008,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
       ];
 
       const permissionValues = [ALL_PERMISSIONS];
@@ -1016,12 +1016,12 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    it("Should revert when caller has no permissions set", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-        "New Contract Name",
+    it('Should revert when caller has no permissions set', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+        'New Contract Name',
       ]);
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         targetContract.address,
         0,
@@ -1029,17 +1029,17 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       ]);
 
       await expect(context.keyManager.connect(addressWithNoPermissions).execute(executePayload))
-        .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+        .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
         .withArgs(addressWithNoPermissions.address);
     });
 
-    it("Should revert when caller calls the KeyManager through execute", async () => {
+    it('Should revert when caller calls the KeyManager through execute', async () => {
       let lsp20VerifyCallPayload = context.keyManager.interface.encodeFunctionData(
-        "lsp20VerifyCall",
-        [context.accounts[2].address, 0, "0xaabbccdd"], // random arguments
+        'lsp20VerifyCall',
+        [context.accounts[2].address, 0, '0xaabbccdd'], // random arguments
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         context.keyManager.address,
         0,
@@ -1048,7 +1048,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
 
       await expect(
         context.keyManager.connect(context.owner).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "CallingKeyManagerNotAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'CallingKeyManagerNotAllowed');
     });
   });
 };

--- a/tests/LSP6KeyManager/Interactions/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionDelegateCall.test.ts
@@ -1,7 +1,7 @@
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { ERC725YDelegateCall, ERC725YDelegateCall__factory } from "../../../types";
+import { ERC725YDelegateCall, ERC725YDelegateCall__factory } from '../../../types';
 
 // constants
 import {
@@ -10,21 +10,21 @@ import {
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
-import { combineAllowedCalls } from "../../utils/helpers";
+import { combineAllowedCalls } from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionDelegateCall = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed", () => {
+  describe('when trying to make a DELEGATECALL via UP, DELEGATECALL is disallowed', () => {
     let addressCanDelegateCall: SignerWithAddress, addressCannotDelegateCall: SignerWithAddress;
 
     let erc725YDelegateCallContract: ERC725YDelegateCall;
@@ -40,10 +40,10 @@ export const shouldBehaveLikePermissionDelegateCall = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanDelegateCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCannotDelegateCall.address.substring(2),
       ];
 
@@ -52,23 +52,23 @@ export const shouldBehaveLikePermissionDelegateCall = (
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    it("should revert even if caller has ALL PERMISSIONS", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert even if caller has ALL PERMISSIONS', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
+        'updateStorage',
         [key, value],
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.DELEGATECALL,
         erc725YDelegateCallContract.address,
         0,
@@ -77,26 +77,26 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       await expect(
         context.keyManager.connect(context.owner).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
 
-    it("should revert even if caller has permission DELEGATECALL", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert even if caller has permission DELEGATECALL', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "updateStorage",
+        'updateStorage',
         [key, value],
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.DELEGATECALL,
         erc725YDelegateCallContract.address,
         0,
@@ -105,26 +105,26 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       await expect(
         context.keyManager.connect(addressCanDelegateCall).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
 
-    it("should revert with operation disallowed, even if caller does not have permission DELEGATECALL", async () => {
-      const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-      const value = "0xbbbbbbbbbbbbbbbb";
+    it('should revert with operation disallowed, even if caller does not have permission DELEGATECALL', async () => {
+      const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const value = '0xbbbbbbbbbbbbbbbb';
 
       // first check that nothing is set under this key
       // inside the storage of the calling UP
       const currentStorage = await context.universalProfile.getData(key);
-      expect(currentStorage).to.equal("0x");
+      expect(currentStorage).to.equal('0x');
 
       // Doing a delegatecall to the setData function of another UP
       // should update the ERC725Y storage of the UP making the delegatecall
       let delegateCallPayload = erc725YDelegateCallContract.interface.encodeFunctionData(
-        "setDataBatch",
+        'setDataBatch',
         [[key], [value]],
       );
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.DELEGATECALL,
         erc725YDelegateCallContract.address,
         0,
@@ -133,11 +133,11 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       await expect(
         context.keyManager.connect(addressCannotDelegateCall).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
   });
 
-  describe("when caller has permission SUPER_DELEGATECALL + 2 x allowed addresses", () => {
+  describe('when caller has permission SUPER_DELEGATECALL + 2 x allowed addresses', () => {
     let caller: SignerWithAddress;
 
     let allowedDelegateCallContracts: [ERC725YDelegateCall, ERC725YDelegateCall];
@@ -157,8 +157,8 @@ export const shouldBehaveLikePermissionDelegateCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionValues = [
@@ -166,15 +166,15 @@ export const shouldBehaveLikePermissionDelegateCall = (
         combineAllowedCalls(
           [CALLTYPE.DELEGATECALL, CALLTYPE.DELEGATECALL],
           [allowedDelegateCallContracts[0].address, allowedDelegateCallContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when calling a disallowed contract", () => {
+    describe('when calling a disallowed contract', () => {
       let randomContracts: ERC725YDelegateCall[];
 
       before(async () => {
@@ -197,14 +197,14 @@ export const shouldBehaveLikePermissionDelegateCall = (
         ];
       });
 
-      describe("it should revert since DELEGATECALL is disallowed", () => {
+      describe('it should revert since DELEGATECALL is disallowed', () => {
         for (let ii = 0; ii < 5; ii++) {
           it(`delegate call to contract nb ${ii}`, async () => {
-            const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-            const value = "0xbbbbbbbbbbbbbbbb";
+            const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+            const value = '0xbbbbbbbbbbbbbbbb';
 
-            const currentStorage = await context.universalProfile["getData(bytes32)"](key);
-            expect(currentStorage).to.equal("0x");
+            const currentStorage = await context.universalProfile['getData(bytes32)'](key);
+            expect(currentStorage).to.equal('0x');
 
             // prettier-ignore
             let delegateCallPayload = randomContracts[ii].interface.encodeFunctionData(
@@ -213,7 +213,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
               value,
             ]);
 
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.DELEGATECALL,
               randomContracts[ii].address,
               0,
@@ -224,25 +224,25 @@ export const shouldBehaveLikePermissionDelegateCall = (
               context.keyManager.connect(caller).execute(executePayload),
             ).to.be.revertedWithCustomError(
               context.keyManager,
-              "DelegateCallDisallowedViaKeyManager",
+              'DelegateCallDisallowedViaKeyManager',
             );
 
             // storage should remain unchanged and not set
-            const newStorage = await context.universalProfile["getData(bytes32)"](key);
-            expect(newStorage).to.equal("0x");
+            const newStorage = await context.universalProfile['getData(bytes32)'](key);
+            expect(newStorage).to.equal('0x');
           });
         }
       });
     });
 
-    describe("when calling an allowed contract", () => {
-      it("should revert with DELEGATECALL disallowed when trying to interact with the 1st allowed contract", async () => {
-        const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        const value = "0xbbbbbbbbbbbbbbbb";
+    describe('when calling an allowed contract', () => {
+      it('should revert with DELEGATECALL disallowed when trying to interact with the 1st allowed contract', async () => {
+        const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const value = '0xbbbbbbbbbbbbbbbb';
 
         // prettier-ignore
         const currentStorage = await context.universalProfile.getData(key);
-        expect(currentStorage).to.equal("0x");
+        expect(currentStorage).to.equal('0x');
 
         // prettier-ignore
         let delegateCallPayload = allowedDelegateCallContracts[0].interface.encodeFunctionData(
@@ -251,7 +251,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
           value,
         ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           allowedDelegateCallContracts[0].address,
           0,
@@ -260,20 +260,20 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload),
-        ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+        ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
 
         // prettier-ignore
         const newStorage = await context.universalProfile.getData(key);
-        expect(newStorage).to.equal("0x");
+        expect(newStorage).to.equal('0x');
       });
 
-      it("should revert with DELEGATECALL disallowed when trying to interact with the 2nd allowed contract", async () => {
-        const key = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        const value = "0xbbbbbbbbbbbbbbbb";
+      it('should revert with DELEGATECALL disallowed when trying to interact with the 2nd allowed contract', async () => {
+        const key = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const value = '0xbbbbbbbbbbbbbbbb';
 
         // prettier-ignore
         const currentStorage = await context.universalProfile.getData(key);
-        expect(currentStorage).to.equal("0x");
+        expect(currentStorage).to.equal('0x');
 
         // prettier-ignore
         let delegateCallPayload = allowedDelegateCallContracts[1].interface.encodeFunctionData(
@@ -282,7 +282,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
           value,
         ]);
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           allowedDelegateCallContracts[1].address,
           0,
@@ -291,11 +291,11 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
         await expect(
           context.keyManager.connect(caller).execute(executePayload),
-        ).to.be.revertedWithCustomError(context.keyManager, "DelegateCallDisallowedViaKeyManager");
+        ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
 
         // prettier-ignore
         const newStorage = await context.universalProfile.getData(key);
-        expect(newStorage).to.equal("0x");
+        expect(newStorage).to.equal('0x');
       });
     });
   });

--- a/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
@@ -1,10 +1,10 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { calculateCreate2 } from "eth-create2-calculator";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { calculateCreate2 } from 'eth-create2-calculator';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
-import { TargetContract__factory, UniversalProfile__factory } from "../../../types";
+import { TargetContract__factory, UniversalProfile__factory } from '../../../types';
 
 // constants
 import {
@@ -13,14 +13,14 @@ import {
   LSP6_VERSION,
   PERMISSIONS,
   OPERATION_TYPES,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
-import { combinePermissions, LOCAL_PRIVATE_KEYS, provider } from "../../utils/helpers";
-import { BigNumber } from "ethers";
+import { combinePermissions, LOCAL_PRIVATE_KEYS, provider } from '../../utils/helpers';
+import { BigNumber } from 'ethers';
 
 export const shouldBehaveLikePermissionDeploy = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -33,7 +33,7 @@ export const shouldBehaveLikePermissionDeploy = (
     addressCannotDeploy: SignerWithAddress;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("100"));
+    context = await buildContext(ethers.utils.parseEther('100'));
 
     addressCanDeploy = context.accounts[1];
     addressCanDeployAndTransferValue = context.accounts[2];
@@ -41,14 +41,14 @@ export const shouldBehaveLikePermissionDeploy = (
     addressCannotDeploy = context.accounts[4];
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeploy.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeployAndTransferValue.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeployAndSuperTransferValue.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCannotDeploy.address.substring(2),
     ];
 
@@ -63,11 +63,11 @@ export const shouldBehaveLikePermissionDeploy = (
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when caller has ALL PERMISSIONS", () => {
-    it("should be allowed to deploy a contract with CREATE", async () => {
+  describe('when caller has ALL PERMISSIONS', () => {
+    it('should be allowed to deploy a contract with CREATE', async () => {
       const contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         0,
@@ -81,16 +81,16 @@ export const shouldBehaveLikePermissionDeploy = (
         .callStatic.execute(payload);
 
       await expect(context.keyManager.connect(context.owner).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should be allowed to deploy + fund a contract with CREATE", async () => {
+    it('should be allowed to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -100,9 +100,9 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -116,12 +116,12 @@ export const shouldBehaveLikePermissionDeploy = (
         .callStatic.execute(payload);
 
       await expect(context.keyManager.connect(context.owner).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           fundingAmount,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
 
       // check that the newly deployed contract (UP) has the correct owner
@@ -134,11 +134,11 @@ export const shouldBehaveLikePermissionDeploy = (
       expect(await provider.getBalance(expectedContractAddress)).to.equal(fundingAmount);
     });
 
-    it("should be allowed to deploy a contract with CREATE2", async () => {
+    it('should be allowed to deploy a contract with CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         0,
@@ -152,11 +152,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).toLowerCase();
 
       await expect(context.keyManager.connect(context.owner).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
 
-    it("should be allowed to deploy + fund a contract with CREATE2", async () => {
+    it('should be allowed to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -166,11 +166,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -184,7 +184,7 @@ export const shouldBehaveLikePermissionDeploy = (
       ).toLowerCase();
 
       await expect(context.keyManager.connect(context.owner).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE2,
           ethers.utils.getAddress(preComputedAddress),
@@ -202,11 +202,11 @@ export const shouldBehaveLikePermissionDeploy = (
     });
   });
 
-  describe("when caller has permission DEPLOY", () => {
-    it("should be allowed to deploy a contract with CREATE", async () => {
+  describe('when caller has permission DEPLOY', () => {
+    it('should be allowed to deploy a contract with CREATE', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         0,
@@ -218,16 +218,16 @@ export const shouldBehaveLikePermissionDeploy = (
         .callStatic.execute(payload);
 
       await expect(context.keyManager.connect(addressCanDeploy).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE", async () => {
+    it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -237,9 +237,9 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -247,15 +247,15 @@ export const shouldBehaveLikePermissionDeploy = (
       ]);
 
       await expect(context.keyManager.connect(addressCanDeploy).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCanDeploy.address, "SUPER_TRANSFERVALUE");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCanDeploy.address, 'SUPER_TRANSFERVALUE');
     });
 
-    it("should be allowed to deploy a contract with CREATE2", async () => {
+    it('should be allowed to deploy a contract with CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         0,
@@ -269,11 +269,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).toLowerCase();
 
       await expect(context.keyManager.connect(addressCanDeploy).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
 
-    it("should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2", async () => {
+    it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -283,11 +283,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -295,16 +295,16 @@ export const shouldBehaveLikePermissionDeploy = (
       ]);
 
       await expect(context.keyManager.connect(addressCanDeploy).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCanDeploy.address, "SUPER_TRANSFERVALUE");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCanDeploy.address, 'SUPER_TRANSFERVALUE');
     });
   });
 
-  describe("when caller has permissions DEPLOY + TRANSFERVALUE", () => {
-    it("should be allowed to deploy a contract with CREATE", async () => {
+  describe('when caller has permissions DEPLOY + TRANSFERVALUE', () => {
+    it('should be allowed to deploy a contract with CREATE', async () => {
       const contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         0,
@@ -318,16 +318,16 @@ export const shouldBehaveLikePermissionDeploy = (
         .callStatic.execute(payload);
 
       await expect(context.keyManager.connect(addressCanDeployAndTransferValue).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE", async () => {
+    it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -337,9 +337,9 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -347,15 +347,15 @@ export const shouldBehaveLikePermissionDeploy = (
       ]);
 
       await expect(context.keyManager.connect(addressCanDeployAndTransferValue).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCanDeployAndTransferValue.address, "SUPER_TRANSFERVALUE");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCanDeployAndTransferValue.address, 'SUPER_TRANSFERVALUE');
     });
 
-    it("should be allowed to deploy a contract with CREATE2", async () => {
+    it('should be allowed to deploy a contract with CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         0,
@@ -369,11 +369,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).toLowerCase();
 
       await expect(context.keyManager.connect(addressCanDeployAndTransferValue).execute(payload))
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
 
-    it("should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2", async () => {
+    it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -383,11 +383,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -395,16 +395,16 @@ export const shouldBehaveLikePermissionDeploy = (
       ]);
 
       await expect(context.keyManager.connect(addressCanDeployAndTransferValue).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCanDeployAndTransferValue.address, "SUPER_TRANSFERVALUE");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCanDeployAndTransferValue.address, 'SUPER_TRANSFERVALUE');
     });
   });
 
-  describe("when caller has permissions DEPLOY + SUPER_TRANSFERVALUE", () => {
-    it("should be allowed to deploy a contract with CREATE", async () => {
+  describe('when caller has permissions DEPLOY + SUPER_TRANSFERVALUE', () => {
+    it('should be allowed to deploy a contract with CREATE', async () => {
       const contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         0,
@@ -420,16 +420,16 @@ export const shouldBehaveLikePermissionDeploy = (
       await expect(
         context.keyManager.connect(addressCanDeployAndSuperTransferValue).execute(payload),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           0,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
     });
 
-    it("should be allowed to deploy + fund a contract with CREATE", async () => {
+    it('should be allowed to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -439,9 +439,9 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -457,12 +457,12 @@ export const shouldBehaveLikePermissionDeploy = (
       await expect(
         context.keyManager.connect(addressCanDeployAndSuperTransferValue).execute(payload),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
           ethers.utils.getAddress(expectedContractAddress),
           fundingAmount,
-          ethers.utils.hexZeroPad("0x00", 32),
+          ethers.utils.hexZeroPad('0x00', 32),
         );
 
       // check that the newly deployed contract (UP) has the correct owner
@@ -475,11 +475,11 @@ export const shouldBehaveLikePermissionDeploy = (
       expect(await provider.getBalance(expectedContractAddress)).to.equal(fundingAmount);
     });
 
-    it("should be allowed to deploy a contract with CREATE2", async () => {
+    it('should be allowed to deploy a contract with CREATE2', async () => {
       let contractBytecodeToDeploy = TargetContract__factory.bytecode;
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         0,
@@ -495,11 +495,11 @@ export const shouldBehaveLikePermissionDeploy = (
       await expect(
         context.keyManager.connect(addressCanDeployAndSuperTransferValue).execute(payload),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
 
-    it("should be allowed to deploy + fund a contract with CREATE2", async () => {
+    it('should be allowed to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
       const initialUpOwner = context.owner.address;
 
@@ -509,11 +509,11 @@ export const shouldBehaveLikePermissionDeploy = (
       ).getDeployTransaction(initialUpOwner);
 
       const contractBytecodeToDeploy = upDeploymentTx.data;
-      const fundingAmount = ethers.utils.parseEther("10");
+      const fundingAmount = ethers.utils.parseEther('10');
 
       let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-      let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CREATE2,
         ethers.constants.AddressZero,
         fundingAmount,
@@ -529,7 +529,7 @@ export const shouldBehaveLikePermissionDeploy = (
       await expect(
         context.keyManager.connect(addressCanDeployAndSuperTransferValue).execute(payload),
       )
-        .to.emit(context.universalProfile, "ContractCreated")
+        .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE2,
           ethers.utils.getAddress(preComputedAddress),
@@ -547,12 +547,12 @@ export const shouldBehaveLikePermissionDeploy = (
     });
   });
 
-  describe("when caller does not have permission DEPLOY", () => {
-    describe("-> interacting via execute(...)", () => {
-      it("should revert when trying to deploy a contract via CREATE", async () => {
+  describe('when caller does not have permission DEPLOY', () => {
+    describe('-> interacting via execute(...)', () => {
+      it('should revert when trying to deploy a contract via CREATE', async () => {
         let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CREATE,
           ethers.constants.AddressZero,
           0,
@@ -560,15 +560,15 @@ export const shouldBehaveLikePermissionDeploy = (
         ]);
 
         await expect(context.keyManager.connect(addressCannotDeploy).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "DEPLOY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotDeploy.address, 'DEPLOY');
       });
 
-      it("should revert when trying to deploy a contract via CREATE2", async () => {
+      it('should revert when trying to deploy a contract via CREATE2', async () => {
         let contractBytecodeToDeploy = TargetContract__factory.bytecode;
         let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
-        let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CREATE2,
           ethers.constants.AddressZero,
           0,
@@ -576,15 +576,15 @@ export const shouldBehaveLikePermissionDeploy = (
         ]);
 
         await expect(context.keyManager.connect(addressCannotDeploy).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCannotDeploy.address, "DEPLOY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCannotDeploy.address, 'DEPLOY');
       });
     });
 
-    describe("-> interacting via executeRelayCall(...)", () => {
-      describe("when deploying a contract via CREATE", () => {
-        describe("when signing with Ethereum Signed Message", () => {
-          it("should recover the wrong signer address and revert with `NoPermissionsSet`", async () => {
+    describe('-> interacting via executeRelayCall(...)', () => {
+      describe('when deploying a contract via CREATE', () => {
+        describe('when signing with Ethereum Signed Message', () => {
+          it('should recover the wrong signer address and revert with `NoPermissionsSet`', async () => {
             let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
             let nonce = await context.keyManager.callStatic.getNonce(
@@ -594,7 +594,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const validityTimestamps = 0;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CREATE,
               ethers.constants.AddressZero,
               0,
@@ -605,7 +605,7 @@ export const shouldBehaveLikePermissionDeploy = (
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
@@ -628,13 +628,13 @@ export const shouldBehaveLikePermissionDeploy = (
                   value: valueToSend,
                 }),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
               .withArgs(incorrectSignerAddress);
           });
         });
 
         describe("when signing with EIP191Signer '\\x19\\x00'", () => {
-          it("should revert with `NotAuthorised` with correct signer address but missing permission DEPLOY", async () => {
+          it('should revert with `NotAuthorised` with correct signer address but missing permission DEPLOY', async () => {
             let contractBytecodeToDeploy = TargetContract__factory.bytecode;
 
             let nonce = await context.keyManager.callStatic.getNonce(
@@ -644,7 +644,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const validityTimestamps = 0;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CREATE,
               ethers.constants.AddressZero,
               0,
@@ -655,7 +655,7 @@ export const shouldBehaveLikePermissionDeploy = (
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
@@ -674,15 +674,15 @@ export const shouldBehaveLikePermissionDeploy = (
                   value: valueToSend,
                 }),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(addressCannotDeploy.address, "DEPLOY");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(addressCannotDeploy.address, 'DEPLOY');
           });
         });
       });
 
-      describe("when deploying a contract via CREATE2", () => {
-        describe("when signing with Ethereum Signed Message", () => {
-          it("should recover the wrong signer address and revert with `NoPermissionsSet`", async () => {
+      describe('when deploying a contract via CREATE2', () => {
+        describe('when signing with Ethereum Signed Message', () => {
+          it('should recover the wrong signer address and revert with `NoPermissionsSet`', async () => {
             let contractBytecodeToDeploy = TargetContract__factory.bytecode;
             let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
@@ -693,7 +693,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const validityTimestamps = 0;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CREATE2,
               ethers.constants.AddressZero,
               0,
@@ -704,7 +704,7 @@ export const shouldBehaveLikePermissionDeploy = (
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
@@ -726,13 +726,13 @@ export const shouldBehaveLikePermissionDeploy = (
                   value: valueToSend,
                 }),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
               .withArgs(incorrectSignerAddress);
           });
         });
 
         describe("when signing with EIP191Signer '\\x19\\x00'", () => {
-          it("should revert with `NotAuthorised` with correct signer address but missing permission DEPLOY", async () => {
+          it('should revert with `NotAuthorised` with correct signer address but missing permission DEPLOY', async () => {
             let contractBytecodeToDeploy = TargetContract__factory.bytecode;
             let salt = ethers.utils.hexlify(ethers.utils.randomBytes(32));
 
@@ -743,7 +743,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const validityTimestamps = 0;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let payload = context.universalProfile.interface.encodeFunctionData('execute', [
               OPERATION_TYPES.CREATE2,
               ethers.constants.AddressZero,
               0,
@@ -754,7 +754,7 @@ export const shouldBehaveLikePermissionDeploy = (
             let valueToSend = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
@@ -773,8 +773,8 @@ export const shouldBehaveLikePermissionDeploy = (
                   value: valueToSend,
                 }),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(addressCannotDeploy.address, "DEPLOY");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(addressCannotDeploy.address, 'DEPLOY');
           });
         });
       });

--- a/tests/LSP6KeyManager/Interactions/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionStaticCall.test.ts
@@ -1,6 +1,6 @@
-import { expect } from "chai";
-import { ethers } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   TargetContract,
@@ -9,7 +9,7 @@ import {
   OnERC721ReceivedExtension,
   SignatureValidator__factory,
   OnERC721ReceivedExtension__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -19,11 +19,11 @@ import {
   OPERATION_TYPES,
   ERC1271_VALUES,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
@@ -31,7 +31,7 @@ import {
   combineAllowedCalls,
   combineCallTypes,
   combinePermissions,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 export const shouldBehaveLikePermissionStaticCall = (
   buildContext: () => Promise<LSP6TestContext>,
@@ -62,14 +62,14 @@ export const shouldBehaveLikePermissionStaticCall = (
     ).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
         addressCanMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCannotMakeStaticCall.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCallNoAllowedCalls.address.substring(2),
     ];
 
@@ -83,8 +83,8 @@ export const shouldBehaveLikePermissionStaticCall = (
           combineCallTypes(CALLTYPE.STATICCALL, CALLTYPE.VALUE),
         ],
         [targetContract.address, signatureValidator.address, onERC721ReceivedContract.address],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff', '0xffffffff'],
       ),
       PERMISSIONS.SETDATA,
       PERMISSIONS.STATICCALL,
@@ -93,13 +93,13 @@ export const shouldBehaveLikePermissionStaticCall = (
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when caller has ALL PERMISSIONS", () => {
-    it("should pass and return data", async () => {
+  describe('when caller has ALL PERMISSIONS', () => {
+    it('should pass and return data', async () => {
       let expectedName = await targetContract.callStatic.getName();
 
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.STATICCALL,
         targetContract.address,
         0,
@@ -110,19 +110,19 @@ export const shouldBehaveLikePermissionStaticCall = (
         .connect(context.owner)
         .callStatic.execute(executePayload);
 
-      let [decodedResult] = abiCoder.decode(["string"], result);
+      let [decodedResult] = abiCoder.decode(['string'], result);
       expect(decodedResult).to.equal(expectedName);
     });
   });
 
-  describe("when caller has permission STATICCALL + some allowed calls", () => {
-    describe("when calling a `view` function on a target contract", () => {
-      it("should pass and return data when `value` param is 0 ", async () => {
+  describe('when caller has permission STATICCALL + some allowed calls', () => {
+    describe('when calling a `view` function on a target contract', () => {
+      it('should pass and return data when `value` param is 0 ', async () => {
         let expectedName = await targetContract.callStatic.getName();
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+        let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
@@ -133,16 +133,16 @@ export const shouldBehaveLikePermissionStaticCall = (
           .connect(addressCanMakeStaticCall)
           .callStatic.execute(executePayload);
 
-        let [decodedResult] = abiCoder.decode(["string"], result);
+        let [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(expectedName);
       });
 
-      it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0", async () => {
-        const LyxAmount = ethers.utils.parseEther("3");
+      it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0', async () => {
+        const LyxAmount = ethers.utils.parseEther('3');
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+        let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           LyxAmount,
@@ -153,24 +153,24 @@ export const shouldBehaveLikePermissionStaticCall = (
           context.keyManager.connect(addressCanMakeStaticCall).callStatic.execute(executePayload),
         ).to.be.revertedWithCustomError(
           context.universalProfile,
-          "ERC725X_MsgValueDisallowedInStaticCall",
+          'ERC725X_MsgValueDisallowedInStaticCall',
         );
       });
     });
 
-    describe("when calling a `pure` function on a target contract", () => {
-      describe("when calling `isValidSignature(bytes32,bytes)` on a contract", () => {
-        it("should pass and return data when `value` param is 0", async () => {
-          const message = "some message to sign";
+    describe('when calling a `pure` function on a target contract', () => {
+      describe('when calling `isValidSignature(bytes32,bytes)` on a contract', () => {
+        it('should pass and return data when `value` param is 0', async () => {
+          const message = 'some message to sign';
           const signature = await context.owner.signMessage(message);
           const messageHash = ethers.utils.hashMessage(message);
 
           let erc1271ContractPayload = signatureValidator.interface.encodeFunctionData(
-            "isValidSignature",
+            'isValidSignature',
             [messageHash, signature],
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.STATICCALL,
             signatureValidator.address,
             0,
@@ -181,23 +181,23 @@ export const shouldBehaveLikePermissionStaticCall = (
             .connect(addressCanMakeStaticCall)
             .callStatic.execute(executePayload);
 
-          let [decodedResult] = abiCoder.decode(["bytes4"], result);
+          let [decodedResult] = abiCoder.decode(['bytes4'], result);
           expect(decodedResult).to.equal(ERC1271_VALUES.MAGIC_VALUE);
         });
 
-        it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0", async () => {
-          const lyxAmount = ethers.utils.parseEther("3");
+        it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0', async () => {
+          const lyxAmount = ethers.utils.parseEther('3');
 
-          const message = "some message to sign";
+          const message = 'some message to sign';
           const signature = await context.owner.signMessage(message);
           const messageHash = ethers.utils.hashMessage(message);
 
           let erc1271ContractPayload = signatureValidator.interface.encodeFunctionData(
-            "isValidSignature",
+            'isValidSignature',
             [messageHash, signature],
           );
 
-          let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.STATICCALL,
             signatureValidator.address,
             lyxAmount,
@@ -208,28 +208,28 @@ export const shouldBehaveLikePermissionStaticCall = (
             context.keyManager.connect(addressCanMakeStaticCall).execute(executePayload),
           ).to.be.revertedWithCustomError(
             context.universalProfile,
-            "ERC725X_MsgValueDisallowedInStaticCall",
+            'ERC725X_MsgValueDisallowedInStaticCall',
           );
         });
       });
 
-      describe("when calling `onERC721Received(address,address,uint256,bytes)` on a contract", () => {
-        it("should pass and return data when `value` param is 0", async () => {
+      describe('when calling `onERC721Received(address,address,uint256,bytes)` on a contract', () => {
+        it('should pass and return data when `value` param is 0', async () => {
           // the params are not relevant for this test and just used as placeholders.
           const onERC721Payload = onERC721ReceivedContract.interface.encodeFunctionData(
-            "onERC721Received",
+            'onERC721Received',
             [
               context.owner.address,
               context.owner.address,
               1,
-              ethers.utils.toUtf8Bytes("some data"),
+              ethers.utils.toUtf8Bytes('some data'),
             ],
           );
 
           // the important part is that the function is `view` and return the correct value
-          const expectedReturnValue = "0x150b7a02";
+          const expectedReturnValue = '0x150b7a02';
 
-          const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.STATICCALL,
             onERC721ReceivedContract.address,
             0,
@@ -240,21 +240,21 @@ export const shouldBehaveLikePermissionStaticCall = (
             .connect(addressCanMakeStaticCall)
             .callStatic.execute(executePayload);
 
-          const [decodedResult] = abiCoder.decode(["bytes4"], result);
+          const [decodedResult] = abiCoder.decode(['bytes4'], result);
           expect(decodedResult).to.equal(expectedReturnValue);
         });
       });
 
-      it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0", async () => {
-        const lyxAmount = ethers.utils.parseEther("3");
+      it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` param is not 0', async () => {
+        const lyxAmount = ethers.utils.parseEther('3');
 
         // the params are not relevant for this test and just used as placeholders.
         const onERC721Payload = onERC721ReceivedContract.interface.encodeFunctionData(
-          "onERC721Received",
-          [context.owner.address, context.owner.address, 1, ethers.utils.toUtf8Bytes("some data")],
+          'onERC721Received',
+          [context.owner.address, context.owner.address, 1, ethers.utils.toUtf8Bytes('some data')],
         );
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           onERC721ReceivedContract.address,
           lyxAmount,
@@ -265,19 +265,19 @@ export const shouldBehaveLikePermissionStaticCall = (
           context.keyManager.connect(addressCanMakeStaticCall).execute(executePayload),
         ).to.be.revertedWithCustomError(
           context.universalProfile,
-          "ERC725X_MsgValueDisallowedInStaticCall",
+          'ERC725X_MsgValueDisallowedInStaticCall',
         );
       });
     }),
-      describe("when calling a state changing function at the target contract", () => {
-        it("should revert (silently) if `value` parameter is 0", async () => {
+      describe('when calling a state changing function at the target contract', () => {
+        it('should revert (silently) if `value` parameter is 0', async () => {
           const initialValue = await targetContract.callStatic.getName();
 
-          const targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-            "modified name",
+          const targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+            'modified name',
           ]);
 
-          const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             0,
@@ -292,14 +292,14 @@ export const shouldBehaveLikePermissionStaticCall = (
           expect(initialValue).to.equal(newValue);
         });
 
-        it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` parameter is not 0", async () => {
-          const lyxAmount = ethers.utils.parseEther("3");
+        it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` if `value` parameter is not 0', async () => {
+          const lyxAmount = ethers.utils.parseEther('3');
 
-          const targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
-            "modified name",
+          const targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
+            'modified name',
           ]);
 
-          const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+          const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.STATICCALL,
             targetContract.address,
             lyxAmount,
@@ -310,17 +310,17 @@ export const shouldBehaveLikePermissionStaticCall = (
             context.keyManager.connect(addressCanMakeStaticCall).execute(executePayload),
           ).to.be.revertedWithCustomError(
             context.universalProfile,
-            "ERC725X_MsgValueDisallowedInStaticCall",
+            'ERC725X_MsgValueDisallowedInStaticCall',
           );
         });
       });
   });
 
-  describe("when caller has permission STATICCALL + no allowed calls", () => {
-    it("should revert with `NotAllowedCall` error", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+  describe('when caller has permission STATICCALL + no allowed calls', () => {
+    it('should revert with `NotAllowedCall` error', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.STATICCALL,
         targetContract.address,
         0,
@@ -332,16 +332,16 @@ export const shouldBehaveLikePermissionStaticCall = (
           .connect(addressCanMakeStaticCallNoAllowedCalls)
           .callStatic.execute(executePayload),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+        .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
         .withArgs(addressCanMakeStaticCallNoAllowedCalls.address);
     });
   });
 
-  describe("when caller does not have permission STATICCALL", () => {
-    it("should revert with `NotAuthorised` error", async () => {
-      let targetContractPayload = targetContract.interface.encodeFunctionData("getName");
+  describe('when caller does not have permission STATICCALL', () => {
+    it('should revert with `NotAuthorised` error', async () => {
+      let targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
-      let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.STATICCALL,
         targetContract.address,
         0,
@@ -349,12 +349,12 @@ export const shouldBehaveLikePermissionStaticCall = (
       ]);
 
       await expect(context.keyManager.connect(addressCannotMakeStaticCall).execute(executePayload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-        .withArgs(addressCannotMakeStaticCall.address, "STATICCALL");
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+        .withArgs(addressCannotMakeStaticCall.address, 'STATICCALL');
     });
   });
 
-  describe("when caller has permission STATICCALL + 2 x allowed addresses", () => {
+  describe('when caller has permission STATICCALL + 2 x allowed addresses', () => {
     let caller: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -369,8 +369,8 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionValues = [
@@ -378,76 +378,76 @@ export const shouldBehaveLikePermissionStaticCall = (
         combineAllowedCalls(
           [CALLTYPE.STATICCALL, CALLTYPE.STATICCALL],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    it("should revert when trying to interact with a non-allowed address", async () => {
+    it('should revert when trying to interact with a non-allowed address', async () => {
       let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.STATICCALL,
         targetContract.address,
         0,
-        targetContract.interface.getSighash("getName"),
+        targetContract.interface.getSighash('getName'),
       ]);
 
       await expect(context.keyManager.connect(caller).execute(payload))
-        .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+        .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
         .withArgs(
           caller.address,
           targetContract.address,
-          targetContract.interface.getSighash("getName"),
+          targetContract.interface.getSighash('getName'),
         );
     });
 
-    describe("when interacting with 1st allowed contract", () => {
-      it("should allow to call view function -> getName()", async () => {
+    describe('when interacting with 1st allowed contract', () => {
+      it('should allow to call view function -> getName()', async () => {
         let targetContract = allowedTargetContracts[0];
 
         const name = await targetContract.getName();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
-          targetContract.interface.getSighash("getName"),
+          targetContract.interface.getSighash('getName'),
         ]);
 
         const result = await context.keyManager.connect(caller).callStatic.execute(payload);
 
-        const [decodedResult] = abiCoder.decode(["string"], result);
+        const [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(name);
       });
 
-      it("should allow to call view function -> getNumber()", async () => {
+      it('should allow to call view function -> getNumber()', async () => {
         let targetContract = allowedTargetContracts[0];
 
         const number = await targetContract.getNumber();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
-          targetContract.interface.getSighash("getNumber"),
+          targetContract.interface.getSighash('getNumber'),
         ]);
 
         const result = await context.keyManager.connect(caller).callStatic.execute(payload);
 
-        const [decodedResult] = abiCoder.decode(["uint256"], result);
+        const [decodedResult] = abiCoder.decode(['uint256'], result);
         expect(decodedResult).to.equal(number);
       });
 
-      it("should revert when calling state changing function -> setName(string)", async () => {
+      it('should revert when calling state changing function -> setName(string)', async () => {
         let targetContract = allowedTargetContracts[0];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
@@ -457,12 +457,12 @@ export const shouldBehaveLikePermissionStaticCall = (
         await expect(context.keyManager.connect(caller).callStatic.execute(payload)).to.be.reverted;
       });
 
-      it("should revert when calling state changing function -> setNumber(uint256)", async () => {
+      it('should revert when calling state changing function -> setNumber(uint256)', async () => {
         let targetContract = allowedTargetContracts[0];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setNumber", [12345]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setNumber', [12345]);
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
@@ -473,49 +473,49 @@ export const shouldBehaveLikePermissionStaticCall = (
       });
     });
 
-    describe("when interacting with 2nd allowed contract", () => {
-      it("should allow to interact with 2nd allowed contract - getName()", async () => {
+    describe('when interacting with 2nd allowed contract', () => {
+      it('should allow to interact with 2nd allowed contract - getName()', async () => {
         let targetContract = allowedTargetContracts[1];
 
         const name = await targetContract.getName();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
-          targetContract.interface.getSighash("getName"),
+          targetContract.interface.getSighash('getName'),
         ]);
 
         const result = await context.keyManager.connect(caller).callStatic.execute(payload);
 
-        const [decodedResult] = abiCoder.decode(["string"], result);
+        const [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(name);
       });
 
-      it("should allow to interact with 2nd allowed contract - getNumber()", async () => {
+      it('should allow to interact with 2nd allowed contract - getNumber()', async () => {
         let targetContract = allowedTargetContracts[1];
 
         const number = await targetContract.getNumber();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
-          targetContract.interface.getSighash("getNumber"),
+          targetContract.interface.getSighash('getNumber'),
         ]);
 
         const result = await context.keyManager.connect(caller).callStatic.execute(payload);
 
-        const [decodedResult] = abiCoder.decode(["uint256"], result);
+        const [decodedResult] = abiCoder.decode(['uint256'], result);
         expect(decodedResult).to.equal(number);
       });
 
-      it("should revert when calling state changing function -> setName(string)", async () => {
+      it('should revert when calling state changing function -> setName(string)', async () => {
         let targetContract = allowedTargetContracts[1];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setName", ["new name"]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setName', ['new name']);
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
@@ -525,12 +525,12 @@ export const shouldBehaveLikePermissionStaticCall = (
         await expect(context.keyManager.connect(caller).callStatic.execute(payload)).to.be.reverted;
       });
 
-      it("should revert when calling state changing function -> setNumber(uint256)", async () => {
+      it('should revert when calling state changing function -> setNumber(uint256)', async () => {
         let targetContract = allowedTargetContracts[1];
 
-        const targetPayload = targetContract.interface.encodeFunctionData("setNumber", [12345]);
+        const targetPayload = targetContract.interface.encodeFunctionData('setNumber', [12345]);
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContract.address,
           0,
@@ -542,7 +542,7 @@ export const shouldBehaveLikePermissionStaticCall = (
     });
   });
 
-  describe("when caller has permission SUPER_STATICCALL + 2 allowed addresses", () => {
+  describe('when caller has permission SUPER_STATICCALL + 2 allowed addresses', () => {
     let addressWithSuperStaticCall: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -557,69 +557,69 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithSuperStaticCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressWithSuperStaticCall.address.substring(2),
       ];
 
       const permissionValues = [
         PERMISSIONS.SUPER_STATICCALL,
         combineAllowedCalls(
-          ["00000004", "00000004"],
+          ['00000004', '00000004'],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when interacting with random contracts", () => {
-      it("should bypass allowed calls check + allow ton interact with a random contract", async () => {
+    describe('when interacting with random contracts', () => {
+      it('should bypass allowed calls check + allow ton interact with a random contract', async () => {
         const randomContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
         const name = await randomContract.getName();
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           randomContract.address,
           0,
-          randomContract.interface.getSighash("getName"),
+          randomContract.interface.getSighash('getName'),
         ]);
 
         const result = await context.keyManager
           .connect(addressWithSuperStaticCall)
           .callStatic.execute(payload);
 
-        const [decodedResult] = abiCoder.decode(["string"], result);
+        const [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(name);
       });
 
-      it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0", async () => {
+      it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0', async () => {
         const randomContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
-        const lyxAmount = ethers.utils.parseEther("3");
+        const lyxAmount = ethers.utils.parseEther('3');
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           randomContract.address,
           lyxAmount,
-          randomContract.interface.getSighash("getName"),
+          randomContract.interface.getSighash('getName'),
         ]);
 
         await expect(
           context.keyManager.connect(addressWithSuperStaticCall).execute(payload),
         ).to.be.revertedWithCustomError(
           context.universalProfile,
-          "ERC725X_MsgValueDisallowedInStaticCall",
+          'ERC725X_MsgValueDisallowedInStaticCall',
         );
       });
     });
   });
 
-  describe("when caller has permission SUPER_CALL + 2 allowed addresses", () => {
+  describe('when caller has permission SUPER_CALL + 2 allowed addresses', () => {
     let addressWithSuperCall: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -634,9 +634,9 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithSuperCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressWithSuperCall.address.substring(2),
       ];
 
@@ -645,19 +645,19 @@ export const shouldBehaveLikePermissionStaticCall = (
         combineAllowedCalls(
           [CALLTYPE.STATICCALL, CALLTYPE.STATICCALL],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when interacting with 1st allowed contract", () => {
-      it("should revert with `NotAuthorised` when using operation type `STATICCALL`", async () => {
-        const targetPayload = allowedTargetContracts[0].interface.getSighash("getName");
+    describe('when interacting with 1st allowed contract', () => {
+      it('should revert with `NotAuthorised` when using operation type `STATICCALL`', async () => {
+        const targetPayload = allowedTargetContracts[0].interface.getSighash('getName');
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[0].address,
           0,
@@ -665,16 +665,16 @@ export const shouldBehaveLikePermissionStaticCall = (
         ]);
 
         await expect(context.keyManager.connect(addressWithSuperCall).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressWithSuperCall.address, "STATICCALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressWithSuperCall.address, 'STATICCALL');
       });
     });
 
-    describe("when interacting with 2nd allowed contract", () => {
-      it("should revert with `NotAuthorised` when using operation type `STATICCALL`", async () => {
-        const targetPayload = allowedTargetContracts[1].interface.getSighash("getName");
+    describe('when interacting with 2nd allowed contract', () => {
+      it('should revert with `NotAuthorised` when using operation type `STATICCALL`', async () => {
+        const targetPayload = allowedTargetContracts[1].interface.getSighash('getName');
 
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[1].address,
           0,
@@ -682,13 +682,13 @@ export const shouldBehaveLikePermissionStaticCall = (
         ]);
 
         await expect(context.keyManager.connect(addressWithSuperCall).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressWithSuperCall.address, "STATICCALL");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressWithSuperCall.address, 'STATICCALL');
       });
     });
   });
 
-  describe("when caller has permission SUPER_CALL + STATICCALL + 2 allowed addresses", () => {
+  describe('when caller has permission SUPER_CALL + STATICCALL + 2 allowed addresses', () => {
     let addressWithSuperCallAndStaticCall: SignerWithAddress;
     let allowedTargetContracts: [TargetContract, TargetContract];
 
@@ -703,9 +703,9 @@ export const shouldBehaveLikePermissionStaticCall = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithSuperCallAndStaticCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           addressWithSuperCallAndStaticCall.address.substring(2),
       ];
 
@@ -717,19 +717,19 @@ export const shouldBehaveLikePermissionStaticCall = (
             combineCallTypes(CALLTYPE.STATICCALL, CALLTYPE.VALUE),
           ],
           [allowedTargetContracts[0].address, allowedTargetContracts[1].address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when interacting with `view` function of 1st allowed contract", () => {
-      it("should pass and return data when `value` param is 0", async () => {
-        const targetPayload = allowedTargetContracts[0].interface.getSighash("getName");
+    describe('when interacting with `view` function of 1st allowed contract', () => {
+      it('should pass and return data when `value` param is 0', async () => {
+        const targetPayload = allowedTargetContracts[0].interface.getSighash('getName');
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[0].address,
           0,
@@ -740,17 +740,17 @@ export const shouldBehaveLikePermissionStaticCall = (
           .connect(addressCanMakeStaticCall)
           .callStatic.execute(executePayload);
 
-        let [decodedResult] = abiCoder.decode(["string"], result);
+        let [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(await targetContract.getName());
       });
 
-      it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0", async () => {
-        const targetPayload = allowedTargetContracts[0].interface.getSighash("getName");
+      it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0', async () => {
+        const targetPayload = allowedTargetContracts[0].interface.getSighash('getName');
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[0].address,
-          ethers.utils.parseEther("3"),
+          ethers.utils.parseEther('3'),
           targetPayload,
         ]);
 
@@ -758,16 +758,16 @@ export const shouldBehaveLikePermissionStaticCall = (
           context.keyManager.connect(addressWithSuperCallAndStaticCall).execute(executePayload),
         ).to.be.revertedWithCustomError(
           context.universalProfile,
-          "ERC725X_MsgValueDisallowedInStaticCall",
+          'ERC725X_MsgValueDisallowedInStaticCall',
         );
       });
     });
 
-    describe("when interacting with `view` function of 2nd allowed contract", () => {
-      it("should pass and return data when `value` param is 0", async () => {
-        const targetPayload = allowedTargetContracts[1].interface.getSighash("getName");
+    describe('when interacting with `view` function of 2nd allowed contract', () => {
+      it('should pass and return data when `value` param is 0', async () => {
+        const targetPayload = allowedTargetContracts[1].interface.getSighash('getName');
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[1].address,
           0,
@@ -778,17 +778,17 @@ export const shouldBehaveLikePermissionStaticCall = (
           .connect(addressCanMakeStaticCall)
           .callStatic.execute(executePayload);
 
-        let [decodedResult] = abiCoder.decode(["string"], result);
+        let [decodedResult] = abiCoder.decode(['string'], result);
         expect(decodedResult).to.equal(await targetContract.getName());
       });
 
-      it("should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0", async () => {
-        const targetPayload = allowedTargetContracts[1].interface.getSighash("getName");
+      it('should revert with error `ERC725X_MsgValueDisallowedInStaticCall` when `value` param is not 0', async () => {
+        const targetPayload = allowedTargetContracts[1].interface.getSighash('getName');
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           allowedTargetContracts[1].address,
-          ethers.utils.parseEther("3"),
+          ethers.utils.parseEther('3'),
           targetPayload,
         ]);
 
@@ -796,7 +796,7 @@ export const shouldBehaveLikePermissionStaticCall = (
           context.keyManager.connect(addressWithSuperCallAndStaticCall).execute(executePayload),
         ).to.be.revertedWithCustomError(
           context.universalProfile,
-          "ERC725X_MsgValueDisallowedInStaticCall",
+          'ERC725X_MsgValueDisallowedInStaticCall',
         );
       });
     });

--- a/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
@@ -1,9 +1,9 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
-import { BigNumber } from "ethers";
-import { FakeContract, smock } from "@defi-wonderland/smock";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
+import { BigNumber } from 'ethers';
+import { FakeContract, smock } from '@defi-wonderland/smock';
 
 import {
   Executor,
@@ -17,7 +17,7 @@ import {
   UniversalProfile,
   GraffitiEventExtension__factory,
   GraffitiEventExtension,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -27,11 +27,11 @@ import {
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
@@ -40,7 +40,7 @@ import {
   combineAllowedCalls,
   LOCAL_PRIVATE_KEYS,
   combineCallTypes,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 const universalProfileInterface = UniversalProfile__factory.createInterface();
 
@@ -49,7 +49,7 @@ export const shouldBehaveLikePermissionTransferValue = (
 ) => {
   let context: LSP6TestContext;
 
-  describe("when caller = EOA", () => {
+  describe('when caller = EOA', () => {
     let canTransferValue: SignerWithAddress,
       canTransferValueAndCall: SignerWithAddress,
       cannotTransferValue: SignerWithAddress;
@@ -62,7 +62,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     let graffitiExtension: GraffitiEventExtension;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       canTransferValue = context.accounts[1];
       canTransferValueAndCall = context.accounts[2];
@@ -76,9 +76,9 @@ export const shouldBehaveLikePermissionTransferValue = (
       graffitiExtension = await new GraffitiEventExtension__factory(context.accounts[0]).deploy();
 
       const lsp17ExtensionDataKeyForGraffiti =
-        ERC725YDataKeys.LSP17["LSP17ExtensionPrefix"] +
-        "00000000" + // selector for graffiti data,
-        "00000000000000000000000000000000"; // zero padded
+        ERC725YDataKeys.LSP17['LSP17ExtensionPrefix'] +
+        '00000000' + // selector for graffiti data,
+        '00000000000000000000000000000000'; // zero padded
 
       await recipientUP
         .connect(context.accounts[0])
@@ -91,16 +91,16 @@ export const shouldBehaveLikePermissionTransferValue = (
       ).to.equal(graffitiExtension.address);
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           canTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValueAndCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           canTransferValueAndCall.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           cannotTransferValue.address.substring(2),
       ];
 
@@ -110,8 +110,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [recipient.address, recipientUP.address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
         combinePermissions(PERMISSIONS.TRANSFERVALUE, PERMISSIONS.CALL),
         combineAllowedCalls(
@@ -120,8 +120,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
           ],
           [recipient.address, recipientUP.address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
         PERMISSIONS.CALL,
       ];
@@ -129,15 +129,15 @@ export const shouldBehaveLikePermissionTransferValue = (
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when recipient = EOA", () => {
-      describe("when transferring value via `execute(...)`", () => {
-        describe("when transferring value without bytes `_data`", () => {
-          const data = "0x";
+    describe('when recipient = EOA', () => {
+      describe('when transferring value via `execute(...)`', () => {
+        describe('when transferring value without bytes `_data`', () => {
+          const data = '0x';
 
-          it("should pass when caller has ALL PERMISSIONS", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has ALL PERMISSIONS', async () => {
+            const amount = ethers.utils.parseEther('3');
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
               amount,
@@ -156,10 +156,10 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should pass when caller has permission TRANSFERVALUE only", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE only', async () => {
+            const amount = ethers.utils.parseEther('3');
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
               amount,
@@ -174,10 +174,10 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
               amount,
@@ -192,20 +192,20 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should fail when caller does not have permission TRANSFERVALUE", async () => {
+          it('should fail when caller does not have permission TRANSFERVALUE', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
-              ethers.utils.parseEther("3"),
+              ethers.utils.parseEther('3'),
               data,
             ]);
 
             await expect(context.keyManager.connect(cannotTransferValue).execute(transferPayload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(cannotTransferValue.address, "TRANSFERVALUE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(cannotTransferValue.address, 'TRANSFERVALUE');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -216,18 +216,18 @@ export const shouldBehaveLikePermissionTransferValue = (
           });
         });
 
-        describe("when transferring value with bytes `_data`", () => {
-          const data = "0xaabbccdd";
+        describe('when transferring value with bytes `_data`', () => {
+          const data = '0xaabbccdd';
 
-          it("should pass when caller has ALL PERMISSIONS", async () => {
+          it('should pass when caller has ALL PERMISSIONS', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
 
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
-              ethers.utils.parseEther("3"),
+              ethers.utils.parseEther('3'),
               data,
             ]);
 
@@ -240,10 +240,10 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(newBalanceRecipient).to.be.gt(initialBalanceRecipient);
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
               amount,
@@ -258,20 +258,20 @@ export const shouldBehaveLikePermissionTransferValue = (
             );
           });
 
-          it("should fail when caller has permission TRANSFERVALUE only", async () => {
+          it('should fail when caller has permission TRANSFERVALUE only', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
-              ethers.utils.parseEther("3"),
+              ethers.utils.parseEther('3'),
               data,
             ]);
 
             await expect(context.keyManager.connect(canTransferValue).execute(transferPayload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canTransferValue.address, "CALL");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canTransferValue.address, 'CALL');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -281,20 +281,20 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
           });
 
-          it("should fail when caller does not have permission TRANSFERVALUE", async () => {
+          it('should fail when caller does not have permission TRANSFERVALUE', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
-            let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+            let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               recipient.address,
-              ethers.utils.parseEther("3"),
+              ethers.utils.parseEther('3'),
               data,
             ]);
 
             await expect(context.keyManager.connect(cannotTransferValue).execute(transferPayload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(cannotTransferValue.address, "TRANSFERVALUE");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(cannotTransferValue.address, 'TRANSFERVALUE');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -305,23 +305,23 @@ export const shouldBehaveLikePermissionTransferValue = (
           });
         });
 
-        describe("when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)", () => {
-          const data = "0x00000000aabbccdd";
+        describe('when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)', () => {
+          const data = '0x00000000aabbccdd';
 
-          it("should fail when caller has permission TRANSFERVALUE only", async () => {
+          it('should fail when caller has permission TRANSFERVALUE only', async () => {
             let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
             let initialBalanceRecipient = await provider.getBalance(recipient.address);
 
             let transferPayload = universalProfileInterface.encodeFunctionData(
-              "execute(uint256,address,uint256,bytes)",
-              [OPERATION_TYPES.CALL, recipient.address, ethers.utils.parseEther("3"), data],
+              'execute(uint256,address,uint256,bytes)',
+              [OPERATION_TYPES.CALL, recipient.address, ethers.utils.parseEther('3'), data],
             );
 
             await expect(
-              context.keyManager.connect(canTransferValue)["execute(bytes)"](transferPayload),
+              context.keyManager.connect(canTransferValue)['execute(bytes)'](transferPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canTransferValue.address, "CALL");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canTransferValue.address, 'CALL');
 
             let newBalanceUP = await provider.getBalance(context.universalProfile.address);
             let newBalanceRecipient = await provider.getBalance(recipient.address);
@@ -331,18 +331,18 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
           });
 
-          it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-            const amount = ethers.utils.parseEther("3");
+          it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+            const amount = ethers.utils.parseEther('3');
 
             let transferPayload = universalProfileInterface.encodeFunctionData(
-              "execute(uint256,address,uint256,bytes)",
+              'execute(uint256,address,uint256,bytes)',
               [OPERATION_TYPES.CALL, recipient.address, amount, data],
             );
 
             await expect(() =>
               context.keyManager
                 .connect(canTransferValueAndCall)
-                ["execute(bytes)"](transferPayload),
+                ['execute(bytes)'](transferPayload),
             ).to.changeEtherBalances(
               [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount],
@@ -351,24 +351,24 @@ export const shouldBehaveLikePermissionTransferValue = (
         });
       });
 
-      describe("when transferring value via `executeRelayCall(...)`", () => {
-        it("should revert if tx was signed with Eth Signed Message", async () => {
-          const amount = ethers.utils.parseEther("3");
+      describe('when transferring value via `executeRelayCall(...)`', () => {
+        it('should revert if tx was signed with Eth Signed Message', async () => {
+          const amount = ethers.utils.parseEther('3');
 
           const validityTimestamps = 0;
 
-          let executeRelayCallPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let executeRelayCallPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient.address,
             amount,
-            "0x",
+            '0x',
           ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
 
           let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
               LSP6_VERSION,
               HARDHAT_CHAINID,
@@ -396,22 +396,22 @@ export const shouldBehaveLikePermissionTransferValue = (
         it("should pass if tx was signed with EIP191Signer '\\x19\\x00' prefix", async () => {
           const eip191Signer = new EIP191Signer();
 
-          const amount = ethers.utils.parseEther("3");
+          const amount = ethers.utils.parseEther('3');
 
           const validityTimestamps = 0;
 
-          let executeRelayCallPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let executeRelayCallPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient.address,
             amount,
-            "0x",
+            '0x',
           ]);
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
 
           let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
               LSP6_VERSION,
               HARDHAT_CHAINID,
@@ -442,24 +442,24 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when recipient is a UP", () => {
-      describe("when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)", () => {
-        const data = "0x00000000aabbccdd";
+    describe('when recipient is a UP', () => {
+      describe('when transferring value with graffiti `_data` (prefixed with `bytes4(0)`)', () => {
+        const data = '0x00000000aabbccdd';
 
-        it("should fail when caller has permission TRANSFERVALUE only", async () => {
+        it('should fail when caller has permission TRANSFERVALUE only', async () => {
           let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
           let initialBalanceRecipient = await provider.getBalance(recipientUP.address);
 
           let transferPayload = universalProfileInterface.encodeFunctionData(
-            "execute(uint256,address,uint256,bytes)",
-            [OPERATION_TYPES.CALL, recipientUP.address, ethers.utils.parseEther("3"), data],
+            'execute(uint256,address,uint256,bytes)',
+            [OPERATION_TYPES.CALL, recipientUP.address, ethers.utils.parseEther('3'), data],
           );
 
           await expect(
-            context.keyManager.connect(canTransferValue)["execute(bytes)"](transferPayload),
+            context.keyManager.connect(canTransferValue)['execute(bytes)'](transferPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canTransferValue.address, "CALL");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canTransferValue.address, 'CALL');
 
           let newBalanceUP = await provider.getBalance(context.universalProfile.address);
           let newBalanceRecipient = await provider.getBalance(recipientUP.address);
@@ -469,10 +469,10 @@ export const shouldBehaveLikePermissionTransferValue = (
           expect(initialBalanceRecipient).to.equal(newBalanceRecipient);
         });
 
-        it("should pass when caller has permission TRANSFERVALUE + CALL", async () => {
-          const amount = ethers.utils.parseEther("3");
+        it('should pass when caller has permission TRANSFERVALUE + CALL', async () => {
+          const amount = ethers.utils.parseEther('3');
 
-          let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipientUP.address,
             amount,
@@ -481,25 +481,25 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           const tx = await context.keyManager
             .connect(canTransferValueAndCall)
-            ["execute(bytes)"](transferPayload);
+            ['execute(bytes)'](transferPayload);
 
           expect(tx).to.changeEtherBalances(
             [context.universalProfile.address, recipientUP.address],
             [`-${amount}`, amount],
           );
 
-          expect(tx).to.emit(graffitiExtension, "EventEmittedInExtension");
+          expect(tx).to.emit(graffitiExtension, 'EventEmittedInExtension');
         });
       });
     });
   });
 
-  describe("when caller = contract", () => {
+  describe('when caller = contract', () => {
     let contractCanTransferValue: Executor;
 
     let recipient: string;
 
-    const hardcodedRecipient: string = "0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe";
+    const hardcodedRecipient: string = '0xCAfEcAfeCAfECaFeCaFecaFecaFECafECafeCaFe';
 
     /**
      * @dev this is necessary when the function being called in the contract
@@ -509,7 +509,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     const GAS_PROVIDED = 200_000;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       recipient = context.accounts[1].address;
 
@@ -519,10 +519,10 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanTransferValue.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           contractCanTransferValue.address.substring(2),
       ];
 
@@ -532,17 +532,17 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [hardcodedRecipient, recipient],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("> Contract calls", () => {
-      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcoded`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+    describe('> Contract calls', () => {
+      it('Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcoded`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxHardcoded({
@@ -557,8 +557,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipient`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxToRecipient(recipient, {
@@ -571,9 +571,9 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("> Low-level calls", () => {
-      it("Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcodedRawCall`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+    describe('> Low-level calls', () => {
+      it('Should send 1 LYX to an address hardcoded in Executor (`sendOneLyxHardcodedRawCall`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxHardcodedRawCall({
@@ -585,8 +585,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('Should send 1 LYX to an address provided to Executor (`sendOneLyxToRecipientRawCall`)', async () => {
+        const amount = ethers.utils.parseEther('1');
 
         await expect(() =>
           contractCanTransferValue.sendOneLyxToRecipientRawCall(recipient, {
@@ -600,7 +600,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller is another UP (with a KeyManager as owner)", () => {
+  describe('when caller is another UP (with a KeyManager as owner)', () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -610,22 +610,22 @@ export const shouldBehaveLikePermissionTransferValue = (
     let bobContext: LSP6TestContext;
 
     before(async () => {
-      aliceContext = await buildContext(ethers.utils.parseEther("50"));
+      aliceContext = await buildContext(ethers.utils.parseEther('50'));
       alice = aliceContext.accounts[0];
 
-      bobContext = await buildContext(ethers.utils.parseEther("50"));
+      bobContext = await buildContext(ethers.utils.parseEther('50'));
       bob = bobContext.accounts[1];
 
       const alicePermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2),
       ];
       const alicePermissionValues = [ALL_PERMISSIONS];
 
       const bobPermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           aliceContext.universalProfile.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           aliceContext.universalProfile.address.substring(2),
       ];
 
@@ -635,8 +635,8 @@ export const shouldBehaveLikePermissionTransferValue = (
         combineAllowedCalls(
           [CALLTYPE.VALUE],
           [aliceContext.universalProfile.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
@@ -644,16 +644,16 @@ export const shouldBehaveLikePermissionTransferValue = (
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
     });
 
-    it("Alice should have ALL PERMISSIONS in her UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2);
+    it('Alice should have ALL PERMISSIONS in her UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2);
 
       // prettier-ignore
       const result = await aliceContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
     });
 
-    it("Bob should have ALL PERMISSIONS in his UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2);
+    it('Bob should have ALL PERMISSIONS in his UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
@@ -661,7 +661,7 @@ export const shouldBehaveLikePermissionTransferValue = (
 
     it("Alice's UP should have permission TRANSFERVALUE on Bob's UP", async () => {
       let key =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         aliceContext.universalProfile.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
@@ -669,19 +669,19 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
 
     it("Alice should be able to send 5 LYX from Bob's UP to her UP", async () => {
-      const amount = ethers.utils.parseEther("5");
+      const amount = ethers.utils.parseEther('5');
 
       let finalTransferLyxPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "execute",
-        [OPERATION_TYPES.CALL, aliceContext.universalProfile.address, amount, "0x"],
+        'execute',
+        [OPERATION_TYPES.CALL, aliceContext.universalProfile.address, amount, '0x'],
       );
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData("execute", [
+      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData('execute', [
         finalTransferLyxPayload,
       ]);
 
       let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [OPERATION_TYPES.CALL, bobContext.keyManager.address, 0, bobKeyManagerPayload],
       );
 
@@ -694,7 +694,7 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller has SUPER_TRANSFERVALUE + CALL", () => {
+  describe('when caller has SUPER_TRANSFERVALUE + CALL', () => {
     let caller: SignerWithAddress;
     let lsp7Token: LSP7Mintable;
     let targetContract: TargetPayableContract;
@@ -713,13 +713,13 @@ export const shouldBehaveLikePermissionTransferValue = (
     let recipientUPs: string[] = [];
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
 
       lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-        "LSP7 Token",
-        "LSP7",
+        'LSP7 Token',
+        'LSP7',
         context.accounts[0].address,
         false,
       );
@@ -731,19 +731,19 @@ export const shouldBehaveLikePermissionTransferValue = (
       // this contract has a payable fallback function and can receive native tokens
       lyxRecipientContract = await smock.fake([
         {
-          stateMutability: "payable",
-          type: "fallback",
+          stateMutability: 'payable',
+          type: 'fallback',
         },
       ]);
       lyxRecipientContract.fallback.returns();
 
       await lsp7Token
         .connect(context.accounts[0])
-        .mint(context.universalProfile.address, 100, false, "0x");
+        .mint(context.universalProfile.address, 100, false, '0x');
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -764,8 +764,8 @@ export const shouldBehaveLikePermissionTransferValue = (
             lyxRecipientEOA,
             lyxRecipientContract.address,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         ),
       ];
 
@@ -779,16 +779,16 @@ export const shouldBehaveLikePermissionTransferValue = (
       }
     });
 
-    describe("when sending native tokens without `data`", () => {
+    describe('when sending native tokens without `data`', () => {
       recipientsEOA.forEach((recipient) => {
         it(`should allow to send LYX to any EOA (e.g; at address -> ${recipient})`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
-          let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient,
             amount,
-            "0x",
+            '0x',
           ]);
 
           await expect(() =>
@@ -802,13 +802,13 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       recipientUPs.forEach((recipientUP) => {
         it(`should allow to send LYX to any UP contract (e.g: at address -> ${recipientUP})`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
-          let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipientUP,
             amount,
-            "0x",
+            '0x',
           ]);
 
           await expect(() =>
@@ -821,13 +821,13 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when sending native tokens with `data`", () => {
+    describe('when sending native tokens with `data`', () => {
       recipientsEOA.forEach((recipient) => {
         it(`should not allow to send LYX with some \`data\` to a random EOA (e.g: at address -> ${recipient})`, async () => {
-          const amount = ethers.utils.parseEther("1");
-          const data = "0x12345678";
+          const amount = ethers.utils.parseEther('1');
+          const data = '0x12345678';
 
-          let transferLyxPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferLyxPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient,
             amount,
@@ -835,17 +835,17 @@ export const shouldBehaveLikePermissionTransferValue = (
           ]);
 
           await expect(context.keyManager.connect(caller).execute(transferLyxPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(caller.address, recipient, data);
         });
       });
 
       recipientUPs.forEach((recipientUP) => {
         it(`should not allow to send LYX with some \`data\` to a random UP (e.g: at address -> ${recipientUP})`, async () => {
-          const amount = ethers.utils.parseEther("1");
-          const data = "0x12345678";
+          const amount = ethers.utils.parseEther('1');
+          const data = '0x12345678';
 
-          let transferLyxPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferLyxPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipientUP,
             amount,
@@ -853,16 +853,16 @@ export const shouldBehaveLikePermissionTransferValue = (
           ]);
 
           await expect(context.keyManager.connect(caller).execute(transferLyxPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(caller.address, recipientUP, data);
         });
       });
 
-      it("should allow to send LYX with some `data` to an EOA listed in the AllowedCalls", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+      it('should allow to send LYX with some `data` to an EOA listed in the AllowedCalls', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
-        let transferLyxPayload = universalProfileInterface.encodeFunctionData("execute", [
+        let transferLyxPayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lyxRecipientEOA,
           amount,
@@ -877,11 +877,11 @@ export const shouldBehaveLikePermissionTransferValue = (
         );
       });
 
-      it("should allow to send LYX with some `data` to a contract listed in the AllowedCalls", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+      it('should allow to send LYX with some `data` to a contract listed in the AllowedCalls', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
-        let transferLyxPayload = universalProfileInterface.encodeFunctionData("execute", [
+        let transferLyxPayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lyxRecipientContract.address,
           amount,
@@ -897,24 +897,24 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("when interacting with some contracts", () => {
-      it("should not be allowed to interact with a disallowed LSP7 contract", async () => {
+    describe('when interacting with some contracts', () => {
+      it('should not be allowed to interact with a disallowed LSP7 contract', async () => {
         let newLSP7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-          "New LSP7 Token",
-          "LSP7TKN",
+          'New LSP7 Token',
+          'LSP7TKN',
           context.accounts[0].address,
           false,
         );
 
-        let lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData("transfer", [
+        let lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           context.accounts[5].address,
           10,
           true, // sending to an EOA
-          "0x",
+          '0x',
         ]);
 
-        let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+        let executePayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           newLSP7Token.address,
           5,
@@ -922,15 +922,15 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]);
 
         await expect(context.keyManager.connect(caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             caller.address,
             newLSP7Token.address,
-            newLSP7Token.interface.getSighash("transfer"),
+            newLSP7Token.interface.getSighash('transfer'),
           );
       });
 
-      it("should be allowed to interact with an allowed LSP7 contract", async () => {
+      it('should be allowed to interact with an allowed LSP7 contract', async () => {
         let recipient = context.accounts[5].address;
         let tokenAmount = ethers.BigNumber.from(10);
 
@@ -938,15 +938,15 @@ export const shouldBehaveLikePermissionTransferValue = (
 
         let lsp7RecipientBalanceBefore = await lsp7Token.balanceOf(recipient);
 
-        let lsp7TransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+        let lsp7TransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
           context.universalProfile.address,
           recipient,
           tokenAmount,
           true, // sending to an EOA
-          "0x",
+          '0x',
         ]);
 
-        let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+        let executePayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           lsp7Token.address,
           0,
@@ -964,12 +964,12 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(lsp7RecipientBalanceAfter).to.equal(lsp7RecipientBalanceBefore.add(tokenAmount));
       });
 
-      it("should be allowed to interact with an allowed contract", async () => {
+      it('should be allowed to interact with an allowed contract', async () => {
         let newValue = 35;
 
-        let targetPayload = targetContract.interface.encodeFunctionData("updateState", [newValue]);
+        let targetPayload = targetContract.interface.encodeFunctionData('updateState', [newValue]);
 
-        let payload = universalProfileInterface.encodeFunctionData("execute", [
+        let payload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           0,
@@ -982,15 +982,15 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(result).to.equal(newValue);
       });
 
-      it("should be allowed to interact with an allowed contract + send some LYX while calling the function", async () => {
+      it('should be allowed to interact with an allowed contract + send some LYX while calling the function', async () => {
         const newValue = 358;
-        const lyxAmount = ethers.utils.parseEther("3");
+        const lyxAmount = ethers.utils.parseEther('3');
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("updateState", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('updateState', [
           newValue,
         ]);
 
-        let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+        let executePayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContract.address,
           lyxAmount,
@@ -1008,20 +1008,20 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(result).to.equal(newValue);
       });
 
-      it("should not be allowed to interact with a not allowed contract + send some LYX while calling the function", async () => {
+      it('should not be allowed to interact with a not allowed contract + send some LYX while calling the function', async () => {
         const newValue = 8910;
-        const lyxAmount = ethers.utils.parseEther("3");
+        const lyxAmount = ethers.utils.parseEther('3');
 
         const randomTargetContract = await new TargetPayableContract__factory(
           context.accounts[0],
         ).deploy();
 
         let targetContractPayload = randomTargetContract.interface.encodeFunctionData(
-          "updateState",
+          'updateState',
           [newValue],
         );
 
-        let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+        let executePayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           randomTargetContract.address,
           lyxAmount,
@@ -1029,29 +1029,29 @@ export const shouldBehaveLikePermissionTransferValue = (
         ]);
 
         await expect(context.keyManager.connect(caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
           .withArgs(
             caller.address,
             randomTargetContract.address,
-            randomTargetContract.interface.getSighash("updateState"),
+            randomTargetContract.interface.getSighash('updateState'),
           );
       });
     });
   });
 
-  describe("when caller has TRANSFERVALUE + SUPER_CALL", () => {
+  describe('when caller has TRANSFERVALUE + SUPER_CALL', () => {
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -1061,33 +1061,33 @@ export const shouldBehaveLikePermissionTransferValue = (
           // is the bit for CALL required as well? (since the controller has SUPER_CALL)
           [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
           [allowedAddress.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when transferring LYX without `data`", () => {
-      it("should not be allowed to transfer LYX to a non-allowed address", async () => {
+    describe('when transferring LYX without `data`', () => {
+      it('should not be allowed to transfer LYX to a non-allowed address', async () => {
         const recipient = context.accounts[3].address;
-        const amount = ethers.utils.parseEther("1");
+        const amount = ethers.utils.parseEther('1');
 
         let initialBalanceUP = await provider.getBalance(context.universalProfile.address);
 
         let initialBalanceRecipient = await provider.getBalance(recipient);
 
-        let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+        let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           recipient,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await expect(context.keyManager.connect(caller).execute(transferPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
-          .withArgs(caller.address, recipient, "0x00000000");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
+          .withArgs(caller.address, recipient, '0x00000000');
 
         let newBalanceUP = await provider.getBalance(context.universalProfile.address);
         expect(newBalanceUP).to.equal(initialBalanceUP);
@@ -1096,14 +1096,14 @@ export const shouldBehaveLikePermissionTransferValue = (
         expect(newBalanceRecipient).to.equal(initialBalanceRecipient);
       });
 
-      it("should be allowed to transfer LYX to an allowed address", async () => {
-        const amount = ethers.utils.parseEther("1");
+      it('should be allowed to transfer LYX to an allowed address', async () => {
+        const amount = ethers.utils.parseEther('1');
 
-        let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+        let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           allowedAddress.address,
           amount,
-          "0x",
+          '0x',
         ]);
 
         await expect(() =>
@@ -1116,12 +1116,12 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
 
     // TODO: this test overlaps with the one above and pass, but the expected behaviour is not clear
-    describe("when transferring LYX with `data`", () => {
-      it("should be allowed to transfer LYX to an allowed address while sending some `data`", async () => {
-        const amount = ethers.utils.parseEther("1");
-        const data = "0x12345678";
+    describe('when transferring LYX with `data`', () => {
+      it('should be allowed to transfer LYX to an allowed address while sending some `data`', async () => {
+        const amount = ethers.utils.parseEther('1');
+        const data = '0x12345678';
 
-        let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+        let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           allowedAddress.address,
           amount,
@@ -1137,17 +1137,17 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should be allowed to interact with any contract", () => {
-      describe("eg: any TargetContract", () => {
+    describe('should be allowed to interact with any contract', () => {
+      describe('eg: any TargetContract', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`TargetContract nb ${ii}`, async () => {
             let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
             let newValue = 12345;
 
-            let payload = targetContract.interface.encodeFunctionData("setNumber", [newValue]);
+            let payload = targetContract.interface.encodeFunctionData('setNumber', [newValue]);
 
-            let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+            let executePayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -1162,18 +1162,18 @@ export const shouldBehaveLikePermissionTransferValue = (
         }
       });
 
-      describe("eg: any LSP7 Token owned by the UP", () => {
+      describe('eg: any LSP7 Token owned by the UP', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`LSP7DigitalAsset nb ${ii}`, async () => {
             let lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-              "LSP7 Token",
-              "LSP7",
+              'LSP7 Token',
+              'LSP7',
               context.accounts[0].address,
               false,
             );
 
             // give some tokens to the UP
-            await lsp7Token.mint(context.universalProfile.address, 100, false, "0x");
+            await lsp7Token.mint(context.universalProfile.address, 100, false, '0x');
 
             const tokenRecipient = context.accounts[5].address;
             const tokenAmount = 10;
@@ -1185,15 +1185,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(senderTokenBalanceBefore).to.equal(100);
             expect(recipientTokenBalanceBefore).to.equal(0);
 
-            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
               context.universalProfile.address,
               tokenRecipient,
               tokenAmount,
               true,
-              "0x",
+              '0x',
             ]);
 
-            let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+            let executePayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               lsp7Token.address,
               0,
@@ -1215,8 +1215,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should not be allowed to interact with any contract if sending LYX along the call", () => {
-      const lyxAmount = ethers.utils.parseEther("1");
+    describe('should not be allowed to interact with any contract if sending LYX along the call', () => {
+      const lyxAmount = ethers.utils.parseEther('1');
 
       for (let ii = 1; ii <= 5; ii++) {
         it(`Target Payable Contract nb ${ii}`, async () => {
@@ -1228,9 +1228,9 @@ export const shouldBehaveLikePermissionTransferValue = (
           let targetContractLyxBalanceBefore = await provider.getBalance(targetContract.address);
           expect(targetContractLyxBalanceBefore).to.equal(0);
 
-          let targetPayload = targetContract.interface.encodeFunctionData("updateState", [35]);
+          let targetPayload = targetContract.interface.encodeFunctionData('updateState', [35]);
 
-          let payload = universalProfileInterface.encodeFunctionData("execute", [
+          let payload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             targetContract.address,
             lyxAmount,
@@ -1238,11 +1238,11 @@ export const shouldBehaveLikePermissionTransferValue = (
           ]);
 
           await expect(context.keyManager.connect(caller).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedCall')
             .withArgs(
               caller.address,
               targetContract.address,
-              targetContract.interface.getSighash("updateState"),
+              targetContract.interface.getSighash('updateState'),
             );
 
           // verify LYX (native tokens) balances have not changed
@@ -1256,19 +1256,19 @@ export const shouldBehaveLikePermissionTransferValue = (
     });
   });
 
-  describe("when caller has SUPER_TRANSFERVALUE + SUPER_CALL", () => {
+  describe('when caller has SUPER_TRANSFERVALUE + SUPER_CALL', () => {
     let caller: SignerWithAddress;
     let allowedAddress: SignerWithAddress;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("100"));
+      context = await buildContext(ethers.utils.parseEther('100'));
 
       caller = context.accounts[1];
       allowedAddress = context.accounts[2];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -1279,15 +1279,15 @@ export const shouldBehaveLikePermissionTransferValue = (
           // since the controller already has permissions SUPER_TRANSFERVALUE + SUPER_CALL
           [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
           [allowedAddress.address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("should be allowed to send LYX to any address", () => {
+    describe('should be allowed to send LYX to any address', () => {
       const recipients: string[] = [
         ethers.Wallet.createRandom().address,
         ethers.Wallet.createRandom().address,
@@ -1298,13 +1298,13 @@ export const shouldBehaveLikePermissionTransferValue = (
 
       recipients.forEach((recipient) => {
         it(`should send LYX to EOA -> ${recipient}`, async () => {
-          const amount = ethers.utils.parseEther("1");
+          const amount = ethers.utils.parseEther('1');
 
-          let transferPayload = universalProfileInterface.encodeFunctionData("execute", [
+          let transferPayload = universalProfileInterface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             recipient,
             amount,
-            "0x",
+            '0x',
           ]);
 
           await expect(() =>
@@ -1317,17 +1317,17 @@ export const shouldBehaveLikePermissionTransferValue = (
       });
     });
 
-    describe("should be allowed to interact with any contract", () => {
-      describe("eg: any TargetContract", () => {
+    describe('should be allowed to interact with any contract', () => {
+      describe('eg: any TargetContract', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`TargetContract nb ${ii}`, async () => {
             let targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
             let newValue = 12345;
 
-            let payload = targetContract.interface.encodeFunctionData("setNumber", [newValue]);
+            let payload = targetContract.interface.encodeFunctionData('setNumber', [newValue]);
 
-            let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+            let executePayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               targetContract.address,
               0,
@@ -1342,18 +1342,18 @@ export const shouldBehaveLikePermissionTransferValue = (
         }
       });
 
-      describe("eg: any LSP7 Token owned by the UP", () => {
+      describe('eg: any LSP7 Token owned by the UP', () => {
         for (let ii = 1; ii <= 5; ii++) {
           it(`LSP7DigitalAsset nb ${ii}`, async () => {
             let lsp7Token = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-              "LSP7 Token",
-              "LSP7",
+              'LSP7 Token',
+              'LSP7',
               context.accounts[0].address,
               false,
             );
 
             // give some tokens to the UP
-            await lsp7Token.mint(context.universalProfile.address, 100, false, "0x");
+            await lsp7Token.mint(context.universalProfile.address, 100, false, '0x');
 
             const tokenRecipient = context.accounts[5].address;
             const tokenAmount = 10;
@@ -1365,15 +1365,15 @@ export const shouldBehaveLikePermissionTransferValue = (
             expect(senderTokenBalanceBefore).to.equal(100);
             expect(recipientTokenBalanceBefore).to.equal(0);
 
-            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData("transfer", [
+            let tokenTransferPayload = lsp7Token.interface.encodeFunctionData('transfer', [
               context.universalProfile.address,
               tokenRecipient,
               tokenAmount,
               true,
-              "0x",
+              '0x',
             ]);
 
-            let executePayload = universalProfileInterface.encodeFunctionData("execute", [
+            let executePayload = universalProfileInterface.encodeFunctionData('execute', [
               OPERATION_TYPES.CALL,
               lsp7Token.address,
               0,

--- a/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
@@ -1,7 +1,7 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { BytesLike } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BytesLike } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   LSP6KeyManager,
@@ -11,10 +11,10 @@ import {
   LSP7Tester__factory,
   LSP8Mintable,
   LSP0ERC725Account__factory,
-} from "../../types";
+} from '../../types';
 
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, ERC1271_VALUES } from "../../constants";
-import { ARRAY_LENGTH, encodeCompactBytesArray } from "../utils/helpers";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, ERC1271_VALUES } from '../../constants';
+import { ARRAY_LENGTH, encodeCompactBytesArray } from '../utils/helpers';
 
 export type LSP6ControlledToken = {
   accounts: SignerWithAddress[];
@@ -27,8 +27,8 @@ const buildContext = async () => {
   const accounts = await ethers.getSigners();
 
   const lsp7 = await new LSP7Mintable__factory(accounts[0]).deploy(
-    "name",
-    "symbol",
+    'name',
+    'symbol',
     accounts[0].address,
     true,
   );
@@ -36,9 +36,9 @@ const buildContext = async () => {
   const keyManager = await new LSP6KeyManager__factory(accounts[0]).deploy(lsp7.address);
 
   const keys = [
-    ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-    ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + accounts[0].address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + accounts[0].address.substring(2),
   ];
 
   const values = [ARRAY_LENGTH.ONE, accounts[0].address, ALL_PERMISSIONS];
@@ -62,19 +62,19 @@ const addControllerWithPermission = async (
   permissions: BytesLike,
 ) => {
   const keys = [
-    ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-    ERC725YDataKeys.LSP6["AddressPermissions[]"].index + arrayIndex,
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + account.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].index + arrayIndex,
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + account.address.substring(2),
   ];
 
   const values = [arrayLength, account.address, permissions];
 
-  const payload = context.token.interface.encodeFunctionData("setDataBatch", [keys, values]);
+  const payload = context.token.interface.encodeFunctionData('setDataBatch', [keys, values]);
 
   await context.keyManager.connect(context.owner).execute(payload);
 };
 
-describe("When deploying LSP7 with LSP6 as owner", () => {
+describe('When deploying LSP7 with LSP6 as owner', () => {
   let context: LSP6ControlledToken;
 
   let newOwner: SignerWithAddress;
@@ -99,15 +99,15 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     addressCanSign = context.accounts[5];
   });
 
-  it("should have lsp6 as owner of the lsp7", async () => {
+  it('should have lsp6 as owner of the lsp7', async () => {
     expect(await context.token.owner()).to.equal(context.keyManager.address);
   });
 
-  it("should set the necessary controller permissions correctly", async () => {
+  it('should set the necessary controller permissions correctly', async () => {
     const keys = [
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
     ];
 
     const values = [ARRAY_LENGTH.ONE, context.owner.address, ALL_PERMISSIONS];
@@ -115,37 +115,37 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     expect(await context.token.getDataBatch(keys)).to.deep.equal(values);
   });
 
-  describe("when trying to call mint(..) function on  in LSP7 through LSP6", () => {
-    it("should revert because function does not exist on LSP6", async () => {
+  describe('when trying to call mint(..) function on  in LSP7 through LSP6', () => {
+    it('should revert because function does not exist on LSP6', async () => {
       const LSP7 = context.token as LSP7Mintable;
-      const mintPayload = LSP7.interface.encodeFunctionData("mint", [
+      const mintPayload = LSP7.interface.encodeFunctionData('mint', [
         context.owner.address,
         1,
         true,
-        "0x",
+        '0x',
       ]);
 
       await expect(context.keyManager.connect(context.owner).execute(mintPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(mintPayload.substring(0, 10));
     });
   });
 
-  describe("using renounceOwnership(..) in LSP7 through LSP6", () => {
-    it("should revert", async () => {
+  describe('using renounceOwnership(..) in LSP7 through LSP6', () => {
+    it('should revert', async () => {
       const renounceOwnershipPayload =
-        context.token.interface.encodeFunctionData("renounceOwnership");
+        context.token.interface.encodeFunctionData('renounceOwnership');
 
       await expect(context.keyManager.connect(context.owner).execute(renounceOwnershipPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(renounceOwnershipPayload);
     });
   });
 
-  describe("using transferOwnership(..) in LSP7 through LSP6", () => {
-    it("should change the owner of LSP7 contract", async () => {
+  describe('using transferOwnership(..) in LSP7 through LSP6', () => {
+    it('should change the owner of LSP7 contract', async () => {
       const LSP7 = context.token as LSP7Mintable;
-      const transferOwnershipPayload = LSP7.interface.encodeFunctionData("transferOwnership", [
+      const transferOwnershipPayload = LSP7.interface.encodeFunctionData('transferOwnership', [
         newOwner.address,
       ]);
 
@@ -155,18 +155,18 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
     });
 
     it("`setData(...)` -> should revert with 'caller is not the owner' error.", async () => {
-      const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString"));
-      const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SecondRandomString"));
-      const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+      const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString'));
+      const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SecondRandomString'));
+      const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
       await expect(context.keyManager.connect(context.owner).execute(payload)).to.be.revertedWith(
-        "Ownable: caller is not the owner",
+        'Ownable: caller is not the owner',
       );
     });
 
-    it("should allow the new owner to call setData(..)", async () => {
-      const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString"));
-      const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SecondRandomString"));
+    it('should allow the new owner to call setData(..)', async () => {
+      const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString'));
+      const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SecondRandomString'));
 
       await context.token.connect(newOwner).setData(key, value);
 
@@ -175,38 +175,38 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
     it("`mint(..)` -> should revert with 'caller is not the owner' error.", async () => {
       const LSP7 = context.token as LSP7Mintable;
-      const mintPayload = LSP7.interface.encodeFunctionData("mint", [
+      const mintPayload = LSP7.interface.encodeFunctionData('mint', [
         context.owner.address,
         1,
         true,
-        "0x",
+        '0x',
       ]);
 
       await expect(context.keyManager.connect(context.owner).execute(mintPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(mintPayload.substring(0, 10));
     });
 
-    it("should allow the new owner to call mint(..)", async () => {
+    it('should allow the new owner to call mint(..)', async () => {
       const LSP7 = context.token as LSP7Mintable;
 
-      await LSP7.connect(newOwner).mint(context.owner.address, 1, true, "0x");
+      await LSP7.connect(newOwner).mint(context.owner.address, 1, true, '0x');
 
       expect(await LSP7.balanceOf(context.owner.address)).to.equal(1);
     });
 
     it("`transferOwnership(..)` -> should revert with 'caller is not the owner' error.", async () => {
       const transferOwnershipPayload = context.token.interface.encodeFunctionData(
-        "transferOwnership",
+        'transferOwnership',
         [context.accounts[1].address],
       );
 
       await expect(
         context.keyManager.connect(context.owner).execute(transferOwnershipPayload),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it("should allow the new owner to call transferOwnership(..)", async () => {
+    it('should allow the new owner to call transferOwnership(..)', async () => {
       await context.token.connect(newOwner).transferOwnership(anotherNewOwner.address);
 
       expect(await context.token.owner()).to.equal(anotherNewOwner.address);
@@ -214,45 +214,45 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
     it("`renounceOwnership(..)` -> should revert with 'caller is not the owner' error.", async () => {
       const renounceOwnershipPayload =
-        context.token.interface.encodeFunctionData("renounceOwnership");
+        context.token.interface.encodeFunctionData('renounceOwnership');
 
       await expect(context.keyManager.connect(context.owner).execute(renounceOwnershipPayload))
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidERC725Function")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidERC725Function')
         .withArgs(renounceOwnershipPayload);
     });
 
-    it("should allow the new owner to call renounceOwnership(..)", async () => {
+    it('should allow the new owner to call renounceOwnership(..)', async () => {
       await context.token.connect(anotherNewOwner).renounceOwnership();
 
       expect(await context.token.owner()).to.equal(ethers.constants.AddressZero);
     });
   });
 
-  describe("using setData(..) in lSP7 through LSP6", () => {
+  describe('using setData(..) in lSP7 through LSP6', () => {
     before(async () => {
       context = await buildContext();
     });
 
-    describe("testing CHANGEOWNER permission", () => {
+    describe('testing CHANGEOWNER permission', () => {
       before(async () => {
         await addControllerWithPermission(
           context,
           addressCanChangeOwner,
           ARRAY_LENGTH.TWO,
-          "0".repeat(31) + "1",
+          '0'.repeat(31) + '1',
           PERMISSIONS.CHANGEOWNER,
         );
       });
 
-      it("should add the new controller without changing other controllers", async () => {
+      it('should add the new controller without changing other controllers', async () => {
         // Check that a new controller was added and other controllers remained intact
         const keys = [
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "1",
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '1',
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanChangeOwner.address.substring(2),
         ];
         const values = [
@@ -268,20 +268,20 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
       it("should revert if the caller doesn't have CHANGEOWNER permission when using `transferOwnership(..)`", async () => {
         const transferOwnershipPayload = context.token.interface.encodeFunctionData(
-          "transferOwnership",
+          'transferOwnership',
           [addressCanChangeOwner.address],
         );
 
         expect(
           context.keyManager.connect(addressCanEditPermissions).execute(transferOwnershipPayload),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
           .withArgs(addressCanEditPermissions.address);
       });
 
-      it("should change the owner of LSP7 contract when using `transferOwnership(..)`", async () => {
+      it('should change the owner of LSP7 contract when using `transferOwnership(..)`', async () => {
         const transferOwnershipPayload = context.token.interface.encodeFunctionData(
-          "transferOwnership",
+          'transferOwnership',
           [addressCanChangeOwner.address],
         );
 
@@ -297,29 +297,29 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
       });
     });
 
-    describe("testing EDITPERMISSIONS permission", () => {
+    describe('testing EDITPERMISSIONS permission', () => {
       before(async () => {
         await addControllerWithPermission(
           context,
           addressCanEditPermissions,
           ARRAY_LENGTH.THREE,
-          "0".repeat(31) + "2",
+          '0'.repeat(31) + '2',
           PERMISSIONS.EDITPERMISSIONS,
         );
       });
 
-      it("should add the new controller without changing other controllers", async () => {
+      it('should add the new controller without changing other controllers', async () => {
         // Check that a new controller was added and other controllers remained intact
         const keys = [
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "1",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "2",
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '1',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '2',
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanChangeOwner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanEditPermissions.address.substring(2),
         ];
         const values = [
@@ -337,34 +337,34 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
 
       it("should revert if caller doesn't have EDITPERMISSIONS permission", async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           context.owner.address.substring(2);
         const value = PERMISSIONS.CALL;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await expect(context.keyManager.connect(addressCanChangeOwner).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCanChangeOwner.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCanChangeOwner.address, 'EDITPERMISSIONS');
       });
 
-      it("should change ALL_PERMISSIONS to CALL permission of the address", async () => {
+      it('should change ALL_PERMISSIONS to CALL permission of the address', async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           context.owner.address.substring(2);
         const value = PERMISSIONS.CALL;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(addressCanEditPermissions).execute(payload);
 
         expect(await context.token.getData(key)).to.equal(value);
       });
 
-      it("should add back ALL_PERMISSIONS of the address", async () => {
+      it('should add back ALL_PERMISSIONS of the address', async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           context.owner.address.substring(2);
         const value = ALL_PERMISSIONS;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(addressCanEditPermissions).execute(payload);
 
@@ -372,32 +372,32 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
       });
     });
 
-    describe("testing ADDCONTROLLER permission", () => {
+    describe('testing ADDCONTROLLER permission', () => {
       before(async () => {
         await addControllerWithPermission(
           context,
           addressCanAddController,
           ARRAY_LENGTH.FOUR,
-          "0".repeat(31) + "3",
+          '0'.repeat(31) + '3',
           PERMISSIONS.ADDCONTROLLER,
         );
       });
 
-      it("should add the new controller without changing other controllers", async () => {
+      it('should add the new controller without changing other controllers', async () => {
         // Check that a new controller was added and other controllers remained intact
         const keys = [
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "1",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "2",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "3",
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '1',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '2',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '3',
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanChangeOwner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanEditPermissions.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanAddController.address.substring(2),
         ];
         const values = [
@@ -415,50 +415,50 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         expect(await context.token.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should be allowed to add a new controller with some permissions", async () => {
+      it('should be allowed to add a new controller with some permissions', async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2);
         const value = ALL_PERMISSIONS;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(addressCanAddController).execute(payload);
 
         expect(await context.token.getData(key)).to.equal(value);
       });
 
-      it("should not be authorized to edit permissions of an existing controller (e.g: removing permissions)", async () => {
+      it('should not be authorized to edit permissions of an existing controller (e.g: removing permissions)', async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2);
         const value = ARRAY_LENGTH.ZERO;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await expect(context.keyManager.connect(addressCanAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(addressCanAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(addressCanAddController.address, 'EDITPERMISSIONS');
       });
 
       after(async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2);
         const value = ARRAY_LENGTH.ZERO;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(context.owner).execute(payload);
       });
     });
 
-    describe("testing SETDATA permission", () => {
+    describe('testing SETDATA permission', () => {
       const firstRandomSringKey = ethers.utils.keccak256(
-        ethers.utils.toUtf8Bytes("FirstRandomString"),
+        ethers.utils.toUtf8Bytes('FirstRandomString'),
       );
       const secondRandomSringKey = ethers.utils.keccak256(
-        ethers.utils.toUtf8Bytes("SecondRandomString"),
+        ethers.utils.toUtf8Bytes('SecondRandomString'),
       );
       const notAllowedKey = ethers.utils.keccak256(
-        ethers.utils.toUtf8Bytes("Not Allowed ERC725Y data key"),
+        ethers.utils.toUtf8Bytes('Not Allowed ERC725Y data key'),
       );
 
       before(async () => {
@@ -466,29 +466,29 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
           context,
           addressCanSetData,
           ARRAY_LENGTH.FIVE,
-          "0".repeat(31) + "4",
+          '0'.repeat(31) + '4',
           PERMISSIONS.SETDATA,
         );
       });
 
-      it("should add the new controller without changing other controllers", async () => {
+      it('should add the new controller without changing other controllers', async () => {
         // Check that a new controller was added and other controllers remained intact
         const keys = [
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "1",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "2",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "3",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "4",
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '1',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '2',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '3',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '4',
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanChangeOwner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanEditPermissions.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanAddController.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanSetData.address.substring(2),
         ];
         const values = [
@@ -508,69 +508,69 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         expect(await context.token.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should not allow second controller to use setData without AllowedERC725YDataKeys", async () => {
+      it('should not allow second controller to use setData without AllowedERC725YDataKeys', async () => {
         const key = firstRandomSringKey;
         const value = secondRandomSringKey;
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await expect(context.keyManager.connect(addressCanSetData).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+          .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
           .withArgs(addressCanSetData.address);
       });
 
-      it("should restrict second controller with AllowedERC725YDataKeys", async () => {
+      it('should restrict second controller with AllowedERC725YDataKeys', async () => {
         const key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           addressCanSetData.address.substring(2);
         const value = encodeCompactBytesArray([firstRandomSringKey.substring(0, 34)]);
-        const payload = context.token.interface.encodeFunctionData("setData", [key, value]);
+        const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(context.owner).execute(payload);
 
         expect(await context.token.getData(key)).to.equal(value);
       });
 
-      it("should change allowed keys", async () => {
+      it('should change allowed keys', async () => {
         const keys = [
           firstRandomSringKey,
-          firstRandomSringKey.substring(0, 34) + "0".repeat(31) + "0",
-          firstRandomSringKey.substring(0, 34) + "0".repeat(31) + "1",
-          firstRandomSringKey.substring(0, 34) + "0".repeat(31) + "2",
-          firstRandomSringKey.substring(0, 34) + "0".repeat(31) + "3",
+          firstRandomSringKey.substring(0, 34) + '0'.repeat(31) + '0',
+          firstRandomSringKey.substring(0, 34) + '0'.repeat(31) + '1',
+          firstRandomSringKey.substring(0, 34) + '0'.repeat(31) + '2',
+          firstRandomSringKey.substring(0, 34) + '0'.repeat(31) + '3',
         ];
         const values = [
           ARRAY_LENGTH.FOUR,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString0")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString1")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString2")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString3")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString0')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString1')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString2')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString3')),
         ];
-        const payload = context.token.interface.encodeFunctionData("setDataBatch", [keys, values]);
+        const payload = context.token.interface.encodeFunctionData('setDataBatch', [keys, values]);
 
         await context.keyManager.connect(addressCanSetData).execute(payload);
 
         expect(await context.token.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should revert when trying to change a key that is not allowed", async () => {
+      it('should revert when trying to change a key that is not allowed', async () => {
         const keys = [
           notAllowedKey,
-          notAllowedKey.substring(0, 34) + "0".repeat(31) + "0",
-          notAllowedKey.substring(0, 34) + "0".repeat(31) + "1",
-          notAllowedKey.substring(0, 34) + "0".repeat(31) + "2",
-          notAllowedKey.substring(0, 34) + "0".repeat(31) + "3",
+          notAllowedKey.substring(0, 34) + '0'.repeat(31) + '0',
+          notAllowedKey.substring(0, 34) + '0'.repeat(31) + '1',
+          notAllowedKey.substring(0, 34) + '0'.repeat(31) + '2',
+          notAllowedKey.substring(0, 34) + '0'.repeat(31) + '3',
         ];
         const values = [
           ARRAY_LENGTH.FOUR,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString0")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString1")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString2")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("FirstRandomString3")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString0')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString1')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString2')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('FirstRandomString3')),
         ];
-        const payload = context.token.interface.encodeFunctionData("setDataBatch", [keys, values]);
+        const payload = context.token.interface.encodeFunctionData('setDataBatch', [keys, values]);
 
         await expect(context.keyManager.connect(addressCanSetData).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(addressCanSetData.address, notAllowedKey);
       });
     });
@@ -585,23 +585,23 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
      * DEPLOY
      * TRANSFERVALUE
      */
-    describe("when trying to call execute(..) function on LSP7 through LSP6", () => {
-      it("should revert because function does not exist on LSP7", async () => {
+    describe('when trying to call execute(..) function on LSP7 through LSP6', () => {
+      it('should revert because function does not exist on LSP7', async () => {
         // deploying a dummy token contract with public mint function
         const newTokenContract = await new LSP7Tester__factory(context.owner).deploy(
-          "NewTokenName",
-          "NewTokenSymbol",
+          'NewTokenName',
+          'NewTokenSymbol',
           context.owner.address,
         );
         // creating a payload to mint tokens in the new contract
-        const mintPayload = newTokenContract.interface.encodeFunctionData("mint", [
+        const mintPayload = newTokenContract.interface.encodeFunctionData('mint', [
           context.owner.address,
           1000,
           true,
-          "0x",
+          '0x',
         ]);
 
-        const payload = LSP0ERC725Account__factory.createInterface().encodeFunctionData("execute", [
+        const payload = LSP0ERC725Account__factory.createInterface().encodeFunctionData('execute', [
           0,
           newTokenContract.address,
           0,
@@ -609,43 +609,43 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         ]);
 
         await expect(context.keyManager.connect(context.owner).execute(payload)).to.be.revertedWith(
-          "LSP6: failed executing payload",
+          'LSP6: failed executing payload',
         );
       });
     });
 
-    describe("testing SIGN permission", () => {
+    describe('testing SIGN permission', () => {
       before(async () => {
         await addControllerWithPermission(
           context,
           addressCanSign,
           ARRAY_LENGTH.SIX,
-          "0".repeat(31) + "5",
+          '0'.repeat(31) + '5',
           PERMISSIONS.SIGN,
         );
       });
 
-      it("should add the new controller without changing other controllers", async () => {
+      it('should add the new controller without changing other controllers', async () => {
         // Check that a new controller was added and other controllers remained intact
         const keys = [
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "0",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "1",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "2",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "3",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "4",
-          ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "0".repeat(31) + "5",
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '0',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '1',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '2',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '3',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '4',
+          ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '0'.repeat(31) + '5',
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanChangeOwner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanEditPermissions.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanAddController.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanSetData.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressCanSign.address.substring(2),
         ];
         const values = [
@@ -667,17 +667,17 @@ describe("When deploying LSP7 with LSP6 as owner", () => {
         expect(await context.token.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should be allowed to sign messages for the token contract", async () => {
-        const dataHash = ethers.utils.hashMessage("Some random message");
-        const signature = await addressCanSign.signMessage("Some random message");
+      it('should be allowed to sign messages for the token contract', async () => {
+        const dataHash = ethers.utils.hashMessage('Some random message');
+        const signature = await addressCanSign.signMessage('Some random message');
         const validityOfTheSig = await context.keyManager.isValidSignature(dataHash, signature);
 
         expect(validityOfTheSig).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
 
-      it("should not be allowed to sign messages for the token contract", async () => {
-        const dataHash = ethers.utils.hashMessage("Some random message");
-        const signature = await addressCanChangeOwner.signMessage("Some random message");
+      it('should not be allowed to sign messages for the token contract', async () => {
+        const dataHash = ethers.utils.hashMessage('Some random message');
+        const signature = await addressCanChangeOwner.signMessage('Some random message');
         const validityOfTheSig = await context.keyManager.isValidSignature(dataHash, signature);
 
         expect(validityOfTheSig).to.equal(ERC1271_VALUES.FAIL_VALUE);

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { BigNumber } from "ethers";
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
 
-import { LSP6TestContext, LSP6InternalsTestContext } from "../utils/context";
-import { INTERFACE_IDS } from "../../constants";
+import { LSP6TestContext, LSP6InternalsTestContext } from '../utils/context';
+import { INTERFACE_IDS } from '../../constants';
 
 import {
   // Admin
@@ -44,77 +44,77 @@ import {
   testReadingPermissionsInternals,
   testSetDataInternals,
   testExecuteInternals,
-} from "./index";
+} from './index';
 
 export const shouldBehaveLikeLSP6 = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
-  describe("CHANGEOWNER", () => {
+  describe('CHANGEOWNER', () => {
     shouldBehaveLikePermissionChangeOwner(buildContext);
   });
 
-  describe("Set Permissions", () => {
+  describe('Set Permissions', () => {
     shouldBehaveLikePermissionChangeOrAddController(buildContext);
     shouldBehaveLikeSettingAllowedCalls(buildContext);
     shouldBehaveLikeSetAllowedERC725YDataKeys(buildContext);
   });
 
-  describe("CHANGE / ADD extensions", () => {
+  describe('CHANGE / ADD extensions', () => {
     shouldBehaveLikePermissionChangeOrAddExtensions(buildContext);
   });
 
-  describe("CHANGE / ADD UniversalReceiverDelegate", () => {
+  describe('CHANGE / ADD UniversalReceiverDelegate', () => {
     shouldBehaveLikePermissionChangeOrAddURD(buildContext);
   });
 
-  describe("SETDATA", () => {
+  describe('SETDATA', () => {
     shouldBehaveLikePermissionSetData(buildContext);
   });
 
-  describe("AllowedERC725YDataKeys", () => {
+  describe('AllowedERC725YDataKeys', () => {
     shouldBehaveLikeAllowedERC725YDataKeys(buildContext);
   });
 
-  describe("Invalid Execute payloads", () => {
+  describe('Invalid Execute payloads', () => {
     testInvalidExecutePayloads(buildContext);
   });
 
-  describe("TRANSFERVALUE", () => {
+  describe('TRANSFERVALUE', () => {
     shouldBehaveLikePermissionTransferValue(buildContext);
   });
 
-  describe("CALL", () => {
+  describe('CALL', () => {
     shouldBehaveLikePermissionCall(buildContext);
   });
 
-  describe("STATICCALL", () => {
+  describe('STATICCALL', () => {
     shouldBehaveLikePermissionStaticCall(buildContext);
   });
 
-  describe("DELEGATECALL", () => {
+  describe('DELEGATECALL', () => {
     shouldBehaveLikePermissionDelegateCall(buildContext);
   });
 
-  describe("DEPLOY", () => {
+  describe('DEPLOY', () => {
     shouldBehaveLikePermissionDeploy(buildContext);
   });
 
-  describe("Batch `execute([])`", () => {
+  describe('Batch `execute([])`', () => {
     shouldBehaveLikeBatchExecute(buildContext);
   });
 
-  describe("ALLOWED CALLS", () => {
+  describe('ALLOWED CALLS', () => {
     shouldBehaveLikeAllowedAddresses(buildContext);
     shouldBehaveLikeAllowedFunctions(buildContext);
     shouldBehaveLikeAllowedStandards(buildContext);
   });
 
-  describe("Single + Batch Meta Transactions", () => {
+  describe('Single + Batch Meta Transactions', () => {
     shouldBehaveLikeExecuteRelayCall(buildContext);
     shouldBehaveLikeMultiChannelNonce(buildContext);
   });
 
-  describe("SIGN (ERC1271)", () => {
+  describe('SIGN (ERC1271)', () => {
     shouldBehaveLikePermissionSign(buildContext);
   });
 };
@@ -126,28 +126,28 @@ export const shouldInitializeLikeLSP6 = (buildContext: () => Promise<LSP6TestCon
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should support ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should support ERC165 interface', async () => {
       const result = await context.keyManager.supportsInterface(INTERFACE_IDS.ERC165);
       expect(result).to.be.true;
     });
 
-    it("should support ERC1271 interface", async () => {
+    it('should support ERC1271 interface', async () => {
       const result = await context.keyManager.supportsInterface(INTERFACE_IDS.ERC1271);
       expect(result).to.be.true;
     });
 
-    it("should support LSP6 interface", async () => {
+    it('should support LSP6 interface', async () => {
       const result = await context.keyManager.supportsInterface(INTERFACE_IDS.LSP6KeyManager);
       expect(result).to.be.true;
     });
 
-    it("should support LSP20CallVerifier interface", async () => {
+    it('should support LSP20CallVerifier interface', async () => {
       const result = await context.keyManager.supportsInterface(INTERFACE_IDS.LSP20CallVerifier);
       expect(result).to.be.true;
     });
 
-    it("should be linked to the right ERC725 account contract", async () => {
+    it('should be linked to the right ERC725 account contract', async () => {
       let account = await context.keyManager.target();
       expect(account).to.equal(context.universalProfile.address);
     });

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -1,21 +1,21 @@
-import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
 
 import {
   UniversalProfile__factory,
   LSP6KeyManager__factory,
   KeyManagerInternalTester__factory,
-} from "../../types";
+} from '../../types';
 
-import { LSP6TestContext } from "../utils/context";
+import { LSP6TestContext } from '../utils/context';
 
 import {
   shouldInitializeLikeLSP6,
   shouldBehaveLikeLSP6,
   testLSP6InternalFunctions,
-} from "./LSP6KeyManager.behaviour";
+} from './LSP6KeyManager.behaviour';
 
-describe("LSP6KeyManager with constructor", () => {
+describe('LSP6KeyManager with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
     const owner = accounts[0];
@@ -29,17 +29,17 @@ describe("LSP6KeyManager with constructor", () => {
     return { accounts, owner, universalProfile, keyManager, initialFunding };
   };
 
-  describe("when deploying the contract", () => {
-    describe("when initializing the contract", () => {
+  describe('when deploying the contract', () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP6(buildTestContext);
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP6(buildTestContext);
   });
 
-  describe("testing internal functions", () => {
+  describe('testing internal functions', () => {
     testLSP6InternalFunctions(async () => {
       const accounts = await ethers.getSigners();
       const owner = accounts[0];

--- a/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
@@ -1,12 +1,12 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { BigNumber } from "ethers";
-import { LSP6TestContext } from "../utils/context";
-import { LSP6KeyManagerInit__factory, UniversalProfileInit__factory } from "../../types";
-import { deployProxy } from "../utils/fixtures";
-import { shouldBehaveLikeLSP6, shouldInitializeLikeLSP6 } from "./LSP6KeyManager.behaviour";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
+import { LSP6TestContext } from '../utils/context';
+import { LSP6KeyManagerInit__factory, UniversalProfileInit__factory } from '../../types';
+import { deployProxy } from '../utils/fixtures';
+import { shouldBehaveLikeLSP6, shouldInitializeLikeLSP6 } from './LSP6KeyManager.behaviour';
 
-describe("LSP6KeyManager with proxy", () => {
+describe('LSP6KeyManager with proxy', () => {
   let context: LSP6TestContext;
 
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
@@ -25,28 +25,28 @@ describe("LSP6KeyManager with proxy", () => {
   };
 
   const initializeProxies = async (context: LSP6TestContext) => {
-    await context.universalProfile["initialize(address)"](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.owner.address, {
       value: context.initialFunding,
     });
 
-    await context.keyManager["initialize(address)"](context.universalProfile.address);
+    await context.keyManager['initialize(address)'](context.universalProfile.address);
 
     return context;
   };
 
-  describe("when deploying the base LSP6KeyManagerInit implementation", () => {
-    it("should prevent any address from calling the `initialize(...)` function on the base contract", async () => {
+  describe('when deploying the base LSP6KeyManagerInit implementation', () => {
+    it('should prevent any address from calling the `initialize(...)` function on the base contract', async () => {
       let context = await buildProxyTestContext();
 
       const baseKM = await new LSP6KeyManagerInit__factory(context.accounts[0]).deploy();
 
       await expect(baseKM.initialize(context.accounts[0].address)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe("when initializing the proxy", () => {
+  describe('when initializing the proxy', () => {
     shouldInitializeLikeLSP6(async () => {
       context = await buildProxyTestContext();
       await initializeProxies(context);
@@ -54,18 +54,18 @@ describe("LSP6KeyManager with proxy", () => {
     });
   });
 
-  describe("when calling `initialize(...) more than once`", () => {
-    it("should revert", async () => {
+  describe('when calling `initialize(...) more than once`', () => {
+    it('should revert', async () => {
       context = await buildProxyTestContext();
       await initializeProxies(context);
 
       await expect(initializeProxies(context)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe("when testing the deployed proxy", () => {
+  describe('when testing the deployed proxy', () => {
     shouldBehaveLikeLSP6(async (initialFunding?: BigNumber) => {
       let context = await buildProxyTestContext(initialFunding);
       await initializeProxies(context);

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -1,16 +1,16 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { time } from "@nomicfoundation/hardhat-network-helpers";
-import { BigNumber } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
+import { BigNumber } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   LSP7Mintable,
   LSP7Mintable__factory,
   TargetContract,
   TargetContract__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
 import {
@@ -21,7 +21,7 @@ import {
   PERMISSIONS,
   CALLTYPE,
   INTERFACE_IDS,
-} from "../../../constants";
+} from '../../../constants';
 
 // helpers
 import {
@@ -29,19 +29,19 @@ import {
   combinePermissions,
   createValidityTimestamps,
   signLSP6ExecuteRelayCall,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
-import { provider, LOCAL_PRIVATE_KEYS, combineCallTypes } from "../../utils/helpers";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
+import { provider, LOCAL_PRIVATE_KEYS, combineCallTypes } from '../../utils/helpers';
 
 export const shouldBehaveLikeExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("`executeRelayCall(..)`", () => {
+  describe('`executeRelayCall(..)`', () => {
     let signer: SignerWithAddress,
       relayer: SignerWithAddress,
       random: SignerWithAddress,
@@ -61,10 +61,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           signerNoAllowedCalls.address.substring(2),
       ];
 
@@ -77,8 +77,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
             combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
           ],
           [random.address, targetContract.address],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
         combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
       ];
@@ -86,13 +86,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    describe("When testing signed message", () => {
-      describe("When testing msg.value", () => {
-        describe("When sending more than the signed msg.value", () => {
-          it("should revert by recovering a non permissioned address", async () => {
+    describe('When testing signed message', () => {
+      describe('When testing msg.value', () => {
+        describe('When sending more than the signed msg.value', () => {
+          it('should revert by recovering a non permissioned address', async () => {
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"],
+              'execute',
+              [OPERATION_TYPES.CALL, random.address, 0, '0x'],
             );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(signer.address, 0);
@@ -113,7 +113,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             let valueToSendFromRelayer = 10;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 signedMessageParams.lsp6Version,
                 signedMessageParams.chainId,
@@ -142,15 +142,15 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   signedMessageParams.payload,
                   { value: valueToSendFromRelayer },
                 ),
-            ).to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet");
+            ).to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet');
           });
         });
 
-        describe("When sending 0 while msg.value signed > 0", () => {
-          it("should revert by recovering a non permissioned address", async () => {
+        describe('When sending 0 while msg.value signed > 0', () => {
+          it('should revert by recovering a non permissioned address', async () => {
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"],
+              'execute',
+              [OPERATION_TYPES.CALL, random.address, 0, '0x'],
             );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(signer.address, 0);
@@ -171,7 +171,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             let valueToSendFromRelayer = 0;
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 signedMessageParams.lsp6Version,
                 signedMessageParams.chainId,
@@ -200,15 +200,15 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   signedMessageParams.payload,
                   { value: valueToSendFromRelayer },
                 ),
-            ).to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet");
+            ).to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet');
           });
         });
 
-        describe("When sending exact msg.value like the one that is signed", () => {
-          it("should pass if signer has the `to` address in its allowed calls", async () => {
+        describe('When sending exact msg.value like the one that is signed', () => {
+          it('should pass if signer has the `to` address in its allowed calls', async () => {
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"],
+              'execute',
+              [OPERATION_TYPES.CALL, random.address, 0, '0x'],
             );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(signer.address, 0);
@@ -227,7 +227,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             };
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 signedMessageParams.lsp6Version,
                 signedMessageParams.chainId,
@@ -259,11 +259,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
               );
 
             expect(tx)
-              .to.emit(context.keyManager, "VerifiedCall")
+              .to.emit(context.keyManager, 'VerifiedCall')
               .withArgs(
                 context.accounts[1].address,
                 signedMessageParams.msgValue,
-                context.universalProfile.interface.getSighash("execute"),
+                context.universalProfile.interface.getSighash('execute'),
               );
 
             const balanceOfUpAfter = await provider.getBalance(context.universalProfile.address);
@@ -271,10 +271,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
             expect(balanceOfUpAfter).to.equal(balanceOfUpBefore.add(valueToSendFromRelayer));
           });
 
-          it("should fail if signer has nothing listed in its allowed calls", async () => {
+          it('should fail if signer has nothing listed in its allowed calls', async () => {
             let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-              "execute",
-              [OPERATION_TYPES.CALL, random.address, 0, "0x"],
+              'execute',
+              [OPERATION_TYPES.CALL, random.address, 0, '0x'],
             );
 
             let latestNonce = await context.keyManager.callStatic.getNonce(
@@ -296,7 +296,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             };
 
             let encodedMessage = ethers.utils.solidityPack(
-              ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+              ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
                 signedMessageParams.lsp6Version,
                 signedMessageParams.chainId,
@@ -326,17 +326,17 @@ export const shouldBehaveLikeExecuteRelayCall = (
                   { value: valueToSendFromRelayer },
                 ),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+              .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
               .withArgs(signerNoAllowedCalls.address);
           });
         });
 
-        describe("When UP have 0 value and interacting with contract that require value", () => {
+        describe('When UP have 0 value and interacting with contract that require value', () => {
           describe("When relayer don't fund the UP so it's balance is greater than the value param of execute(..)", () => {
-            it("should revert", async () => {
-              let nameToSet = "Alice";
+            it('should revert', async () => {
+              let nameToSet = 'Alice';
               let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
+                'setNamePayable',
                 [nameToSet],
               );
 
@@ -347,7 +347,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const validityTimestamps = 0;
 
               let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [
                   OPERATION_TYPES.CALL,
                   targetContract.address,
@@ -368,7 +368,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               };
 
               let encodedMessage = ethers.utils.solidityPack(
-                ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+                ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
                   signedMessageParams.lsp6Version,
                   signedMessageParams.chainId,
@@ -400,7 +400,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               )
                 .to.be.revertedWithCustomError(
                   context.universalProfile,
-                  "ERC725X_InsufficientBalance",
+                  'ERC725X_InsufficientBalance',
                 )
                 .withArgs(
                   await provider.getBalance(context.universalProfile.address),
@@ -410,10 +410,10 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
 
           describe("When relayer fund the UP so it's balance is greater than the value param of execute(..)", () => {
-            it("should pass if signer has the target contract address in its list of allowed calls", async () => {
-              let nameToSet = "Alice";
+            it('should pass if signer has the target contract address in its list of allowed calls', async () => {
+              let nameToSet = 'Alice';
               let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
+                'setNamePayable',
                 [nameToSet],
               );
 
@@ -424,7 +424,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const validityTimestamps = 0;
 
               let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [
                   OPERATION_TYPES.CALL,
                   targetContract.address,
@@ -445,7 +445,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               };
 
               let encodedMessage = ethers.utils.solidityPack(
-                ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+                ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
                   signedMessageParams.lsp6Version,
                   signedMessageParams.chainId,
@@ -479,9 +479,9 @@ export const shouldBehaveLikeExecuteRelayCall = (
             });
 
             it("should revert with 'NotAllowedCall' error if signer does not have any listed under its allowed calls", async () => {
-              let nameToSet = "Alice";
+              let nameToSet = 'Alice';
               let targetContractPayload = targetContract.interface.encodeFunctionData(
-                "setNamePayable",
+                'setNamePayable',
                 [nameToSet],
               );
 
@@ -495,7 +495,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const validityTimestamps = 0;
 
               let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [
                   OPERATION_TYPES.CALL,
                   targetContract.address,
@@ -516,7 +516,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               };
 
               let encodedMessage = ethers.utils.solidityPack(
-                ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+                ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
                   signedMessageParams.lsp6Version,
                   signedMessageParams.chainId,
@@ -546,17 +546,17 @@ export const shouldBehaveLikeExecuteRelayCall = (
                     { value: valueToSendFromRelayer },
                   ),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed")
+                .to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed')
                 .withArgs(signerNoAllowedCalls.address);
             });
           });
         });
       });
 
-      describe("When testing `validityTimestamps`", () => {
-        describe("(invalid timestamps) `startingTimestamp` is greter than `endingTimestamp`", () => {
-          describe("`now` is equal to `startingTimestamp` and `now` is greter than `endingTimestamp`", () => {
-            it("reverts", async () => {
+      describe('When testing `validityTimestamps`', () => {
+        describe('(invalid timestamps) `startingTimestamp` is greter than `endingTimestamp`', () => {
+          describe('`now` is equal to `startingTimestamp` and `now` is greter than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
               const startingTimestamp = now;
 
@@ -568,7 +568,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 endingTimestamp,
               );
 
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -583,12 +583,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallExpired");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallExpired');
             });
           });
 
-          describe("`now` is greater than `startingTimestamp` and `now` is greater than `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('`now` is greater than `startingTimestamp` and `now` is greater than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const endingTimestamp = now - 2000;
@@ -599,7 +599,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -614,12 +614,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallExpired");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallExpired');
             });
           });
 
-          describe("`now` is lesser than `startingTimestamp` and `now` is lesser than `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('`now` is lesser than `startingTimestamp` and `now` is lesser than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const nonce = await context.keyManager.callStatic.getNonce(signer.address, 3);
 
               const now = await time.latest();
@@ -632,7 +632,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 endingTimestamp,
               );
 
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -647,12 +647,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallBeforeStartTime");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
             });
           });
 
-          describe("`now` is lesser than `startingTimestamp` and `now` is greater than `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('`now` is lesser than `startingTimestamp` and `now` is greater than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now + 1000;
@@ -663,7 +663,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -678,12 +678,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallBeforeStartTime");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
             });
           });
 
-          describe("`now` is lesser than `startingTimestamp` and `now` is equal to `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('`now` is lesser than `startingTimestamp` and `now` is equal to `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now + 1000;
@@ -694,7 +694,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -709,14 +709,14 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallBeforeStartTime");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
             });
           });
         });
 
-        describe("(valid timestamps) `startingTimestamp` is lesser than `endingTimestamp`", () => {
-          describe("(tx can be executed) `now` is equal to `startingTimestamp` and `now` is lesser than `endingTimestamp`", () => {
-            it("passes", async () => {
+        describe('(valid timestamps) `startingTimestamp` is lesser than `endingTimestamp`', () => {
+          describe('(tx can be executed) `now` is equal to `startingTimestamp` and `now` is lesser than `endingTimestamp`', () => {
+            it('passes', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now;
@@ -727,11 +727,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
                 0,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData("setNumber", [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -751,8 +751,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
             });
           });
 
-          describe("(tx cannot be executed yet) `now` is lesser than `startingTimestamp` and `now` is lesser than `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('(tx cannot be executed yet) `now` is lesser than `startingTimestamp` and `now` is lesser than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now + 1000;
@@ -763,7 +763,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -778,12 +778,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallBeforeStartTime");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
             });
           });
 
-          describe("(tx is expired) `now` is greater than `startingTimestamp` and `now` is greater than `endingTimestamp`", () => {
-            it("reverts", async () => {
+          describe('(tx is expired) `now` is greater than `startingTimestamp` and `now` is greater than `endingTimestamp`', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now - 1500;
@@ -794,7 +794,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -809,12 +809,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallExpired");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallExpired');
             });
           });
 
-          describe("(tx can be executed) `now` is greater than `startingTimestamp` and `now` is lesser than `endingTimestamp`", () => {
-            it("passes", async () => {
+          describe('(tx can be executed) `now` is greater than `startingTimestamp` and `now` is lesser than `endingTimestamp`', () => {
+            it('passes', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now - 1000;
@@ -825,11 +825,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
                 0,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData("setNumber", [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -849,8 +849,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
             });
           });
 
-          describe("(tx can be executed) `now` is greater than `startingTimestamp` and `now` is equal to `endingTimestamp`", () => {
-            it("passes", async () => {
+          describe('(tx can be executed) `now` is greater than `startingTimestamp` and `now` is equal to `endingTimestamp`', () => {
+            it('passes', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now - 1000;
@@ -862,11 +862,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
                 0,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData("setNumber", [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -889,9 +889,9 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
         });
 
-        describe("start timestamp = end timestamp", () => {
-          describe("start timestamp = end timestamp < now", () => {
-            it("reverts", async () => {
+        describe('start timestamp = end timestamp', () => {
+          describe('start timestamp = end timestamp < now', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now - 100;
@@ -902,7 +902,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -917,12 +917,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallExpired");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallExpired');
             });
           });
 
-          describe("start timestamp = end timestamp > now", () => {
-            it("reverts", async () => {
+          describe('start timestamp = end timestamp > now', () => {
+            it('reverts', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now + 100;
@@ -933,7 +933,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = "0xcafecafe";
+              const calldata = '0xcafecafe';
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
                 context.keyManager,
@@ -948,12 +948,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 context.keyManager
                   .connect(relayer)
                   .executeRelayCall(signature, nonce, validityTimestamps, calldata),
-              ).to.be.revertedWithCustomError(context.keyManager, "RelayCallBeforeStartTime");
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
             });
           });
 
-          describe("start timestamp = end timestamp = now", () => {
-            it("passes", async () => {
+          describe('start timestamp = end timestamp = now', () => {
+            it('passes', async () => {
               const now = await time.latest();
 
               const startingTimestamp = now;
@@ -964,11 +964,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
-              const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
                 0,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData("setNumber", [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -991,15 +991,15 @@ export const shouldBehaveLikeExecuteRelayCall = (
           });
         });
 
-        describe("when `validityTimestamps == 0`", () => {
-          it("passes", async () => {
+        describe('when `validityTimestamps == 0`', () => {
+          it('passes', async () => {
             const nonce = await context.keyManager.callStatic.getNonce(signer.address, 14);
             const validityTimestamps = 0;
-            const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+            const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
               0,
               targetContract.address,
               0,
-              targetContract.interface.encodeFunctionData("setNumber", [nonce]),
+              targetContract.interface.encodeFunctionData('setNumber', [nonce]),
             ]);
             const value = 0;
             const signature = await signLSP6ExecuteRelayCall(
@@ -1022,7 +1022,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
     });
   });
 
-  describe("`executeRelayCallBatch()", () => {
+  describe('`executeRelayCallBatch()', () => {
     let context: LSP6TestContext;
 
     let minter: SignerWithAddress;
@@ -1031,21 +1031,21 @@ export const shouldBehaveLikeExecuteRelayCall = (
     let tokenContract: LSP7Mintable;
 
     before(async () => {
-      context = await buildContext(ethers.utils.parseEther("10"));
+      context = await buildContext(ethers.utils.parseEther('10'));
 
       minter = context.accounts[1];
       tokenRecipient = context.accounts[2];
 
       // deploy token contract
       tokenContract = await new LSP7Mintable__factory(context.accounts[0]).deploy(
-        "My LSP7 Token",
-        "LSP7",
+        'My LSP7 Token',
+        'LSP7',
         context.universalProfile.address,
         false,
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
       ];
 
       const permissionsValues = [ALL_PERMISSIONS];
@@ -1053,13 +1053,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    it("should revert when there are not the same number of elements for each parameters", async () => {
+    it('should revert when there are not the same number of elements for each parameters', async () => {
       // these are dummy values parameters. The aim is to check that it reverts in the first place.
-      const signatures = ["0x" + "aa".repeat(65), "0x" + "bb".repeat(65), "0x" + "cc".repeat(65)];
+      const signatures = ['0x' + 'aa'.repeat(65), '0x' + 'bb'.repeat(65), '0x' + 'cc'.repeat(65)];
       const nonces = [0, 1, 2];
       const values = [0, 0, 0];
       const validityTimestamps = [0, 0, 0];
-      const payloads = ["0xcafecafe", "0xbeefbeef"];
+      const payloads = ['0xcafecafe', '0xbeefbeef'];
 
       await expect(
         context.keyManager
@@ -1067,19 +1067,19 @@ export const shouldBehaveLikeExecuteRelayCall = (
           .executeRelayCallBatch(signatures, nonces, validityTimestamps, values, payloads),
       ).to.be.revertedWithCustomError(
         context.keyManager,
-        "BatchExecuteRelayCallParamsLengthMismatch",
+        'BatchExecuteRelayCallParamsLengthMismatch',
       );
     });
 
-    it("should revert when we are specifying the same signature twice", async () => {
+    it('should revert when we are specifying the same signature twice', async () => {
       const recipient = context.accounts[1].address;
-      const amountForRecipient = ethers.utils.parseEther("1");
+      const amountForRecipient = ethers.utils.parseEther('1');
 
-      const transferLyxPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const transferLyxPayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         recipient,
         amountForRecipient,
-        "0x",
+        '0x',
       ]);
 
       const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1115,7 +1115,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
       const eip191 = new EIP191Signer();
 
       let encodedMessage = ethers.utils.solidityPack(
-        ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+        ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
         [6, 31337, ownerNonce.add(1), validityTimestamps, 0, transferLyxPayload],
       );
 
@@ -1142,11 +1142,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
             [transferLyxPayload, transferLyxPayload],
           ),
       )
-        .to.be.revertedWithCustomError(context.keyManager, "InvalidRelayNonce")
+        .to.be.revertedWithCustomError(context.keyManager, 'InvalidRelayNonce')
         .withArgs(incorrectRecoveredAddress, ownerNonce.add(1), transferLyxSignature);
     });
 
-    it("should 1) give the permission to someone to mint, 2) let the controller mint, 3) remove the permission to the controller to mint", async () => {
+    it('should 1) give the permission to someone to mint, 2) let the controller mint, 3) remove the permission to the controller to mint', async () => {
       let signatures: string[];
       let nonces: BigNumber[];
       let payloads: string[];
@@ -1156,11 +1156,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
       // step 1 - give minter permissions to mint
       const giveMinterPermissionsPayload = context.universalProfile.interface.encodeFunctionData(
-        "setDataBatch",
+        'setDataBatch',
         [
           [
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + minter.address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + minter.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + minter.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + minter.address.substring(2),
           ],
           [
             PERMISSIONS.CALL,
@@ -1168,7 +1168,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               [CALLTYPE.CALL],
               [tokenContract.address],
               [INTERFACE_IDS.LSP7DigitalAsset],
-              [tokenContract.interface.getSighash("mint")],
+              [tokenContract.interface.getSighash('mint')],
             ),
           ],
         ],
@@ -1186,13 +1186,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
       );
 
       // Step 2 - let minter mint
-      const minterMintPayload = tokenContract.interface.encodeFunctionData("mint", [
+      const minterMintPayload = tokenContract.interface.encodeFunctionData('mint', [
         tokenRecipient.address,
         tokensToMint,
         true,
-        "0x",
+        '0x',
       ]);
-      const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         tokenContract.address,
         0,
@@ -1212,13 +1212,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
       // Step 3 - remove minter permissions to mint
       const removeMinterPermissionsPayload = context.universalProfile.interface.encodeFunctionData(
-        "setDataBatch",
+        'setDataBatch',
         [
           [
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + minter.address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + minter.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + minter.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + minter.address.substring(2),
           ],
-          ["0x", "0x"],
+          ['0x', '0x'],
         ],
       );
       const newOwnerNonce = ownerNonce.add(1);
@@ -1248,34 +1248,34 @@ export const shouldBehaveLikeExecuteRelayCall = (
       // CHECK that the minter does not have permissions anymore
       expect(
         await context.universalProfile.getDataBatch([
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + minter.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + minter.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + minter.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + minter.address.substring(2),
         ]),
-      ).to.deep.equal(["0x", "0x"]);
+      ).to.deep.equal(['0x', '0x']);
 
       // CHECK that the minter cannot mint anymore
       await expect(context.keyManager.connect(minter).execute(executePayload))
-        .to.be.revertedWithCustomError(context.keyManager, "NoPermissionsSet")
+        .to.be.revertedWithCustomError(context.keyManager, 'NoPermissionsSet')
         .withArgs(minter.address);
     });
 
-    describe("when specifying msg.value", () => {
-      describe("when total `values[]` is LESS than `msg.value`", () => {
-        it("should revert because insufficent `msg.value`", async () => {
+    describe('when specifying msg.value', () => {
+      describe('when total `values[]` is LESS than `msg.value`', () => {
+        it('should revert because insufficent `msg.value`', async () => {
           const firstRecipient = context.accounts[1].address;
           const secondRecipient = context.accounts[2].address;
           const thirdRecipient = context.accounts[3].address;
 
           const transferAmounts = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const values = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const totalValues = values.reduce((accumulator, currentValue) =>
@@ -1286,18 +1286,18 @@ export const shouldBehaveLikeExecuteRelayCall = (
           const amountToFund = totalValues.sub(1);
 
           const firstLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], '0x'],
           );
 
           const secondLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], '0x'],
           );
 
           const thirdLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
           const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1341,27 +1341,27 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 { value: amountToFund },
               ),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "LSP6BatchInsufficientValueSent")
+            .to.be.revertedWithCustomError(context.keyManager, 'LSP6BatchInsufficientValueSent')
             .withArgs(totalValues, amountToFund);
         });
       });
 
-      describe("when total `values[]` is MORE than `msg.value`", () => {
-        it("should revert to not leave any remaining funds on the Key Manager", async () => {
+      describe('when total `values[]` is MORE than `msg.value`', () => {
+        it('should revert to not leave any remaining funds on the Key Manager', async () => {
           const firstRecipient = context.accounts[1].address;
           const secondRecipient = context.accounts[2].address;
           const thirdRecipient = context.accounts[3].address;
 
           const transferAmounts = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const values = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const totalValues = values.reduce((accumulator, currentValue) =>
@@ -1372,18 +1372,18 @@ export const shouldBehaveLikeExecuteRelayCall = (
           const amountToFund = totalValues.add(1);
 
           const firstLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], '0x'],
           );
 
           const secondLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], '0x'],
           );
 
           const thirdLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
           const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1427,27 +1427,27 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 { value: amountToFund },
               ),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "LSP6BatchExcessiveValueSent")
+            .to.be.revertedWithCustomError(context.keyManager, 'LSP6BatchExcessiveValueSent')
             .withArgs(totalValues, amountToFund);
         });
       });
 
-      describe("when total `values[]` is EQUAL to `msg.value`", () => {
-        it("should pass", async () => {
+      describe('when total `values[]` is EQUAL to `msg.value`', () => {
+        it('should pass', async () => {
           const firstRecipient = context.accounts[1].address;
           const secondRecipient = context.accounts[2].address;
           const thirdRecipient = context.accounts[3].address;
 
           const transferAmounts = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const values = [
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
-            ethers.utils.parseEther("1"),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
+            ethers.utils.parseEther('1'),
           ];
 
           const amountToFund = values.reduce((accumulator, currentValue) =>
@@ -1455,18 +1455,18 @@ export const shouldBehaveLikeExecuteRelayCall = (
           );
 
           const firstLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, firstRecipient, transferAmounts[0], '0x'],
           );
 
           const secondLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, secondRecipient, transferAmounts[1], '0x'],
           );
 
           const thirdLyxTransfer = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
           const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1517,11 +1517,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
       });
     });
 
-    describe("when one of the payload reverts", () => {
-      it("should revert the whole transaction if first payload reverts", async () => {
+    describe('when one of the payload reverts', () => {
+      it('should revert the whole transaction if first payload reverts', async () => {
         const upBalance = await provider.getBalance(context.universalProfile.address);
 
-        const validAmount = ethers.utils.parseEther("1");
+        const validAmount = ethers.utils.parseEther('1');
         expect(validAmount).to.be.lt(upBalance); // sanity check
 
         // make it revert by sending too much value than the actual balance
@@ -1530,18 +1530,18 @@ export const shouldBehaveLikeExecuteRelayCall = (
         const randomRecipient = ethers.Wallet.createRandom().address;
 
         const failingTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, '0x'],
         );
 
         const firstTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
         const secondTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
         const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1590,13 +1590,13 @@ export const shouldBehaveLikeExecuteRelayCall = (
               [0, 0, 0],
               payloads,
             ),
-        ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_InsufficientBalance");
+        ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
       });
 
-      it("should revert the whole transaction if last payload reverts", async () => {
+      it('should revert the whole transaction if last payload reverts', async () => {
         const upBalance = await provider.getBalance(context.universalProfile.address);
 
-        const validAmount = ethers.utils.parseEther("1");
+        const validAmount = ethers.utils.parseEther('1');
         expect(validAmount).to.be.lt(upBalance); // sanity check
 
         // make it revert by sending too much value than the actual balance
@@ -1605,18 +1605,18 @@ export const shouldBehaveLikeExecuteRelayCall = (
         const randomRecipient = ethers.Wallet.createRandom().address;
 
         const failingTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, invalidAmount, '0x'],
         );
 
         const firstTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
         const secondTransferPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
-          [OPERATION_TYPES.CALL, randomRecipient, validAmount, "0x"],
+          'execute',
+          [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
         const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
@@ -1666,7 +1666,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               values,
               payloads,
             ),
-        ).to.be.revertedWithCustomError(context.universalProfile, "ERC725X_InsufficientBalance");
+        ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
       });
     });
   });

--- a/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
@@ -1,9 +1,9 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
-import { TargetContract, TargetContract__factory } from "../../../types";
+import { TargetContract, TargetContract__factory } from '../../../types';
 
 // constants
 import {
@@ -13,12 +13,12 @@ import {
   LSP6_VERSION,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
-import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from "../../utils/helpers";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
+import { LOCAL_PRIVATE_KEYS, combineAllowedCalls } from '../../utils/helpers';
 
 export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
@@ -35,11 +35,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
       // TODO: why the allowed calls for this controller are set twice? duplicate?
-      ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
     ];
 
     const permissionsValues = [
@@ -48,36 +48,36 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
       combineAllowedCalls(
         [CALLTYPE.CALL],
         [targetContract.address],
-        ["0xffffffff"],
-        ["0xffffffff"],
+        ['0xffffffff'],
+        ['0xffffffff'],
       ),
       combineAllowedCalls(
         [CALLTYPE.CALL],
         [targetContract.address],
-        ["0xffffffff"],
-        ["0xffffffff"],
+        ['0xffffffff'],
+        ['0xffffffff'],
       ),
     ];
 
     await setupKeyManager(context, permissionKeys, permissionsValues);
   });
 
-  describe("when calling `getNonce(...)` with a channel ID greater than 2 ** 128", () => {
-    it("should revert", async () => {
+  describe('when calling `getNonce(...)` with a channel ID greater than 2 ** 128', () => {
+    it('should revert', async () => {
       let channelId = ethers.BigNumber.from(2).pow(129);
 
       await expect(context.keyManager.getNonce(signer.address, channelId)).to.be.revertedWithPanic;
     });
   });
 
-  describe("testing sequential nonces (channel = 0)", () => {
+  describe('testing sequential nonces (channel = 0)', () => {
     const channelId = 0;
 
     [
-      { callNb: "First", newName: "Yamen", expectedNonce: 1 },
-      { callNb: "Second", newName: "Nour", expectedNonce: 2 },
-      { callNb: "Third", newName: "Huss", expectedNonce: 3 },
-      { callNb: "Fourth", newName: "Moussa", expectedNonce: 4 },
+      { callNb: 'First', newName: 'Yamen', expectedNonce: 1 },
+      { callNb: 'Second', newName: 'Nour', expectedNonce: 2 },
+      { callNb: 'Third', newName: 'Huss', expectedNonce: 3 },
+      { callNb: 'Fourth', newName: 'Moussa', expectedNonce: 4 },
     ].forEach(({ callNb, newName, expectedNonce }) => {
       // prettier-ignore
       it(`${callNb} call > nonce should increment from ${expectedNonce - 1} to ${expectedNonce}`, async () => {
@@ -145,12 +145,12 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
     });
   });
 
-  describe("out of order execution (channel = n)", () => {
+  describe('out of order execution (channel = n)', () => {
     let nonces = [0, 1];
 
-    describe("channel 1", () => {
+    describe('channel 1', () => {
       let channelId = 1;
-      let names = ["Fabian", "Yamen"];
+      let names = ['Fabian', 'Yamen'];
 
       it(`First call > nonce should increment from ${nonces[0]} to ${nonces[0] + 1}`, async () => {
         let nonceBefore = await context.keyManager.callStatic.getNonce(signer.address, channelId);
@@ -159,11 +159,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[0];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -171,7 +171,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -210,11 +210,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[1];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -222,7 +222,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -255,9 +255,9 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
       });
     });
 
-    describe("channel 2", () => {
+    describe('channel 2', () => {
       let channelId = 2;
-      let names = ["Hugo", "Reto"];
+      let names = ['Hugo', 'Reto'];
 
       it(`First call > nonce should increment from ${nonces[0]} to ${nonces[0] + 1}`, async () => {
         let nonceBefore = await context.keyManager.getNonce(signer.address, channelId);
@@ -266,11 +266,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[0];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -278,7 +278,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -317,11 +317,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[1];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -329,7 +329,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -362,9 +362,9 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
       });
     });
 
-    describe("channel 3", () => {
+    describe('channel 3', () => {
       let channelId = 3;
-      let names = ["Jean", "Lenny"];
+      let names = ['Jean', 'Lenny'];
 
       it(`First call > nonce should increment from ${nonces[0]} to ${nonces[0] + 1}`, async () => {
         let nonceBefore = await context.keyManager.getNonce(signer.address, channelId);
@@ -373,11 +373,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[0];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -385,7 +385,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -424,11 +424,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
 
         let newName = names[1];
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -436,7 +436,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,
@@ -469,21 +469,21 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
       });
     });
 
-    describe("channel 15", () => {
+    describe('channel 15', () => {
       let channelId = 15;
 
-      it("First call > nonce should increment from 0 to 1", async () => {
+      it('First call > nonce should increment from 0 to 1', async () => {
         let nonceBefore = await context.keyManager.getNonce(signer.address, channelId);
 
         const validityTimestamps = 0;
 
-        let newName = "Lukasz";
+        let newName = 'Lukasz';
 
-        let targetContractPayload = targetContract.interface.encodeFunctionData("setName", [
+        let targetContractPayload = targetContract.interface.encodeFunctionData('setName', [
           newName,
         ]);
         let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-          "execute",
+          'execute',
           [OPERATION_TYPES.CALL, targetContract.address, 0, targetContractPayload],
         );
 
@@ -491,7 +491,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         let valueToSend = 0;
 
         let encodedMessage = ethers.utils.solidityPack(
-          ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+          ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
             LSP6_VERSION,
             HARDHAT_CHAINID,

--- a/tests/LSP6KeyManager/SetData/AllowedERC725YDataKeys.test.ts
+++ b/tests/LSP6KeyManager/SetData/AllowedERC725YDataKeys.test.ts
@@ -1,17 +1,17 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { BytesLike } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BytesLike } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
-import { encodeCompactBytesArray, decodeCompactBytes } from "../../utils/helpers";
+import { encodeCompactBytesArray, decodeCompactBytes } from '../../utils/helpers';
 
 export type TestCase = {
   datakeyToSet: BytesLike;
@@ -23,13 +23,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 ) => {
   let context: LSP6TestContext;
 
-  describe("keyType: Singleton", () => {
+  describe('keyType: Singleton', () => {
     let controllerCanSetOneKey: SignerWithAddress, controllerCanSetManyKeys: SignerWithAddress;
 
-    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey1"));
-    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey2"));
-    const customKey3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey3"));
-    const customKey4 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey4"));
+    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey1'));
+    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey2'));
+    const customKey3 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey3'));
+    const customKey4 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey4'));
 
     before(async () => {
       context = await buildContext();
@@ -38,14 +38,14 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetManyKeys = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetOneKey.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetManyKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetOneKey.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetManyKeys.address.substring(2),
       ];
 
@@ -60,10 +60,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("verify Allowed ERC725Y data keys set", () => {
-      it("`controllerCanSetOneKey` should have 1 x key in its list of allowed keys", async () => {
+    describe('verify Allowed ERC725Y data keys set', () => {
+      it('`controllerCanSetOneKey` should have 1 x key in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetOneKey.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -71,9 +71,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.have.lengthOf(1);
       });
 
-      it("`controllerCanSetManyKeys` should have 3 x keys in its list of allowed keys", async () => {
+      it('`controllerCanSetManyKeys` should have 3 x keys in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetManyKeys.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -81,9 +81,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.have.lengthOf(3);
       });
 
-      it("`controllerCanSetOneKey` should have the right keys set in its list of allowed keys", async () => {
+      it('`controllerCanSetOneKey` should have the right keys set in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetOneKey.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -91,9 +91,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(decodedResult).to.include(customKey1);
       });
 
-      it("`controllerCanSetManyKeys` should have the right keys set in its list of allowed keys", async () => {
+      it('`controllerCanSetManyKeys` should have the right keys set in its list of allowed keys', async () => {
         const result = await context.universalProfile.getData(
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetManyKeys.address.substring(2),
         );
         let decodedResult = decodeCompactBytes(result);
@@ -104,13 +104,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       });
     });
 
-    describe("when address can set only one key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting the right key", async () => {
+    describe('when address can set only one key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting the right key', async () => {
           let key = customKey1;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
@@ -120,78 +120,78 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should fail when setting the wrong key", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NotAllowedKey"));
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+        it('should fail when setting the wrong key', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NotAllowedKey'));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
 
           await expect(context.keyManager.connect(controllerCanSetOneKey).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, key);
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should fail when the list contains none of the allowed keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should fail when the list contains none of the allowed keys', async () => {
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [keys, values],
           );
 
           await expect(context.keyManager.connect(controllerCanSetOneKey).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, keys[0]);
         });
 
-        it("should fail, even if the list contains the allowed key", async () => {
+        it('should fail, even if the list contains the allowed key', async () => {
           let keys = [
             customKey1,
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [keys, values],
           );
 
           await expect(context.keyManager.connect(controllerCanSetOneKey).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetOneKey.address, keys[1]);
         });
       });
     });
 
-    describe("when address can set multiple keys", () => {
-      it("should pass when the input is all the allowed keys", async () => {
+    describe('when address can set multiple keys', () => {
+      it('should pass when the input is all the allowed keys', async () => {
         let keys = [customKey2, customKey3, customKey4];
         let values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 3")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 3')),
         ];
 
-        let setDataPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        let setDataPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           keys,
           values,
         ]);
@@ -202,34 +202,34 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.deep.equal(values);
       });
 
-      it("should fail when the input contains none of the allowed keys", async () => {
+      it('should fail when the input contains none of the allowed keys', async () => {
         let keys = [
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
         ];
         let values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
         ];
 
-        let setDataPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        let setDataPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           keys,
           values,
         ]);
 
         await expect(context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetManyKeys.address, keys[0]);
       });
 
-      describe("when setting one key", () => {
-        it("should pass when trying to set the 1st allowed key", async () => {
+      describe('when setting one key', () => {
+        it('should pass when trying to set the 1st allowed key', async () => {
           let key = customKey2;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
@@ -239,11 +239,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should pass when trying to set the 2nd allowed key", async () => {
+        it('should pass when trying to set the 2nd allowed key', async () => {
           let key = customKey3;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
@@ -253,11 +253,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should pass when trying to set the 3rd allowed key", async () => {
+        it('should pass when trying to set the 3rd allowed key', async () => {
           let key = customKey4;
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
@@ -267,32 +267,32 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(newValue);
         });
 
-        it("should fail when setting a not-allowed Singleton key", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NotAllowedKey"));
-          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+        it('should fail when setting a not-allowed Singleton key', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NotAllowedKey'));
+          let newValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             newValue,
           ]);
 
           await expect(context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetManyKeys.address, key);
         });
       });
 
-      describe("when setting 2 x keys", () => {
-        describe("should pass when", () => {
-          it("the input is the first two (subset) allowed keys", async () => {
+      describe('when setting 2 x keys', () => {
+        describe('should pass when', () => {
+          it('the input is the first two (subset) allowed keys', async () => {
             let keys = [customKey2, customKey3];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
             await context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload);
@@ -301,15 +301,15 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             expect(result).to.deep.equal(values);
           });
 
-          it("the input is the last two (subset) allowed keys", async () => {
+          it('the input is the last two (subset) allowed keys', async () => {
             let keys = [customKey3, customKey4];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
             await context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload);
@@ -318,15 +318,15 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             expect(result).to.deep.equal(values);
           });
 
-          it("the input is the first + last (subset) allowed keys", async () => {
+          it('the input is the first + last (subset) allowed keys', async () => {
             let keys = [customKey2, customKey4];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
             await context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload);
@@ -337,366 +337,366 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting 3 x keys", () => {
-        describe("should fail when", () => {
-          it("1st key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+      describe('when setting 3 x keys', () => {
+        describe('should fail when', () => {
+          it('1st key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 1st allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 1st allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey2,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('1st key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 2nd allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 2nd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey3,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('1st key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
               customKey4,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("2nd key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('2nd key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey4,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("3rd key in input = 3rd allowed key. Other 2 keys = not allowed", async () => {
+          it('3rd key in input = 3rd allowed key. Other 2 keys = not allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
               customKey4,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("1st key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('1st key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey2,
               customKey3,
             ];
 
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[0]);
           });
 
-          it("2nd key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('2nd key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
               customKey2,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               customKey3,
             ];
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[1]);
           });
 
-          it("3rd key in input = not allowed key. Other 2 keys = allowed", async () => {
+          it('3rd key in input = not allowed key. Other 2 keys = allowed', async () => {
             let keys = [
               customKey2,
               customKey3,
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
             ];
 
             let values = [
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-              ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+              ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
             ];
 
             let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setDataBatch",
+              'setDataBatch',
               [keys, values],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetManyKeys.address, keys[2]);
           });
         });
       });
 
-      describe("when setting multiple keys", () => {
-        describe("when input is bigger than the number of allowed keys", () => {
-          describe("should fail when", () => {
-            it("input = all the allowed keys + 1 x not-allowed key", async () => {
+      describe('when setting multiple keys', () => {
+        describe('when input is bigger than the number of allowed keys', () => {
+          describe('should fail when', () => {
+            it('input = all the allowed keys + 1 x not-allowed key', async () => {
               let keys = [
                 customKey2,
                 customKey3,
                 customKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey3")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey3')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
               ];
 
               let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-                "setDataBatch",
+                'setDataBatch',
                 [keys, values],
               );
 
               await expect(
                 context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
                 .withArgs(controllerCanSetManyKeys.address, keys[3]);
             });
 
-            it("input = all the allowed keys + 5 x not-allowed key", async () => {
+            it('input = all the allowed keys + 5 x not-allowed key', async () => {
               let keys = [
                 customKey2,
                 customKey3,
                 customKey4,
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("XXXXXXXXXX")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("YYYYYYYYYY")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("ZZZZZZZZZZ")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("AAAAAAAAAA")),
-                ethers.utils.keccak256(ethers.utils.toUtf8Bytes("BBBBBBBBBB")),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('XXXXXXXXXX')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('YYYYYYYYYY')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('ZZZZZZZZZZ')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('AAAAAAAAAA')),
+                ethers.utils.keccak256(ethers.utils.toUtf8Bytes('BBBBBBBBBB')),
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 3")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Custom Value 4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value XXXXXXXX")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value YYYYYYYY")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value ZZZZZZZZ")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value AAAAAAAA")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Value BBBBBBBB")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 3')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Custom Value 4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value XXXXXXXX')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value YYYYYYYY')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value ZZZZZZZZ')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value AAAAAAAA')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Value BBBBBBBB')),
               ];
 
               let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-                "setDataBatch",
+                'setDataBatch',
                 [keys, values],
               );
 
               await expect(
                 context.keyManager.connect(controllerCanSetManyKeys).execute(setDataPayload),
               )
-                .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
                 .withArgs(controllerCanSetManyKeys.address, keys[3]);
             });
           });
 
-          describe("should pass when", () => {
-            it("input contains all the allowed keys as DUPLICATE", async () => {
+          describe('should pass when', () => {
+            it('input contains all the allowed keys as DUPLICATE', async () => {
               let keys = [
                 customKey2,
                 customKey4,
@@ -709,31 +709,31 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
                 customKey4,
               ];
               let values = [
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey2")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey4")),
-                ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some Data for customKey3")),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey2')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey4')),
+                ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some Data for customKey3')),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey2"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey2'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey3"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey3'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey2"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey2'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 1) for customKey4"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 1) for customKey4'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey3"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey3'),
                 ),
                 ethers.utils.hexlify(
-                  ethers.utils.toUtf8Bytes("Some Data (override 2) for customKey4"),
+                  ethers.utils.toUtf8Bytes('Some Data (override 2) for customKey4'),
                 ),
               ];
 
               let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-                "setDataBatch",
+                'setDataBatch',
                 [keys, values],
               );
 
@@ -757,13 +757,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       });
     });
 
-    describe("when address can set any key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting any random key", async () => {
+    describe('when address can set any key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting any random key', async () => {
           let key = ethers.utils.hexlify(ethers.utils.randomBytes(32));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -774,21 +774,21 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when setting any multiple keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when setting any multiple keys', async () => {
           let keys = [
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
           ];
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some data 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 3')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [keys, values],
           );
           await context.keyManager.connect(context.owner).execute(setDataPayload);
@@ -801,20 +801,20 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
   });
 
-  describe("keyType: Mapping", () => {
+  describe('keyType: Mapping', () => {
     let controllerCanSetMappingKeys: SignerWithAddress;
 
     // all mapping keys starting with: SupportedStandards:...
-    const supportedStandardKey = "0xeafec4d89fa9619884b6b89135626455";
+    const supportedStandardKey = '0xeafec4d89fa9619884b6b89135626455';
 
     // SupportedStandards:LSPX
-    const LSPXKey = "0xeafec4d89fa9619884b6b8913562645500000000000000000000000024ae6f23";
+    const LSPXKey = '0xeafec4d89fa9619884b6b8913562645500000000000000000000000024ae6f23';
 
     // SupportedStandards:LSPY
-    const LSPYKey = "0xeafec4d89fa9619884b6b891356264550000000000000000000000005e8d18c5";
+    const LSPYKey = '0xeafec4d89fa9619884b6b891356264550000000000000000000000005e8d18c5';
 
     // SupportedStandards:LSPZ
-    const LSPZKey = "0xeafec4d89fa9619884b6b8913562645500000000000000000000000025b71a36";
+    const LSPZKey = '0xeafec4d89fa9619884b6b8913562645500000000000000000000000025b71a36';
 
     before(async () => {
       context = await buildContext();
@@ -822,10 +822,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetMappingKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetMappingKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetMappingKeys.address.substring(2),
       ];
 
@@ -839,12 +839,12 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
 
     describe("when address can set Mapping keys starting with a 'SupportedStandards:...'", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting SupportedStandards:LSPX", async () => {
+      describe('when setting one key', () => {
+        it('should pass when setting SupportedStandards:LSPX', async () => {
           let mappingKey = LSPXKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x24ae6f23"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x24ae6f23'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             mappingKey,
             mappingValue,
           ]);
@@ -855,11 +855,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when overriding SupportedStandards:LSPX", async () => {
+        it('should pass when overriding SupportedStandards:LSPX', async () => {
           let mappingKey = LSPXKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x24ae6f23"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x24ae6f23'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             mappingKey,
             mappingValue,
           ]);
@@ -870,11 +870,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when setting SupportedStandards:LSPY", async () => {
+        it('should pass when setting SupportedStandards:LSPY', async () => {
           let mappingKey = LSPYKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x5e8d18c5"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x5e8d18c5'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             mappingKey,
             mappingValue,
           ]);
@@ -884,11 +884,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should pass when setting SupportedStandards:LSPZ", async () => {
+        it('should pass when setting SupportedStandards:LSPZ', async () => {
           let mappingKey = LSPZKey;
-          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x25b71a36"));
+          let mappingValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x25b71a36'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             mappingKey,
             mappingValue,
           ]);
@@ -899,13 +899,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(mappingValue);
         });
 
-        it("should fail when setting any other not-allowed Mapping key", async () => {
+        it('should fail when setting any other not-allowed Mapping key', async () => {
           // CustomMapping:...
           let notAllowedMappingKey =
-            "0xb8a73e856fea3d5a518029e588a713f300000000000000000000000000000000";
-          let notAllowedMappingValue = "0xbeefbeef";
+            '0xb8a73e856fea3d5a518029e588a713f300000000000000000000000000000000';
+          let notAllowedMappingValue = '0xbeefbeef';
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             notAllowedMappingKey,
             notAllowedMappingValue,
           ]);
@@ -913,18 +913,18 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           await expect(
             context.keyManager.connect(controllerCanSetMappingKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, notAllowedMappingKey);
         });
       });
 
-      describe("when setting multiple keys", () => {
+      describe('when setting multiple keys', () => {
         it('(2 x keys) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [LSPYKey, LSPZKey];
-          let mappingValues = ["0x5e8d18c5", "0x5e8d18c5"];
+          let mappingValues = ['0x5e8d18c5', '0x5e8d18c5'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [mappingKeys, mappingValues],
           );
 
@@ -936,10 +936,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(2 x keys) (override) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [LSPYKey, LSPZKey];
-          let mappingValues = ["0x5e8d18c5", "0x5e8d18c5"];
+          let mappingValues = ['0x5e8d18c5', '0x5e8d18c5'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [mappingKeys, mappingValues],
           );
 
@@ -951,14 +951,14 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(3 x keys) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc",
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc',
           ];
-          let mappingValues = ["0xaaaaaaaa", "0xbbbbbbbb", "0xcccccccc"];
+          let mappingValues = ['0xaaaaaaaa', '0xbbbbbbbb', '0xcccccccc'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [mappingKeys, mappingValues],
           );
 
@@ -970,14 +970,14 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         it('(3 x keys) (override) should pass when all the keys in the list start with bytes16(keccak256("SupportedStandards"))', async () => {
           let mappingKeys = [
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb",
-            "0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc",
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000aaaaaaaa',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000bbbbbbbb',
+            '0xeafec4d89fa9619884b6b89135626455000000000000000000000000cccccccc',
           ];
-          let mappingValues = ["0xaaaaaaaa", "0xbbbbbbbb", "0xcccccccc"];
+          let mappingValues = ['0xaaaaaaaa', '0xbbbbbbbb', '0xcccccccc'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [mappingKeys, mappingValues],
           );
 
@@ -987,66 +987,66 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.deep.equal(mappingValues);
         });
 
-        it("should fail when the list contains none of the allowed Mapping keys", async () => {
+        it('should fail when the list contains none of the allowed Mapping keys', async () => {
           let randomMappingKeys = [
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111",
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111',
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let randomMappingValues = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 3')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [randomMappingKeys, randomMappingValues],
           );
 
           await expect(
             context.keyManager.connect(controllerCanSetMappingKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, randomMappingKeys[0]);
         });
 
-        it("should fail, even if the list contains some keys starting with `SupportedStandards`", async () => {
+        it('should fail, even if the list contains some keys starting with `SupportedStandards`', async () => {
           let mappingKeys = [
             LSPXKey,
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let mappingValues = [
-            "0x24ae6f23",
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
+            '0x24ae6f23',
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [mappingKeys, mappingValues],
           );
 
           await expect(
             context.keyManager.connect(controllerCanSetMappingKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetMappingKeys.address, mappingKeys[1]);
         });
       });
     });
 
-    describe("when address can set any key", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting any random Mapping key", async () => {
+    describe('when address can set any key', () => {
+      describe('when setting one key', () => {
+        it('should pass when setting any random Mapping key', async () => {
           let randomMappingKey =
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111";
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111';
           let randomMappingValue = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("Random Mapping Value"),
+            ethers.utils.toUtf8Bytes('Random Mapping Value'),
           );
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             randomMappingKey,
             randomMappingValue,
           ]);
@@ -1058,21 +1058,21 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when setting any random set of Mapping keys", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when setting any random set of Mapping keys', async () => {
           let randomMappingKeys = [
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111",
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222",
-            "0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222",
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00000000000000000000000011111111',
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb00000000000000000000000022222222',
+            '0xcccccccccccccccccccccccccccccccc00000000000000000000000022222222',
           ];
           let randomMappingValues = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 1")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 2")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random Mapping Value 3")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 1')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 2')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random Mapping Value 3')),
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [randomMappingKeys, randomMappingValues],
           );
           await context.keyManager.connect(context.owner).execute(setDataPayload);
@@ -1085,32 +1085,32 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
   });
 
-  describe("keyType: Array", () => {
+  describe('keyType: Array', () => {
     let controllerCanSetArrayKeys: SignerWithAddress;
 
-    const allowedArrayKey = "0x868affce801d08a5948eebc349a5c8ff";
+    const allowedArrayKey = '0x868affce801d08a5948eebc349a5c8ff';
 
     // keccak256("MyArray[]")
-    const arrayKeyLength = "0x868affce801d08a5948eebc349a5c8ff18e4c7076d14879dd5d19180dff1f547";
+    const arrayKeyLength = '0x868affce801d08a5948eebc349a5c8ff18e4c7076d14879dd5d19180dff1f547';
 
     // MyArray[0]
-    const arrayKeyElement1 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000000";
+    const arrayKeyElement1 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000000';
 
     // MyArray[1]
-    const arrayKeyElement2 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000001";
+    const arrayKeyElement2 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000001';
 
     // MyArray[2]
-    const arrayKeyElement3 = "0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000002";
+    const arrayKeyElement3 = '0x868affce801d08a5948eebc349a5c8ff00000000000000000000000000000002';
 
     before(async () => {
       context = await buildContext();
       controllerCanSetArrayKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetArrayKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetArrayKeys.address.substring(2),
       ];
 
@@ -1124,13 +1124,13 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
     });
 
     describe("when address can set Array element in 'MyArray[]", () => {
-      describe("when setting one key", () => {
-        it("should pass when setting array key length MyArray[]", async () => {
+      describe('when setting one key', () => {
+        it('should pass when setting array key length MyArray[]', async () => {
           let key = arrayKeyLength;
           // eg: MyArray[].length = 10 elements
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0x0a"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0x0a'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1141,11 +1141,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 1st array element MyArray[0]", async () => {
+        it('should pass when setting 1st array element MyArray[0]', async () => {
           let key = arrayKeyElement1;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xaaaaaaaa"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xaaaaaaaa'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1156,11 +1156,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 2nd array element MyArray[1]", async () => {
+        it('should pass when setting 2nd array element MyArray[1]', async () => {
           let key = arrayKeyElement2;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xbbbbbbbb"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xbbbbbbbb'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1171,11 +1171,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when setting 3rd array element MyArray[3]", async () => {
+        it('should pass when setting 3rd array element MyArray[3]', async () => {
           let key = arrayKeyElement3;
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xcccccccc"));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xcccccccc'));
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1186,29 +1186,29 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting elements of a not-allowed Array (eg: LSP5ReceivedAssets)", async () => {
-          let notAllowedArrayKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
+        it('should fail when setting elements of a not-allowed Array (eg: LSP5ReceivedAssets)', async () => {
+          let notAllowedArrayKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
 
-          let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             notAllowedArrayKey,
-            "0x00",
+            '0x00',
           ]);
 
           await expect(
             context.keyManager.connect(controllerCanSetArrayKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, notAllowedArrayKey);
         });
       });
 
-      describe("when setting multiple keys", () => {
-        it("should pass when all the keys in the list are from the allowed array MyArray[]", async () => {
+      describe('when setting multiple keys', () => {
+        it('should pass when all the keys in the list are from the allowed array MyArray[]', async () => {
           let keys = [arrayKeyElement1, arrayKeyElement2];
-          let values = ["0xaaaaaaaa", "0xbbbbbbbb"];
+          let values = ['0xaaaaaaaa', '0xbbbbbbbb'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [keys, values],
           );
 
@@ -1218,82 +1218,82 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           expect(result).to.deep.equal(values);
         });
 
-        it("should fail when the list contains elements keys of a non-allowed Array (RandomArray[])", async () => {
+        it('should fail when the list contains elements keys of a non-allowed Array (RandomArray[])', async () => {
           let randomArrayKeys = [
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000002",
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000002',
           ];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
-            [randomArrayKeys, ["0xdeadbeef", "0xdeadbeef", "0xdeadbeef"]],
+            'setDataBatch',
+            [randomArrayKeys, ['0xdeadbeef', '0xdeadbeef', '0xdeadbeef']],
           );
 
           await expect(
             context.keyManager.connect(controllerCanSetArrayKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, randomArrayKeys[0]);
         });
 
-        it("should fail, even if the list contains a mix of allowed + not-allowed array element keys (MyArray[] + RandomArray[])", async () => {
+        it('should fail, even if the list contains a mix of allowed + not-allowed array element keys (MyArray[] + RandomArray[])', async () => {
           let keys = [
             arrayKeyElement1,
             arrayKeyElement2,
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000",
-            "0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001",
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000000',
+            '0xb722d6e40cf8e32ad09d16af664b960500000000000000000000000000000001',
           ];
-          let values = ["0xaaaaaaaa", "0xbbbbbbbb", "0xdeadbeef", "0xdeadbeef"];
+          let values = ['0xaaaaaaaa', '0xbbbbbbbb', '0xdeadbeef', '0xdeadbeef'];
 
           let setDataPayload = context.universalProfile.interface.encodeFunctionData(
-            "setDataBatch",
+            'setDataBatch',
             [keys, values],
           );
 
           await expect(
             context.keyManager.connect(controllerCanSetArrayKeys).execute(setDataPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetArrayKeys.address, keys[2]);
         });
       });
     });
   });
 
-  describe("Testing bytes32(0) (= zero key) edge cases", () => {
+  describe('Testing bytes32(0) (= zero key) edge cases', () => {
     let controllerCanSetSomeKeys: SignerWithAddress;
 
-    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey1"));
-    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("CustomKey2"));
+    const customKey1 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey1'));
+    const customKey2 = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('CustomKey2'));
 
-    const zeroKey = "0x0000000000000000000000000000000000000000000000000000000000000000";
+    const zeroKey = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
     const bytes31DynamicKeyPrefix =
-      "0x00000000000000000000000000000000000000000000000000000000000000";
+      '0x00000000000000000000000000000000000000000000000000000000000000';
 
-    const bytes31DynamicKey = "0x00000000000000000000000000000000000000000000000000000000000000ca";
+    const bytes31DynamicKey = '0x00000000000000000000000000000000000000000000000000000000000000ca';
 
-    const bytes20DynamicKeyPrefix = "0x0000000000000000000000000000000000000000";
+    const bytes20DynamicKeyPrefix = '0x0000000000000000000000000000000000000000';
 
-    const bytes20DynamicKey = "0x0000000000000000000000000000000000000000cafecafecafecafecafecafe";
+    const bytes20DynamicKey = '0x0000000000000000000000000000000000000000cafecafecafecafecafecafe';
 
-    const bytes24DynamicKey = "0x000000000000000000000000000000000000000000000000cafecafecafecafe";
+    const bytes24DynamicKey = '0x000000000000000000000000000000000000000000000000cafecafecafecafe';
 
-    const bytes19DynamicKey = "0x00000000000000000000000000000000000000cafecafecafecafecafecafeca";
+    const bytes19DynamicKey = '0x00000000000000000000000000000000000000cafecafecafecafecafecafeca';
 
-    describe("When bytes32(0) key is part of the AllowedERC725YDataKeys", () => {
+    describe('When bytes32(0) key is part of the AllowedERC725YDataKeys', () => {
       before(async () => {
         context = await buildContext();
 
         controllerCanSetSomeKeys = context.accounts[1];
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetSomeKeys.address.substring(2),
         ];
 
@@ -1309,9 +1309,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       [{ allowedDataKey: customKey1 }, { allowedDataKey: customKey2 }].forEach((testCase) => {
         it(`should pass when setting a data key listed in the allowed ERC725Y data keys: ${testCase.allowedDataKey}`, async () => {
           const key = testCase.allowedDataKey;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-          const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1325,55 +1325,55 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
       [
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 1")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 1')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 2")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 2')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 3")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 3')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 4")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 4')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 5")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 5')),
         },
       ].forEach((testCase) => {
         it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-          const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
         });
       });
 
-      it("should revert when trying to set bytes31(0) dynamic key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set bytes31(0) dynamic key, not in AllowedERC725YDataKeys', async () => {
         const key = bytes31DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, key);
       });
 
-      it("should pass and allow to set the bytes32(0) data key", async () => {
+      it('should pass and allow to set the bytes32(0) data key', async () => {
         const key = zeroKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1383,16 +1383,16 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getData(key)).to.equal(value);
       });
 
-      it("should pass when trying to set an array of data keys that includes bytes32(0) (= zero data key)", async () => {
+      it('should pass when trying to set an array of data keys that includes bytes32(0) (= zero data key)', async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
@@ -1401,55 +1401,55 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes31(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes31(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes31DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
         await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes20(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes20(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes20DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
         await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
     });
 
-    describe("When bytes32(0) key is not part of the AllowedERC725YDataKeys", () => {
+    describe('When bytes32(0) key is not part of the AllowedERC725YDataKeys', () => {
       before(async () => {
         context = await buildContext();
 
         controllerCanSetSomeKeys = context.accounts[1];
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             controllerCanSetSomeKeys.address.substring(2),
         ];
 
@@ -1470,9 +1470,9 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       [{ allowedDataKey: customKey1 }, { allowedDataKey: customKey2 }].forEach((testCase) => {
         it(`should pass when setting a data key listed in the allowed ERC725Y data keys: ${testCase.allowedDataKey}`, async () => {
           const key = testCase.allowedDataKey;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-          const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1486,41 +1486,41 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
       [
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 1")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 1')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 2")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 2')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 3")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 3')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 4")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 4')),
         },
         {
-          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some random data key 5")),
+          datakeyToSet: ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Some random data key 5')),
         },
       ].forEach((testCase) => {
         it(`should revert when trying to set any random data key (e.g: ${testCase.datakeyToSet})`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-          const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(controllerCanSetSomeKeys.address, testCase.datakeyToSet);
         });
       });
 
-      it("should allow setting up a key with a prefix of 31 null bytes, as bytes31(0) is part of AllowedERC725YDataKeys", async () => {
+      it('should allow setting up a key with a prefix of 31 null bytes, as bytes31(0) is part of AllowedERC725YDataKeys', async () => {
         const key = bytes31DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1531,11 +1531,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.equal(value);
       });
 
-      it("should allow setting up a key with a prefix of 20 null bytes, as bytes20(0) is part of AllowedERC725YDataKeys", async () => {
+      it('should allow setting up a key with a prefix of 20 null bytes, as bytes20(0) is part of AllowedERC725YDataKeys', async () => {
         const key = bytes20DynamicKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1548,11 +1548,11 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(result).to.equal(value);
       });
 
-      it("should pass and allow to set the bytes32(0) data key", async () => {
+      it('should pass and allow to set the bytes32(0) data key', async () => {
         const key = zeroKey;
-        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+        const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1562,16 +1562,16 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getData(key)).to.equal(value);
       });
 
-      it("should pass when setting an array of data keys that includes bytes32(0) (= zero data key)", async () => {
+      it('should pass when setting an array of data keys that includes bytes32(0) (= zero data key)', async () => {
         const keys = [customKey1, customKey2, zeroKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
@@ -1580,16 +1580,16 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should pass when trying to set an array of data keys including a dynamic bytes24(0) data key, because bytes20(0) dynamic data ke is in AllowedERC725YDataKeys", async () => {
+      it('should pass when trying to set an array of data keys including a dynamic bytes24(0) data key, because bytes20(0) dynamic data ke is in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes24DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
@@ -1598,30 +1598,30 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
       });
 
-      it("should revert when trying to set an array of data keys including a dynamic bytes19(0) data key, not in AllowedERC725YDataKeys", async () => {
+      it('should revert when trying to set an array of data keys including a dynamic bytes19(0) data key, not in AllowedERC725YDataKeys', async () => {
         const keys = [customKey1, customKey2, bytes19DynamicKey];
         const values = [
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[0])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[1])),
-          ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + keys[2])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[0])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[1])),
+          ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + keys[2])),
         ];
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [keys, values],
         );
 
         await expect(context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
           .withArgs(controllerCanSetSomeKeys.address, keys[2]);
       });
     });
   });
 
-  describe("one single byte as an allowed data key (e.g: 0xaa0000...0000", () => {
+  describe('one single byte as an allowed data key (e.g: 0xaa0000...0000', () => {
     let controllerCanSetSomeKeys: SignerWithAddress;
 
-    const allowedDataKey = "0xaa";
+    const allowedDataKey = '0xaa';
 
     before(async () => {
       context = await buildContext();
@@ -1629,10 +1629,10 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetSomeKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetSomeKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           controllerCanSetSomeKeys.address.substring(2),
       ];
 
@@ -1645,23 +1645,23 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("should pass when setting a data key that starts with `0xaa`", () => {
+    describe('should pass when setting a data key that starts with `0xaa`', () => {
       [
         {
-          datakeyToSet: "0xaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          datakeyToSet: '0xaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
         },
         {
-          datakeyToSet: "0xaacccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          datakeyToSet: '0xaacccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
         },
         {
-          datakeyToSet: "0xaadddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          datakeyToSet: '0xaadddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
         },
       ].forEach((testCase) => {
         it(`e.g: ${testCase.datakeyToSet}`, async () => {
           const key = testCase.datakeyToSet;
-          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+          const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
-          const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -1674,40 +1674,40 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
         });
       });
 
-      describe("when trying to set a data key that does not start with `0xaa`", () => {
+      describe('when trying to set a data key that does not start with `0xaa`', () => {
         [
           {
-            datakeyToSet: "0xbb00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xbb00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xcc00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xcc00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xdd00000000000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xdd00000000000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xbb12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xbb12345678000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xcc12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xcc12345678000000000000000000000000000000000000000000000000000000',
           },
           {
-            datakeyToSet: "0xdd12345678000000000000000000000000000000000000000000000000000000",
+            datakeyToSet: '0xdd12345678000000000000000000000000000000000000000000000000000000',
           },
         ].forEach((testCase) => {
           it(`should revert (e.g: ${testCase.datakeyToSet})`, async () => {
             const key = testCase.datakeyToSet;
-            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value for " + key));
+            const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value for ' + key));
 
             const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-              "setData",
+              'setData',
               [key, value],
             );
 
             await expect(
               context.keyManager.connect(controllerCanSetSomeKeys).execute(setDataPayload),
             )
-              .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
               .withArgs(controllerCanSetSomeKeys.address, key);
           });
         });

--- a/tests/LSP6KeyManager/SetData/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/SetData/PermissionSetData.test.ts
@@ -1,52 +1,52 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { encodeData, ERC725JSONSchema } from "@erc725/erc725.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { encodeData, ERC725JSONSchema } from '@erc725/erc725.js';
 
-import { Executor, Executor__factory } from "../../../types";
+import { Executor, Executor__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, OPERATION_TYPES } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, OPERATION_TYPES } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
 import {
   getRandomAddresses,
   combinePermissions,
   encodeCompactBytesArray,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 const BasicUPSetup_Schema: ERC725JSONSchema[] = [
   {
-    name: "LSP3Profile",
-    key: ERC725YDataKeys.LSP3["LSP3Profile"],
-    keyType: "Singleton",
-    valueContent: "JSONURL",
-    valueType: "bytes",
+    name: 'LSP3Profile',
+    key: ERC725YDataKeys.LSP3['LSP3Profile'],
+    keyType: 'Singleton',
+    valueContent: 'JSONURL',
+    valueType: 'bytes',
   },
   {
-    name: "LSP1UniversalReceiverDelegate",
+    name: 'LSP1UniversalReceiverDelegate',
     key: ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-    keyType: "Singleton",
-    valueContent: "Address",
-    valueType: "address",
+    keyType: 'Singleton',
+    valueContent: 'Address',
+    valueType: 'address',
   },
   {
-    name: "LSP12IssuedAssets[]",
-    key: ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length,
-    keyType: "Array",
-    valueContent: "Number",
-    valueType: "uint256",
+    name: 'LSP12IssuedAssets[]',
+    key: ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].length,
+    keyType: 'Array',
+    valueContent: 'Number',
+    valueType: 'uint256',
   },
 ];
 
 export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LSP6TestContext>) => {
   let context: LSP6TestContext;
 
-  describe("when caller is an EOA", () => {
+  describe('when caller is an EOA', () => {
     let canSetDataWithAllowedERC725YDataKeys: SignerWithAddress,
       canSetDataWithoutAllowedERC725YDataKeys: SignerWithAddress,
       cannotSetData: SignerWithAddress;
@@ -59,14 +59,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       cannotSetData = context.accounts[3];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithoutAllowedERC725YDataKeys.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + cannotSetData.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + cannotSetData.address.substring(2),
       ];
 
       const permissionsValues = [
@@ -75,13 +75,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         encodeCompactBytesArray([
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
           ERC725YDataKeys.LSP3.LSP3Profile,
-          ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index,
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+          ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index,
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
         ]),
         combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.CALL),
         PERMISSIONS.CALL,
@@ -90,45 +90,45 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(context, permissionsKeys, permissionsValues);
     });
 
-    describe("when setting one key", () => {
-      describe("For UP owner", () => {
-        it("should pass", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+    describe('when setting one key', () => {
+      describe('For UP owner', () => {
+        it('should pass', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await context.keyManager.connect(context.owner).execute(payload);
-          const fetchedResult = await context.universalProfile.callStatic["getData(bytes32)"](key);
+          const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
         });
       });
 
-      describe("For address that has permission SETDATA with AllowedERC725YDataKeys", () => {
-        it("should pass", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+      describe('For address that has permission SETDATA with AllowedERC725YDataKeys', () => {
+        it('should pass', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await context.keyManager.connect(canSetDataWithAllowedERC725YDataKeys).execute(payload);
-          const fetchedResult = await context.universalProfile.callStatic["getData(bytes32)"](key);
+          const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
         });
       });
 
-      describe("For address that has permission SETDATA without any AllowedERC725YDataKeys", () => {
-        it("should revert", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+      describe('For address that has permission SETDATA without any AllowedERC725YDataKeys', () => {
+        it('should revert', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -136,33 +136,33 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           await expect(
             context.keyManager.connect(canSetDataWithoutAllowedERC725YDataKeys).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
       describe("For address that doesn't have permission SETDATA", () => {
-        it("should not allow", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!"));
+        it('should not allow', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(cannotSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
       });
 
-      describe("when sending value while setting data", async () => {
-        it("should revert with Key Manager error `CannotSendValueToSetData`", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
-          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Hello Lukso!!!"));
+      describe('when sending value while setting data', async () => {
+        it('should revert with Key Manager error `CannotSendValueToSetData`', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
+          let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!!!'));
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -171,31 +171,31 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             context.keyManager
               .connect(canSetDataWithAllowedERC725YDataKeys)
               .execute(payload, { value: 12 }),
-          ).to.be.revertedWithCustomError(context.keyManager, "CannotSendValueToSetData");
+          ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
         });
       });
     });
 
-    describe("when setting multiple keys", () => {
-      describe("For UP owner", () => {
-        it("(should pass): adding 5 singleton keys", async () => {
+    describe('when setting multiple keys', () => {
+      describe('For UP owner', () => {
+        it('(should pass): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -207,14 +207,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+        it('(should pass): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -225,32 +225,32 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)", async () => {
+        it('(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
             {
-              keyName: "LSP1UniversalReceiverDelegate",
-              value: "0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb",
+              keyName: 'LSP1UniversalReceiverDelegate',
+              value: '0x1183790f29BE3cDfD0A102862fEA1a4a30b3AdAb',
             },
           ];
 
           let { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -262,25 +262,25 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
       });
 
-      describe("For address that has permission SETDATA with AllowedERC725YDataKeys", () => {
-        it("(should pass): adding 5 singleton keys", async () => {
+      describe('For address that has permission SETDATA with AllowedERC725YDataKeys', () => {
+        it('(should pass): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -292,14 +292,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): adding 10 LSP12IssuedAssets", async () => {
+        it('(should pass): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -310,28 +310,28 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should pass): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
 
           let { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -343,25 +343,25 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
       });
 
-      describe("For address that has permission SETDATA without AllowedERC725YDataKeys", () => {
-        it("(should revert): adding 5 singleton keys", async () => {
+      describe('For address that has permission SETDATA without AllowedERC725YDataKeys', () => {
+        it('(should revert): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -369,18 +369,18 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           await expect(
             context.keyManager.connect(canSetDataWithoutAllowedERC725YDataKeys).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
-        it("(should revert): adding 10 LSP12IssuedAssets", async () => {
+        it('(should revert): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -388,32 +388,32 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           await expect(
             context.keyManager.connect(canSetDataWithoutAllowedERC725YDataKeys).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
 
-        it("(should revert): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should revert): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
 
           let { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -421,124 +421,124 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           await expect(
             context.keyManager.connect(canSetDataWithoutAllowedERC725YDataKeys).execute(payload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed")
+            .to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed')
             .withArgs(canSetDataWithoutAllowedERC725YDataKeys.address);
         });
       });
 
       describe("For address that doesn't have permission SETDATA", () => {
-        it("(should fail): adding 5 singleton keys", async () => {
+        it('(should fail): adding 5 singleton keys', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFirstKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MySecondKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyThirdKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFourthKey")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("MyFifthKey")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFirstKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MySecondKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyThirdKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFourthKey')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('MyFifthKey')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("aaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("bbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("cccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("dddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("eeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('aaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('bbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('cccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('dddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(cannotSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
 
-        it("(should fail): adding 10 LSP12IssuedAssets", async () => {
+        it('(should fail): adding 10 LSP12IssuedAssets', async () => {
           let lsp12IssuedAssets = getRandomAddresses(10);
 
-          const data = [{ keyName: "LSP12IssuedAssets[]", value: lsp12IssuedAssets }];
+          const data = [{ keyName: 'LSP12IssuedAssets[]', value: lsp12IssuedAssets }];
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(cannotSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
 
-        it("(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)", async () => {
+        it('(should fail): setup a basic Universal Profile (`LSP3Profile`, `LSP12IssuedAssets[]`)', async () => {
           const basicUPSetup = [
             {
-              keyName: "LSP3Profile",
+              keyName: 'LSP3Profile',
               value: {
-                hashFunction: "keccak256(utf8)",
-                hash: "0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361",
-                url: "ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx",
+                hashFunction: 'keccak256(utf8)',
+                hash: '0x820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361',
+                url: 'ifps://QmYr1VJLwerg6pEoscdhVGugo39pa6rycEZLjtRPDfW84UAx',
               },
             },
             {
-              keyName: "LSP12IssuedAssets[]",
+              keyName: 'LSP12IssuedAssets[]',
               value: [
-                "0xD94353D9B005B3c0A9Da169b768a31C57844e490",
-                "0xDaea594E385Fc724449E3118B2Db7E86dFBa1826",
+                '0xD94353D9B005B3c0A9Da169b768a31C57844e490',
+                '0xDaea594E385Fc724449E3118B2Db7E86dFBa1826',
               ],
             },
           ];
 
           let { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(cannotSetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(cannotSetData.address, "SETDATA");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(cannotSetData.address, 'SETDATA');
         });
       });
 
-      describe("when sending value while setting data", async () => {
-        it("should revert with Key Manager error `CannotSendValueToSetData`", async () => {
+      describe('when sending value while setting data', async () => {
+        it('should revert with Key Manager error `CannotSendValueToSetData`', async () => {
           const keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Third Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fourth Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Fifth Key")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Third Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fourth Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Fifth Key')),
           ];
 
           const values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xaaaaaaaaaa")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xbbbbbbbbbb")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xcccccccccc")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xdddddddddd")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("0xeeeeeeeeee")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xaaaaaaaaaa')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xbbbbbbbbbb')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xcccccccccc')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xdddddddddd')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('0xeeeeeeeeee')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(
             context.keyManager.connect(context.owner).execute(payload, { value: 12 }),
-          ).to.be.revertedWithCustomError(context.keyManager, "CannotSendValueToSetData");
+          ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
         });
       });
     });
   });
 
-  describe("when caller is a contract", () => {
+  describe('when caller is a contract', () => {
     let contractCanSetData: Executor;
 
-    const hardcodedDataKey = "0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1";
-    const hardcodedDataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Some value"));
+    const hardcodedDataKey = '0x562d53c1631c0c1620e183763f5f6356addcf78f26cbbd0b9eb7061d7c897ea1';
+    const hardcodedDataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some value'));
 
     /**
      * @dev this is necessary when the function being called in the contract
@@ -556,10 +556,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           contractCanSetData.address.substring(2),
       ];
 
@@ -579,69 +579,69 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
     afterEach(async () => {
       // teardown to start always with empty storage under the hardcoded data key
-      await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, "0x");
+      await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, '0x');
     });
 
-    describe("> contract calls", () => {
-      it("should allow to set a key hardcoded inside a function of the calling contract", async () => {
+    describe('> contract calls', () => {
+      it('should allow to set a key hardcoded inside a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setHardcodedKey();
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to set a key computed inside a function of the calling contract", async () => {
+      it('Should allow to set a key computed inside a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKey();
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to set a key computed from parameters given to a function of the calling contract", async () => {
+      it('Should allow to set a key computed from parameters given to a function of the calling contract', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyFromParams(hardcodedDataKey, hardcodedDataValue);
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
     });
 
-    describe("> Low-level calls", () => {
-      it("Should allow to `setHardcodedKeyRawCall` on UP", async () => {
+    describe('> Low-level calls', () => {
+      it('Should allow to `setHardcodedKeyRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // check if low-level call succeeded
         let result = await contractCanSetData.callStatic.setHardcodedKeyRawCall({
@@ -655,18 +655,18 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to `setComputedKeyRawCall` on UP", async () => {
+      it('Should allow to `setComputedKeyRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        const initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyRawCall({
@@ -674,18 +674,18 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         });
 
         // check that store[key] is now set to value
-        const newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        const newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
       });
 
-      it("Should allow to `setComputedKeyFromParamsRawCall` on UP", async () => {
+      it('Should allow to `setComputedKeyFromParamsRawCall` on UP', async () => {
         // check that nothing is set at store[key]
-        let initialStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        let initialStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
-        expect(initialStorage).to.equal("0x");
+        expect(initialStorage).to.equal('0x');
 
         // make the executor call
         await contractCanSetData.setComputedKeyFromParamsRawCall(
@@ -697,7 +697,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         );
 
         // check that store[key] is now set to value
-        let newStorage = await context.universalProfile.callStatic["getData(bytes32)"](
+        let newStorage = await context.universalProfile.callStatic['getData(bytes32)'](
           hardcodedDataKey,
         );
         expect(newStorage).to.equal(hardcodedDataValue);
@@ -705,7 +705,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     });
   });
 
-  describe("when caller is another UniversalProfile (with a KeyManager attached as owner)", () => {
+  describe('when caller is another UniversalProfile (with a KeyManager attached as owner)', () => {
     // UP making the call
     let alice: SignerWithAddress;
     let aliceContext: LSP6TestContext;
@@ -722,13 +722,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       bob = bobContext.accounts[1];
 
       const alicePermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2),
       ];
       const alicePermissionValues = [ALL_PERMISSIONS];
 
       const bobPermissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           aliceContext.universalProfile.address.substring(2),
       ];
 
@@ -739,15 +739,15 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(bobContext, bobPermissionKeys, bobPermissionValues);
     });
 
-    it("Alice should have ALL PERMISSIONS in her UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + alice.address.substring(2);
+    it('Alice should have ALL PERMISSIONS in her UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + alice.address.substring(2);
 
       const result = await aliceContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
     });
 
-    it("Bob should have ALL PERMISSIONS in his UP", async () => {
-      let key = ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + bob.address.substring(2);
+    it('Bob should have ALL PERMISSIONS in his UP', async () => {
+      let key = ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + bob.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
       expect(result).to.equal(ALL_PERMISSIONS);
@@ -755,7 +755,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
     it("Alice's UP should have permission SETDATA on Bob's UP", async () => {
       let key =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         aliceContext.universalProfile.address.substring(2);
 
       const result = await bobContext.universalProfile.getData(key);
@@ -767,21 +767,21 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Alice's Value"));
 
       let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "setData",
+        'setData',
         [key, value],
       );
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData("execute", [
+      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData('execute', [
         finalSetDataPayload,
       ]);
 
       let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [OPERATION_TYPES.CALL, bobContext.keyManager.address, 0, bobKeyManagerPayload],
       );
 
       await expect(aliceContext.keyManager.connect(alice).execute(aliceUniversalProfilePayload))
-        .to.be.revertedWithCustomError(bobContext.keyManager, "NoERC725YDataKeysAllowed")
+        .to.be.revertedWithCustomError(bobContext.keyManager, 'NoERC725YDataKeysAllowed')
         .withArgs(aliceContext.universalProfile.address);
     });
 
@@ -790,24 +790,24 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Alice's Value"));
 
       // Adding `key` to AllowedERC725YDataKeys for Alice
-      const payload = bobContext.universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+      const payload = bobContext.universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           aliceContext.universalProfile.address.substring(2),
         encodeCompactBytesArray([key]),
       ]);
       await bobContext.keyManager.connect(bob).execute(payload);
 
       let finalSetDataPayload = bobContext.universalProfile.interface.encodeFunctionData(
-        "setData",
+        'setData',
         [key, value],
       );
 
-      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData("execute", [
+      let bobKeyManagerPayload = bobContext.keyManager.interface.encodeFunctionData('execute', [
         finalSetDataPayload,
       ]);
 
       let aliceUniversalProfilePayload = aliceContext.universalProfile.interface.encodeFunctionData(
-        "execute",
+        'execute',
         [OPERATION_TYPES.CALL, bobContext.keyManager.address, 0, bobKeyManagerPayload],
       );
 
@@ -818,13 +818,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     });
   });
 
-  describe("when caller has SUPER_SETDATA + some allowed ERC725YDataKeys", () => {
+  describe('when caller has SUPER_SETDATA + some allowed ERC725YDataKeys', () => {
     let caller: SignerWithAddress;
 
     const AllowedERC725YDataKeys = [
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 1st allowed key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 2nd allowed key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 3rd allowed key")),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 1st allowed key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 2nd allowed key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 3rd allowed key')),
     ];
 
     before(async () => {
@@ -833,8 +833,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       caller = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           caller.address.substring(2),
       ];
 
@@ -846,13 +846,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when trying to set a disallowed key", () => {
+    describe('when trying to set a disallowed key', () => {
       for (let ii = 1; ii <= 5; ii++) {
         let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`dissallowed key ${ii}`));
         let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(`some value ${ii}`));
 
         it(`should be allowed to set a disallowed key: ${key}`, async () => {
-          const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -865,11 +865,11 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       }
     });
 
-    describe("when trying to set an allowed key", () => {
-      it("should be allowed to set the 1st allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 1"));
+    describe('when trying to set an allowed key', () => {
+      it('should be allowed to set the 1st allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 1'));
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           AllowedERC725YDataKeys[0],
           value,
         ]);
@@ -880,10 +880,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         expect(result).to.equal(value);
       });
 
-      it("should be allowed to set the 2nd allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 2"));
+      it('should be allowed to set the 2nd allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 2'));
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           AllowedERC725YDataKeys[1],
           value,
         ]);
@@ -894,10 +894,10 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
         expect(result).to.equal(value);
       });
 
-      it("should be allowed to set the 3rd allowed key", async () => {
-        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value 3"));
+      it('should be allowed to set the 3rd allowed key', async () => {
+        let value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value 3'));
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           AllowedERC725YDataKeys[2],
           value,
         ]);

--- a/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
@@ -1,23 +1,23 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // helpers
-import { combinePermissions, encodeCompactBytesArray } from "../../utils/helpers";
+import { combinePermissions, encodeCompactBytesArray } from '../../utils/helpers';
 
 async function setupPermissions(
   context: LSP6TestContext,
   permissionsKeys: string[],
   permissionValues: string[],
 ) {
-  const setupPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+  const setupPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
     permissionsKeys,
     permissionValues,
   ]);
@@ -29,9 +29,9 @@ async function setupPermissions(
  * @dev fixture to reset all the permissions to 0x
  */
 async function resetPermissions(context: LSP6TestContext, permissionsKeys: string[]) {
-  const teardownPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+  const teardownPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
     permissionsKeys,
-    Array(permissionsKeys.length).fill("0x"),
+    Array(permissionsKeys.length).fill('0x'),
   ]);
 
   await context.keyManager.connect(context.owner).execute(teardownPayload);
@@ -48,24 +48,24 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
   let permissionArrayKeys: string[] = [];
   let permissionArrayValues: string[] = [];
 
-  before("setup", async () => {
+  before('setup', async () => {
     context = await buildContext();
 
     await setupKeyManager(
       context,
-      [ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2)],
+      [ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2)],
       [ALL_PERMISSIONS],
     );
   });
 
-  describe("setting permissions keys (EDIT vs ADD Permissions)", () => {
+  describe('setting permissions keys (EDIT vs ADD Permissions)', () => {
     // this data key is hardcoded to be removed in teardown
     const permissionArrayIndexToAdd =
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000006";
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000006';
 
     // this data key is hardcoded for readability
     const permissionArrayIndexToEdit =
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004";
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004';
 
     let canOnlyAddController: SignerWithAddress,
       canOnlyEditPermissions: SignerWithAddress,
@@ -74,7 +74,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressToEditPermissions: SignerWithAddress,
       addressWithZeroHexPermissions: SignerWithAddress;
 
-    before("prepare permissions data keys", async () => {
+    before('prepare permissions data keys', async () => {
       canOnlyAddController = context.accounts[1];
       canOnlyEditPermissions = context.accounts[2];
       canOnlySetData = context.accounts[3];
@@ -82,15 +82,15 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressWithZeroHexPermissions = context.accounts[5];
 
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlySetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressToEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressWithZeroHexPermissions.address.substring(2),
       ];
 
@@ -101,17 +101,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         // placeholder permission
         PERMISSIONS.TRANSFERVALUE,
         // 0x0000... = similar to empty, or 'no permissions set'
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
         permissionArrayIndexToEdit,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000005",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000005',
       ];
 
       permissionArrayValues = [
@@ -125,13 +125,13 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       ];
     });
 
-    describe("when setting one permission key", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
+    describe('when setting one permission key', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -139,7 +139,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -147,14 +147,14 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should be allowed to ADD a permission", async () => {
+        it('should be allowed to ADD a permission', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             PERMISSIONS.SETDATA,
           ]);
@@ -166,14 +166,14 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(PERMISSIONS.SETDATA);
         });
 
-        it("should be allowed to EDIT a permission", async () => {
+        it('should be allowed to EDIT a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -185,17 +185,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -207,16 +207,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should be allowed to decrement the length", async () => {
-            let key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should be allowed to decrement the length', async () => {
+            let key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            let currentLength = await context.universalProfile["getData(bytes32)"](key);
+            let currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -229,12 +229,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should be allowed to set a 20 bytes long address", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should be allowed to set a 20 bytes long address', async () => {
             let key = permissionArrayIndexToAdd;
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -245,12 +245,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key = permissionArrayIndexToAdd;
-            let randomValue = "0xcafecafecafecafecafe";
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -258,17 +258,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key = permissionArrayIndexToAdd;
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -276,21 +276,21 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should be allowed to set a new 20 bytes long address", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should be allowed to set a new 20 bytes long address', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key = permissionArrayIndexToEdit;
 
             let value = randomWallet.address;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -302,12 +302,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(ethers.utils.getAddress(result)).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key = permissionArrayIndexToEdit;
-            let randomValue = "0xcafecafecafecafecafe";
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -315,17 +315,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key = permissionArrayIndexToEdit;
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -333,19 +333,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should pass", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should pass', async () => {
             let key = permissionArrayIndexToEdit;
 
-            let value = "0x";
+            let value = '0x';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -359,34 +359,34 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
 
         // this include any permission data key that start with bytes6(keccak256('AddressPermissions'))
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert', async () => {
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(context.owner).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission ADDCONTROLLER", () => {
+      describe('when caller is an address with permission ADDCONTROLLER', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -394,7 +394,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           // teardown in one batch `setData(bytes32[])` for efficiency
           await resetPermissions(context, [
             ...permissionKeys,
@@ -403,16 +403,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should be allowed to ADD a new controller", async () => {
+        it('should be allowed to ADD a new controller', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -424,34 +424,34 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        it("should not be allowed to EDIT a permission", async () => {
+        it('should not be allowed to EDIT a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -463,33 +463,33 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should not be allowed to decrement the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should not be allowed to decrement the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             let value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should be allowed to set a new 20 bytes long address", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should be allowed to set a new 20 bytes long address', async () => {
             let key = permissionArrayIndexToAdd;
 
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -500,12 +500,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(result).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key = permissionArrayIndexToAdd;
-            let randomValue = "0xcafecafecafecafecafe";
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -513,17 +513,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(canOnlyAddController).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key = permissionArrayIndexToAdd;
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -531,77 +531,77 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(canOnlyAddController).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should not be allowed to set an address", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should not be allowed to set an address', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key = permissionArrayIndexToEdit;
 
             let value = randomWallet.address;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should not be allowed to remove an address", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should not be allowed to remove an address', async () => {
             let key = permissionArrayIndexToEdit;
 
-            let value = "0x";
+            let value = '0x';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission EDITPERMISSIONS", () => {
+      describe('when caller is an address with permission EDITPERMISSIONS', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -609,7 +609,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -617,49 +617,49 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should not be allowed to ADD a permission", async () => {
+        it('should not be allowed to ADD a permission', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it('should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should be allowed to CHANGE a permission", async () => {
+        it('should be allowed to CHANGE a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -671,36 +671,36 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(result).to.equal(value);
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
+        describe('when editing `AddressPermissions[]` array length', () => {
           it("should not be allowed to increment the 'AddressPermissions[]' key (length)", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
             let value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
           });
 
           it("should be allowed to decrement the 'AddressPermissions[]' key (length)", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 32);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -713,31 +713,31 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("when adding a new address at index -> AddressPermissions[6]", () => {
-          it("should not be allowed", async () => {
+        describe('when adding a new address at index -> AddressPermissions[6]', () => {
+          it('should not be allowed', async () => {
             let key = permissionArrayIndexToAdd;
             let value = ethers.Wallet.createRandom().address.toLowerCase();
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
           });
         });
 
-        describe("when editing the value stored at index -> AddressPermissions[4]", () => {
-          it("should be allowed", async () => {
+        describe('when editing the value stored at index -> AddressPermissions[4]', () => {
+          it('should be allowed', async () => {
             let randomWallet = ethers.Wallet.createRandom();
 
             let key = permissionArrayIndexToEdit;
 
             let value = randomWallet.address;
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -749,12 +749,12 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             expect(ethers.utils.getAddress(result)).to.equal(value);
           });
 
-          it("should revert when setting a random 10 bytes value", async () => {
+          it('should revert when setting a random 10 bytes value', async () => {
             let key = permissionArrayIndexToEdit;
-            let randomValue = "0xcafecafecafecafecafe";
+            let randomValue = '0xcafecafecafecafecafe';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -762,17 +762,17 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
 
-          it("should revert when setting a random 30 bytes value", async () => {
+          it('should revert when setting a random 30 bytes value', async () => {
             let key = permissionArrayIndexToEdit;
-            let randomValue = "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef";
+            let randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
 
             // set some random bytes under AddressPermissions[7]
-            let setupPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setupPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               randomValue,
             ]);
@@ -780,19 +780,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(setupPayload))
               .to.be.revertedWithCustomError(
                 context.keyManager,
-                "AddressPermissionArrayIndexValueNotAnAddress",
+                'AddressPermissionArrayIndexValueNotAnAddress',
               )
               .withArgs(key, randomValue);
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should pass", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should pass', async () => {
             let key = permissionArrayIndexToEdit;
 
-            let value = "0x";
+            let value = '0x';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -805,35 +805,35 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           });
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
       });
 
-      describe("when caller is an address with permission SETDATA", () => {
+      describe('when caller is an address with permission SETDATA', () => {
         // ----------------------
         // because we are editing ther permissions of a controller,
         // we need to setup + teardown for each describe blocks
         // related to each controller making the change
-        before("setup permissions", async () => {
+        before('setup permissions', async () => {
           // setup AddressPersmissions:Permissions:<controllers>
           await setupPermissions(context, permissionKeys, permissionValues);
 
@@ -841,7 +841,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           await setupPermissions(context, permissionArrayKeys, permissionArrayValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, [
             ...permissionKeys,
             ...permissionArrayKeys,
@@ -849,164 +849,164 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it("should not be allowed to ADD a permission", async () => {
+        it('should not be allowed to ADD a permission', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value", async () => {
+        it('should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to EDIT a permission", async () => {
+        it('should not be allowed to EDIT a permission', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
 
           let value = PERMISSIONS.SETDATA;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
         });
 
-        describe("when editing `AddressPermissions[]` array length", () => {
-          it("should not be allowed to increment the length", async () => {
-            const key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+        describe('when editing `AddressPermissions[]` array length', () => {
+          it('should not be allowed to increment the length', async () => {
+            const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).add(1).toNumber();
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
           });
 
-          it("should not be allowed to decrement the length", async () => {
-            let key = ERC725YDataKeys.LSP6["AddressPermissions[]"].length;
+          it('should not be allowed to decrement the length', async () => {
+            let key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
 
-            const currentLength = await context.universalProfile["getData(bytes32)"](key);
+            const currentLength = await context.universalProfile['getData(bytes32)'](key);
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
             let value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
           });
         });
 
-        describe("when removing the address at index -> AddressPermissions[4]", () => {
-          it("should revert", async () => {
+        describe('when removing the address at index -> AddressPermissions[4]', () => {
+          it('should revert', async () => {
             let key = permissionArrayIndexToEdit;
 
-            let value = "0x";
+            let value = '0x';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-              .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
           });
         });
 
-        it("should not be allowed to add a new controller address at index -> AddressPermissions[6]", async () => {
+        it('should not be allowed to add a new controller address at index -> AddressPermissions[6]', async () => {
           let key = permissionArrayIndexToAdd;
           let value = ethers.Wallet.createRandom().address.toLowerCase();
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
         });
 
-        it("should not be allowed to edit controller address at index -> AddressPermissions[4]", async () => {
+        it('should not be allowed to edit controller address at index -> AddressPermissions[4]', async () => {
           let randomWallet = ethers.Wallet.createRandom();
 
           let key = permissionArrayIndexToEdit;
 
           let value = randomWallet.address;
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlySetData.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'EDITPERMISSIONS');
         });
 
-        describe("if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key", () => {
-          it("should revert when trying to set a non-standard LSP6 permission data key", async () => {
+        describe('if the data key starts with AddressPermissions: but is a non-standard LSP6 permission data key', () => {
+          it('should revert when trying to set a non-standard LSP6 permission data key', async () => {
             // this include any permission data key that start with bytes8(keccak256('AddressPermissions'))
             let beneficiary = context.accounts[8];
 
             // AddressPermissions:MyCustomPermissions:<address>
-            let key = "0x4b80742de2bf9e659ba40000" + beneficiary.address.substring(2);
+            let key = '0x4b80742de2bf9e659ba40000' + beneficiary.address.substring(2);
 
             // the value does not matter in the case of the test here
-            let value = "0x0000000000000000000000000000000000000000000000000000000000000008";
+            let value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
-            let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             await expect(context.keyManager.connect(canOnlySetData).execute(payload))
-              .to.be.revertedWithCustomError(context.keyManager, "NotRecognisedPermissionKey")
+              .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
         });
@@ -1014,16 +1014,16 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
     });
   });
 
-  describe("setting mixed keys (SETDATA, CHANGE & ADD Permissions)", () => {
+  describe('setting mixed keys (SETDATA, CHANGE & ADD Permissions)', () => {
     let canSetDataAndAddController: SignerWithAddress,
       canSetDataAndEditPermissions: SignerWithAddress;
     // addresses being used to CHANGE (= edit) permissions
     let addressesToEditPermissions: [SignerWithAddress, SignerWithAddress];
 
     const allowedERC725YDataKeys = [
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Third Key")),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Third Key')),
     ];
 
     let permissionKeys: string[];
@@ -1036,19 +1036,19 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       addressesToEditPermissions = [context.accounts[3], context.accounts[4]];
 
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataAndAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataAndAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataAndEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           canSetDataAndEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressesToEditPermissions[0].address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressesToEditPermissions[1].address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
       ];
 
       permissionValues = [
@@ -1064,37 +1064,37 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
       ];
     });
 
-    describe("when setting multiple keys", () => {
-      describe("when caller is an address with ALL PERMISSIONS", () => {
-        before("setup permissions", async () => {
+    describe('when setting multiple keys', () => {
+      describe('when caller is an address with ALL PERMISSIONS', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should pass): 2 x keys + add 2 x new permissions", async () => {
+        it('(should pass): 2 x keys + add 2 x new permissions', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1106,24 +1106,24 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x keys + change 2 x existing permissions", async () => {
+        it('(should pass): 2 x keys + change 2 x existing permissions', async () => {
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 1st Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My 2nd Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 1st Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My 2nd Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1135,26 +1135,26 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(fetchedResult).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)", async () => {
+        it('(should pass): 2 x keys + (add 1 x new permission) + (change 1 x existing permission)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1167,109 +1167,109 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
       });
 
-      describe("when caller is an address with permission SETDATA + ADDCONTROLLER + 3x Allowed ERC725Y data keys", () => {
-        before("setup permissions", async () => {
+      describe('when caller is an address with permission SETDATA + ADDCONTROLLER + 3x Allowed ERC725Y data keys', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should fail): 2 x allowed data keys + add 2 x new controllers + decrement AddressPermissions[].length by -1", async () => {
+        it('(should fail): 2 x allowed data keys + add 2 x new controllers + decrement AddressPermissions[].length by -1', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
             ethers.utils.hexZeroPad(ethers.utils.hexlify(5), 16),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 2 x allowed data keys + edit permissions of 2 x existing controllers", async () => {
+        it('(should fail): 2 x allowed data keys + edit permissions of 2 x existing controllers', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 2 x allowed data keys + (add 1 x new controller) + (edit permission of 1 x existing controller)", async () => {
+        it('(should fail): 2 x allowed data keys + (add 1 x new controller) + (edit permission of 1 x existing controller)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My SecondKey Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My SecondKey Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("(should fail): 1 x allowed data key + 1 x NOT allowed data key + 2 x new controllers", async () => {
+        it('(should fail): 1 x allowed data key + 1 x NOT allowed data key + 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           const NotAllowedERC725YDataKey = ethers.utils.keccak256(
-            ethers.utils.toUtf8Bytes("Not Allowed Data Key"),
+            ethers.utils.toUtf8Bytes('Not Allowed Data Key'),
           );
 
           // prettier-ignore
@@ -1290,37 +1290,37 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             PERMISSIONS.SETDATA,
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             dataKeys,
             dataValues,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(canSetDataAndAddController.address, NotAllowedERC725YDataKey);
         });
 
-        it("(should pass): 2 x allowed data keys + add 2 x new controllers", async () => {
+        it('(should pass): 2 x allowed data keys + add 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My First Key")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Second Key")),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1330,9 +1330,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x allowed data keys + add 2 x new controllers + increment AddressPermissions[].length by +2", async () => {
-          const currentPermissionsArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        it('(should pass): 2 x allowed data keys + add 2 x new controllers + increment AddressPermissions[].length by +2', async () => {
+          const currentPermissionsArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           const newPermissionsArrayLength = ethers.BigNumber.from(currentPermissionsArrayLength)
@@ -1345,22 +1345,22 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
             ethers.utils.hexZeroPad(ethers.utils.hexlify(newPermissionsArrayLength), 16),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1371,48 +1371,48 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         });
       });
 
-      describe("when caller is an address with permission SETDATA + EDITPERMISSIONS + 3x Allowed ERC725Y data keys", () => {
-        before("setup permissions", async () => {
+      describe('when caller is an address with permission SETDATA + EDITPERMISSIONS + 3x Allowed ERC725Y data keys', () => {
+        before('setup permissions', async () => {
           await setupPermissions(context, permissionKeys, permissionValues);
         });
 
-        after("reset permissions", async () => {
+        after('reset permissions', async () => {
           await resetPermissions(context, permissionKeys);
         });
 
-        it("(should fail): 2 x allowed data keys + add 2 x new controllers", async () => {
+        it('(should fail): 2 x allowed data keys + add 2 x new controllers', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
           let newControllerKeyTwo = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyTwo.address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SETDATA,
             PERMISSIONS.SETDATA,
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): 2 x allowed data keys + increment AddressPermissions[].length by +1", async () => {
-          const currentArrayLength = await context.universalProfile["getData(bytes32)"](
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        it('(should fail): 2 x allowed data keys + increment AddressPermissions[].length by +1', async () => {
+          const currentArrayLength = await context.universalProfile['getData(bytes32)'](
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           );
 
           const newArrayLength = ethers.BigNumber.from(currentArrayLength).add(1).toNumber();
@@ -1420,63 +1420,63 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             ethers.utils.hexZeroPad(ethers.utils.hexlify(newArrayLength), 16),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): 2 x allowed data keys + (add 1 x new permission) + (edit permission of 1 x existing controller)", async () => {
+        it('(should fail): 2 x allowed data keys + (add 1 x new permission) + (edit permission of 1 x existing controller)', async () => {
           let newControllerKeyOne = ethers.Wallet.createRandom();
 
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               newControllerKeyOne.address.substr(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substr(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             PERMISSIONS.SIGN,
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canSetDataAndEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canSetDataAndEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("(should fail): edit permissions of 2 x existing controllers + (set 1 x allowed data key) + (set 1 x NOT allowed data key)", async () => {
+        it('(should fail): edit permissions of 2 x existing controllers + (set 1 x allowed data key) + (set 1 x NOT allowed data key)', async () => {
           const NotAllowedERC725YDataKey = ethers.utils.keccak256(
-            ethers.utils.toUtf8Bytes("Not Allowed Data Key"),
+            ethers.utils.toUtf8Bytes('Not Allowed Data Key'),
           );
 
           let keys = [
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
             allowedERC725YDataKeys[0],
             NotAllowedERC725YDataKey,
@@ -1485,38 +1485,38 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           let values = [
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("Random data for not allowed value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Random data for not allowed value')),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
 
           await expect(context.keyManager.connect(canSetDataAndEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAllowedERC725YDataKey")
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAllowedERC725YDataKey')
             .withArgs(canSetDataAndEditPermissions.address, NotAllowedERC725YDataKey);
         });
 
-        it("(should pass): 2 x allowed data keys + edit permissions of 2 x existing controllers", async () => {
+        it('(should pass): 2 x allowed data keys + edit permissions of 2 x existing controllers', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);
@@ -1526,26 +1526,26 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           expect(await context.universalProfile.getDataBatch(keys)).to.deep.equal(values);
         });
 
-        it("(should pass): 2 x allowed data keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2", async () => {
+        it('(should pass): 2 x allowed data keys + remove 2 x addresses with permissions + decrement AddressPermissions[].length by -2', async () => {
           let keys = [
             allowedERC725YDataKeys[0],
             allowedERC725YDataKeys[1],
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[0].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               addressesToEditPermissions[1].address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+            ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
           ];
 
           let values = [
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My First Value")),
-            ethers.utils.hexlify(ethers.utils.toUtf8Bytes("My Second Value")),
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My First Value')),
+            ethers.utils.hexlify(ethers.utils.toUtf8Bytes('My Second Value')),
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
             ethers.utils.hexZeroPad(ethers.utils.hexlify(4), 16),
           ];
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
             keys,
             values,
           ]);

--- a/tests/LSP6KeyManager/SetPermissions/SetAllowedCalls.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/SetAllowedCalls.test.ts
@@ -1,23 +1,23 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS, INTERFACE_IDS, CALLTYPE } from "../../../constants";
+import { ERC725YDataKeys, PERMISSIONS, INTERFACE_IDS, CALLTYPE } from '../../../constants';
 
 // helpers
-import { combineAllowedCalls } from "../../utils/helpers";
+import { combineAllowedCalls } from '../../utils/helpers';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 export const shouldBehaveLikeSettingAllowedCalls = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("deleting AllowedCalls", () => {
+  describe('deleting AllowedCalls', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress;
@@ -35,15 +35,15 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       noBytes = context.accounts[5];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + invalidBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + noBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + invalidBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + noBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + invalidBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + noBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + invalidBytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + noBytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -55,45 +55,45 @@ export const shouldBehaveLikeSettingAllowedCalls = (
           // allow the beneficiary to transfer value to addresses 0xcafe... and 0xbeef...
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0xbadbadbadbad",
-        "0x",
+        '0xbadbadbadbad',
+        '0x',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADD permission", () => {
-      it("should revert and not be allowed to clear the list of allowed calls for an address", async () => {
+    describe('when caller has ADD permission', () => {
+      it('should revert and not be allowed to clear the list of allowed calls for an address', async () => {
         const dataKey =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
-        const dataValue = "0x";
+        const dataValue = '0x';
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           dataKey,
           dataValue,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(setDataPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
     });
 
-    describe("when caller has CHANGE permission", () => {
-      it("should allow to clear the list of allowed calls for an address", async () => {
+    describe('when caller has CHANGE permission', () => {
+      it('should allow to clear the list of allowed calls for an address', async () => {
         const dataKey =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
-        const dataValue = "0x";
+        const dataValue = '0x';
 
-        const setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           dataKey,
           dataValue,
         ]);
@@ -106,7 +106,7 @@ export const shouldBehaveLikeSettingAllowedCalls = (
     });
   });
 
-  describe("setting Allowed Calls -> Addresses", () => {
+  describe('setting Allowed Calls -> Addresses', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -126,15 +126,15 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -144,49 +144,49 @@ export const shouldBehaveLikeSettingAllowedCalls = (
           // allow the beneficiary to transfer value to addresses 0xcafe... and 0xbeef...
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has permission ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed addresses for an address", async () => {
+    describe('when caller has permission ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed addresses for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xca11ca11ca11ca11ca11ca11ca11ca11ca11ca11",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xca11ca11ca11ca11ca11ca11ca11ca11ca11ca11',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompatBytesArray]", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompatBytesArray]', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         // try to set for the invalidBeneficiary some allowed calls
@@ -194,98 +194,98 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         // set for the newController some allowed calls
         // that allow it to transfer value to addresses 0xcafe... and 0xbeef...
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -297,79 +297,79 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] for a new beneficiary", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] for a new beneficiary', () => {
+        it('should revert with error when value = random bytes', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length bytes)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0x00000001cafecafecafecafecafecafecafecafecafecafeffffffffffffffff";
+          let value = '0x00000001cafecafecafecafecafecafecafecafecafecafeffffffffffffffff';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has permission EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has permission EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         // try to set for the newController some allowed calls
         // that allow it to transfer value to addresses 0xcafe... and 0xbeef...
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed addresses for an address", async () => {
+      it('should pass when trying to edit existing allowed addresses for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         // edit the allowed calls of the beneficiary
@@ -378,14 +378,14 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xf00df00df00df00df00df00df00df00df00df00d",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xf00df00df00df00df00df00df00df00df00df00d',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -397,23 +397,23 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         // set some allowed calls for the beneficiary
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -428,22 +428,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -458,22 +458,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed addresses", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed addresses', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
-            "0xcafecafecafecafecafecafecafecafecafecafe",
-            "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            '0xcafecafecafecafecafecafecafecafecafecafe',
+            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -485,45 +485,45 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of allowed calls from existing ANY:<address>:ANY to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of allowed calls from existing ANY:<address>:ANY to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing the first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0x00000001cafecafecafecafecafecafecafecafecafecafeffffffffffffffff";
+          let value = '0x00000001cafecafecafecafecafecafecafecafecafecafeffffffffffffffff';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
   });
 
-  describe("setting Allowed Calls -> Functions", () => {
+  describe('setting Allowed Calls -> Functions', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -543,15 +543,15 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -560,147 +560,147 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has permission ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed functions for an address", async () => {
+    describe('when caller has permission ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed functions for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to make a CALL to only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to make a CALL to only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xca11ca11"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xca11ca11'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xca11ca11"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xca11ca11'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xf00df00d
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xf00df00d"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xf00df00d'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -712,92 +712,92 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] for a new beneficiary", () => {
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (= random bytes)", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] for a new beneficiary', () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (= random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0x00000002ffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0x00000002ffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed bytes4 selectors under ANY:ANY:<selector>", async () => {
+      it('should pass when trying to edit existing allowed bytes4 selectors under ANY:ANY:<selector>', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -809,23 +809,23 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           // allow beneficiary to CALL only function selectors 0xcafecafe and 0xbeefbeef
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -840,22 +840,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -870,22 +870,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed functions", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed functions', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
-          ["0xffffffff", "0xffffffff"],
-          ["0xcafecafe", "0xbeefbeef"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xcafecafe', '0xbeefbeef'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -897,45 +897,45 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of selectors in allowed calls from existing ANY:ANY:<selector> to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of selectors in allowed calls from existing ANY:ANY:<selector> to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0x00000002ffffffffffffffffffffffffffffffffffffffffffffffffcafecafe";
+          let value = '0x00000002ffffffffffffffffffffffffffffffffffffffffffffffffcafecafe';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
   });
 
-  describe("setting Allowed Calls -> Standards", () => {
+  describe('setting Allowed Calls -> Standards', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -955,15 +955,15 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + beneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + zero40Bytes.address.substring(2),
       ];
 
       let permissionValues = [
@@ -974,33 +974,33 @@ export const shouldBehaveLikeSettingAllowedCalls = (
           // on any LSP7 or ERC20 contracts
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         ),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADDCONTROLLER", () => {
-      it("should fail when trying to edit existing allowed standards for an address", async () => {
+    describe('when caller has ADDCONTROLLER', () => {
+      it('should fail when trying to edit existing allowed standards for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1011,31 +1011,31 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should fail with NotAuthorised -> when beneficiary address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1046,34 +1046,34 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1081,34 +1081,34 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1116,32 +1116,32 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      it("should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]", async () => {
+      it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1152,10 +1152,10 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1167,89 +1167,89 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when setting an invalid bytes28[CompactBytesArray] of allowed calls for a new beneficiary", () => {
-        it("should fail when setting an bytes28[CompactBytesArray] (= random bytes)", async () => {
+      describe('when setting an invalid bytes28[CompactBytesArray] of allowed calls for a new beneficiary', () => {
+        it('should fail when setting an bytes28[CompactBytesArray] (= random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should fail when setting an invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             newController.address.substr(2);
 
-          let value = "0x00000002ffffffffffffffffffffffffffffffffffffffffcafecafeffffffff";
+          let value = '0x00000002ffffffffffffffffffffffffffffffffffffffffcafecafeffffffff';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      it("should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      it('should fail when beneficiary had no values set under AddressPermissions:AllowedCalls:...', async () => {
         let newController = ethers.Wallet.createRandom();
 
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + newController.address.substr(2);
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + newController.address.substr(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           // try to add in the list of allowed calls for the beneficiary controller
           // the rights to CALL any LSP7 or ERC20 token contract
           // (NB: just the AllowedCalls, not the permission CALL)
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
 
         await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
       });
 
-      it("should pass when trying to edit existing allowed standards for an address", async () => {
+      it('should pass when trying to edit existing allowed standards for an address', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           beneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [
             INTERFACE_IDS.LSP7DigitalAsset,
@@ -1260,10 +1260,10 @@ export const shouldBehaveLikeSettingAllowedCalls = (
             INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
             INTERFACE_IDS.ERC721,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1275,22 +1275,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      it("should pass when address had an invalid bytes28[CompactBytesArray] initially", async () => {
+      it('should pass when address had an invalid bytes28[CompactBytesArray] initially', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           invalidBeneficiary.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1305,22 +1305,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 32 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero32Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1335,22 +1335,22 @@ export const shouldBehaveLikeSettingAllowedCalls = (
       /**
        * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
        */
-      it.skip("should pass when address had 40 x 0 bytes set initially as allowed calls", async () => {
+      it.skip('should pass when address had 40 x 0 bytes set initially as allowed calls', async () => {
         let key =
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           zero40Bytes.address.substring(2);
 
         let value = combineAllowedCalls(
           [CALLTYPE.CALL, CALLTYPE.CALL],
           [
-            "0xffffffffffffffffffffffffffffffffffffffff",
-            "0xffffffffffffffffffffffffffffffffffffffff",
+            '0xffffffffffffffffffffffffffffffffffffffff',
+            '0xffffffffffffffffffffffffffffffffffffffff',
           ],
           [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
         );
 
-        let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let payload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -1362,38 +1362,38 @@ export const shouldBehaveLikeSettingAllowedCalls = (
         expect(result).to.equal(value);
       });
 
-      describe("when changing the list of interface IDs in allowed calls <standard>:ANY:ANY to an invalid value", () => {
-        it("should revert with error when value = random bytes", async () => {
+      describe('when changing the list of interface IDs in allowed calls <standard>:ANY:ANY to an invalid value', () => {
+        it('should revert with error when value = random bytes', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
 
-        it("should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)", async () => {
+        it('should revert with error when value = invalid bytes28[CompactBytesArray] (not enough bytes, missing first length byte)', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             beneficiary.address.substring(2);
 
-          let value = "0x00000002ffffffffffffffffffffffffffffffffffffffffcafecafeffffffff";
+          let value = '0x00000002ffffffffffffffffffffffffffffffffffffffffcafecafeffffffff';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidEncodedAllowedCalls")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidEncodedAllowedCalls')
             .withArgs(value);
         });
       });

--- a/tests/LSP6KeyManager/SetPermissions/SetAllowedERC725YDataKeys.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/SetAllowedERC725YDataKeys.test.ts
@@ -1,21 +1,21 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS } from '../../../constants';
 
 // helpers
-import { encodeCompactBytesArray } from "../../utils/helpers";
-import { LSP6TestContext } from "../../utils/context";
-import { setupKeyManager } from "../../utils/fixtures";
+import { encodeCompactBytesArray } from '../../utils/helpers';
+import { LSP6TestContext } from '../../utils/context';
+import { setupKeyManager } from '../../utils/fixtures';
 
 export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
   buildContext: () => Promise<LSP6TestContext>,
 ) => {
   let context: LSP6TestContext;
 
-  describe("setting Allowed ERC725YDataKeys", () => {
+  describe('setting Allowed ERC725YDataKeys', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
     let beneficiary: SignerWithAddress,
@@ -35,17 +35,17 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
       zero40Bytes = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           zero40Bytes.address.substring(2),
       ];
 
@@ -53,85 +53,85 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
         PERMISSIONS.ADDCONTROLLER,
         PERMISSIONS.EDITPERMISSIONS,
         encodeCompactBytesArray([
-          ERC725YDataKeys.LSP3["LSP3Profile"],
+          ERC725YDataKeys.LSP3['LSP3Profile'],
           // prettier-ignore
           ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
         ]),
-        "0x11223344",
-        "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        '0x11223344',
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000',
       ];
 
       await setupKeyManager(context, permissionKeys, permissionValues);
     });
 
-    describe("when caller has ADDCONTROLLER", () => {
-      describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should fail when adding an extra allowed ERC725Y data key", async () => {
+    describe('when caller has ADDCONTROLLER', () => {
+      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should fail when adding an extra allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
           let value = encodeCompactBytesArray([
-            ERC725YDataKeys.LSP3["LSP3Profile"],
+            ERC725YDataKeys.LSP3['LSP3Profile'],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
           ]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when removing an allowed ERC725Y data key", async () => {
+        it('should fail when removing an allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when trying to clear the CompactedBytesArray completely", async () => {
+        it('should fail when trying to clear the CompactedBytesArray completely', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0x";
+          let value = '0x';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyAddController.address, "EDITPERMISSIONS");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -139,18 +139,18 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
             .to.be.revertedWithCustomError(
               context.keyManager,
-              "InvalidEncodedAllowedERC725YDataKeys",
+              'InvalidEncodedAllowedERC725YDataKeys',
             )
             .withArgs(value, "couldn't VALIDATE the data value");
         });
       });
 
-      describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should pass when setting a valid CompactedBytesArray", async () => {
+      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should pass when setting a valid CompactedBytesArray', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
           let value = encodeCompactBytesArray([
@@ -160,7 +160,7 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 2")),
           ]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -172,16 +172,16 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid CompactedBytesArray (random bytes)", async () => {
+        it('should fail when setting an invalid CompactedBytesArray (random bytes)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -189,29 +189,29 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
             .to.be.revertedWithCustomError(
               context.keyManager,
-              "InvalidEncodedAllowedERC725YDataKeys",
+              'InvalidEncodedAllowedERC725YDataKeys',
             )
             .withArgs(value, "couldn't VALIDATE the data value");
         });
       });
     });
 
-    describe("when caller has EDITPERMISSIONS", () => {
-      describe("when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should pass when adding an extra allowed ERC725Y data key", async () => {
+    describe('when caller has EDITPERMISSIONS', () => {
+      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should pass when adding an extra allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
           let value = encodeCompactBytesArray([
-            ERC725YDataKeys.LSP3["LSP3Profile"],
+            ERC725YDataKeys.LSP3['LSP3Profile'],
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
           ]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -223,14 +223,14 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when removing an allowed ERC725Y data key", async () => {
+        it('should pass when removing an allowed ERC725Y data key', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3["LSP3Profile"]]);
+          let value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -242,14 +242,14 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should pass when trying to clear the CompactedBytesArray completely", async () => {
+        it('should pass when trying to clear the CompactedBytesArray completely', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0x";
+          let value = '0x';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -261,14 +261,14 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           expect(result).to.equal(value);
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             beneficiary.address.substring(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -276,45 +276,45 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
             .to.be.revertedWithCustomError(
               context.keyManager,
-              "InvalidEncodedAllowedERC725YDataKeys",
+              'InvalidEncodedAllowedERC725YDataKeys',
             )
             .withArgs(value, "couldn't VALIDATE the data value");
         });
       });
 
-      describe("when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...", () => {
-        it("should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)", async () => {
+      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+        it('should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
           let value = encodeCompactBytesArray([
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 1")),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Key 2")),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 1')),
+            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 2')),
           ]);
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-            .withArgs(canOnlyEditPermissions.address, "ADDCONTROLLER");
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it("should fail when setting an invalid CompactedBytesArray", async () => {
+        it('should fail when setting an invalid CompactedBytesArray', async () => {
           let newController = ethers.Wallet.createRandom();
 
           let key =
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
             newController.address.substr(2);
 
-          let value = "0xbadbadbadbad";
+          let value = '0xbadbadbadbad';
 
-          let payload = context.universalProfile.interface.encodeFunctionData("setData", [
+          let payload = context.universalProfile.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
@@ -322,7 +322,7 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
             .to.be.revertedWithCustomError(
               context.keyManager,
-              "InvalidEncodedAllowedERC725YDataKeys",
+              'InvalidEncodedAllowedERC725YDataKeys',
             )
             .withArgs(value, "couldn't VALIDATE the data value");
         });

--- a/tests/LSP6KeyManager/index.ts
+++ b/tests/LSP6KeyManager/index.ts
@@ -1,42 +1,42 @@
 // Admin
-export * from "./Admin/PermissionChangeOwner.test";
-export * from "./Admin/PermissionChangeAddExtensions.test";
-export * from "./Admin/PermissionChangeAddURD.test";
-export * from "./Admin/PermissionSign.test";
+export * from './Admin/PermissionChangeOwner.test';
+export * from './Admin/PermissionChangeAddExtensions.test';
+export * from './Admin/PermissionChangeAddURD.test';
+export * from './Admin/PermissionSign.test';
 
 // Set Permissions
-export * from "./SetPermissions/PermissionChangeAddController.test";
-export * from "./SetPermissions/SetAllowedCalls.test";
-export * from "./SetPermissions/SetAllowedERC725YDataKeys.test";
+export * from './SetPermissions/PermissionChangeAddController.test';
+export * from './SetPermissions/SetAllowedCalls.test';
+export * from './SetPermissions/SetAllowedERC725YDataKeys.test';
 
 // Interactions
-export * from "./Interactions/InvalidExecutePayloads.test";
-export * from "./Interactions/PermissionCall.test";
-export * from "./Interactions/PermissionStaticCall.test";
-export * from "./Interactions/PermissionDelegateCall.test";
-export * from "./Interactions/PermissionDeploy.test";
-export * from "./Interactions/PermissionTransferValue.test";
-export * from "./Interactions/AllowedAddresses.test";
-export * from "./Interactions/AllowedFunctions.test";
-export * from "./Interactions/AllowedStandards.test";
+export * from './Interactions/InvalidExecutePayloads.test';
+export * from './Interactions/PermissionCall.test';
+export * from './Interactions/PermissionStaticCall.test';
+export * from './Interactions/PermissionDelegateCall.test';
+export * from './Interactions/PermissionDeploy.test';
+export * from './Interactions/PermissionTransferValue.test';
+export * from './Interactions/AllowedAddresses.test';
+export * from './Interactions/AllowedFunctions.test';
+export * from './Interactions/AllowedStandards.test';
 
 // Batch
-export * from "./Interactions/BatchExecute.test";
+export * from './Interactions/BatchExecute.test';
 
 // Relay
-export * from "./Relay/MultiChannelNonce.test";
-export * from "./Relay/ExecuteRelayCall.test";
+export * from './Relay/MultiChannelNonce.test';
+export * from './Relay/ExecuteRelayCall.test';
 
 // Set Data
-export * from "./SetData/PermissionSetData.test";
-export * from "./SetData/AllowedERC725YDataKeys.test";
+export * from './SetData/PermissionSetData.test';
+export * from './SetData/AllowedERC725YDataKeys.test';
 
 // Others
-export * from "./LSP6ControlledToken.test";
+export * from './LSP6ControlledToken.test';
 
 // Internals (Unit Tests for internal functions)
-export * from "./internals/AllowedCalls.internal";
-export * from "./internals/AllowedERC725YDataKeys.internal";
-export * from "./internals/ReadPermissions.internal";
-export * from "./internals/SetData.internal";
-export * from "./internals/Execute.internal";
+export * from './internals/AllowedCalls.internal';
+export * from './internals/AllowedERC725YDataKeys.internal';
+export * from './internals/ReadPermissions.internal';
+export * from './internals/SetData.internal';
+export * from './internals/Execute.internal';

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -1,8 +1,8 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract, TargetContract__factory, UniversalProfile__factory } from "../../../types";
+import { TargetContract, TargetContract__factory, UniversalProfile__factory } from '../../../types';
 
 // constants
 import {
@@ -11,22 +11,22 @@ import {
   OPERATION_TYPES,
   PERMISSIONS,
   CALLTYPE,
-} from "../../../constants";
+} from '../../../constants';
 
 // setup
-import { LSP6InternalsTestContext } from "../../utils/context";
-import { setupKeyManagerHelper } from "../../utils/fixtures";
+import { LSP6InternalsTestContext } from '../../utils/context';
+import { setupKeyManagerHelper } from '../../utils/fixtures';
 
 // helpers
-import { combinePermissions, combineAllowedCalls, combineCallTypes } from "../../utils/helpers";
+import { combinePermissions, combineAllowedCalls, combineCallTypes } from '../../utils/helpers';
 
 async function teardownKeyManagerHelper(
   context: LSP6InternalsTestContext,
   permissionsKeys: string[],
 ) {
-  const teardownPayload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+  const teardownPayload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
     permissionsKeys,
-    Array(permissionsKeys.length).fill("0x"),
+    Array(permissionsKeys.length).fill('0x'),
   ]);
 
   await context.keyManagerInternalTester.connect(context.owner).execute(teardownPayload);
@@ -41,14 +41,14 @@ export const testAllowedCallsInternals = (
     context = await buildContext();
   });
 
-  describe("`isCompactBytesArrayOfAllowedCalls`", () => {
-    describe("when passing a compact bytes array with 1 element", () => {
-      it("should return `true` if element is 32 bytes long", async () => {
+  describe('`isCompactBytesArrayOfAllowedCalls`', () => {
+    describe('when passing a compact bytes array with 1 element', () => {
+      it('should return `true` if element is 32 bytes long', async () => {
         const allowedCalls = combineAllowedCalls(
           [CALLTYPE.VALUE],
           [context.accounts[5].address],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0xffffffff'],
+          ['0xffffffff'],
         );
 
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
@@ -58,7 +58,7 @@ export const testAllowedCallsInternals = (
         expect(result).to.be.true;
       });
 
-      it("should return `false` if element is not 28 bytes long", async () => {
+      it('should return `false` if element is not 28 bytes long', async () => {
         const allowedCalls = ethers.utils.hexlify(ethers.utils.randomBytes(27));
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
           allowedCalls,
@@ -66,24 +66,24 @@ export const testAllowedCallsInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `false` if element is 0x0000 (zero length elements not allowed)", async () => {
-        const allowedCalls = "0x0000";
+      it('should return `false` if element is 0x0000 (zero length elements not allowed)', async () => {
+        const allowedCalls = '0x0000';
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
           allowedCalls,
         );
         expect(result).to.be.false;
       });
 
-      it("should return `false` if there are just 2 x length bytes but not followed by the value (the allowed calls)", async () => {
-        const allowedCalls = "0x001c";
+      it('should return `false` if there are just 2 x length bytes but not followed by the value (the allowed calls)', async () => {
+        const allowedCalls = '0x001c';
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
           allowedCalls,
         );
         expect(result).to.be.false;
       });
 
-      it("should return `false` if there are just 2 x length bytes equal to `0x0002`", async () => {
-        const allowedCalls = "0x0002";
+      it('should return `false` if there are just 2 x length bytes equal to `0x0002`', async () => {
+        const allowedCalls = '0x0002';
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
           allowedCalls,
         );
@@ -91,13 +91,13 @@ export const testAllowedCallsInternals = (
       });
     });
 
-    describe("when passing a compact bytes array with 3 x elements", () => {
-      it("should pass if all elements are 28 bytes long", async () => {
+    describe('when passing a compact bytes array with 3 x elements', () => {
+      it('should pass if all elements are 28 bytes long', async () => {
         const allowedCalls = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE, CALLTYPE.VALUE],
           [context.accounts[5].address, context.accounts[6].address, context.accounts[7].address],
-          ["0xffffffff", "0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
@@ -107,7 +107,7 @@ export const testAllowedCallsInternals = (
         expect(result).to.be.true;
       });
 
-      it("should fail if one of the element is not 28 bytes long", async () => {
+      it('should fail if one of the element is not 28 bytes long', async () => {
         const allowedCalls = combineAllowedCalls(
           [CALLTYPE.VALUE, CALLTYPE.VALUE, CALLTYPE.VALUE],
           [
@@ -115,8 +115,8 @@ export const testAllowedCallsInternals = (
             ethers.utils.hexlify(ethers.utils.randomBytes(27)),
             context.accounts[7].address,
           ],
-          ["0xffffffff", "0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
         );
 
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
@@ -127,7 +127,7 @@ export const testAllowedCallsInternals = (
     });
   });
 
-  describe("testing 2 x addresses encoded as LSP2 CompactBytesArray under `AllowedCalls`", () => {
+  describe('testing 2 x addresses encoded as LSP2 CompactBytesArray under `AllowedCalls`', () => {
     let canCallOnlyTwoAddresses: SignerWithAddress, canCallNoAllowedCalls: SignerWithAddress;
 
     let allowedEOA: SignerWithAddress,
@@ -158,15 +158,15 @@ export const testAllowedCallsInternals = (
           combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
         ],
         [allowedEOA.address.toLowerCase(), allowedTargetContract.address.toLowerCase()],
-        ["0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff'],
       );
 
       let permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canCallOnlyTwoAddresses.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           canCallOnlyTwoAddresses.address.substring(2),
       ];
 
@@ -179,8 +179,8 @@ export const testAllowedCallsInternals = (
       await setupKeyManagerHelper(context, permissionsKeys, permissionsValues);
     });
 
-    describe("`getAllowedCallsFor(...)`", () => {
-      it("should return the list of allowed calls", async () => {
+    describe('`getAllowedCallsFor(...)`', () => {
+      it('should return the list of allowed calls', async () => {
         let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
           canCallOnlyTwoAddresses.address,
         );
@@ -188,28 +188,28 @@ export const testAllowedCallsInternals = (
         expect(bytesResult).to.equal(encodedAllowedCalls);
       });
 
-      it("should return no bytes when no allowed calls were set", async () => {
+      it('should return no bytes when no allowed calls were set', async () => {
         let bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
           context.owner.address,
         );
-        expect(bytesResult).to.equal("0x");
+        expect(bytesResult).to.equal('0x');
 
-        let resultFromAccount = await context.universalProfile["getData(bytes32)"](
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        let resultFromAccount = await context.universalProfile['getData(bytes32)'](
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             context.owner.address.substring(2),
         );
-        expect(resultFromAccount).to.equal("0x");
+        expect(resultFromAccount).to.equal('0x');
       });
     });
 
-    describe("`verifyAllowedCall(...)`", () => {
-      describe("when the ERC725X payload (transfer 1 LYX) is for an address listed in the allowed calls", () => {
-        it("should pass", async () => {
-          const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+    describe('`verifyAllowedCall(...)`', () => {
+      describe('when the ERC725X payload (transfer 1 LYX) is for an address listed in the allowed calls', () => {
+        it('should pass', async () => {
+          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             allowedEOA.address,
-            ethers.utils.parseEther("1"),
-            "0x",
+            ethers.utils.parseEther('1'),
+            '0x',
           ]);
 
           await expect(
@@ -221,17 +221,17 @@ export const testAllowedCallsInternals = (
         });
       });
 
-      describe("when the ERC725X payload (transfer 1 LYX)  is for an address not listed in the allowed calls", () => {
-        it("should revert", async () => {
+      describe('when the ERC725X payload (transfer 1 LYX)  is for an address not listed in the allowed calls', () => {
+        it('should revert', async () => {
           let disallowedAddress = ethers.utils.getAddress(
-            "0xdeadbeefdeadbeefdeaddeadbeefdeadbeefdead",
+            '0xdeadbeefdeadbeefdeaddeadbeefdeadbeefdead',
           );
 
-          const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             disallowedAddress,
-            ethers.utils.parseEther("1"),
-            "0x",
+            ethers.utils.parseEther('1'),
+            '0x',
           ]);
 
           await expect(
@@ -240,20 +240,20 @@ export const testAllowedCallsInternals = (
               payload,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
-            .withArgs(canCallOnlyTwoAddresses.address, disallowedAddress, "0x00000000");
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
+            .withArgs(canCallOnlyTwoAddresses.address, disallowedAddress, '0x00000000');
         });
       });
 
-      describe("when there is nothing stored under `AllowedCalls` for a controller", () => {
-        it("should revert", async () => {
+      describe('when there is nothing stored under `AllowedCalls` for a controller', () => {
+        it('should revert', async () => {
           let randomAddress = ethers.Wallet.createRandom().address;
 
-          const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
             OPERATION_TYPES.CALL,
             randomAddress,
-            ethers.utils.parseEther("1"),
-            "0x",
+            ethers.utils.parseEther('1'),
+            '0x',
           ]);
 
           await expect(
@@ -262,18 +262,18 @@ export const testAllowedCallsInternals = (
               payload,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NoCallsAllowed")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NoCallsAllowed')
             .withArgs(canCallNoAllowedCalls.address);
         });
       });
     });
   });
 
-  describe("`verifyAllowedCall(...)` with `vcsd` permissions per Allowed Call", () => {
+  describe('`verifyAllowedCall(...)` with `vcsd` permissions per Allowed Call', () => {
     // for testing purpose, we use a random payload
     // we are not doing integration tests to tests the effects on the TargetContract
     // we are just testing that the `verifyAllowedCall(...)` function works as expected
-    const randomPayload = "0xcafecafe";
+    const randomPayload = '0xcafecafe';
 
     let targetContractValue: TargetContract,
       targetContractCall: TargetContract,
@@ -282,7 +282,7 @@ export const testAllowedCallsInternals = (
 
     let allowedCalls: string;
 
-    before("setup AllowedCalls", async () => {
+    before('setup AllowedCalls', async () => {
       context = await buildContext();
 
       targetContractValue = await new TargetContract__factory(context.accounts[0]).deploy();
@@ -301,31 +301,31 @@ export const testAllowedCallsInternals = (
           targetContractStaticCall.address,
           targetContractDelegateCall.address,
         ],
-        ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
-        ["0xffffffff", "0xffffffff", "0xffffffff", "0xffffffff"],
+        ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
+        ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
       );
 
       // setup empty allowed calls
       await setupKeyManagerHelper(context, [], []);
     });
 
-    describe("when controller has permission CALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == CALL`", () => {
+    describe('when controller has permission CALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == CALL`', () => {
       let controller: SignerWithAddress;
 
       let permissionKeys: string[];
       let permissionValues: string[];
 
-      before("setup permissions", async () => {
+      before('setup permissions', async () => {
         controller = context.accounts[1];
 
         permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + controller.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + controller.address.substring(2),
         ];
 
         permissionValues = [combinePermissions(PERMISSIONS.CALL), allowedCalls];
 
-        const setup = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        const setup = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           permissionKeys,
           permissionValues,
         ]);
@@ -333,12 +333,12 @@ export const testAllowedCallsInternals = (
         await context.keyManagerInternalTester.connect(context.owner).execute(setup);
       });
 
-      after("reset permissions", async () => {
+      after('reset permissions', async () => {
         await teardownKeyManagerHelper(context, permissionKeys);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContractValue.address,
           0,
@@ -348,12 +348,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
-      it("should pass when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should pass when the allowed address has `c` permission only (`c` = CALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContractCall.address,
           0,
@@ -365,8 +365,8 @@ export const testAllowedCallsInternals = (
         ).to.not.be.reverted;
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContractStaticCall.address,
           0,
@@ -376,12 +376,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractStaticCall.address, randomPayload);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           targetContractDelegateCall.address,
           0,
@@ -391,28 +391,28 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractDelegateCall.address, randomPayload);
       });
     });
 
-    describe("when controller has permission STATICCALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == STATICCALL`", () => {
+    describe('when controller has permission STATICCALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == STATICCALL`', () => {
       let controller: SignerWithAddress;
 
       let permissionKeys: string[];
       let permissionValues: string[];
 
-      before("setup permissions", async () => {
+      before('setup permissions', async () => {
         controller = context.accounts[1];
 
         permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + controller.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + controller.address.substring(2),
         ];
 
         permissionValues = [combinePermissions(PERMISSIONS.STATICCALL), allowedCalls];
 
-        const setup = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        const setup = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           permissionKeys,
           permissionValues,
         ]);
@@ -420,12 +420,12 @@ export const testAllowedCallsInternals = (
         await context.keyManagerInternalTester.connect(context.owner).execute(setup);
       });
 
-      after("reset permissions", async () => {
+      after('reset permissions', async () => {
         await teardownKeyManagerHelper(context, permissionKeys);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContractValue.address,
           0,
@@ -435,12 +435,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContractCall.address,
           0,
@@ -450,12 +450,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractCall.address, randomPayload);
       });
 
-      it("should pass when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should pass when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContractStaticCall.address,
           0,
@@ -467,8 +467,8 @@ export const testAllowedCallsInternals = (
         ).to.not.be.reverted;
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.STATICCALL,
           targetContractDelegateCall.address,
           0,
@@ -478,28 +478,28 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractDelegateCall.address, randomPayload);
       });
     });
 
-    describe("when controller has permission DELEGATECALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == DELEGATECALL`", () => {
+    describe('when controller has permission DELEGATECALL + some AllowedCalls + does `ERC725X.execute(...)` with `operationType == DELEGATECALL`', () => {
       let controller: SignerWithAddress;
 
       let permissionKeys: string[];
       let permissionValues: string[];
 
-      before("setup permissions", async () => {
+      before('setup permissions', async () => {
         controller = context.accounts[1];
 
         permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + controller.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + controller.address.substring(2),
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + controller.address.substring(2),
         ];
 
         permissionValues = [combinePermissions(PERMISSIONS.DELEGATECALL), allowedCalls];
 
-        const setup = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        const setup = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           permissionKeys,
           permissionValues,
         ]);
@@ -507,12 +507,12 @@ export const testAllowedCallsInternals = (
         await context.keyManagerInternalTester.connect(context.owner).execute(setup);
       });
 
-      after("reset permissions", async () => {
+      after('reset permissions', async () => {
         await teardownKeyManagerHelper(context, permissionKeys);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           targetContractValue.address,
           0,
@@ -522,12 +522,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           targetContractCall.address,
           0,
@@ -537,12 +537,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractCall.address, randomPayload);
       });
 
-      it("should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           targetContractStaticCall.address,
           0,
@@ -552,12 +552,12 @@ export const testAllowedCallsInternals = (
         await expect(
           context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
         )
-          .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractStaticCall.address, randomPayload);
       });
 
-      it("should pass when the allowed address has `d` permission only (`d` = DELEGATECALL)", async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      it('should pass when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
+        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.DELEGATECALL,
           targetContractDelegateCall.address,
           0,
@@ -584,14 +584,14 @@ export const testAllowedCallsInternals = (
     };
 
     const zeroBytesValues = [
-      "0x",
-      "0x" + "00".repeat(1),
-      "0x" + "00".repeat(10),
-      "0x" + "00".repeat(20),
-      "0x" + "00".repeat(32),
-      "0x" + "00".repeat(40),
-      "0x" + "00".repeat(64),
-      "0x" + "00".repeat(100),
+      '0x',
+      '0x' + '00'.repeat(1),
+      '0x' + '00'.repeat(10),
+      '0x' + '00'.repeat(20),
+      '0x' + '00'.repeat(32),
+      '0x' + '00'.repeat(40),
+      '0x' + '00'.repeat(64),
+      '0x' + '00'.repeat(100),
     ];
 
     let controller: ControllersContext;
@@ -611,15 +611,15 @@ export const testAllowedCallsInternals = (
       };
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
         ...Object.values(controller).map(
           (controller) =>
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controller.address.substring(2),
         ),
         ...Object.values(controller).map(
           (controller) =>
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             controller.address.substring(2),
         ),
       ];
@@ -635,20 +635,20 @@ export const testAllowedCallsInternals = (
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
-    describe("`verifyAllowedCall(...)`", () => {
+    describe('`verifyAllowedCall(...)`', () => {
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
-      const randomData = "0xaabbccdd";
+      const randomData = '0xaabbccdd';
 
       const universalProfileInterface = UniversalProfile__factory.createInterface();
 
-      let payload: string = universalProfileInterface.encodeFunctionData("execute", [
+      let payload: string = universalProfileInterface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         randomAddress,
-        ethers.utils.parseEther("1"),
+        ethers.utils.parseEther('1'),
         randomData,
       ]);
 
-      describe("should revert with `NoAllowedCall` error", () => {
+      describe('should revert with `NoAllowedCall` error', () => {
         it(`noBytes -> ${zeroBytesValues[0]}`, async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(controller.noBytes.address, payload),
@@ -686,7 +686,7 @@ export const testAllowedCallsInternals = (
       /**
        * TODO: define the new behaviour when some empty zero bytes 0x00 are stored under `AddressPermissions:AllowedCalls:<address>`
        */
-      describe("should revert with NotAllowedCall(...) error for:", () => {
+      describe('should revert with NotAllowedCall(...) error for:', () => {
         it.skip(`thirtyTwoZeroBytes -> ${zeroBytesValues[4]}`, async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
@@ -694,7 +694,7 @@ export const testAllowedCallsInternals = (
               payload,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
             .withArgs(
               controller.thirtyTwoZeroBytes.address,
               ethers.utils.getAddress(randomAddress),
@@ -709,7 +709,7 @@ export const testAllowedCallsInternals = (
               randomAddress,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
             .withArgs(
               controller.fourtyZeroBytes.address,
               ethers.utils.getAddress(randomAddress),
@@ -724,7 +724,7 @@ export const testAllowedCallsInternals = (
               randomAddress,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedAddress")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedAddress')
             .withArgs(
               controller.sixtyFourZeroBytes.address,
               ethers.utils.getAddress(randomAddress),
@@ -738,14 +738,14 @@ export const testAllowedCallsInternals = (
               randomAddress,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedAddress")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedAddress')
             .withArgs(controller.hundredZeroBytes.address, ethers.utils.getAddress(randomAddress));
         });
       });
     });
   });
 
-  describe("testing random values under the key `AddressPermissions:AllowedCalls:<address>`", () => {
+  describe('testing random values under the key `AddressPermissions:AllowedCalls:<address>`', () => {
     type ControllersContext = {
       multipleOf29Bytes: SignerWithAddress;
       shortBytes: SignerWithAddress;
@@ -753,13 +753,13 @@ export const testAllowedCallsInternals = (
     };
 
     const randomValues = [
-      "0x001c00000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000",
-      "0xaabbccdd",
-      "0x1234567890abcdef1234567890abcdef1234",
+      '0x001c00000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000',
+      '0xaabbccdd',
+      '0x1234567890abcdef1234567890abcdef1234',
     ];
 
     const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
-    const randomData = "0xaabbccdd";
+    const randomData = '0xaabbccdd';
 
     let payload: string;
     let controller: ControllersContext;
@@ -767,10 +767,10 @@ export const testAllowedCallsInternals = (
     before(async () => {
       context = await buildContext();
 
-      payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         randomAddress,
-        ethers.utils.parseEther("1"),
+        ethers.utils.parseEther('1'),
         randomData,
       ]);
 
@@ -781,18 +781,18 @@ export const testAllowedCallsInternals = (
       };
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controller.multipleOf29Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controller.shortBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controller.longBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           controller.multipleOf29Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           controller.shortBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           controller.longBytes.address.substring(2),
       ];
 
@@ -808,8 +808,8 @@ export const testAllowedCallsInternals = (
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
-    describe("`verifyAllowedCall(...)`", () => {
-      describe("should revert with NotAllowedCall(...) error for:", () => {
+    describe('`verifyAllowedCall(...)`', () => {
+      describe('should revert with NotAllowedCall(...) error for:', () => {
         // this test is invalid
         it.skip(`multipleOf29Bytes -> ${randomValues[0]}`, async () => {
           await expect(
@@ -818,7 +818,7 @@ export const testAllowedCallsInternals = (
               payload,
             ),
           )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, "NotAllowedCall")
+            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
             .withArgs(
               controller.multipleOf29Bytes.address,
               ethers.utils.getAddress(randomAddress),
@@ -827,7 +827,7 @@ export const testAllowedCallsInternals = (
         });
       });
 
-      describe("should revert", () => {
+      describe('should revert', () => {
         it(`shortBytes -> ${randomValues[1]}`, async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
@@ -850,7 +850,7 @@ export const testAllowedCallsInternals = (
     });
   });
 
-  describe("when caller as `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff` in its allowed calls", () => {
+  describe('when caller as `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff` in its allowed calls', () => {
     let anyAllowedCalls: SignerWithAddress;
 
     before(async () => {
@@ -859,10 +859,10 @@ export const testAllowedCallsInternals = (
       anyAllowedCalls = context.accounts[1];
 
       let permissionsKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           anyAllowedCalls.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
           anyAllowedCalls.address.substring(2),
       ];
 
@@ -874,31 +874,31 @@ export const testAllowedCallsInternals = (
           // as they are for the call types
           // the test below should revert regardless of the call type
           // TODO: is this the correct behaviour?
-          ["0x00000000"],
-          ["0xffffffffffffffffffffffffffffffffffffffff"],
-          ["0xffffffff"],
-          ["0xffffffff"],
+          ['0x00000000'],
+          ['0xffffffffffffffffffffffffffffffffffffffff'],
+          ['0xffffffff'],
+          ['0xffffffff'],
         ),
       ];
 
       await setupKeyManagerHelper(context, permissionsKeys, permissionsValues);
     });
 
-    it("should revert", async () => {
-      const randomData = "0xaabbccdd";
+    it('should revert', async () => {
+      const randomData = '0xaabbccdd';
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
-      const payload = context.universalProfile.interface.encodeFunctionData("execute", [
+      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         randomAddress,
-        ethers.utils.parseEther("1"),
+        ethers.utils.parseEther('1'),
         randomData,
       ]);
 
       await expect(
         context.keyManagerInternalTester.verifyAllowedCall(anyAllowedCalls.address, payload),
       )
-        .to.be.revertedWithCustomError(context.keyManagerInternalTester, "InvalidWhitelistedCall")
+        .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'InvalidWhitelistedCall')
         .withArgs(anyAllowedCalls.address);
     });
   });

--- a/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedERC725YDataKeys.internal.ts
@@ -1,8 +1,8 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { BytesLike } from "ethers";
-import { LSP6InternalsTestContext } from "../../utils/context";
-import { encodeCompactBytesArray } from "../../utils/helpers";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BytesLike } from 'ethers';
+import { LSP6InternalsTestContext } from '../../utils/context';
+import { encodeCompactBytesArray } from '../../utils/helpers';
 
 export type DataKey = {
   length: BytesLike;
@@ -12,7 +12,7 @@ export type DataKey = {
 export const testAllowedERC725YDataKeysInternals = (
   buildContext: () => Promise<LSP6InternalsTestContext>,
 ) => {
-  describe("Testing CheckAllowedERC725YDataKeys", () => {
+  describe('Testing CheckAllowedERC725YDataKeys', () => {
     let context: LSP6InternalsTestContext;
     let dataKeys: {
       firstDynamicKey: DataKey;
@@ -34,49 +34,49 @@ export const testAllowedERC725YDataKeysInternals = (
       context = await buildContext();
       dataKeys = {
         firstDynamicKey: {
-          length: "0x0011",
-          key: "0xaf449139942203369080622073bf7f2dab",
+          length: '0x0011',
+          key: '0xaf449139942203369080622073bf7f2dab',
         },
         secondDynamicKey: {
-          length: "0x0001",
-          key: "0x1c",
+          length: '0x0001',
+          key: '0x1c',
         },
         thirdDynamicKey: {
-          length: "0x001c",
-          key: "0x4f042128e305e375c54b8782c3f9f1bde93f3586649d48db9c68beef",
+          length: '0x001c',
+          key: '0x4f042128e305e375c54b8782c3f9f1bde93f3586649d48db9c68beef',
         },
         fourthDynamicKey: {
-          length: "0x0015",
-          key: "0xe6e8c1d23558e2a87caf19b7cc928eff323881d3e6",
+          length: '0x0015',
+          key: '0xe6e8c1d23558e2a87caf19b7cc928eff323881d3e6',
         },
         firstFixedKey: {
-          length: "0x0020",
-          key: "0xcbfb606f69bb97c04cbaea2a8b7cb13a2e229fafa3fb3be6db11d96ee3add114",
+          length: '0x0020',
+          key: '0xcbfb606f69bb97c04cbaea2a8b7cb13a2e229fafa3fb3be6db11d96ee3add114',
         },
         secondFixedKey: {
-          length: "0x0020",
-          key: "0xa2c116feaaf87e499ac78081e8ce74b0a85627265144d605904971a89f81220a",
+          length: '0x0020',
+          key: '0xa2c116feaaf87e499ac78081e8ce74b0a85627265144d605904971a89f81220a',
         },
         thirdFixedKey: {
-          length: "0x0020",
-          key: "0x7b68176ed8c5774f16c8040df3f2c4aac9959612242613785716c4263670fe18",
+          length: '0x0020',
+          key: '0x7b68176ed8c5774f16c8040df3f2c4aac9959612242613785716c4263670fe18',
         },
         fourthFixedKey: {
-          length: "0x0020",
-          key: "0x2b58178172d258515ef1d9e7c467f6f6a09510e863ef5ad383dbfc50721183df",
+          length: '0x0020',
+          key: '0x2b58178172d258515ef1d9e7c467f6f6a09510e863ef5ad383dbfc50721183df',
         },
       };
       dataKeysToReturn = [
-        "0x6fae27edb0b5020ca98b9af9014331fcc79241c7f12d6afbcaea07f00e53b45d",
-        "0xfd63b8f031e1f4c43fbb4956e08c686aa350a051d4d3e77a1e1c7f70366207b2",
-        "0xf4fafa18dc0e9916a17a5d14b39a4dc68fb56cfaf964aceca8456b424331adb4",
-        "0x92f9ce0fd87f5477d0aec48786bfebf80a51700879505dea17852f0777b114d3",
-        "0x0c02c965d192a6666110f3806dc2cd489ce2f7ca43f08a9ff33ad74d2fb30dc7",
-        "0x108eae0761cc2f55fab5acf94bc557dd0e550e60be19de83c513cd17821227a8",
-        "0xe2bfbedc99949767be4c79d5d10deaffc1c207560d29e4070f450faabb562d3b",
-        "0xe5f29667509d955384331154d9fa3b9e53ae230c44e722983a42f4d9608ef9b6",
-        "0x9fedfe7c7366c70c52b6f11531196d0c5baa77abd16117ae30dc4eeb16dd6da2",
-        "0x8741530fb57ca8556c5e7b45ffac62c178d8c0ff070ff1c99652e3f099997fa6",
+        '0x6fae27edb0b5020ca98b9af9014331fcc79241c7f12d6afbcaea07f00e53b45d',
+        '0xfd63b8f031e1f4c43fbb4956e08c686aa350a051d4d3e77a1e1c7f70366207b2',
+        '0xf4fafa18dc0e9916a17a5d14b39a4dc68fb56cfaf964aceca8456b424331adb4',
+        '0x92f9ce0fd87f5477d0aec48786bfebf80a51700879505dea17852f0777b114d3',
+        '0x0c02c965d192a6666110f3806dc2cd489ce2f7ca43f08a9ff33ad74d2fb30dc7',
+        '0x108eae0761cc2f55fab5acf94bc557dd0e550e60be19de83c513cd17821227a8',
+        '0xe2bfbedc99949767be4c79d5d10deaffc1c207560d29e4070f450faabb562d3b',
+        '0xe5f29667509d955384331154d9fa3b9e53ae230c44e722983a42f4d9608ef9b6',
+        '0x9fedfe7c7366c70c52b6f11531196d0c5baa77abd16117ae30dc4eeb16dd6da2',
+        '0x8741530fb57ca8556c5e7b45ffac62c178d8c0ff070ff1c99652e3f099997fa6',
       ];
       compactBytesArray_2d =
         dataKeys.firstDynamicKey.length +
@@ -114,9 +114,9 @@ export const testAllowedERC725YDataKeysInternals = (
         dataKeys.thirdFixedKey.key.toString().substring(2);
     });
 
-    describe("`isCompactBytesArrayOfAllowedERC725YDataKeys(..)`", () => {
-      it("should return `false` if element is 0x0000 (zero length elements not allowed)", async () => {
-        const allowedERC25YDataKeys = "0x0000";
+    describe('`isCompactBytesArrayOfAllowedERC725YDataKeys(..)`', () => {
+      it('should return `false` if element is 0x0000 (zero length elements not allowed)', async () => {
+        const allowedERC25YDataKeys = '0x0000';
         const result =
           await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedERC725YDataKeys(
             allowedERC25YDataKeys,
@@ -124,8 +124,8 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `false` if there are just 2 x length bytes but not followed by the value (the allowed ERC725Y Data Key)", async () => {
-        const allowedCalls = "0x0020";
+      it('should return `false` if there are just 2 x length bytes but not followed by the value (the allowed ERC725Y Data Key)', async () => {
+        const allowedCalls = '0x0020';
         const result =
           await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedERC725YDataKeys(
             allowedCalls,
@@ -133,8 +133,8 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `false` if there are just 2 x length bytes equal to `0x0002`", async () => {
-        const allowedCalls = "0x0002";
+      it('should return `false` if there are just 2 x length bytes equal to `0x0002`', async () => {
+        const allowedCalls = '0x0002';
         const result =
           await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedERC725YDataKeys(
             allowedCalls,
@@ -142,7 +142,7 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `true` for a CompactBytesArray containing 2 dynamic keys", async () => {
+      it('should return `true` for a CompactBytesArray containing 2 dynamic keys', async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArrayOfAllowedERC725YDataKeys(
             compactBytesArray_2d,
@@ -151,7 +151,7 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("should return `true` for a CompactBytesArray containing 2 fixed keys", async () => {
+      it('should return `true` for a CompactBytesArray containing 2 fixed keys', async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArrayOfAllowedERC725YDataKeys(
             compactBytesArray_2f,
@@ -160,7 +160,7 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("should return `true` for a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", async () => {
+      it('should return `true` for a CompactBytesArray containing 2 dynamic keys and 2 fixed keys', async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArrayOfAllowedERC725YDataKeys(
             compactBytesArray_2d_2f,
@@ -169,7 +169,7 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("should return `true` for a CompactBytesArray with mixed dynamic and fixed keys", async () => {
+      it('should return `true` for a CompactBytesArray with mixed dynamic and fixed keys', async () => {
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArrayOfAllowedERC725YDataKeys(
             compactBytesArray_mixed_d_f,
@@ -178,11 +178,11 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.true;
       });
 
-      it("should return `false` if the CompactBytesArray contains a zero length data key", async () => {
+      it('should return `false` if the CompactBytesArray contains a zero length data key', async () => {
         const data = encodeCompactBytesArray([
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("1st Data Key")),
-          "0x",
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("2nd Data Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('1st Data Key')),
+          '0x',
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('2nd Data Key')),
         ]);
 
         const result =
@@ -192,10 +192,10 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `false` if the CompactBytesArray contains an entry larger than 32 bytes", async () => {
+      it('should return `false` if the CompactBytesArray contains an entry larger than 32 bytes', async () => {
         const data = encodeCompactBytesArray([
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("1st Data Key")),
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("2nd Data Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('1st Data Key')),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('2nd Data Key')),
           ethers.utils.hexlify(ethers.utils.randomBytes(33)),
         ]);
 
@@ -206,15 +206,15 @@ export const testAllowedERC725YDataKeysInternals = (
         expect(result).to.be.false;
       });
 
-      it("should return `false` if the CompactBytesArray contains a data key with a length byte that does not correspond to the length of its element", async () => {
+      it('should return `false` if the CompactBytesArray contains a data key with a length byte that does not correspond to the length of its element', async () => {
         let data = encodeCompactBytesArray([
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("1st Data Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('1st Data Key')),
           ethers.utils.hexlify(ethers.utils.randomBytes(10)), // <-- replace length byte here
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("3rd Data Key")),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('3rd Data Key')),
         ]);
 
         // replace the length byte of the 2nd data key with a different value
-        data = data.replace(/000a/g, "0030");
+        data = data.replace(/000a/g, '0030');
 
         const result =
           await context.keyManagerInternalTester.callStatic.isCompactBytesArrayOfAllowedERC725YDataKeys(
@@ -224,9 +224,9 @@ export const testAllowedERC725YDataKeysInternals = (
       });
     });
 
-    describe("`verifyAllowedERC725YSingleKey(..)`", () => {
-      describe("checking a CompactBytesArray containing 2 dynamic keys", () => {
-        it("checking first dynamic key: should return true", async () => {
+    describe('`verifyAllowedERC725YSingleKey(..)`', () => {
+      describe('checking a CompactBytesArray containing 2 dynamic keys', () => {
+        it('checking first dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.firstDynamicKey.key +
             ethers.utils
@@ -246,7 +246,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second dynamic key: should return true", async () => {
+        it('checking second dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.secondDynamicKey.key +
             ethers.utils
@@ -266,7 +266,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking 10 random data keys: all should return false", async () => {
+        it('checking 10 random data keys: all should return false', async () => {
           for (let i = 0; i < 10; i++) {
             const dataKeyToCheck = dataKeysToReturn[i];
 
@@ -279,15 +279,15 @@ export const testAllowedERC725YDataKeysInternals = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManagerInternalTester,
-                "NotAllowedERC725YDataKey",
+                'NotAllowedERC725YDataKey',
               )
               .withArgs(context.universalProfile.address, dataKeyToCheck);
           }
         });
       });
 
-      describe("checking a CompactBytesArray containing 2 fixed keys", () => {
-        it("checking first fixed key: should return true", async () => {
+      describe('checking a CompactBytesArray containing 2 fixed keys', () => {
+        it('checking first fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.firstFixedKey.key;
 
           expect(
@@ -299,7 +299,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second fixed key: should return true", async () => {
+        it('checking second fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.secondFixedKey.key;
 
           expect(
@@ -311,7 +311,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking 10 random data keys: all should return false", async () => {
+        it('checking 10 random data keys: all should return false', async () => {
           for (let i = 0; i < 10; i++) {
             const dataKeyToCheck = dataKeysToReturn[i];
 
@@ -324,15 +324,15 @@ export const testAllowedERC725YDataKeysInternals = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManagerInternalTester,
-                "NotAllowedERC725YDataKey",
+                'NotAllowedERC725YDataKey',
               )
               .withArgs(context.universalProfile.address, dataKeyToCheck);
           }
         });
       });
 
-      describe("checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", () => {
-        it("checking first dynamic key: should return true", async () => {
+      describe('checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys', () => {
+        it('checking first dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.firstDynamicKey.key +
             ethers.utils
@@ -352,7 +352,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second dynamic key: should return true", async () => {
+        it('checking second dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.secondDynamicKey.key +
             ethers.utils
@@ -372,7 +372,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking first fixed key: should return true", async () => {
+        it('checking first fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.firstFixedKey.key;
 
           expect(
@@ -384,7 +384,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second fixed key: should return true", async () => {
+        it('checking second fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.secondFixedKey.key;
 
           expect(
@@ -396,7 +396,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking 10 random data keys: all should return false", async () => {
+        it('checking 10 random data keys: all should return false', async () => {
           for (let i = 0; i < 10; i++) {
             const dataKeyToCheck = dataKeysToReturn[i];
 
@@ -409,15 +409,15 @@ export const testAllowedERC725YDataKeysInternals = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManagerInternalTester,
-                "NotAllowedERC725YDataKey",
+                'NotAllowedERC725YDataKey',
               )
               .withArgs(context.universalProfile.address, dataKeyToCheck);
           }
         });
       });
 
-      describe("checking a CompactBytesArray containing mixed dynamic and fixed keys", () => {
-        it("checking first dynamic key: should return true", async () => {
+      describe('checking a CompactBytesArray containing mixed dynamic and fixed keys', () => {
+        it('checking first dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.firstDynamicKey.key +
             ethers.utils
@@ -437,7 +437,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second dynamic key: should return true", async () => {
+        it('checking second dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.secondDynamicKey.key +
             ethers.utils
@@ -457,7 +457,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking third dynamic key: should return true", async () => {
+        it('checking third dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.thirdDynamicKey.key +
             ethers.utils
@@ -477,7 +477,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking fourth dynamic key: should return true", async () => {
+        it('checking fourth dynamic key: should return true', async () => {
           const checkedDataKey =
             dataKeys.fourthDynamicKey.key +
             ethers.utils
@@ -497,7 +497,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking first fixed key: should return true", async () => {
+        it('checking first fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.firstFixedKey.key;
 
           expect(
@@ -509,7 +509,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking second fixed key: should return true", async () => {
+        it('checking second fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.secondFixedKey.key;
 
           expect(
@@ -521,7 +521,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking third fixed key: should return true", async () => {
+        it('checking third fixed key: should return true', async () => {
           const checkedDataKey = dataKeys.thirdFixedKey.key;
 
           expect(
@@ -533,7 +533,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking 10 random data keys: all should return false", async () => {
+        it('checking 10 random data keys: all should return false', async () => {
           for (let i = 0; i < 10; i++) {
             const dataKeyToCheck = dataKeysToReturn[i];
 
@@ -546,13 +546,13 @@ export const testAllowedERC725YDataKeysInternals = (
             )
               .to.be.revertedWithCustomError(
                 context.keyManagerInternalTester,
-                "NotAllowedERC725YDataKey",
+                'NotAllowedERC725YDataKey',
               )
               .withArgs(context.universalProfile.address, dataKeyToCheck);
           }
         });
 
-        it("should revert if compactBytesArray length element is superior at 32", async () => {
+        it('should revert if compactBytesArray length element is superior at 32', async () => {
           const dynamicKeyOfLength33 = ethers.utils.hexlify(ethers.utils.randomBytes(33));
           const compactBytesArray_with_invalid_length = encodeCompactBytesArray([
             dataKeys.firstDynamicKey.key,
@@ -569,16 +569,16 @@ export const testAllowedERC725YDataKeysInternals = (
           )
             .to.be.revertedWithCustomError(
               context.keyManagerInternalTester,
-              "InvalidEncodedAllowedERC725YDataKeys",
+              'InvalidEncodedAllowedERC725YDataKeys',
             )
             .withArgs(compactBytesArray_with_invalid_length, "couldn't DECODE from storage");
         });
       });
     });
 
-    describe("`verifyAllowedERC725YDataKeys(..)`", () => {
-      describe("checking a CompactBytesArray containing 2 dynamic keys", () => {
-        it("checking an array of valid keys: should return true", async () => {
+    describe('`verifyAllowedERC725YDataKeys(..)`', () => {
+      describe('checking a CompactBytesArray containing 2 dynamic keys', () => {
+        it('checking an array of valid keys: should return true', async () => {
           const checkedDataKeys = [
             dataKeys.firstDynamicKey.key +
               ethers.utils
@@ -609,7 +609,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking an array of invalid keys: all should return false", async () => {
+        it('checking an array of invalid keys: all should return false', async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YDataKeys(
               context.universalProfile.address,
@@ -621,14 +621,14 @@ export const testAllowedERC725YDataKeysInternals = (
           )
             .to.be.revertedWithCustomError(
               context.keyManagerInternalTester,
-              "NotAllowedERC725YDataKey",
+              'NotAllowedERC725YDataKey',
             )
             .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
-      describe("checking a CompactBytesArray containing 2 fixed keys", () => {
-        it("checking an array of valid keys: should return true", async () => {
+      describe('checking a CompactBytesArray containing 2 fixed keys', () => {
+        it('checking an array of valid keys: should return true', async () => {
           const checkedDataKeys = [dataKeys.firstFixedKey.key, dataKeys.secondFixedKey.key];
 
           expect(
@@ -642,7 +642,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking an array of invalid keys: all should return false", async () => {
+        it('checking an array of invalid keys: all should return false', async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YDataKeys(
               context.universalProfile.address,
@@ -654,14 +654,14 @@ export const testAllowedERC725YDataKeysInternals = (
           )
             .to.be.revertedWithCustomError(
               context.keyManagerInternalTester,
-              "NotAllowedERC725YDataKey",
+              'NotAllowedERC725YDataKey',
             )
             .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
-      describe("checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys", () => {
-        it("checking an array of valid keys: should return true", async () => {
+      describe('checking a CompactBytesArray containing 2 dynamic keys and 2 fixed keys', () => {
+        it('checking an array of valid keys: should return true', async () => {
           const checkedDataKeys = [
             dataKeys.firstDynamicKey.key +
               ethers.utils
@@ -694,7 +694,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking an array of invalid keys: all should return false", async () => {
+        it('checking an array of invalid keys: all should return false', async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YDataKeys(
               context.universalProfile.address,
@@ -706,14 +706,14 @@ export const testAllowedERC725YDataKeysInternals = (
           )
             .to.be.revertedWithCustomError(
               context.keyManagerInternalTester,
-              "NotAllowedERC725YDataKey",
+              'NotAllowedERC725YDataKey',
             )
             .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });
       });
 
-      describe("checking a CompactBytesArray containing mixed dynamic and fixed keys", () => {
-        it("checking an array of valid keys: should return true", async () => {
+      describe('checking a CompactBytesArray containing mixed dynamic and fixed keys', () => {
+        it('checking an array of valid keys: should return true', async () => {
           const checkedDataKeys = [
             dataKeys.firstDynamicKey.key +
               ethers.utils
@@ -763,7 +763,7 @@ export const testAllowedERC725YDataKeysInternals = (
           ).to.not.be.reverted;
         });
 
-        it("checking an array of invalid keys: all should return false", async () => {
+        it('checking an array of invalid keys: all should return false', async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedERC725YDataKeys(
               context.universalProfile.address,
@@ -775,7 +775,7 @@ export const testAllowedERC725YDataKeysInternals = (
           )
             .to.be.revertedWithCustomError(
               context.keyManagerInternalTester,
-              "NotAllowedERC725YDataKey",
+              'NotAllowedERC725YDataKey',
             )
             .withArgs(context.universalProfile.address, dataKeysToReturn[0]);
         });

--- a/tests/LSP6KeyManager/internals/Execute.internal.ts
+++ b/tests/LSP6KeyManager/internals/Execute.internal.ts
@@ -1,11 +1,11 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 // setup
-import { LSP6InternalsTestContext } from "../../utils/context";
-import { setupKeyManagerHelper } from "../../utils/fixtures";
-import { ALL_PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES } from "../../../constants";
-import { abiCoder } from "../../utils/helpers";
+import { LSP6InternalsTestContext } from '../../utils/context';
+import { setupKeyManagerHelper } from '../../utils/fixtures';
+import { ALL_PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES } from '../../../constants';
+import { abiCoder } from '../../utils/helpers';
 
 export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTestContext>) => {
   let context: LSP6InternalsTestContext;
@@ -14,7 +14,7 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
     context = await buildContext();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
     ];
 
     const permissionValues = [ALL_PERMISSIONS];
@@ -22,16 +22,16 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
     await setupKeyManagerHelper(context, permissionKeys, permissionValues);
   });
 
-  describe("`_extractExecuteParameters(bytes)`", () => {
-    it("should pass when the function is called with valid parameters", async () => {
+  describe('`_extractExecuteParameters(bytes)`', () => {
+    it('should pass when the function is called with valid parameters', async () => {
       const executeParameters = {
         operationType: OPERATION_TYPES.CALL,
         to: context.accounts[3].address,
-        value: ethers.utils.parseEther("5"),
-        data: "0xcafecafecafecafe",
+        value: ethers.utils.parseEther('5'),
+        data: '0xcafecafecafecafe',
       };
 
-      const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+      const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
         executeParameters.operationType,
         executeParameters.to,
         executeParameters.value,
@@ -46,29 +46,29 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
         executeParameters.value,
 
         // only the first 4 bytes of the `data` param (the function selector) is extracted
-        "0xcafecafe",
+        '0xcafecafe',
         false,
       ]);
     });
 
-    it("should revert with `InvalidPayload` error if the address param is not left padded with 12 x `00` bytes", async () => {
+    it('should revert with `InvalidPayload` error if the address param is not left padded with 12 x `00` bytes', async () => {
       const executeParameters = {
         operationType: OPERATION_TYPES.CALL,
         to: context.accounts[3].address,
-        value: ethers.utils.parseEther("5"),
-        data: "0xcafecafecafecafe",
+        value: ethers.utils.parseEther('5'),
+        data: '0xcafecafecafecafe',
       };
 
-      const calldata = context.universalProfile.interface.encodeFunctionData("execute", [
+      const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
         executeParameters.operationType,
         executeParameters.to,
         executeParameters.value,
         executeParameters.data,
       ]);
 
-      const abiEncodedAddress = abiCoder.encode(["address"], [executeParameters.to]);
+      const abiEncodedAddress = abiCoder.encode(['address'], [executeParameters.to]);
 
-      const invalidPart = "deadbeefdeadbeefdeadbeef";
+      const invalidPart = 'deadbeefdeadbeefdeadbeef';
       const addressPart = executeParameters.to.toLowerCase().substring(2);
 
       const invalidCalldata = calldata.replace(
@@ -77,7 +77,7 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
       );
 
       await expect(context.keyManagerInternalTester.extractExecuteParameters(invalidCalldata))
-        .to.be.revertedWithCustomError(context.keyManagerInternalTester, "InvalidPayload")
+        .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'InvalidPayload')
         .withArgs(invalidCalldata);
     });
   });

--- a/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
+++ b/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
@@ -1,23 +1,23 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys, PERMISSIONS } from '../../../constants';
 
 // setup
-import { LSP6InternalsTestContext } from "../../utils/context";
-import { setupKeyManagerHelper } from "../../utils/fixtures";
+import { LSP6InternalsTestContext } from '../../utils/context';
+import { setupKeyManagerHelper } from '../../utils/fixtures';
 
 // helpers
-import { abiCoder, combinePermissions } from "../../utils/helpers";
+import { abiCoder, combinePermissions } from '../../utils/helpers';
 
 export const testReadingPermissionsInternals = (
   buildContext: () => Promise<LSP6InternalsTestContext>,
 ) => {
   let context: LSP6InternalsTestContext;
 
-  describe("`getPermissionsFor(...)` -> reading permissions", () => {
+  describe('`getPermissionsFor(...)` -> reading permissions', () => {
     let addressCanSetData: SignerWithAddress, addressCanSetDataAndCall: SignerWithAddress;
 
     before(async () => {
@@ -27,10 +27,10 @@ export const testReadingPermissionsInternals = (
       addressCanSetDataAndCall = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetDataAndCall.address.substring(2),
       ];
 
@@ -43,33 +43,33 @@ export const testReadingPermissionsInternals = (
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
-    it("Should return ALL_PERMISSIONS for owner", async () => {
+    it('Should return ALL_PERMISSIONS for owner', async () => {
       expect(
         await context.keyManagerInternalTester.getPermissionsFor(context.owner.address),
       ).to.equal(ALL_PERMISSIONS); // ALL_PERMISSIONS = "0xffff..."
     });
 
-    it("Should return SETDATA", async () => {
+    it('Should return SETDATA', async () => {
       expect(
         await context.keyManagerInternalTester.getPermissionsFor(addressCanSetData.address),
       ).to.equal(PERMISSIONS.SETDATA);
     });
 
-    it("Should return SETDATA + CALL", async () => {
+    it('Should return SETDATA + CALL', async () => {
       expect(
         await context.keyManagerInternalTester.getPermissionsFor(addressCanSetDataAndCall.address),
       ).to.equal(combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.CALL));
     });
   });
 
-  describe("`getPermissionsFor(...)` -> reading empty permissions", () => {
+  describe('`getPermissionsFor(...)` -> reading empty permissions', () => {
     let moreThan32EmptyBytes: SignerWithAddress,
       lessThan32EmptyBytes: SignerWithAddress,
       oneEmptyByte: SignerWithAddress;
 
     const expectedEmptyPermission = abiCoder.encode(
-      ["bytes32"],
-      ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+      ['bytes32'],
+      ['0x0000000000000000000000000000000000000000000000000000000000000000'],
     );
 
     before(async () => {
@@ -80,43 +80,43 @@ export const testReadingPermissionsInternals = (
       oneEmptyByte = context.accounts[3];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           moreThan32EmptyBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           lessThan32EmptyBytes.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + oneEmptyByte.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + oneEmptyByte.address.substring(2),
       ];
 
       const permissionValues = [
-        "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x000000000000000000000000000000",
-        "0x00",
+        '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+        '0x000000000000000000000000000000',
+        '0x00',
       ];
 
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
-    it("should cast permissions to 32 bytes when reading permissions stored as more than 32 empty bytes", async () => {
+    it('should cast permissions to 32 bytes when reading permissions stored as more than 32 empty bytes', async () => {
       const result = await context.keyManagerInternalTester.getPermissionsFor(
         moreThan32EmptyBytes.address,
       );
       expect(result).to.equal(expectedEmptyPermission);
     });
 
-    it("should cast permissions to 32 bytes when reading permissions stored as less than 32 empty bytes", async () => {
+    it('should cast permissions to 32 bytes when reading permissions stored as less than 32 empty bytes', async () => {
       const result = await context.keyManagerInternalTester.getPermissionsFor(
         lessThan32EmptyBytes.address,
       );
       expect(result).to.equal(expectedEmptyPermission);
     });
 
-    it("should cast permissions to 32 bytes when reading permissions stored as one empty byte", async () => {
+    it('should cast permissions to 32 bytes when reading permissions stored as one empty byte', async () => {
       const result = await context.keyManagerInternalTester.getPermissionsFor(oneEmptyByte.address);
       expect(result).to.equal(expectedEmptyPermission);
     });
   });
 
-  describe("`includesPermissions(...)`", () => {
+  describe('`includesPermissions(...)`', () => {
     let addressCanSetData: SignerWithAddress;
 
     before(async () => {
@@ -125,8 +125,8 @@ export const testReadingPermissionsInternals = (
       addressCanSetData = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2),
       ];
 
@@ -135,7 +135,7 @@ export const testReadingPermissionsInternals = (
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
-    it("Should return true when checking if has permission SETDATA", async () => {
+    it('Should return true when checking if has permission SETDATA', async () => {
       let appPermissions = await context.keyManagerInternalTester.getPermissionsFor(
         addressCanSetData.address,
       );
@@ -146,7 +146,7 @@ export const testReadingPermissionsInternals = (
     });
   });
 
-  describe("AddressPermissions[]", () => {
+  describe('AddressPermissions[]', () => {
     let firstBeneficiary: SignerWithAddress,
       secondBeneficiary: SignerWithAddress,
       thirdBeneficiary: SignerWithAddress,
@@ -164,14 +164,14 @@ export const testReadingPermissionsInternals = (
       fourthBeneficiary = context.accounts[4];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           firstBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           secondBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           thirdBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           fourthBeneficiary.address.substring(2),
       ];
 
@@ -185,17 +185,17 @@ export const testReadingPermissionsInternals = (
 
       // set AddressPermissions array keys
       permissionArrayKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000002",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000003",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000004",
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000002',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000003',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000004',
       ];
 
       // set AddressPermissions array values
       permissionArrayValues = [
-        "0x05",
+        '0x05',
         context.owner.address,
         firstBeneficiary.address,
         secondBeneficiary.address,
@@ -211,9 +211,9 @@ export const testReadingPermissionsInternals = (
 
     it("Value should be 5 for key 'AddressPermissions[]'", async () => {
       let result = await context.universalProfile.getData(
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
       );
-      expect(result).to.equal("0x05");
+      expect(result).to.equal('0x05');
     });
 
     // check array indexes individually

--- a/tests/LSP6KeyManager/internals/SetData.internal.ts
+++ b/tests/LSP6KeyManager/internals/SetData.internal.ts
@@ -1,10 +1,10 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 // setup
-import { LSP6InternalsTestContext } from "../../utils/context";
-import { setupKeyManagerHelper } from "../../utils/fixtures";
-import { ALL_PERMISSIONS, ERC725YDataKeys } from "../../../constants";
+import { LSP6InternalsTestContext } from '../../utils/context';
+import { setupKeyManagerHelper } from '../../utils/fixtures';
+import { ALL_PERMISSIONS, ERC725YDataKeys } from '../../../constants';
 
 export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTestContext>) => {
   let context: LSP6InternalsTestContext;
@@ -13,7 +13,7 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
     context = await buildContext();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
     ];
 
     const permissionValues = [ALL_PERMISSIONS];
@@ -21,10 +21,10 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
     await setupKeyManagerHelper(context, permissionKeys, permissionValues);
   });
 
-  describe("`_verifyCanSetData(...)` array", () => {
-    describe("when providing a `setData(bytes32[],bytes[])` array payload", () => {
-      describe("when there is not the same number of dataKeys[] and dataValues[] in each arrays", () => {
-        it("should revert with error `...` if the dataValues is < (less than) dataKeys", async () => {
+  describe('`_verifyCanSetData(...)` array', () => {
+    describe('when providing a `setData(bytes32[],bytes[])` array payload', () => {
+      describe('when there is not the same number of dataKeys[] and dataValues[] in each arrays', () => {
+        it('should revert with error `...` if the dataValues is < (less than) dataKeys', async () => {
           const dataKeys = [
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
@@ -45,11 +45,11 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
             ),
           ).to.be.revertedWithCustomError(
             context.keyManagerInternalTester,
-            "ERC725Y_DataKeysValuesLengthMismatch",
+            'ERC725Y_DataKeysValuesLengthMismatch',
           );
         });
 
-        it("should revert with error `...` if the dataValues > (greater than) dataKeys", async () => {
+        it('should revert with error `...` if the dataValues > (greater than) dataKeys', async () => {
           const dataKeys = [
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
@@ -70,13 +70,13 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
             ),
           ).to.be.revertedWithCustomError(
             context.keyManagerInternalTester,
-            "ERC725Y_DataKeysValuesLengthMismatch",
+            'ERC725Y_DataKeysValuesLengthMismatch',
           );
         });
       });
 
-      describe("when there is the same number of dataKeys[] and dataValues[] in each array", () => {
-        it("should pass", async () => {
+      describe('when there is the same number of dataKeys[] and dataValues[] in each array', () => {
+        it('should pass', async () => {
           const dataKeys = [
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),
             ethers.utils.hexlify(ethers.utils.randomBytes(32)),

--- a/tests/LSP7DigitalAsset/LSP7CappedSupply.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7CappedSupply.behaviour.ts
@@ -1,9 +1,9 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { LSP7CappedSupplyTester } from "../../types";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { LSP7CappedSupplyTester } from '../../types';
 
-import type { BigNumber } from "ethers";
+import type { BigNumber } from 'ethers';
 
 export type LSP7CappedSupplyTestAccounts = {
   owner: SignerWithAddress;
@@ -35,15 +35,15 @@ export const shouldBehaveLikeLSP7CappedSupply = (
     context = await buildContext();
   });
 
-  describe("tokenSupplyCap", () => {
-    it("should allow reading tokenSupplyCap", async () => {
+  describe('tokenSupplyCap', () => {
+    it('should allow reading tokenSupplyCap', async () => {
       const tokenSupplyCap = await context.lsp7CappedSupply.tokenSupplyCap();
       expect(tokenSupplyCap).to.equal(context.deployParams.tokenSupplyCap);
     });
   });
 
-  describe("when minting tokens", () => {
-    it("should allow minting amount up to tokenSupplyCap", async () => {
+  describe('when minting tokens', () => {
+    it('should allow minting amount up to tokenSupplyCap', async () => {
       const preTokenSupplyCap = await context.lsp7CappedSupply.tokenSupplyCap();
       const preTotalSupply = await context.lsp7CappedSupply.totalSupply();
       expect(preTokenSupplyCap.sub(preTotalSupply)).to.equal(context.deployParams.tokenSupplyCap);
@@ -58,8 +58,8 @@ export const shouldBehaveLikeLSP7CappedSupply = (
       expect(postTotalSupply.sub(postTokenSupplyCap)).to.equal(ethers.constants.Zero);
     });
 
-    describe("when cap has been reached", () => {
-      it("should error when minting more than tokenSupplyCapTokens", async () => {
+    describe('when cap has been reached', () => {
+      it('should error when minting more than tokenSupplyCapTokens', async () => {
         await context.lsp7CappedSupply.mint(
           context.accounts.tokenReceiver.address,
           context.deployParams.tokenSupplyCap,
@@ -73,11 +73,11 @@ export const shouldBehaveLikeLSP7CappedSupply = (
           context.lsp7CappedSupply.mint(context.accounts.tokenReceiver.address, 1),
         ).to.be.revertedWithCustomError(
           context.lsp7CappedSupply,
-          "LSP7CappedSupplyCannotMintOverCap",
+          'LSP7CappedSupplyCannotMintOverCap',
         );
       });
 
-      it("should allow minting after burning", async () => {
+      it('should allow minting after burning', async () => {
         await context.lsp7CappedSupply.mint(
           context.accounts.tokenReceiver.address,
           context.deployParams.tokenSupplyCap,

--- a/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
@@ -1,11 +1,11 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber, ContractTransaction } from "ethers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { BigNumber, ContractTransaction } from 'ethers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
-import { INTERFACE_IDS, SupportedStandards } from "../../constants";
+import { INTERFACE_IDS, SupportedStandards } from '../../constants';
 import {
   CheckInterface__factory,
   LSP7CompatibleERC20,
@@ -14,8 +14,8 @@ import {
   TokenReceiverWithLSP1__factory,
   TokenReceiverWithoutLSP1,
   TokenReceiverWithoutLSP1__factory,
-} from "../../types";
-import { ERC725YDataKeys } from "../../constants";
+} from '../../types';
+import { ERC725YDataKeys } from '../../constants';
 
 type LSP7CompatibleERC20TestAccounts = {
   owner: SignerWithAddress;
@@ -57,20 +57,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
     context = await buildContext();
   });
 
-  describe("approve", () => {
-    describe("when operator is the zero address", () => {
-      it("should revert", async () => {
+  describe('approve', () => {
+    describe('when operator is the zero address', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp7CompatibleERC20.approve(ethers.constants.AddressZero, context.initialSupply),
         ).to.be.revertedWithCustomError(
           context.lsp7CompatibleERC20,
-          "LSP7CannotUseAddressZeroAsOperator",
+          'LSP7CannotUseAddressZeroAsOperator',
         );
       });
     });
 
-    describe("when the operator had no authorized amount", () => {
-      it("should succeed by setting the given amount", async () => {
+    describe('when the operator had no authorized amount', () => {
+      it('should succeed by setting the given amount', async () => {
         const operator = context.accounts.operator.address;
         const tokenOwner = context.accounts.owner.address;
         const authorizedAmount = 1;
@@ -81,11 +81,11 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         const tx = await context.lsp7CompatibleERC20.approve(operator, authorizedAmount);
 
         await expect(tx)
-          .to.emit(context.lsp7CompatibleERC20, "AuthorizedOperator")
+          .to.emit(context.lsp7CompatibleERC20, 'AuthorizedOperator')
           .withArgs(operator, tokenOwner, authorizedAmount);
 
         await expect(tx)
-          .to.emit(context.lsp7CompatibleERC20, "Approval")
+          .to.emit(context.lsp7CompatibleERC20, 'Approval')
           .withArgs(tokenOwner, operator, authorizedAmount);
 
         const postAllowance = await context.lsp7CompatibleERC20.allowance(tokenOwner, operator);
@@ -93,13 +93,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       });
     });
 
-    describe("when the operator had an authorized amount", () => {
-      describe("when the operator authorized amount is changed to another non-zero value", () => {
-        it("should succeed by replacing the existing amount with the given amount", async () => {
+    describe('when the operator had an authorized amount', () => {
+      describe('when the operator authorized amount is changed to another non-zero value', () => {
+        it('should succeed by replacing the existing amount with the given amount', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
-          const previouslyAuthorizedAmount = "20";
-          const authorizedAmount = "1";
+          const previouslyAuthorizedAmount = '20';
+          const authorizedAmount = '1';
 
           await context.lsp7CompatibleERC20.approve(operator, previouslyAuthorizedAmount);
 
@@ -109,11 +109,11 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           const tx = await context.lsp7CompatibleERC20.approve(operator, authorizedAmount);
 
           await expect(tx)
-            .to.emit(context.lsp7CompatibleERC20, "AuthorizedOperator")
+            .to.emit(context.lsp7CompatibleERC20, 'AuthorizedOperator')
             .withArgs(operator, tokenOwner, authorizedAmount);
 
           await expect(tx)
-            .to.emit(context.lsp7CompatibleERC20, "Approval")
+            .to.emit(context.lsp7CompatibleERC20, 'Approval')
             .withArgs(tokenOwner, operator, authorizedAmount);
 
           const postAllowance = await context.lsp7CompatibleERC20.allowance(tokenOwner, operator);
@@ -121,12 +121,12 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         });
       });
 
-      describe("when the operator authorized amount is changed to zero", () => {
-        it("should succeed by replacing the existing amount with the given amount", async () => {
+      describe('when the operator authorized amount is changed to zero', () => {
+        it('should succeed by replacing the existing amount with the given amount', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
-          const previouslyAuthorizedAmount = "20";
-          const authorizedAmount = "0";
+          const previouslyAuthorizedAmount = '20';
+          const authorizedAmount = '0';
 
           await context.lsp7CompatibleERC20.approve(operator, previouslyAuthorizedAmount);
 
@@ -136,11 +136,11 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           const tx = await context.lsp7CompatibleERC20.approve(operator, authorizedAmount);
 
           await expect(tx)
-            .to.emit(context.lsp7CompatibleERC20, "RevokedOperator")
+            .to.emit(context.lsp7CompatibleERC20, 'RevokedOperator')
             .withArgs(operator, tokenOwner);
 
           await expect(tx)
-            .to.emit(context.lsp7CompatibleERC20, "Approval")
+            .to.emit(context.lsp7CompatibleERC20, 'Approval')
             .withArgs(tokenOwner, operator, authorizedAmount);
 
           const postAllowance = await context.lsp7CompatibleERC20.allowance(tokenOwner, operator);
@@ -150,9 +150,9 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
     });
   });
 
-  describe("allowance", () => {
-    describe("when operator has been approved", () => {
-      it("should return approval amount", async () => {
+  describe('allowance', () => {
+    describe('when operator has been approved', () => {
+      it('should return approval amount', async () => {
         await context.lsp7CompatibleERC20.approve(
           context.accounts.operator.address,
           context.initialSupply,
@@ -167,8 +167,8 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       });
     });
 
-    describe("when operator has not been approved", () => {
-      it("should return zero", async () => {
+    describe('when operator has not been approved', () => {
+      it('should return zero', async () => {
         expect(
           await context.lsp7CompatibleERC20.allowance(
             context.accounts.owner.address,
@@ -179,13 +179,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
     });
   });
 
-  describe("mint", () => {
-    describe("when a token is minted", () => {
-      it("should have expected events", async () => {
+  describe('mint', () => {
+    describe('when a token is minted', () => {
+      it('should have expected events', async () => {
         const txParams = {
           to: context.accounts.owner.address,
           amount: context.initialSupply,
-          data: ethers.utils.toUtf8Bytes("mint tokens for the owner"),
+          data: ethers.utils.toUtf8Bytes('mint tokens for the owner'),
         };
         const operator = context.accounts.owner;
 
@@ -196,7 +196,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         await expect(tx)
           .to.emit(
             context.lsp7CompatibleERC20,
-            "Transfer(address,address,address,uint256,bool,bytes)",
+            'Transfer(address,address,address,uint256,bool,bytes)',
           )
           .withArgs(
             operator.address,
@@ -208,27 +208,27 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           );
 
         await expect(tx)
-          .to.emit(context.lsp7CompatibleERC20, "Transfer(address,address,uint256)")
+          .to.emit(context.lsp7CompatibleERC20, 'Transfer(address,address,uint256)')
           .withArgs(ethers.constants.AddressZero, txParams.to, txParams.amount);
       });
     });
   });
 
-  describe("burn", () => {
-    describe("when a token is burned", () => {
+  describe('burn', () => {
+    describe('when a token is burned', () => {
       beforeEach(async () => {
         await context.lsp7CompatibleERC20.mint(
           context.accounts.owner.address,
           context.initialSupply,
-          ethers.utils.toUtf8Bytes("mint tokens for owner"),
+          ethers.utils.toUtf8Bytes('mint tokens for owner'),
         );
       });
 
-      it("should have expected events", async () => {
+      it('should have expected events', async () => {
         const txParams = {
           from: context.accounts.owner.address,
           amount: context.initialSupply,
-          data: ethers.utils.toUtf8Bytes("burn tokens from the owner"),
+          data: ethers.utils.toUtf8Bytes('burn tokens from the owner'),
         };
         const operator = context.accounts.owner;
 
@@ -239,7 +239,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         await expect(tx)
           .to.emit(
             context.lsp7CompatibleERC20,
-            "Transfer(address,address,address,uint256,bool,bytes)",
+            'Transfer(address,address,address,uint256,bool,bytes)',
           )
           .withArgs(
             operator.address,
@@ -251,13 +251,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           );
 
         await expect(tx)
-          .to.emit(context.lsp7CompatibleERC20, "Transfer(address,address,uint256)")
+          .to.emit(context.lsp7CompatibleERC20, 'Transfer(address,address,uint256)')
           .withArgs(txParams.from, ethers.constants.AddressZero, txParams.amount);
       });
     });
   });
 
-  describe("transfers", () => {
+  describe('transfers', () => {
     type TestDeployedContracts = {
       tokenReceiverWithLSP1: TokenReceiverWithLSP1;
       tokenReceiverWithoutLSP1: TokenReceiverWithoutLSP1;
@@ -280,7 +280,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       await context.lsp7CompatibleERC20.mint(
         context.accounts.owner.address,
         context.initialSupply,
-        ethers.utils.toUtf8Bytes("mint tokens for the owner"),
+        ethers.utils.toUtf8Bytes('mint tokens for the owner'),
       );
 
       // setup so we can observe allowance values during transfer tests
@@ -318,7 +318,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       await expect(tx)
         .to.emit(
           context.lsp7CompatibleERC20,
-          "Transfer(address,address,address,uint256,bool,bytes)",
+          'Transfer(address,address,address,uint256,bool,bytes)',
         )
         .withArgs(
           txParams.operator.address,
@@ -330,7 +330,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         );
 
       await expect(tx)
-        .to.emit(context.lsp7CompatibleERC20, "Transfer(address,address,uint256)")
+        .to.emit(context.lsp7CompatibleERC20, 'Transfer(address,address,uint256)')
         .withArgs(txParams.from, txParams.to, txParams.amount);
 
       // post-conditions
@@ -346,7 +346,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
         // check for ERC20 Approval event
         await expect(tx)
-          .to.emit(context.lsp7CompatibleERC20, "Approval(address,address,uint256)")
+          .to.emit(context.lsp7CompatibleERC20, 'Approval(address,address,uint256)')
           .withArgs(txParams.from, txParams.operator.address, postAllowance);
       }
 
@@ -366,16 +366,16 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
         // TODO: the Helper contract TokenReceiverWithLSP1 does not emit the standard `UniversalReceiver` event.
         // modify this behaviour to emit the UniversalReceiver event
-        await expect(tx).to.emit(receiver, "UniversalReceiverCalled");
+        await expect(tx).to.emit(receiver, 'UniversalReceiverCalled');
       }
     };
 
-    describe("ERC20 -> `transfer(address,uint256)`", () => {
-      describe("when sender has enough balance", () => {
-        const transferAmount = ethers.BigNumber.from("10");
+    describe('ERC20 -> `transfer(address,uint256)`', () => {
+      describe('when sender has enough balance', () => {
+        const transferAmount = ethers.BigNumber.from('10');
 
-        describe("when `to` is an EOA", () => {
-          it("should allow transfering the tokens", async () => {
+        describe('when `to` is an EOA', () => {
+          it('should allow transfering the tokens', async () => {
             const txParams = {
               operator: context.accounts.owner,
               from: context.accounts.owner.address,
@@ -388,15 +388,15 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               () =>
                 context.lsp7CompatibleERC20
                   .connect(txParams.operator)
-                  ["transfer(address,uint256)"](txParams.to, txParams.amount),
-              "0x",
+                  ['transfer(address,uint256)'](txParams.to, txParams.amount),
+              '0x',
             );
           });
         });
 
-        describe("when `to` is a contract", () => {
-          describe("when receiving contract supports LSP1", () => {
-            it("should allow transfering the tokens", async () => {
+        describe('when `to` is a contract', () => {
+          describe('when receiving contract supports LSP1', () => {
+            it('should allow transfering the tokens', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
@@ -409,14 +409,14 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 () =>
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,uint256)"](txParams.to, txParams.amount),
-                "0x",
+                    ['transfer(address,uint256)'](txParams.to, txParams.amount),
+                '0x',
               );
             });
           });
 
-          describe("when receiving contract does not support LSP1", () => {
-            it("should allow transfering the tokens", async () => {
+          describe('when receiving contract does not support LSP1', () => {
+            it('should allow transfering the tokens', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
@@ -429,15 +429,15 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 () =>
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,uint256)"](txParams.to, txParams.amount),
-                "0x",
+                    ['transfer(address,uint256)'](txParams.to, txParams.amount),
+                '0x',
               );
             });
           });
         });
       });
 
-      describe("when sender does not have enough balance", () => {
+      describe('when sender does not have enough balance', () => {
         it("should revert with `LSP7AmountExceedsBalance` error if sending more tokens than the tokenOwner's balance", async () => {
           const ownerBalance = await context.lsp7CompatibleERC20.balanceOf(
             context.accounts.owner.address,
@@ -456,13 +456,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           await expect(
             context.lsp7CompatibleERC20
               .connect(txParams.operator)
-              ["transferFrom(address,address,uint256)"](
+              ['transferFrom(address,address,uint256)'](
                 txParams.from,
                 txParams.to,
                 txParams.amount,
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp7CompatibleERC20, "LSP7AmountExceedsBalance")
+            .to.be.revertedWithCustomError(context.lsp7CompatibleERC20, 'LSP7AmountExceedsBalance')
             .withArgs(ownerBalance.toHexString(), txParams.from, txParams.amount.toHexString());
 
           // post-conditions
@@ -472,13 +472,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       });
     });
 
-    describe("ERC20 -> `transferFrom(address,address,uint256)`", () => {
-      describe("when sender has enough balance", () => {
-        const transferAmount = ethers.BigNumber.from("10");
+    describe('ERC20 -> `transferFrom(address,address,uint256)`', () => {
+      describe('when sender has enough balance', () => {
+        const transferAmount = ethers.BigNumber.from('10');
 
-        describe("when caller (msg.sender) is the `from` address", () => {
-          describe("when `to` is an EOA", () => {
-            it("should allow transfering the tokens", async () => {
+        describe('when caller (msg.sender) is the `from` address', () => {
+          describe('when `to` is an EOA', () => {
+            it('should allow transfering the tokens', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
@@ -492,14 +492,14 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
                     .transferFrom(txParams.from, txParams.to, txParams.amount),
-                "0x",
+                '0x',
               );
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokens", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokens', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -513,13 +513,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
                       .transferFrom(txParams.from, txParams.to, txParams.amount),
-                  "0x",
+                  '0x',
                 );
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokens", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokens', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -533,16 +533,16 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
                       .transferFrom(txParams.from, txParams.to, txParams.amount),
-                  "0x",
+                  '0x',
                 );
               });
             });
           });
         });
 
-        describe("when caller (msg.sender) is an operator (= Not the `from` address)", () => {
-          describe("when `to` is an EOA", () => {
-            it("should allow transfering the tokens", async () => {
+        describe('when caller (msg.sender) is an operator (= Not the `from` address)', () => {
+          describe('when `to` is an EOA', () => {
+            it('should allow transfering the tokens', async () => {
               const txParams = {
                 operator: context.accounts.operator,
                 from: context.accounts.owner.address,
@@ -556,14 +556,14 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
                     .transferFrom(txParams.from, txParams.to, txParams.amount),
-                "0x",
+                '0x',
               );
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokens", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokens', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -577,13 +577,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
                       .transferFrom(txParams.from, txParams.to, txParams.amount),
-                  "0x",
+                  '0x',
                 );
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokens", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokens', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -597,7 +597,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
                       .transferFrom(txParams.from, txParams.to, txParams.amount),
-                  "0x",
+                  '0x',
                 );
               });
             });
@@ -605,8 +605,8 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         });
       });
 
-      describe("when sender does not have enough balance", () => {
-        describe("when caller (msg.sender) is the `from` address", () => {
+      describe('when sender does not have enough balance', () => {
+        describe('when caller (msg.sender) is the `from` address', () => {
           it("should revert with `LSP7AmountExceedsBalance` error if sending more tokens than the tokenOwner's balance", async () => {
             const ownerBalance = await context.lsp7CompatibleERC20.balanceOf(
               context.accounts.owner.address,
@@ -629,7 +629,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             )
               .to.be.revertedWithCustomError(
                 context.lsp7CompatibleERC20,
-                "LSP7AmountExceedsBalance",
+                'LSP7AmountExceedsBalance',
               )
               .withArgs(ownerBalance.toHexString(), txParams.from, txParams.amount.toHexString());
 
@@ -639,7 +639,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           });
         });
 
-        describe("when caller (msg.sender) is an operator (= Not the `from` address)", () => {
+        describe('when caller (msg.sender) is an operator (= Not the `from` address)', () => {
           it("should revert with `LSP7AmountExceedsAuthorizedAmount` error if sending more tokens than the tokenOwner's balance", async () => {
             const ownerBalance = await context.lsp7CompatibleERC20.balanceOf(
               context.accounts.owner.address,
@@ -662,7 +662,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             )
               .to.be.revertedWithCustomError(
                 context.lsp7CompatibleERC20,
-                "LSP7AmountExceedsAuthorizedAmount",
+                'LSP7AmountExceedsAuthorizedAmount',
               )
               .withArgs(
                 context.accounts.owner.address,
@@ -679,15 +679,15 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       });
     });
 
-    describe("LSP7 -> `transfer(address,address,uint256,bool,bytes)`", () => {
-      const expectedData = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP7 token transfer"));
+    describe('LSP7 -> `transfer(address,address,uint256,bool,bytes)`', () => {
+      const expectedData = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP7 token transfer'));
 
-      describe("when sender has enough balance", () => {
-        const transferAmount = ethers.BigNumber.from("10");
+      describe('when sender has enough balance', () => {
+        const transferAmount = ethers.BigNumber.from('10');
 
-        describe("when caller (msg.sender) is the `from` address", () => {
-          describe("when `to` is an EOA", () => {
-            it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+        describe('when caller (msg.sender) is the `from` address', () => {
+          describe('when `to` is an EOA', () => {
+            it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
@@ -702,7 +702,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 () =>
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,address,uint256,bool,bytes)"](
+                    ['transfer(address,address,uint256,bool,bytes)'](
                       txParams.from,
                       txParams.to,
                       txParams.amount,
@@ -713,7 +713,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               );
             });
 
-            it("should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+            it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
@@ -729,7 +729,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               await expect(
                 context.lsp7CompatibleERC20
                   .connect(txParams.operator)
-                  ["transfer(address,address,uint256,bool,bytes)"](
+                  ['transfer(address,address,uint256,bool,bytes)'](
                     txParams.from,
                     txParams.to,
                     txParams.amount,
@@ -739,7 +739,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               )
                 .to.be.revertedWithCustomError(
                   context.lsp7CompatibleERC20,
-                  "LSP7NotifyTokenReceiverIsEOA",
+                  'LSP7NotifyTokenReceiverIsEOA',
                 )
                 .withArgs(txParams.to);
 
@@ -749,9 +749,9 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -766,7 +766,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -777,7 +777,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 );
               });
 
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -792,7 +792,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -804,8 +804,8 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -820,7 +820,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -831,7 +831,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 );
               });
 
-              it("should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+              it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
@@ -847,7 +847,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 await expect(
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,address,uint256,bool,bytes)"](
+                    ['transfer(address,address,uint256,bool,bytes)'](
                       txParams.from,
                       txParams.to,
                       txParams.amount,
@@ -857,7 +857,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 )
                   .to.be.revertedWithCustomError(
                     context.lsp7CompatibleERC20,
-                    "LSP7NotifyTokenReceiverContractMissingLSP1Interface",
+                    'LSP7NotifyTokenReceiverContractMissingLSP1Interface',
                   )
                   .withArgs(txParams.to);
 
@@ -869,9 +869,9 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           });
         });
 
-        describe("when caller (msg.sender) is an operator (= Not the `from` address)", () => {
-          describe("when `to` is an EOA", () => {
-            it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+        describe('when caller (msg.sender) is an operator (= Not the `from` address)', () => {
+          describe('when `to` is an EOA', () => {
+            it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
               const txParams = {
                 operator: context.accounts.operator,
                 from: context.accounts.owner.address,
@@ -886,7 +886,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 () =>
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,address,uint256,bool,bytes)"](
+                    ['transfer(address,address,uint256,bool,bytes)'](
                       txParams.from,
                       txParams.to,
                       txParams.amount,
@@ -897,7 +897,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               );
             });
 
-            it("should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+            it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
               const txParams = {
                 operator: context.accounts.operator,
                 from: context.accounts.owner.address,
@@ -913,7 +913,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               await expect(
                 context.lsp7CompatibleERC20
                   .connect(txParams.operator)
-                  ["transfer(address,address,uint256,bool,bytes)"](
+                  ['transfer(address,address,uint256,bool,bytes)'](
                     txParams.from,
                     txParams.to,
                     txParams.amount,
@@ -923,7 +923,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               )
                 .to.be.revertedWithCustomError(
                   context.lsp7CompatibleERC20,
-                  "LSP7NotifyTokenReceiverIsEOA",
+                  'LSP7NotifyTokenReceiverIsEOA',
                 )
                 .withArgs(txParams.to);
 
@@ -933,9 +933,9 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -950,7 +950,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -961,7 +961,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 );
               });
 
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -976,7 +976,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -988,8 +988,8 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokens with `allowNonLSP1Recipient` param = true", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -1004,7 +1004,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   () =>
                     context.lsp7CompatibleERC20
                       .connect(txParams.operator)
-                      ["transfer(address,address,uint256,bool,bytes)"](
+                      ['transfer(address,address,uint256,bool,bytes)'](
                         txParams.from,
                         txParams.to,
                         txParams.amount,
@@ -1015,7 +1015,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 );
               });
 
-              it("should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false", async () => {
+              it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
@@ -1031,7 +1031,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 await expect(
                   context.lsp7CompatibleERC20
                     .connect(txParams.operator)
-                    ["transfer(address,address,uint256,bool,bytes)"](
+                    ['transfer(address,address,uint256,bool,bytes)'](
                       txParams.from,
                       txParams.to,
                       txParams.amount,
@@ -1041,7 +1041,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                 )
                   .to.be.revertedWithCustomError(
                     context.lsp7CompatibleERC20,
-                    "LSP7NotifyTokenReceiverContractMissingLSP1Interface",
+                    'LSP7NotifyTokenReceiverContractMissingLSP1Interface',
                   )
                   .withArgs(txParams.to);
 
@@ -1054,8 +1054,8 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
         });
       });
 
-      describe("when sender does not have enough balance", () => {
-        describe("when caller (msg.sender) is the `from` address", () => {
+      describe('when sender does not have enough balance', () => {
+        describe('when caller (msg.sender) is the `from` address', () => {
           it("should revert with `LSP7AmountExceedsBalance` error if sending more tokens than the tokenOwner's balance", async () => {
             const ownerBalance = await context.lsp7CompatibleERC20.balanceOf(
               context.accounts.owner.address,
@@ -1076,7 +1076,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             await expect(
               context.lsp7CompatibleERC20
                 .connect(txParams.operator)
-                ["transfer(address,address,uint256,bool,bytes)"](
+                ['transfer(address,address,uint256,bool,bytes)'](
                   txParams.from,
                   txParams.to,
                   txParams.amount,
@@ -1086,7 +1086,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             )
               .to.be.revertedWithCustomError(
                 context.lsp7CompatibleERC20,
-                "LSP7AmountExceedsBalance",
+                'LSP7AmountExceedsBalance',
               )
               .withArgs(ownerBalance.toHexString(), txParams.from, txParams.amount.toHexString());
 
@@ -1096,7 +1096,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           });
         });
 
-        describe("when caller (msg.sender) is an operator (= Not the `from` address)", () => {
+        describe('when caller (msg.sender) is an operator (= Not the `from` address)', () => {
           it("should revert with `LSP7AmountExceedsAuthorizedAmount` error if sending more tokens than the tokenOwner's balance", async () => {
             const ownerBalance = await context.lsp7CompatibleERC20.balanceOf(
               context.accounts.owner.address,
@@ -1117,7 +1117,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             await expect(
               context.lsp7CompatibleERC20
                 .connect(txParams.operator)
-                ["transfer(address,address,uint256,bool,bytes)"](
+                ['transfer(address,address,uint256,bool,bytes)'](
                   txParams.from,
                   txParams.to,
                   txParams.amount,
@@ -1127,7 +1127,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             )
               .to.be.revertedWithCustomError(
                 context.lsp7CompatibleERC20,
-                "LSP7AmountExceedsAuthorizedAmount",
+                'LSP7AmountExceedsAuthorizedAmount',
               )
               .withArgs(
                 context.accounts.owner.address,
@@ -1161,14 +1161,14 @@ export const shouldInitializeLikeLSP7CompatibleERC20 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered its ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered its ERC165 interface', async () => {
       expect(await context.lsp7CompatibleERC20.supportsInterface(INTERFACE_IDS.LSP7DigitalAsset));
     });
 
-    it("should have set expected entries with ERC725Y.setData", async () => {
+    it('should have set expected entries with ERC725Y.setData', async () => {
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7CompatibleERC20, "DataChanged")
+        .to.emit(context.lsp7CompatibleERC20, 'DataChanged')
         .withArgs(
           SupportedStandards.LSP4DigitalAsset.key,
           SupportedStandards.LSP4DigitalAsset.value,
@@ -1182,7 +1182,7 @@ export const shouldInitializeLikeLSP7CompatibleERC20 = (
         ethers.utils.toUtf8Bytes(context.deployParams.name),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7CompatibleERC20, "DataChanged")
+        .to.emit(context.lsp7CompatibleERC20, 'DataChanged')
         .withArgs(nameKey, expectedNameValue);
       expect(await context.lsp7CompatibleERC20.getData(nameKey)).to.equal(expectedNameValue);
 
@@ -1191,7 +1191,7 @@ export const shouldInitializeLikeLSP7CompatibleERC20 = (
         ethers.utils.toUtf8Bytes(context.deployParams.symbol),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7CompatibleERC20, "DataChanged")
+        .to.emit(context.lsp7CompatibleERC20, 'DataChanged')
         .withArgs(symbolKey, expectedSymbolValue);
       expect(await context.lsp7CompatibleERC20.getData(symbolKey)).to.equal(expectedSymbolValue);
     });

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -1,8 +1,8 @@
-import { ethers } from "hardhat";
-import { assert, expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import type { BigNumber } from "ethers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
+import { ethers } from 'hardhat';
+import { assert, expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { BigNumber } from 'ethers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
 // types
 import {
@@ -12,10 +12,10 @@ import {
   TokenReceiverWithLSP1__factory,
   TokenReceiverWithoutLSP1,
   TokenReceiverWithoutLSP1__factory,
-} from "../../types";
+} from '../../types';
 
 // constants
-import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from "../../constants";
+import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from '../../constants';
 
 export type LSP7TestAccounts = {
   owner: SignerWithAddress;
@@ -71,14 +71,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
     context = await buildContext();
   });
 
-  describe("when minting tokens", () => {
-    describe("when `amount == 0`", () => {
-      it("should revert if `allowNonLSP1Recipient == false`", async () => {
+  describe('when minting tokens', () => {
+    describe('when `amount == 0`', () => {
+      it('should revert if `allowNonLSP1Recipient == false`', async () => {
         const txParams = {
           to: context.accounts.anotherTokenReceiver.address,
           amount: 0,
           allowNonLSP1Recipient: false,
-          data: "0x",
+          data: '0x',
         };
 
         await expect(
@@ -86,16 +86,16 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             .connect(context.accounts.anyone)
             .mint(txParams.to, txParams.amount, txParams.allowNonLSP1Recipient, txParams.data),
         )
-          .to.be.revertedWithCustomError(context.lsp7, "LSP7NotifyTokenReceiverIsEOA")
+          .to.be.revertedWithCustomError(context.lsp7, 'LSP7NotifyTokenReceiverIsEOA')
           .withArgs(txParams.to);
       });
 
-      it("should pass if `allowNonLSP1Recipient == true`", async () => {
+      it('should pass if `allowNonLSP1Recipient == true`', async () => {
         const txParams = {
           to: context.accounts.anotherTokenReceiver.address,
           amount: 0,
           allowNonLSP1Recipient: true,
-          data: "0x",
+          data: '0x',
         };
 
         await expect(
@@ -103,7 +103,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             .connect(context.accounts.anyone)
             .mint(txParams.to, txParams.amount, txParams.allowNonLSP1Recipient, txParams.data),
         )
-          .to.emit(context.lsp7, "Transfer")
+          .to.emit(context.lsp7, 'Transfer')
           .withArgs(
             context.accounts.anyone.address,
             ethers.constants.AddressZero,
@@ -115,13 +115,13 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       });
     });
 
-    describe("when `to` is the zero address", () => {
-      it("should revert", async () => {
+    describe('when `to` is the zero address', () => {
+      it('should revert', async () => {
         const txParams = {
           to: ethers.constants.AddressZero,
-          amount: ethers.BigNumber.from("1"),
+          amount: ethers.BigNumber.from('1'),
           allowNonLSP1Recipient: true,
-          data: "0x",
+          data: '0x',
         };
 
         await expect(
@@ -131,17 +131,17 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             txParams.allowNonLSP1Recipient,
             txParams.data,
           ),
-        ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotSendWithAddressZero");
+        ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotSendWithAddressZero');
       });
     });
 
-    describe("when `to` is not the zero address", () => {
-      it("should mint the token amount", async () => {
+    describe('when `to` is not the zero address', () => {
+      it('should mint the token amount', async () => {
         const txParams = {
           to: context.accounts.tokenReceiver.address,
-          amount: ethers.BigNumber.from("1"),
+          amount: ethers.BigNumber.from('1'),
           allowNonLSP1Recipient: true,
-          data: ethers.utils.toUtf8Bytes("we need more tokens"),
+          data: ethers.utils.toUtf8Bytes('we need more tokens'),
         };
 
         // pre-conditions
@@ -162,24 +162,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
     });
   });
 
-  describe("when tokens have been minted", () => {
-    describe("totalSupply", () => {
-      it("should return total token supply", async () => {
+  describe('when tokens have been minted', () => {
+    describe('totalSupply', () => {
+      it('should return total token supply', async () => {
         expect(await context.lsp7.totalSupply()).to.equal(context.initialSupply);
       });
     });
 
-    describe("balanceOf", () => {
-      describe("when the given address owns tokens", () => {
-        it("should return the owned token count", async () => {
+    describe('balanceOf', () => {
+      describe('when the given address owns tokens', () => {
+        it('should return the owned token count', async () => {
           expect(await context.lsp7.balanceOf(context.accounts.owner.address)).to.equal(
             context.initialSupply,
           );
         });
       });
 
-      describe("when the given address does not own tokens", () => {
-        it("should return zero", async () => {
+      describe('when the given address does not own tokens', () => {
+        it('should return zero', async () => {
           expect(await context.lsp7.balanceOf(context.accounts.anyone.address)).to.equal(
             ethers.constants.Zero,
           );
@@ -187,15 +187,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       });
     });
 
-    describe("decimals", () => {
-      it("should return 18 as default value", async () => {
+    describe('decimals', () => {
+      it('should return 18 as default value', async () => {
         expect(await context.lsp7.decimals()).to.equal(18);
       });
     });
 
-    describe("authorizeOperator", () => {
-      describe("when operator is not the zero address", () => {
-        it("should succeed", async () => {
+    describe('authorizeOperator', () => {
+      describe('when operator is not the zero address', () => {
+        it('should succeed', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
           const amount = context.initialSupply;
@@ -203,13 +203,13 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           const tx = await context.lsp7.authorizeOperator(operator, amount);
 
           await expect(tx)
-            .to.emit(context.lsp7, "AuthorizedOperator")
+            .to.emit(context.lsp7, 'AuthorizedOperator')
             .withArgs(operator, tokenOwner, amount);
 
           expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(amount);
         });
 
-        describe("when operator is already authorized", () => {
+        describe('when operator is already authorized', () => {
           beforeEach(async () => {
             await context.lsp7.authorizeOperator(
               context.accounts.operator.address,
@@ -217,7 +217,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             );
           });
 
-          it("should succeed", async () => {
+          it('should succeed', async () => {
             const operator = context.accounts.operator.address;
             const tokenOwner = context.accounts.owner.address;
             const amount = context.initialSupply.add(1);
@@ -227,7 +227,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             const tx = await context.lsp7.authorizeOperator(operator, amount);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, amount);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(amount);
@@ -235,28 +235,28 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when operator is the zero address", () => {
-        it("should revert", async () => {
+      describe('when operator is the zero address', () => {
+        it('should revert', async () => {
           const operator = ethers.constants.AddressZero;
 
           await expect(
             context.lsp7.authorizeOperator(operator, context.initialSupply),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotUseAddressZeroAsOperator");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotUseAddressZeroAsOperator');
         });
       });
 
-      describe("when operator is the token owner", () => {
-        it("should revert", async () => {
+      describe('when operator is the token owner', () => {
+        it('should revert', async () => {
           const operator = context.accounts.owner.address;
 
           await expect(
             context.lsp7.authorizeOperator(operator, context.initialSupply),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7TokenOwnerCannotBeOperator");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7TokenOwnerCannotBeOperator');
         });
       });
     });
 
-    describe("increaseAllowance", () => {
+    describe('increaseAllowance', () => {
       beforeEach(async () => {
         const operator = context.accounts.operator.address;
         const tokenOwner = context.accounts.owner.address;
@@ -265,30 +265,30 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         const tx = await context.lsp7.authorizeOperator(operator, amount);
 
         await expect(tx)
-          .to.emit(context.lsp7, "AuthorizedOperator")
+          .to.emit(context.lsp7, 'AuthorizedOperator')
           .withArgs(operator, tokenOwner, amount);
 
         expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(amount);
       });
 
-      describe("when the sender has enough balance (more than the `addedAmount` to add for the operator)", () => {
-        const addedAmount = ethers.BigNumber.from("1");
+      describe('when the sender has enough balance (more than the `addedAmount` to add for the operator)', () => {
+        const addedAmount = ethers.BigNumber.from('1');
 
-        beforeEach("pre-checks", async () => {
+        beforeEach('pre-checks', async () => {
           const senderBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
 
           expect(senderBalance).to.be.greaterThanOrEqual(addedAmount);
         });
 
-        describe("when there was no allowance before for the operator (`authorizedAmountFor` operator = 0)", () => {
-          it("should authorize for the `addedAmount`", async () => {
+        describe('when there was no allowance before for the operator (`authorizedAmountFor` operator = 0)', () => {
+          it('should authorize for the `addedAmount`', async () => {
             const operator = context.accounts.anyone.address;
             const tokenOwner = context.accounts.owner.address;
 
             const tx = await context.lsp7.increaseAllowance(operator, addedAmount);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, addedAmount);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -297,7 +297,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           });
         });
 
-        describe("when there was an allowance for the operator already (`authorizedAmountFor` operator > 0)", () => {
+        describe('when there was an allowance for the operator already (`authorizedAmountFor` operator > 0)', () => {
           it("should increase the operator's allowance by the `addedAmount`", async () => {
             const operator = context.accounts.operator.address;
             const tokenOwner = context.accounts.owner.address;
@@ -309,7 +309,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             const tx = await context.lsp7.increaseAllowance(operator, addedAmount);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, expectedNewAllowance);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -319,24 +319,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when the sender does not have enough balance (less than the `addedAmount` to add for the operator)", () => {
+      describe('when the sender does not have enough balance (less than the `addedAmount` to add for the operator)', () => {
         let addedAmountLargerThanBalance: BigNumber;
 
-        beforeEach("set `addedAmount` larger than balance", async () => {
+        beforeEach('set `addedAmount` larger than balance', async () => {
           const senderBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
 
           addedAmountLargerThanBalance = senderBalance.add(5);
         });
 
-        describe("when there was no authorized amount before for the operator (`authorizedAmountFor` operator = 0)", () => {
-          it("should authorize for the `addedAmount`", async () => {
+        describe('when there was no authorized amount before for the operator (`authorizedAmountFor` operator = 0)', () => {
+          it('should authorize for the `addedAmount`', async () => {
             const operator = context.accounts.anyone.address;
             const tokenOwner = context.accounts.owner.address;
 
             const tx = await context.lsp7.increaseAllowance(operator, addedAmountLargerThanBalance);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, addedAmountLargerThanBalance);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -345,7 +345,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           });
         });
 
-        describe("when there was an authorized amount for the operator already (`authorizedAmountFor` operator > 0)", () => {
+        describe('when there was an authorized amount for the operator already (`authorizedAmountFor` operator > 0)', () => {
           it("should increase the operator's allowance by the `addedAmount`", async () => {
             const operator = context.accounts.operator.address;
             const tokenOwner = context.accounts.owner.address;
@@ -357,7 +357,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             const tx = await context.lsp7.increaseAllowance(operator, addedAmountLargerThanBalance);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, expectedNewAllowance);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -367,28 +367,28 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when `operator` param is the zero address", () => {
-        it("should revert", async () => {
-          const addedAmount = ethers.BigNumber.from("1");
+      describe('when `operator` param is the zero address', () => {
+        it('should revert', async () => {
+          const addedAmount = ethers.BigNumber.from('1');
 
           await expect(
             context.lsp7.increaseAllowance(ethers.constants.AddressZero, addedAmount),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotUseAddressZeroAsOperator");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotUseAddressZeroAsOperator');
         });
       });
 
-      describe("when `operator` param is `msg.sender`", () => {
-        it("should revert", async () => {
-          const addedAmount = ethers.BigNumber.from("1");
+      describe('when `operator` param is `msg.sender`', () => {
+        it('should revert', async () => {
+          const addedAmount = ethers.BigNumber.from('1');
 
           await expect(
             context.lsp7.increaseAllowance(context.accounts.owner.address, addedAmount),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7TokenOwnerCannotBeOperator");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7TokenOwnerCannotBeOperator');
         });
       });
     });
 
-    describe("decreaseAllowance", () => {
+    describe('decreaseAllowance', () => {
       beforeEach(async () => {
         const operator = context.accounts.operator.address;
         const tokenOwner = context.accounts.owner.address;
@@ -397,15 +397,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         const tx = await context.lsp7.authorizeOperator(operator, amount);
 
         await expect(tx)
-          .to.emit(context.lsp7, "AuthorizedOperator")
+          .to.emit(context.lsp7, 'AuthorizedOperator')
           .withArgs(operator, tokenOwner, amount);
 
         expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(amount);
       });
 
-      describe("when `operator` param is the zero address", () => {
-        it("should revert", async () => {
-          const subtractedAmount = ethers.BigNumber.from("1");
+      describe('when `operator` param is the zero address', () => {
+        it('should revert', async () => {
+          const subtractedAmount = ethers.BigNumber.from('1');
 
           await expect(
             context.lsp7.decreaseAllowance(ethers.constants.AddressZero, subtractedAmount),
@@ -413,13 +413,13 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             context.lsp7,
             // Since we can never grant allowance for address(0), address(0) will always have 0 allowance
             // and this error message will always be thrown first
-            "LSP7DecreasedAllowanceBelowZero",
+            'LSP7DecreasedAllowanceBelowZero',
           );
         });
       });
 
-      describe("when there was no allowance before for the operator", () => {
-        it("should revert", async () => {
+      describe('when there was no allowance before for the operator', () => {
+        it('should revert', async () => {
           const operator = context.accounts.anyone.address;
           const tokenOwner = context.accounts.owner.address;
 
@@ -429,17 +429,17 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
           await expect(
             context.lsp7.decreaseAllowance(operator, subtractedAmount),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7DecreasedAllowanceBelowZero");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7DecreasedAllowanceBelowZero');
         });
       });
 
-      describe("when there was an allowance before for the operator", () => {
+      describe('when there was an allowance before for the operator', () => {
         describe("when decreasing the operator's allowance by an amount smaller than the full allowance", () => {
           it("should decrease the operator's allowance by the `subtractedAmount` + emit `AuthorizedOperator` event", async () => {
             const operator = context.accounts.operator.address;
             const tokenOwner = context.accounts.owner.address;
 
-            const subtractedAmount = ethers.BigNumber.from("1");
+            const subtractedAmount = ethers.BigNumber.from('1');
 
             const allowanceBefore = await context.lsp7.authorizedAmountFor(operator, tokenOwner);
 
@@ -448,7 +448,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             const expectedNewAllowance = allowanceBefore.sub(subtractedAmount);
 
             await expect(tx)
-              .to.emit(context.lsp7, "AuthorizedOperator")
+              .to.emit(context.lsp7, 'AuthorizedOperator')
               .withArgs(operator, tokenOwner, expectedNewAllowance);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -469,7 +469,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             const expectedNewAllowance = 0;
 
             await expect(tx)
-              .to.emit(context.lsp7, "RevokedOperator")
+              .to.emit(context.lsp7, 'RevokedOperator')
               .withArgs(operator, tokenOwner);
 
             expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -479,18 +479,18 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when `operator` param is `msg.sender`", () => {
-        it("should revert", async () => {
-          const subtractedAmount = ethers.BigNumber.from("1");
+      describe('when `operator` param is `msg.sender`', () => {
+        it('should revert', async () => {
+          const subtractedAmount = ethers.BigNumber.from('1');
 
           await expect(
             context.lsp7.decreaseAllowance(context.accounts.owner.address, subtractedAmount),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7TokenOwnerCannotBeOperator");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7TokenOwnerCannotBeOperator');
         });
       });
 
-      describe("when decreasing the operator allowance by an amount larger than the current allowance", () => {
-        it("should revert", async () => {
+      describe('when decreasing the operator allowance by an amount larger than the current allowance', () => {
+        it('should revert', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
 
@@ -500,15 +500,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
           await expect(
             context.lsp7.decreaseAllowance(operator, subtractedAmountLargerThanAllowance),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7DecreasedAllowanceBelowZero");
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7DecreasedAllowanceBelowZero');
         });
       });
     });
   });
 
-  describe("revokeOperator", () => {
-    describe("when operator is not the zero address", () => {
-      it("should succeed", async () => {
+  describe('revokeOperator', () => {
+    describe('when operator is not the zero address', () => {
+      it('should succeed', async () => {
         const operator = context.accounts.operator.address;
         const tokenOwner = context.accounts.owner.address;
         const amount = context.initialSupply;
@@ -519,7 +519,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
         // effects
         const tx = await context.lsp7.revokeOperator(operator);
-        await expect(tx).to.emit(context.lsp7, "RevokedOperator").withArgs(operator, tokenOwner);
+        await expect(tx).to.emit(context.lsp7, 'RevokedOperator').withArgs(operator, tokenOwner);
 
         // post-conditions
         expect(await context.lsp7.authorizedAmountFor(operator, tokenOwner)).to.equal(
@@ -528,31 +528,31 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       });
     });
 
-    describe("when operator is the zero address", () => {
-      it("should revert", async () => {
+    describe('when operator is the zero address', () => {
+      it('should revert', async () => {
         const operator = ethers.constants.AddressZero;
 
         await expect(context.lsp7.revokeOperator(operator)).to.be.revertedWithCustomError(
           context.lsp7,
-          "LSP7CannotUseAddressZeroAsOperator",
+          'LSP7CannotUseAddressZeroAsOperator',
         );
       });
     });
 
-    describe("when operator is the token owner", () => {
-      it("should revert", async () => {
+    describe('when operator is the token owner', () => {
+      it('should revert', async () => {
         const operator = context.accounts.owner.address;
 
         await expect(context.lsp7.revokeOperator(operator)).to.be.revertedWithCustomError(
           context.lsp7,
-          "LSP7TokenOwnerCannotBeOperator",
+          'LSP7TokenOwnerCannotBeOperator',
         );
       });
     });
 
-    describe("authorizedAmountFor", () => {
-      describe("when operator is the token owner", () => {
-        it("should return the balance of the token owner", async () => {
+    describe('authorizedAmountFor', () => {
+      describe('when operator is the token owner', () => {
+        it('should return the balance of the token owner', async () => {
           expect(
             await context.lsp7.authorizedAmountFor(
               context.accounts.owner.address,
@@ -562,8 +562,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when operator has not been authorized", () => {
-        it("should return zero", async () => {
+      describe('when operator has not been authorized', () => {
+        it('should return zero', async () => {
           expect(
             await context.lsp7.authorizedAmountFor(
               context.accounts.operator.address,
@@ -573,8 +573,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when one account have been authorized", () => {
-        it("should return the authorized amount", async () => {
+      describe('when one account have been authorized', () => {
+        it('should return the authorized amount', async () => {
           await context.lsp7.authorizeOperator(
             context.accounts.operator.address,
             context.initialSupply,
@@ -589,15 +589,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("when many accounts have been authorized", () => {
-        it("should return the authorized amount for each operator", async () => {
+      describe('when many accounts have been authorized', () => {
+        it('should return the authorized amount for each operator', async () => {
           await context.lsp7.authorizeOperator(
             context.accounts.operator.address,
             context.initialSupply,
           );
           await context.lsp7.authorizeOperator(
             context.accounts.operatorWithLowAuthorizedAmount.address,
-            ethers.BigNumber.from("1"),
+            ethers.BigNumber.from('1'),
           );
 
           expect(
@@ -617,7 +617,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       });
     });
 
-    describe("transfers", () => {
+    describe('transfers', () => {
       type HelperContracts = {
         tokenReceiverWithLSP1: TokenReceiverWithLSP1;
         tokenReceiverWithoutLSP1: TokenReceiverWithoutLSP1;
@@ -643,11 +643,11 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         );
         await context.lsp7.authorizeOperator(
           context.accounts.operatorWithLowAuthorizedAmount.address,
-          ethers.BigNumber.from("1"),
+          ethers.BigNumber.from('1'),
         );
       });
 
-      describe("transfer", () => {
+      describe('transfer', () => {
         type TransferTxParams = {
           from: string;
           to: string;
@@ -670,7 +670,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             .connect(operator)
             .transfer(from, to, amount, allowNonLSP1Recipient, data);
           await expect(tx)
-            .to.emit(context.lsp7, "Transfer")
+            .to.emit(context.lsp7, 'Transfer')
             .withArgs(operator.address, from, to, amount, allowNonLSP1Recipient, data);
 
           // post-conditions
@@ -687,13 +687,13 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             );
             expect(postIsOperatorFor).to.equal(preIsOperatorFor.sub(amount));
 
-            if (postIsOperatorFor.eq("0")) {
+            if (postIsOperatorFor.eq('0')) {
               await expect(tx)
-                .to.emit(context.lsp7, "RevokedOperator")
+                .to.emit(context.lsp7, 'RevokedOperator')
                 .withArgs(context.accounts.operator.address, from);
             } else {
               await expect(tx)
-                .to.emit(context.lsp7, "AuthorizedOperator")
+                .to.emit(context.lsp7, 'AuthorizedOperator')
                 .withArgs(context.accounts.operator.address, from, postIsOperatorFor);
             }
           }
@@ -709,15 +709,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             operator = getOperator();
           });
 
-          describe("when using allowNonLSP1Recipient=true", () => {
+          describe('when using allowNonLSP1Recipient=true', () => {
             const allowNonLSP1Recipient = true;
             const data = ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("doing a transfer with allowNonLSP1Recipient"),
+              ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
             );
 
-            describe("when `to` is an EOA", () => {
-              describe("when `to` is not the zero address", () => {
-                it("should allow transfering", async () => {
+            describe('when `to` is an EOA', () => {
+              describe('when `to` is not the zero address', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: context.accounts.owner.address,
                     to: context.accounts.tokenReceiver.address,
@@ -730,16 +730,16 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 });
               });
 
-              describe("when `to` is the zero address", () => {
-                it("should revert", async () => {
+              describe('when `to` is the zero address', () => {
+                it('should revert', async () => {
                   const txParams: TransferTxParams = {
                     from: operator.address,
                     to: ethers.constants.AddressZero,
                     amount: context.initialSupply,
                     allowNonLSP1Recipient: true,
-                    data: "0x",
+                    data: '0x',
                   };
-                  const expectedError = "LSP7CannotSendWithAddressZero";
+                  const expectedError = 'LSP7CannotSendWithAddressZero';
 
                   await expect(
                     context.lsp7
@@ -751,14 +751,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                         txParams.allowNonLSP1Recipient,
                         txParams.data,
                       ),
-                  ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotSendWithAddressZero");
+                  ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotSendWithAddressZero');
                 });
               });
             });
 
-            describe("when `to` is a contract", () => {
-              describe("when receiving contract supports LSP1", () => {
-                it("should allow transfering", async () => {
+            describe('when `to` is a contract', () => {
+              describe('when receiving contract supports LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: context.accounts.owner.address,
                     to: helperContracts.tokenReceiverWithLSP1.address,
@@ -771,18 +771,18 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
-                    ["address", "address", "uint256", "bytes"],
+                    ['address', 'address', 'uint256', 'bytes'],
                     [txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
 
                   await expect(tx)
-                    .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                     .withArgs(typeId, packedData);
                 });
               });
 
-              describe("when receiving contract does not support LSP1", () => {
-                it("should allow transfering", async () => {
+              describe('when receiving contract does not support LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: context.accounts.owner.address,
                     to: helperContracts.tokenReceiverWithoutLSP1.address,
@@ -797,14 +797,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when allowNonLSP1Recipient=false", () => {
+          describe('when allowNonLSP1Recipient=false', () => {
             const allowNonLSP1Recipient = false;
             const data = ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+              ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
             );
 
-            describe("when `to` is an EOA", () => {
-              it("should revert", async () => {
+            describe('when `to` is an EOA', () => {
+              it('should revert', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: context.accounts.tokenReceiver.address,
@@ -824,14 +824,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                       txParams.data,
                     ),
                 )
-                  .to.be.revertedWithCustomError(context.lsp7, "LSP7NotifyTokenReceiverIsEOA")
+                  .to.be.revertedWithCustomError(context.lsp7, 'LSP7NotifyTokenReceiverIsEOA')
                   .withArgs(txParams.to);
               });
             });
 
-            describe("when `to` is a contract", () => {
-              describe("when receiving contract supports LSP1", () => {
-                it("should allow transfering", async () => {
+            describe('when `to` is a contract', () => {
+              describe('when receiving contract supports LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: context.accounts.owner.address,
                     to: helperContracts.tokenReceiverWithLSP1.address,
@@ -844,18 +844,18 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = ethers.utils.solidityPack(
-                    ["address", "address", "uint256", "bytes"],
+                    ['address', 'address', 'uint256', 'bytes'],
                     [txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
 
                   await expect(tx)
-                    .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                     .withArgs(typeId, packedData);
                 });
               });
 
-              describe("when receiving contract does not support LSP1", () => {
-                it("should revert", async () => {
+              describe('when receiving contract does not support LSP1', () => {
+                it('should revert', async () => {
                   const txParams = {
                     from: context.accounts.owner.address,
                     to: helperContracts.tokenReceiverWithoutLSP1.address,
@@ -877,7 +877,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   )
                     .to.be.revertedWithCustomError(
                       context.lsp7,
-                      "LSP7NotifyTokenReceiverContractMissingLSP1Interface",
+                      'LSP7NotifyTokenReceiverContractMissingLSP1Interface',
                     )
                     .withArgs(txParams.to);
                 });
@@ -885,14 +885,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when the given amount is more than balance of tokenOwner", () => {
-            it("should revert", async () => {
+          describe('when the given amount is more than balance of tokenOwner', () => {
+            it('should revert', async () => {
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 amount: context.initialSupply.add(1),
                 allowNonLSP1Recipient: true,
-                data: "0x",
+                data: '0x',
               };
 
               if (txParams.from !== operator.address) {
@@ -910,7 +910,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     txParams.data,
                   ),
               )
-                .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsBalance")
+                .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsBalance')
                 .withArgs(
                   context.initialSupply.toHexString(),
                   txParams.from,
@@ -920,23 +920,23 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           });
         };
 
-        describe("when tokenOwner sends tx", () => {
+        describe('when tokenOwner sends tx', () => {
           sendingTransferTransactions(() => context.accounts.owner);
         });
 
-        describe("when operator sends tx", () => {
+        describe('when operator sends tx', () => {
           sendingTransferTransactions(() => context.accounts.operator);
 
-          describe("when `from` and `to` address are the same", () => {
-            it("should revert", async () => {
+          describe('when `from` and `to` address are the same', () => {
+            it('should revert', async () => {
               const operator = context.accounts.operator;
 
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.owner.address,
-                amount: ethers.BigNumber.from("1"),
+                amount: ethers.BigNumber.from('1'),
                 allowNonLSP1Recipient: true,
-                data: "0x",
+                data: '0x',
               };
 
               const preFromBalanceOf = await context.lsp7.balanceOf(txParams.from);
@@ -955,7 +955,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     txParams.allowNonLSP1Recipient,
                     txParams.data,
                   ),
-              ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotSendToSelf");
+              ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotSendToSelf');
 
               // token owner balance should not have changed
               const postFromBalanceOf = await context.lsp7.balanceOf(txParams.from);
@@ -970,8 +970,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when `amount == 0`", () => {
-            it("should revert with `allowNonLSP1Recipient == false`", async () => {
+          describe('when `amount == 0`', () => {
+            it('should revert with `allowNonLSP1Recipient == false`', async () => {
               const caller = context.accounts.anyone;
 
               const txParams = {
@@ -979,7 +979,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 to: context.accounts.anotherTokenReceiver.address,
                 amount: ethers.BigNumber.from(0),
                 allowNonLSP1Recipient: false,
-                data: "0x",
+                data: '0x',
               };
 
               await expect(
@@ -993,11 +993,11 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     txParams.data,
                   ),
               )
-                .to.be.revertedWithCustomError(context.lsp7, "LSP7NotifyTokenReceiverIsEOA")
+                .to.be.revertedWithCustomError(context.lsp7, 'LSP7NotifyTokenReceiverIsEOA')
                 .withArgs(txParams.to);
             });
 
-            it("should pass with `allowNonLSP1Recipient == true`", async () => {
+            it('should pass with `allowNonLSP1Recipient == true`', async () => {
               const caller = context.accounts.anyone;
 
               const txParams = {
@@ -1005,22 +1005,22 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 to: context.accounts.anotherTokenReceiver.address,
                 amount: ethers.BigNumber.from(0),
                 allowNonLSP1Recipient: true,
-                data: "0x",
+                data: '0x',
               };
 
               await transferSuccessScenario(txParams, caller);
             });
           });
 
-          describe("when operator does not have enough authorized amount", () => {
-            it("should revert", async () => {
+          describe('when operator does not have enough authorized amount', () => {
+            it('should revert', async () => {
               const operator = context.accounts.operatorWithLowAuthorizedAmount;
               const txParams = {
                 from: context.accounts.owner.address,
                 to: helperContracts.tokenReceiverWithoutLSP1.address,
                 amount: context.initialSupply,
                 allowNonLSP1Recipient: true,
-                data: "0x",
+                data: '0x',
               };
               const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
@@ -1038,7 +1038,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     txParams.data,
                   ),
               )
-                .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsAuthorizedAmount")
+                .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsAuthorizedAmount')
                 .withArgs(
                   txParams.from,
                   operatorAmount.toHexString(),
@@ -1049,15 +1049,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           });
         });
 
-        describe("when the caller is not an operator", () => {
-          it("should revert", async () => {
+        describe('when the caller is not an operator', () => {
+          it('should revert', async () => {
             const operator = context.accounts.anyone;
             const txParams = {
               from: context.accounts.owner.address,
               to: context.accounts.tokenReceiver.address,
               amount: context.initialSupply,
               allowNonLSP1Recipient: true,
-              data: "0x",
+              data: '0x',
             };
             const operatorAmount = await context.lsp7.authorizedAmountFor(
               operator.address,
@@ -1081,7 +1081,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   txParams.data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsAuthorizedAmount")
+              .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsAuthorizedAmount')
               .withArgs(
                 txParams.from,
                 operatorAmount.toHexString(),
@@ -1092,7 +1092,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         });
       });
 
-      describe("transferBatch", () => {
+      describe('transferBatch', () => {
         beforeEach(async () => {
           // setup so we can observe operator amounts during transferBatch tests
           await context.lsp7.authorizeOperator(
@@ -1101,7 +1101,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           );
           await context.lsp7.authorizeOperator(
             context.accounts.operatorWithLowAuthorizedAmount.address,
-            ethers.BigNumber.from("1"),
+            ethers.BigNumber.from('1'),
           );
         });
 
@@ -1133,7 +1133,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           await Promise.all(
             amount.map(async (_, index) => {
               await expect(tx)
-                .to.emit(context.lsp7, "Transfer")
+                .to.emit(context.lsp7, 'Transfer')
                 .withArgs(
                   operator.address,
                   from[index],
@@ -1158,13 +1158,13 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 );
                 expect(postIsOperatorFor).to.equal(postIsOperatorFor.sub(amount[index]));
 
-                if (postIsOperatorFor.eq("0")) {
+                if (postIsOperatorFor.eq('0')) {
                   await expect(tx)
-                    .to.emit(context.lsp7, "RevokedOperator")
+                    .to.emit(context.lsp7, 'RevokedOperator')
                     .withArgs(context.accounts.operator.address, from[index], postIsOperatorFor);
                 } else {
                   await expect(tx)
-                    .to.emit(context.lsp7, "AuthorizedOperator")
+                    .to.emit(context.lsp7, 'AuthorizedOperator')
                     .withArgs(context.accounts.operator.address, from, postIsOperatorFor);
                 }
               }
@@ -1202,22 +1202,22 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             operator = getOperator();
           });
 
-          describe("when allowNonLSP1Recipient=true", () => {
+          describe('when allowNonLSP1Recipient=true', () => {
             const data = ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("doing a transfer with allowNonLSP1Recipient"),
+              ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
             );
 
-            describe("when `to` is an EOA", () => {
-              describe("when `to` is the zero address", () => {
-                it("should revert", async () => {
+            describe('when `to` is an EOA', () => {
+              describe('when `to` is the zero address', () => {
+                it('should revert', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [context.accounts.tokenReceiver.address, ethers.constants.AddressZero],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, true],
                     data: [data, data],
                   };
-                  const expectedError = "LSP7CannotSendWithAddressZero";
+                  const expectedError = 'LSP7CannotSendWithAddressZero';
 
                   await transferBatchFailScenario(txParams, operator, {
                     error: expectedError,
@@ -1226,15 +1226,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 });
               });
 
-              describe("when `to` is not the zero address", () => {
-                it("should allow transfering", async () => {
+              describe('when `to` is not the zero address', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       context.accounts.tokenReceiver.address,
                       context.accounts.anotherTokenReceiver.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, true],
                     data: [data, data],
                   };
@@ -1244,16 +1244,16 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
               });
             });
 
-            describe("when `to` is a contract", () => {
-              describe("when receiving contract supports LSP1", () => {
-                it("should allow transfering", async () => {
+            describe('when `to` is a contract', () => {
+              describe('when receiving contract supports LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithLSP1.address,
                       helperContracts.tokenReceiverWithLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, true],
                     data: [data, data],
                   };
@@ -1263,9 +1263,9 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   await Promise.all(
                     txParams.amount.map((_, index) => async () => {
                       const typeId =
-                        "0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895";
+                        '0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895';
                       const packedData = ethers.utils.solidityPack(
-                        ["address", "address", "uint256", "bytes"],
+                        ['address', 'address', 'uint256', 'bytes'],
                         [
                           txParams.from[index],
                           txParams.to[index],
@@ -1275,22 +1275,22 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                       );
 
                       await expect(tx)
-                        .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                        .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                         .withArgs(typeId, packedData);
                     }),
                   );
                 });
               });
 
-              describe("when receiving contract does not support LSP1", () => {
-                it("should allow transfering", async () => {
+              describe('when receiving contract does not support LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithoutLSP1.address,
                       helperContracts.tokenReceiverWithoutLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, true],
                     data: [data, data],
                   };
@@ -1301,24 +1301,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when allowNonLSP1Recipient=false", () => {
+          describe('when allowNonLSP1Recipient=false', () => {
             const data = ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+              ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
             );
 
-            describe("when `to` is an EOA", () => {
-              it("should revert", async () => {
+            describe('when `to` is an EOA', () => {
+              it('should revert', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
                     context.accounts.tokenReceiver.address,
                     context.accounts.anotherTokenReceiver.address,
                   ],
-                  amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                  amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                   allowNonLSP1Recipient: [false, false],
                   data: [data, data],
                 };
-                const expectedError = "LSP7NotifyTokenReceiverIsEOA";
+                const expectedError = 'LSP7NotifyTokenReceiverIsEOA';
 
                 await transferBatchFailScenario(txParams, operator, {
                   error: expectedError,
@@ -1327,16 +1327,16 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
               });
             });
 
-            describe("when `to` is a contract", () => {
-              describe("when receiving contract supports LSP1", () => {
-                it("should allow transfering", async () => {
+            describe('when `to` is a contract', () => {
+              describe('when receiving contract supports LSP1', () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithLSP1.address,
                       helperContracts.tokenReceiverWithLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [false, false],
                     data: [data, data],
                   };
@@ -1345,19 +1345,19 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 });
               });
 
-              describe("when receiving contract does not support LSP1", () => {
-                it("should revert", async () => {
+              describe('when receiving contract does not support LSP1', () => {
+                it('should revert', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithoutLSP1.address,
                       helperContracts.tokenReceiverWithoutLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [false, false],
                     data: [data, data],
                   };
-                  const expectedError = "LSP7NotifyTokenReceiverContractMissingLSP1Interface";
+                  const expectedError = 'LSP7NotifyTokenReceiverContractMissingLSP1Interface';
 
                   await transferBatchFailScenario(txParams, operator, {
                     error: expectedError,
@@ -1368,24 +1368,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when allowNonLSP1Recipient is mixed(true/false) respectively", () => {
+          describe('when allowNonLSP1Recipient is mixed(true/false) respectively', () => {
             const data = ethers.utils.hexlify(
-              ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+              ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
             );
 
-            describe("when `to` is an EOA", () => {
-              it("should revert", async () => {
+            describe('when `to` is an EOA', () => {
+              it('should revert', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
                     context.accounts.tokenReceiver.address,
                     context.accounts.anotherTokenReceiver.address,
                   ],
-                  amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                  amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                   allowNonLSP1Recipient: [true, false],
                   data: [data, data],
                 };
-                const expectedError = "LSP7NotifyTokenReceiverIsEOA";
+                const expectedError = 'LSP7NotifyTokenReceiverIsEOA';
 
                 await transferBatchFailScenario(txParams, operator, {
                   error: expectedError,
@@ -1394,21 +1394,21 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
               });
             });
 
-            describe("when `to` is a contract", () => {
+            describe('when `to` is a contract', () => {
               describe("when first receiving contract support LSP1 but the second doesn't", () => {
-                it("should allow transfering", async () => {
+                it('should allow transfering', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithLSP1.address,
                       helperContracts.tokenReceiverWithoutLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, false],
                     data: [data, data],
                   };
 
-                  const expectedError = "LSP7NotifyTokenReceiverContractMissingLSP1Interface";
+                  const expectedError = 'LSP7NotifyTokenReceiverContractMissingLSP1Interface';
 
                   await transferBatchFailScenario(txParams, operator, {
                     error: expectedError,
@@ -1417,15 +1417,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                 });
               });
 
-              describe("when receiving contract both support LSP1", () => {
-                it("should pass regardless of allowNonLSP1Recipient params", async () => {
+              describe('when receiving contract both support LSP1', () => {
+                it('should pass regardless of allowNonLSP1Recipient params', async () => {
                   const txParams = {
                     from: [context.accounts.owner.address, context.accounts.owner.address],
                     to: [
                       helperContracts.tokenReceiverWithLSP1.address,
                       helperContracts.tokenReceiverWithLSP1.address,
                     ],
-                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                    amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                     allowNonLSP1Recipient: [true, false],
                     data: [data, data],
                   };
@@ -1436,21 +1436,21 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when the given amount is more than balance of tokenOwner", () => {
-            it("should revert", async () => {
+          describe('when the given amount is more than balance of tokenOwner', () => {
+            it('should revert', async () => {
               const txParams = {
                 from: [context.accounts.owner.address],
                 to: [context.accounts.tokenReceiver.address],
                 amount: [context.initialSupply.add(1)],
                 allowNonLSP1Recipient: [true],
-                data: ["0x"],
+                data: ['0x'],
               };
-              const expectedError = "LSP7AmountExceedsBalance";
+              const expectedError = 'LSP7AmountExceedsBalance';
 
               if (txParams.from.filter((x) => x !== operator.address).length !== 0) {
                 const totalAmount = txParams.amount.reduce(
                   (acc, amount) => acc.add(amount),
-                  ethers.BigNumber.from("0"),
+                  ethers.BigNumber.from('0'),
                 );
                 await context.lsp7.authorizeOperator(operator.address, totalAmount);
               }
@@ -1466,21 +1466,21 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when function parameters list length does not match", () => {
-            it("should revert", async () => {
+          describe('when function parameters list length does not match', () => {
+            it('should revert', async () => {
               const validTxParams = {
                 from: [context.accounts.owner.address, context.accounts.owner.address],
                 to: [
                   context.accounts.tokenReceiver.address,
                   context.accounts.tokenReceiver.address,
                 ],
-                amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                 allowNonLSP1Recipient: [true, true],
-                data: ["0x", "0x"],
+                data: ['0x', '0x'],
               };
 
               await Promise.all(
-                ["from", "to", "amount", "data"].map(async (arrayParam) => {
+                ['from', 'to', 'amount', 'data'].map(async (arrayParam) => {
                   await transferBatchFailScenario(
                     {
                       ...validTxParams,
@@ -1488,7 +1488,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     },
                     operator,
                     {
-                      error: "LSP7InvalidTransferBatch",
+                      error: 'LSP7InvalidTransferBatch',
                       args: [],
                     },
                   );
@@ -1498,24 +1498,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           });
         };
 
-        describe("when tokenOwner sends tx", () => {
+        describe('when tokenOwner sends tx', () => {
           sendingTransferBatchTransactions(() => context.accounts.owner);
         });
 
-        describe("when operator sends tx", () => {
+        describe('when operator sends tx', () => {
           sendingTransferBatchTransactions(() => context.accounts.operator);
 
-          describe("when `to` and `from` are the same address", () => {
-            it("should revert", async () => {
+          describe('when `to` and `from` are the same address', () => {
+            it('should revert', async () => {
               const operator = context.accounts.operator;
               const txParams = {
                 from: [context.accounts.owner.address, context.accounts.owner.address],
                 to: [context.accounts.tokenReceiver.address, context.accounts.owner.address],
-                amount: [context.initialSupply.sub(1), ethers.BigNumber.from("1")],
+                amount: [context.initialSupply.sub(1), ethers.BigNumber.from('1')],
                 allowNonLSP1Recipient: [true, true],
-                data: ["0x", "0x"],
+                data: ['0x', '0x'],
               };
-              const expectedError = "LSP7CannotSendToSelf";
+              const expectedError = 'LSP7CannotSendToSelf';
 
               await transferBatchFailScenario(txParams, operator, {
                 error: expectedError,
@@ -1524,17 +1524,17 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when operator does not have enough authorized amount", () => {
-            it("should revert", async () => {
+          describe('when operator does not have enough authorized amount', () => {
+            it('should revert', async () => {
               const operator = context.accounts.operatorWithLowAuthorizedAmount;
               const txParams = {
                 from: [context.accounts.owner.address],
                 to: [context.accounts.tokenReceiver.address],
                 amount: [context.initialSupply],
                 allowNonLSP1Recipient: [true],
-                data: ["0x"],
+                data: ['0x'],
               };
-              const expectedError = "LSP7AmountExceedsAuthorizedAmount";
+              const expectedError = 'LSP7AmountExceedsAuthorizedAmount';
               const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
                 txParams.from[0],
@@ -1552,17 +1552,17 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             });
           });
 
-          describe("when the caller is not an operator", () => {
-            it("should revert", async () => {
+          describe('when the caller is not an operator', () => {
+            it('should revert', async () => {
               const operator = context.accounts.anyone;
               const txParams = {
                 from: [context.accounts.owner.address],
                 to: [context.accounts.tokenReceiver.address],
                 amount: [context.initialSupply],
                 allowNonLSP1Recipient: [true],
-                data: ["0x"],
+                data: ['0x'],
               };
-              const expectedError = "LSP7AmountExceedsAuthorizedAmount";
+              const expectedError = 'LSP7AmountExceedsAuthorizedAmount';
               const operatorAmount = await context.lsp7.authorizedAmountFor(
                 operator.address,
                 txParams.from[0],
@@ -1584,182 +1584,182 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
     });
   });
 
-  describe("burn", () => {
-    describe("when `amount == 0`", () => {
-      it("should pass", async () => {
+  describe('burn', () => {
+    describe('when `amount == 0`', () => {
+      it('should pass', async () => {
         const caller = context.accounts.anyone;
         const amount = 1;
 
         await context.lsp7
           .connect(context.accounts.anyone)
-          .mint(caller.address, amount, true, "0x");
+          .mint(caller.address, amount, true, '0x');
 
-        await expect(context.lsp7.connect(caller).burn(caller.address, amount, "0x"))
-          .to.emit(context.lsp7, "Transfer")
+        await expect(context.lsp7.connect(caller).burn(caller.address, amount, '0x'))
+          .to.emit(context.lsp7, 'Transfer')
           .withArgs(
             caller.address,
             caller.address,
             ethers.constants.AddressZero,
             amount,
             false,
-            "0x",
+            '0x',
           );
       });
     });
-    describe("when caller is the `from` address", () => {
-      describe("when using address(0) as `from` address", () => {
-        it("should revert", async () => {
+    describe('when caller is the `from` address', () => {
+      describe('when using address(0) as `from` address', () => {
+        it('should revert', async () => {
           const caller = context.accounts.anyone;
           const amount = 10;
 
           await expect(
-            context.lsp7.connect(caller).burn(ethers.constants.AddressZero, amount, "0x"),
-          ).to.be.revertedWithCustomError(context.lsp7, "LSP7CannotSendWithAddressZero");
+            context.lsp7.connect(caller).burn(ethers.constants.AddressZero, amount, '0x'),
+          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotSendWithAddressZero');
         });
       });
 
-      describe("when caller has no token balance", () => {
-        it("should revert", async () => {
+      describe('when caller has no token balance', () => {
+        it('should revert', async () => {
           const caller = context.accounts.anyone;
           const amount = 10;
 
-          await expect(context.lsp7.connect(caller).burn(caller.address, amount, "0x"))
-            .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsBalance")
+          await expect(context.lsp7.connect(caller).burn(caller.address, amount, '0x'))
+            .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsBalance')
             .withArgs(0, caller.address, amount);
         });
       });
 
-      describe("when caller has some token balance", () => {
+      describe('when caller has some token balance', () => {
         beforeEach(async () => {
           // mint some initial tokens
-          await context.lsp7.mint(context.accounts.owner.address, 100, true, "0x");
+          await context.lsp7.mint(context.accounts.owner.address, 100, true, '0x');
         });
 
-        describe("when burning all its tokens", () => {
-          it("caller balance should then be zero", async () => {
+        describe('when burning all its tokens', () => {
+          it('caller balance should then be zero', async () => {
             const caller = context.accounts.owner;
             const amount = await context.lsp7.balanceOf(caller.address);
 
-            await context.lsp7.connect(caller).burn(caller.address, amount, "0x");
+            await context.lsp7.connect(caller).burn(caller.address, amount, '0x');
 
             const newBalance = await context.lsp7.balanceOf(caller.address);
             expect(newBalance).to.equal(0);
           });
 
-          it("should have decreased the total supply", async () => {
+          it('should have decreased the total supply', async () => {
             const caller = context.accounts.owner;
             const amount = await context.lsp7.balanceOf(caller.address);
             const initialSupply = await context.lsp7.totalSupply();
 
-            await context.lsp7.connect(caller).burn(caller.address, amount, "0x");
+            await context.lsp7.connect(caller).burn(caller.address, amount, '0x');
 
             const newSupply = await context.lsp7.totalSupply();
             expect(newSupply).to.equal(initialSupply.sub(amount));
           });
 
-          it("should emit a Transfer event with address(0) for `to`", async () => {
+          it('should emit a Transfer event with address(0) for `to`', async () => {
             const caller = context.accounts.owner;
             const amount = await context.lsp7.balanceOf(caller.address);
 
-            await expect(context.lsp7.connect(caller).burn(caller.address, amount, "0x"))
-              .to.emit(context.lsp7, "Transfer")
+            await expect(context.lsp7.connect(caller).burn(caller.address, amount, '0x'))
+              .to.emit(context.lsp7, 'Transfer')
               .withArgs(
                 caller.address,
                 caller.address,
                 ethers.constants.AddressZero,
                 amount,
                 false,
-                "0x",
+                '0x',
               );
           });
         });
 
-        describe("when burning less than its tokens balance", () => {
-          it("caller balance should then be decreased", async () => {
+        describe('when burning less than its tokens balance', () => {
+          it('caller balance should then be decreased', async () => {
             const caller = context.accounts.owner;
             const initialBalance = await context.lsp7.balanceOf(caller.address);
             const amount = 10;
 
-            await context.lsp7.connect(caller).burn(caller.address, amount, "0x");
+            await context.lsp7.connect(caller).burn(caller.address, amount, '0x');
 
             const newBalance = await context.lsp7.balanceOf(caller.address);
             expect(newBalance).to.equal(initialBalance.sub(amount));
           });
 
-          it("should have decreased the total supply", async () => {
+          it('should have decreased the total supply', async () => {
             const caller = context.accounts.owner;
             const amount = 10;
             const initialSupply = await context.lsp7.totalSupply();
 
-            await context.lsp7.connect(caller).burn(caller.address, amount, "0x");
+            await context.lsp7.connect(caller).burn(caller.address, amount, '0x');
 
             const newSupply = await context.lsp7.totalSupply();
             expect(newSupply).to.equal(initialSupply.sub(amount));
           });
 
-          it("should emit a Transfer event with address(0) for `to`", async () => {
+          it('should emit a Transfer event with address(0) for `to`', async () => {
             const caller = context.accounts.owner;
             const amount = 10;
 
-            await expect(context.lsp7.connect(caller).burn(caller.address, amount, "0x"))
-              .to.emit(context.lsp7, "Transfer")
+            await expect(context.lsp7.connect(caller).burn(caller.address, amount, '0x'))
+              .to.emit(context.lsp7, 'Transfer')
               .withArgs(
                 caller.address,
                 caller.address,
                 ethers.constants.AddressZero,
                 amount,
                 false,
-                "0x",
+                '0x',
               );
           });
         });
 
-        describe("when burning more than its token balance", () => {
-          it("should revert", async () => {
+        describe('when burning more than its token balance', () => {
+          it('should revert', async () => {
             const caller = context.accounts.owner;
             const balance = await context.lsp7.balanceOf(caller.address);
             const amount = 1000;
 
-            await expect(context.lsp7.connect(caller).burn(caller.address, amount, "0x"))
-              .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsBalance")
+            await expect(context.lsp7.connect(caller).burn(caller.address, amount, '0x'))
+              .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsBalance')
               .withArgs(balance, caller.address, amount);
           });
         });
       });
     });
 
-    describe("when caller is not an operator for `from`", () => {
-      it("should revert", async () => {
+    describe('when caller is not an operator for `from`', () => {
+      it('should revert', async () => {
         // mint some initial tokens
-        await context.lsp7.mint(context.accounts.owner.address, 100, true, "0x");
+        await context.lsp7.mint(context.accounts.owner.address, 100, true, '0x');
 
         const caller = context.accounts.anyone;
         const amount = 10;
 
         await expect(
-          context.lsp7.connect(caller).burn(context.accounts.owner.address, amount, "0x"),
+          context.lsp7.connect(caller).burn(context.accounts.owner.address, amount, '0x'),
         )
-          .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsAuthorizedAmount")
+          .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsAuthorizedAmount')
           .withArgs(context.accounts.owner.address, 0, caller.address, amount);
       });
     });
 
-    describe("when caller is an operator for `from`", () => {
+    describe('when caller is an operator for `from`', () => {
       const operatorAllowance = 20;
 
       beforeEach(async () => {
         // mint some initial tokens
-        await context.lsp7.mint(context.accounts.owner.address, 100, true, "0x");
+        await context.lsp7.mint(context.accounts.owner.address, 100, true, '0x');
 
         await context.lsp7.authorizeOperator(context.accounts.operator.address, operatorAllowance);
       });
 
-      describe("when burning all its allowance", () => {
-        it("operator allowance should then be zero", async () => {
+      describe('when burning all its allowance', () => {
+        it('operator allowance should then be zero', async () => {
           const operator = context.accounts.operator;
           const amount = operatorAllowance;
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newAllowance = await context.lsp7.authorizedAmountFor(
             operator.address,
@@ -1768,49 +1768,49 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           expect(newAllowance).to.equal(0);
         });
 
-        it("token owner balance should have decreased", async () => {
+        it('token owner balance should have decreased', async () => {
           const operator = context.accounts.operator;
           const amount = operatorAllowance;
           const initialBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
           expect(newBalance).to.equal(initialBalance.sub(amount));
         });
 
-        it("should have decreased the total supply", async () => {
+        it('should have decreased the total supply', async () => {
           const operator = context.accounts.operator;
           const amount = operatorAllowance;
           const initialSupply = await context.lsp7.totalSupply();
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newSupply = await context.lsp7.totalSupply();
           expect(newSupply).to.equal(initialSupply.sub(amount));
         });
 
-        it("should emit a Transfer event with address(0) for `to`", async () => {
+        it('should emit a Transfer event with address(0) for `to`', async () => {
           const operator = context.accounts.operator;
           const amount = operatorAllowance;
 
           await expect(
-            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x"),
+            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x'),
           )
-            .to.emit(context.lsp7, "Transfer")
+            .to.emit(context.lsp7, 'Transfer')
             .withArgs(
               operator.address,
               context.accounts.owner.address,
               ethers.constants.AddressZero,
               amount,
               false,
-              "0x",
+              '0x',
             );
         });
       });
 
-      describe("when burning part of its allowance", () => {
-        it("operator allowance should have decreased", async () => {
+      describe('when burning part of its allowance', () => {
+        it('operator allowance should have decreased', async () => {
           const amount = 10;
           assert.isBelow(amount, operatorAllowance);
 
@@ -1820,7 +1820,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
             context.accounts.owner.address,
           );
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newAllowance = await context.lsp7.authorizedAmountFor(
             operator.address,
@@ -1830,64 +1830,64 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           expect(newAllowance).to.equal(initialAllowance.sub(amount));
         });
 
-        it("token owner balance should have decreased", async () => {
+        it('token owner balance should have decreased', async () => {
           const amount = 10;
           assert.isBelow(amount, operatorAllowance);
 
           const operator = context.accounts.operator;
           const initialBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newBalance = await context.lsp7.balanceOf(context.accounts.owner.address);
           expect(newBalance).to.equal(initialBalance.sub(amount));
         });
 
-        it("should have decreased the total supply", async () => {
+        it('should have decreased the total supply', async () => {
           const amount = 10;
           assert.isBelow(amount, operatorAllowance);
 
           const operator = context.accounts.operator;
           const initialSupply = await context.lsp7.totalSupply();
 
-          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x");
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
 
           const newSupply = await context.lsp7.totalSupply();
           expect(newSupply).to.equal(initialSupply.sub(amount));
         });
 
-        it("should emit a Transfer event with address(0) for `to`", async () => {
+        it('should emit a Transfer event with address(0) for `to`', async () => {
           const amount = 10;
           assert.isBelow(amount, operatorAllowance);
 
           const operator = context.accounts.operator;
 
           await expect(
-            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, "0x"),
+            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x'),
           )
-            .to.emit(context.lsp7, "Transfer")
+            .to.emit(context.lsp7, 'Transfer')
             .withArgs(
               operator.address,
               context.accounts.owner.address,
               ethers.constants.AddressZero,
               amount,
               false,
-              "0x",
+              '0x',
             );
         });
       });
 
-      describe("when burning more than its allowance", () => {
-        it("should revert", async () => {
+      describe('when burning more than its allowance', () => {
+        it('should revert', async () => {
           const amount = 100;
           assert.isAbove(amount, operatorAllowance);
 
           await expect(
             context.lsp7
               .connect(context.accounts.operator)
-              .burn(context.accounts.owner.address, amount, "0x"),
+              .burn(context.accounts.owner.address, amount, '0x'),
           )
-            .to.be.revertedWithCustomError(context.lsp7, "LSP7AmountExceedsAuthorizedAmount")
+            .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsAuthorizedAmount')
             .withArgs(
               context.accounts.owner.address,
               operatorAllowance,
@@ -1899,7 +1899,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
     });
   });
 
-  describe("transferOwnership", () => {
+  describe('transferOwnership', () => {
     let oldOwner: SignerWithAddress;
     let newOwner: SignerWithAddress;
 
@@ -1909,45 +1909,45 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       newOwner = context.accounts.anyone;
     });
 
-    it("should transfer ownership of the contract", async () => {
+    it('should transfer ownership of the contract', async () => {
       await context.lsp7.connect(oldOwner).transferOwnership(newOwner.address);
       expect(await context.lsp7.owner()).to.equal(newOwner.address);
     });
 
-    it("should not allow non-owners to transfer ownership", async () => {
+    it('should not allow non-owners to transfer ownership', async () => {
       const newOwner = context.accounts.anyone;
       await expect(
         context.lsp7.connect(newOwner).transferOwnership(newOwner.address),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    describe("after transferring ownership of the contract", () => {
+    describe('after transferring ownership of the contract', () => {
       beforeEach(async () => {
         await context.lsp7.connect(oldOwner).transferOwnership(newOwner.address);
       });
 
-      it("old owner should not be allowed to use `transferOwnership(..)`", async () => {
+      it('old owner should not be allowed to use `transferOwnership(..)`', async () => {
         const randomAddress = context.accounts.anyone.address;
         await expect(
           context.lsp7.connect(oldOwner).transferOwnership(randomAddress),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("old owner should not be allowed to use `renounceOwnership(..)`", async () => {
+      it('old owner should not be allowed to use `renounceOwnership(..)`', async () => {
         await expect(context.lsp7.connect(oldOwner).renounceOwnership()).to.be.revertedWith(
-          "Ownable: caller is not the owner",
+          'Ownable: caller is not the owner',
         );
       });
 
-      it("old owner should not be allowed to use `setData(..)`", async () => {
-        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key"));
-        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("value"));
+      it('old owner should not be allowed to use `setData(..)`', async () => {
+        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key'));
+        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('value'));
         await expect(context.lsp7.connect(oldOwner).setData(key, value)).to.be.revertedWith(
-          "Ownable: caller is not the owner",
+          'Ownable: caller is not the owner',
         );
       });
 
-      it("new owner should be allowed to use `transferOwnership(..)`", async () => {
+      it('new owner should be allowed to use `transferOwnership(..)`', async () => {
         const randomAddress = context.accounts.anyone.address;
 
         await context.lsp7.connect(newOwner).transferOwnership(randomAddress);
@@ -1955,15 +1955,15 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
         expect(await context.lsp7.owner()).to.equal(randomAddress);
       });
 
-      it("new owner should be allowed to use `renounceOwnership(..)`", async () => {
+      it('new owner should be allowed to use `renounceOwnership(..)`', async () => {
         await context.lsp7.connect(newOwner).renounceOwnership();
 
         expect(await context.lsp7.owner()).to.equal(ethers.constants.AddressZero);
       });
 
-      it("new owner should be allowed to use `setData(..)`", async () => {
-        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key"));
-        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("value"));
+      it('new owner should be allowed to use `setData(..)`', async () => {
+        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key'));
+        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('value'));
         await context.lsp7.connect(newOwner).setData(key, value);
 
         expect(await context.lsp7.getData(key)).to.equal(value);
@@ -1987,22 +1987,22 @@ export const shouldInitializeLikeLSP7 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered the ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered the ERC165 interface', async () => {
       expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC165));
     });
 
-    it("should have registered the ERC725Y interface", async () => {
+    it('should have registered the ERC725Y interface', async () => {
       expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC725Y));
     });
 
-    it("should have registered the LSP7 interface", async () => {
+    it('should have registered the LSP7 interface', async () => {
       expect(await context.lsp7.supportsInterface(INTERFACE_IDS.LSP7DigitalAsset));
     });
 
-    it("should have set expected entries with ERC725Y.setData", async () => {
+    it('should have set expected entries with ERC725Y.setData', async () => {
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7, "DataChanged")
+        .to.emit(context.lsp7, 'DataChanged')
         .withArgs(
           SupportedStandards.LSP4DigitalAsset.key,
           SupportedStandards.LSP4DigitalAsset.value,
@@ -2011,21 +2011,21 @@ export const shouldInitializeLikeLSP7 = (
         SupportedStandards.LSP4DigitalAsset.value,
       );
 
-      const nameKey = ERC725YDataKeys.LSP4["LSP4TokenName"];
+      const nameKey = ERC725YDataKeys.LSP4['LSP4TokenName'];
       const expectedNameValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.name),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7, "DataChanged")
+        .to.emit(context.lsp7, 'DataChanged')
         .withArgs(nameKey, expectedNameValue);
       expect(await context.lsp7.getData(nameKey)).to.equal(expectedNameValue);
 
-      const symbolKey = ERC725YDataKeys.LSP4["LSP4TokenSymbol"];
+      const symbolKey = ERC725YDataKeys.LSP4['LSP4TokenSymbol'];
       const expectedSymbolValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.symbol),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp7, "DataChanged")
+        .to.emit(context.lsp7, 'DataChanged')
         .withArgs(symbolKey, expectedSymbolValue);
       expect(await context.lsp7.getData(symbolKey)).to.equal(expectedSymbolValue);
     });

--- a/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
@@ -1,17 +1,17 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   LSP7Mintable,
   UniversalProfile,
   LSP6KeyManager,
   UniversalReceiverDelegateTokenReentrant__factory,
-} from "../../types";
+} from '../../types';
 
-import { setupProfileWithKeyManagerWithURD } from "../utils/fixtures";
+import { setupProfileWithKeyManagerWithURD } from '../utils/fixtures';
 
-import { PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES, CALLTYPE } from "../../constants";
-import { combineAllowedCalls, combinePermissions } from "../utils/helpers";
+import { PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES, CALLTYPE } from '../../constants';
+import { combineAllowedCalls, combinePermissions } from '../utils/helpers';
 
 export type LSP7MintableTestAccounts = {
   owner: SignerWithAddress;
@@ -46,24 +46,24 @@ export const shouldBehaveLikeLSP7Mintable = (
     context = await buildContext();
   });
 
-  describe("when owner minting tokens", () => {
-    it("should increase the total supply", async () => {
-      const amountToMint = ethers.BigNumber.from("100");
+  describe('when owner minting tokens', () => {
+    it('should increase the total supply', async () => {
+      const amountToMint = ethers.BigNumber.from('100');
       const preTotalSupply = await context.lsp7Mintable.totalSupply();
 
       await context.lsp7Mintable.mint(
         context.accounts.tokenReceiver.address,
         amountToMint,
         true, // beneficiary is an EOA, so we need to allowNonLSP1Recipient minting
-        "0x",
+        '0x',
       );
 
       let postTotalSupply = await context.lsp7Mintable.totalSupply();
       expect(postTotalSupply).to.equal(preTotalSupply.add(amountToMint));
     });
 
-    it("should increase the tokenReceiver balance", async () => {
-      const amountToMint = ethers.BigNumber.from("100");
+    it('should increase the tokenReceiver balance', async () => {
+      const amountToMint = ethers.BigNumber.from('100');
 
       const tokenReceiverBalance = await context.lsp7Mintable.balanceOf(
         context.accounts.tokenReceiver.address,
@@ -73,20 +73,20 @@ export const shouldBehaveLikeLSP7Mintable = (
     });
   });
 
-  describe("when non-owner minting tokens", () => {
-    it("should revert", async () => {
-      const amountToMint = ethers.BigNumber.from("100");
+  describe('when non-owner minting tokens', () => {
+    it('should revert', async () => {
+      const amountToMint = ethers.BigNumber.from('100');
 
       // use any other account
       const nonOwner = context.accounts.tokenReceiver;
 
       await expect(
-        context.lsp7Mintable.connect(nonOwner).mint(nonOwner.address, amountToMint, true, "0x"),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+        context.lsp7Mintable.connect(nonOwner).mint(nonOwner.address, amountToMint, true, '0x'),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
   });
 
-  describe("when owner try to re-enter mint function through the UniversalReceiverDelegate", () => {
+  describe('when owner try to re-enter mint function through the UniversalReceiverDelegate', () => {
     let universalProfile;
     let lsp6KeyManager;
 
@@ -104,11 +104,11 @@ export const shouldBehaveLikeLSP7Mintable = (
         context.accounts.profileOwner,
       ).deploy();
 
-      const setDataPayload = universalProfile.interface.encodeFunctionData("setDataBatch", [
+      const setDataPayload = universalProfile.interface.encodeFunctionData('setDataBatch', [
         [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             URDTokenReentrant.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             URDTokenReentrant.address.substring(2),
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
         ],
@@ -117,8 +117,8 @@ export const shouldBehaveLikeLSP7Mintable = (
           combineAllowedCalls(
             [CALLTYPE.CALL],
             [context.lsp7Mintable.address],
-            ["0xffffffff"],
-            ["0xffffffff"],
+            ['0xffffffff'],
+            ['0xffffffff'],
           ),
           URDTokenReentrant.address,
         ],
@@ -127,25 +127,25 @@ export const shouldBehaveLikeLSP7Mintable = (
       await lsp6KeyManager.connect(context.accounts.profileOwner).execute(setDataPayload);
     });
 
-    it("should pass", async () => {
+    it('should pass', async () => {
       const firstAmount = 50;
       const secondAmount = 150;
 
-      const reentrantMintPayload = context.lsp7Mintable.interface.encodeFunctionData("mint", [
+      const reentrantMintPayload = context.lsp7Mintable.interface.encodeFunctionData('mint', [
         universalProfile.address,
         firstAmount,
         false,
-        "0x",
+        '0x',
       ]);
 
-      const mintPayload = context.lsp7Mintable.interface.encodeFunctionData("mint", [
+      const mintPayload = context.lsp7Mintable.interface.encodeFunctionData('mint', [
         universalProfile.address,
         secondAmount,
         false,
         reentrantMintPayload,
       ]);
 
-      const executePayload = universalProfile.interface.encodeFunctionData("execute", [
+      const executePayload = universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         context.lsp7Mintable.address,
         0,

--- a/tests/LSP7DigitalAsset/proxy/LSP7CappedSupplyInit.test.ts
+++ b/tests/LSP7DigitalAsset/proxy/LSP7CappedSupplyInit.test.ts
@@ -1,25 +1,25 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP7CappedSupplyInitTester__factory } from "../../../types";
+import { LSP7CappedSupplyInitTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP7 } from "../LSP7DigitalAsset.behaviour";
+import { shouldInitializeLikeLSP7 } from '../LSP7DigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP7CappedSupply,
   LSP7CappedSupplyTestContext,
   getNamedAccounts,
-} from "../LSP7CappedSupply.behaviour";
+} from '../LSP7CappedSupply.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP7CappedSupplyInit with proxy", () => {
+describe('LSP7CappedSupplyInit with proxy', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP7 capped supply - deployed with proxy",
-      symbol: "CAP",
+      name: 'LSP7 capped supply - deployed with proxy',
+      symbol: 'CAP',
       newOwner: accounts.owner.address,
-      tokenSupplyCap: ethers.BigNumber.from("2"),
+      tokenSupplyCap: ethers.BigNumber.from('2'),
     };
     const lsp7CappedSupplyInit = await new LSP7CappedSupplyInitTester__factory(
       accounts.owner,
@@ -31,7 +31,7 @@ describe("LSP7CappedSupplyInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP7CappedSupplyTestContext) => {
-    return context.lsp7CappedSupply["initialize(string,string,address,uint256)"](
+    return context.lsp7CappedSupply['initialize(string,string,address,uint256)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
@@ -39,14 +39,14 @@ describe("LSP7CappedSupplyInit with proxy", () => {
     );
   };
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP7CappedSupplyTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP7(async () => {
         const { lsp7CappedSupply: lsp7, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -59,16 +59,16 @@ describe("LSP7CappedSupplyInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7CappedSupply(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP7DigitalAsset/proxy/LSP7CompatibleERC20Init.test.ts
+++ b/tests/LSP7DigitalAsset/proxy/LSP7CompatibleERC20Init.test.ts
@@ -1,27 +1,27 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
 import {
   LSP7CompatibleERC20InitTester__factory,
   LSP7CompatibleERC20MintableInit__factory,
-} from "../../../types";
+} from '../../../types';
 
 import {
   getNamedAccounts,
   LSP7CompatibleERC20TestContext,
   shouldInitializeLikeLSP7CompatibleERC20,
   shouldBehaveLikeLSP7CompatibleERC20,
-} from "../LSP7CompatibleERC20.behaviour";
+} from '../LSP7CompatibleERC20.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP7CompatibleERC20Init with proxy", () => {
+describe('LSP7CompatibleERC20Init with proxy', () => {
   const buildTestContext = async (): Promise<LSP7CompatibleERC20TestContext> => {
     const accounts = await getNamedAccounts();
-    const initialSupply = ethers.BigNumber.from("1000");
+    const initialSupply = ethers.BigNumber.from('1000');
     const deployParams = {
-      name: "LSP7 - deployed with constructor",
-      symbol: "NFT",
+      name: 'LSP7 - deployed with constructor',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
     };
 
@@ -45,15 +45,15 @@ describe("LSP7CompatibleERC20Init with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP7CompatibleERC20TestContext) => {
-    return context.lsp7CompatibleERC20["initialize(string,string,address)"](
+    return context.lsp7CompatibleERC20['initialize(string,string,address)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
     );
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("LSP7CompatibleERC20Init: prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('LSP7CompatibleERC20Init: prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp7CompatibilityForERC20TesterInit = await new LSP7CompatibleERC20InitTester__factory(
@@ -63,15 +63,15 @@ describe("LSP7CompatibleERC20Init with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp7CompatibilityForERC20TesterInit["initialize(string,string,address)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp7CompatibilityForERC20TesterInit['initialize(string,string,address)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
-    it("LSP7CompatibleERC20MintableInit: prevent any address from calling the initialize(...) function on the implementation", async () => {
+    it('LSP7CompatibleERC20MintableInit: prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp7CompatibleERC20MintableInit = await new LSP7CompatibleERC20MintableInit__factory(
@@ -81,23 +81,23 @@ describe("LSP7CompatibleERC20Init with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp7CompatibleERC20MintableInit["initialize(string,string,address)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp7CompatibleERC20MintableInit['initialize(string,string,address)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP7CompatibleERC20TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP7CompatibleERC20(async () => {
         const { lsp7CompatibleERC20, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -110,16 +110,16 @@ describe("LSP7CompatibleERC20Init with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7CompatibleERC20(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP7DigitalAsset/proxy/LSP7DigitalAssetInit.test.ts
+++ b/tests/LSP7DigitalAsset/proxy/LSP7DigitalAssetInit.test.ts
@@ -1,29 +1,29 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP7InitTester__factory, LSP7DigitalAsset } from "../../../types";
+import { LSP7InitTester__factory, LSP7DigitalAsset } from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP7,
   shouldInitializeLikeLSP7,
   LSP7TestContext,
-} from "../LSP7DigitalAsset.behaviour";
+} from '../LSP7DigitalAsset.behaviour';
 
 import {
   LS4DigitalAssetMetadataTestContext,
   shouldBehaveLikeLSP4DigitalAssetMetadata,
-} from "../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour";
+} from '../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP7DigitalAssetInit with proxy", () => {
+describe('LSP7DigitalAssetInit with proxy', () => {
   const buildTestContext = async (): Promise<LSP7TestContext> => {
     const accounts = await getNamedAccounts();
-    const initialSupply = ethers.BigNumber.from("3");
+    const initialSupply = ethers.BigNumber.from('3');
     const deployParams = {
-      name: "LSP7 - deployed with proxy",
-      symbol: "TKN",
+      name: 'LSP7 - deployed with proxy',
+      symbol: 'TKN',
       newOwner: accounts.owner.address,
     };
 
@@ -34,7 +34,7 @@ describe("LSP7DigitalAssetInit with proxy", () => {
     const lsp7 = lsp7TesterInit.attach(lsp7Proxy);
 
     // mint tokens for the owner
-    await lsp7.mint(accounts.owner.address, initialSupply, true, "0x");
+    await lsp7.mint(accounts.owner.address, initialSupply, true, '0x');
 
     return { accounts, lsp7, deployParams, initialSupply };
   };
@@ -56,7 +56,7 @@ describe("LSP7DigitalAssetInit with proxy", () => {
     };
 
   const initializeProxy = async (context: LSP7TestContext) => {
-    return context.lsp7["initialize(string,string,address,bool)"](
+    return context.lsp7['initialize(string,string,address,bool)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
@@ -64,25 +64,25 @@ describe("LSP7DigitalAssetInit with proxy", () => {
     );
   };
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP7TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    it("should revert when initializing with address(0) as owner", async () => {
+    it('should revert when initializing with address(0) as owner', async () => {
       await expect(
-        context.lsp7["initialize(string,string,address,bool)"](
+        context.lsp7['initialize(string,string,address,bool)'](
           context.deployParams.name,
           context.deployParams.symbol,
           ethers.constants.AddressZero,
           false,
         ),
-      ).to.be.revertedWith("Ownable: new owner is the zero address");
+      ).to.be.revertedWith('Ownable: new owner is the zero address');
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP7(async () => {
         const { lsp7, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -95,22 +95,22 @@ describe("LSP7DigitalAssetInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP4DigitalAssetMetadata(async () => {
       let lsp4Context = await buildLSP4DigitalAssetMetadataTestContext();
 
-      await lsp4Context.contract["initialize(string,string,address,bool)"](
-        "LSP7 - deployed with proxy",
-        "TKN",
+      await lsp4Context.contract['initialize(string,string,address,bool)'](
+        'LSP7 - deployed with proxy',
+        'TKN',
         lsp4Context.deployParams.owner.address,
         false,
       );

--- a/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
+++ b/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
@@ -1,24 +1,24 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { LSP7MintableInit, LSP7MintableInit__factory } from "../../../types";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { LSP7MintableInit, LSP7MintableInit__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP7 } from "../LSP7DigitalAsset.behaviour";
+import { shouldInitializeLikeLSP7 } from '../LSP7DigitalAsset.behaviour';
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP7Mintable,
   LSP7MintableTestContext,
   LSP7MintableDeployParams,
-} from "../LSP7Mintable.behaviour";
+} from '../LSP7Mintable.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP7MintableInit with proxy", () => {
+describe('LSP7MintableInit with proxy', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
 
     const deployParams: LSP7MintableDeployParams = {
-      name: "LSP7 Mintable - deployed with proxy",
-      symbol: "LSP7 MNTBL",
+      name: 'LSP7 Mintable - deployed with proxy',
+      symbol: 'LSP7 MNTBL',
       newOwner: accounts.owner.address,
       isNFT: false,
     };
@@ -34,7 +34,7 @@ describe("LSP7MintableInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP7MintableTestContext) => {
-    return context.lsp7Mintable["initialize(string,string,address,bool)"](
+    return context.lsp7Mintable['initialize(string,string,address,bool)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
@@ -42,8 +42,8 @@ describe("LSP7MintableInit with proxy", () => {
     );
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp7MintableInit = await new LSP7MintableInit__factory(accounts[0]).deploy();
@@ -51,24 +51,24 @@ describe("LSP7MintableInit with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp7MintableInit["initialize(string,string,address,bool)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp7MintableInit['initialize(string,string,address,bool)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
           false,
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP7MintableTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP7(async () => {
         const { lsp7Mintable: lsp7, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -81,16 +81,16 @@ describe("LSP7MintableInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7Mintable(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP7DigitalAsset/standard/LSP7CappedSupply.test.ts
+++ b/tests/LSP7DigitalAsset/standard/LSP7CappedSupply.test.ts
@@ -1,22 +1,22 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
-import { LSP7CappedSupplyTester__factory } from "../../../types";
+import { LSP7CappedSupplyTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP7 } from "../LSP7DigitalAsset.behaviour";
+import { shouldInitializeLikeLSP7 } from '../LSP7DigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP7CappedSupply,
   LSP7CappedSupplyTestContext,
   getNamedAccounts,
-} from "../LSP7CappedSupply.behaviour";
+} from '../LSP7CappedSupply.behaviour';
 
-describe("LSP7CappedSupply with constructor", () => {
+describe('LSP7CappedSupply with constructor', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP7 capped supply - deployed with constructor",
-      symbol: "CAP",
+      name: 'LSP7 capped supply - deployed with constructor',
+      symbol: 'CAP',
       newOwner: accounts.owner.address,
-      tokenSupplyCap: ethers.BigNumber.from("2"),
+      tokenSupplyCap: ethers.BigNumber.from('2'),
     };
     const lsp7CappedSupply = await new LSP7CappedSupplyTester__factory(accounts.owner).deploy(
       deployParams.name,
@@ -28,7 +28,7 @@ describe("LSP7CappedSupply with constructor", () => {
     return { accounts, lsp7CappedSupply, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP7CappedSupplyTestContext;
 
     before(async () => {
@@ -46,7 +46,7 @@ describe("LSP7CappedSupply with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7CappedSupply(buildTestContext);
   });
 });

--- a/tests/LSP7DigitalAsset/standard/LSP7CompatibleERC20.test.ts
+++ b/tests/LSP7DigitalAsset/standard/LSP7CompatibleERC20.test.ts
@@ -1,21 +1,21 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
-import { LSP7CompatibleERC20Tester__factory } from "../../../types";
+import { LSP7CompatibleERC20Tester__factory } from '../../../types';
 
 import {
   getNamedAccounts,
   LSP7CompatibleERC20TestContext,
   shouldInitializeLikeLSP7CompatibleERC20,
   shouldBehaveLikeLSP7CompatibleERC20,
-} from "../LSP7CompatibleERC20.behaviour";
+} from '../LSP7CompatibleERC20.behaviour';
 
-describe("LSP7CompatibleERC20 with constructor", () => {
+describe('LSP7CompatibleERC20 with constructor', () => {
   const buildTestContext = async (): Promise<LSP7CompatibleERC20TestContext> => {
     const accounts = await getNamedAccounts();
-    const initialSupply = ethers.BigNumber.from("1000");
+    const initialSupply = ethers.BigNumber.from('1000');
     const deployParams = {
-      name: "Compat for ERC20",
-      symbol: "NFT",
+      name: 'Compat for ERC20',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
     };
 
@@ -33,14 +33,14 @@ describe("LSP7CompatibleERC20 with constructor", () => {
     };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP7CompatibleERC20TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP7CompatibleERC20(async () => {
         const { lsp7CompatibleERC20, deployParams } = context;
         return {
@@ -52,7 +52,7 @@ describe("LSP7CompatibleERC20 with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7CompatibleERC20(buildTestContext);
   });
 });

--- a/tests/LSP7DigitalAsset/standard/LSP7DigitalAsset.test.ts
+++ b/tests/LSP7DigitalAsset/standard/LSP7DigitalAsset.test.ts
@@ -1,27 +1,27 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP7Tester__factory, LSP7DigitalAsset } from "../../../types";
+import { LSP7Tester__factory, LSP7DigitalAsset } from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP7,
   shouldInitializeLikeLSP7,
   LSP7TestContext,
-} from "../LSP7DigitalAsset.behaviour";
+} from '../LSP7DigitalAsset.behaviour';
 
 import {
   LS4DigitalAssetMetadataTestContext,
   shouldBehaveLikeLSP4DigitalAssetMetadata,
-} from "../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour";
+} from '../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour';
 
-describe("LSP7DigitalAsset with constructor", () => {
+describe('LSP7DigitalAsset with constructor', () => {
   const buildTestContext = async (): Promise<LSP7TestContext> => {
     const accounts = await getNamedAccounts();
-    const initialSupply = ethers.BigNumber.from("3");
+    const initialSupply = ethers.BigNumber.from('3');
     const deployParams = {
-      name: "LSP7 - deployed with constructor",
-      symbol: "Token",
+      name: 'LSP7 - deployed with constructor',
+      symbol: 'Token',
       newOwner: accounts.owner.address,
     };
 
@@ -32,7 +32,7 @@ describe("LSP7DigitalAsset with constructor", () => {
     );
 
     // mint tokens for the owner
-    await lsp7.mint(accounts.owner.address, initialSupply, true, "0x");
+    await lsp7.mint(accounts.owner.address, initialSupply, true, '0x');
 
     return { accounts, lsp7, deployParams, initialSupply };
   };
@@ -53,13 +53,13 @@ describe("LSP7DigitalAsset with constructor", () => {
       };
     };
 
-  describe("when deploying the contract", () => {
-    it("should revert when deploying with address(0) as owner", async () => {
+  describe('when deploying the contract', () => {
+    it('should revert when deploying with address(0) as owner', async () => {
       const accounts = await ethers.getSigners();
 
       const deployParams = {
-        name: "LSP7 - deployed with constructor",
-        symbol: "Token",
+        name: 'LSP7 - deployed with constructor',
+        symbol: 'Token',
         newOwner: ethers.constants.AddressZero,
       };
 
@@ -69,10 +69,10 @@ describe("LSP7DigitalAsset with constructor", () => {
           deployParams.symbol,
           deployParams.newOwner,
         ),
-      ).to.be.revertedWith("Ownable: new owner is the zero address");
+      ).to.be.revertedWith('Ownable: new owner is the zero address');
     });
 
-    describe("once the contract was deployed", () => {
+    describe('once the contract was deployed', () => {
       let context: LSP7TestContext;
 
       before(async () => {
@@ -90,7 +90,7 @@ describe("LSP7DigitalAsset with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP4DigitalAssetMetadata(buildLSP4DigitalAssetMetadataTestContext);
     shouldBehaveLikeLSP7(buildTestContext);
   });

--- a/tests/LSP7DigitalAsset/standard/LSP7Mintable.test.ts
+++ b/tests/LSP7DigitalAsset/standard/LSP7Mintable.test.ts
@@ -1,20 +1,20 @@
-import { LSP7Mintable, LSP7Mintable__factory } from "../../../types";
+import { LSP7Mintable, LSP7Mintable__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP7 } from "../LSP7DigitalAsset.behaviour";
+import { shouldInitializeLikeLSP7 } from '../LSP7DigitalAsset.behaviour';
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP7Mintable,
   LSP7MintableTestContext,
   LSP7MintableDeployParams,
-} from "../LSP7Mintable.behaviour";
+} from '../LSP7Mintable.behaviour';
 
-describe("LSP7Mintable with constructor", () => {
+describe('LSP7Mintable with constructor', () => {
   const buildTestContext = async (): Promise<LSP7MintableTestContext> => {
     const accounts = await getNamedAccounts();
 
     const deployParams: LSP7MintableDeployParams = {
-      name: "LSP7Mintable - deployed with constructor",
-      symbol: "LSP7MNT",
+      name: 'LSP7Mintable - deployed with constructor',
+      symbol: 'LSP7MNT',
       newOwner: accounts.owner.address,
       isNFT: false,
     };
@@ -29,7 +29,7 @@ describe("LSP7Mintable with constructor", () => {
     return { accounts, lsp7Mintable, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP7MintableTestContext;
 
     before(async () => {
@@ -46,7 +46,7 @@ describe("LSP7Mintable with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP7Mintable(buildTestContext);
   });
 });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8CappedSupply.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8CappedSupply.behaviour.ts
@@ -1,9 +1,9 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { LSP8CappedSupplyTester } from "../../types";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { LSP8CappedSupplyTester } from '../../types';
 
-import type { BigNumber, BytesLike } from "ethers";
+import type { BigNumber, BytesLike } from 'ethers';
 
 export type LSP8CappedSupplyTestAccounts = {
   owner: SignerWithAddress;
@@ -40,15 +40,15 @@ export const shouldBehaveLikeLSP8CappedSupply = (
       .map((_, i) => ethers.utils.keccak256(ethers.BigNumber.from(i).toHexString()));
   });
 
-  describe("tokenSupplyCap", () => {
-    it("should allow reading tokenSupplyCap", async () => {
+  describe('tokenSupplyCap', () => {
+    it('should allow reading tokenSupplyCap', async () => {
       const tokenSupplyCap = await context.lsp8CappedSupply.tokenSupplyCap();
       expect(tokenSupplyCap).to.equal(context.deployParams.tokenSupplyCap);
     });
   });
 
-  describe("when minting tokens", () => {
-    it("should allow minting amount up to tokenSupplyCap", async () => {
+  describe('when minting tokens', () => {
+    it('should allow minting amount up to tokenSupplyCap', async () => {
       const preTokenSupplyCap = await context.lsp8CappedSupply.tokenSupplyCap();
       const preTotalSupply = await context.lsp8CappedSupply.totalSupply();
       expect(preTokenSupplyCap.sub(preTotalSupply)).to.equal(String(mintedTokenIds.length));
@@ -68,10 +68,10 @@ export const shouldBehaveLikeLSP8CappedSupply = (
       expect(postTotalSupply.sub(postTokenSupplyCap)).to.equal(ethers.constants.Zero);
     });
 
-    describe("when cap has been reached", () => {
-      const anotherTokenId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("VIP token"));
+    describe('when cap has been reached', () => {
+      const anotherTokenId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('VIP token'));
 
-      it("should error when minting more than tokenSupplyCapTokens", async () => {
+      it('should error when minting more than tokenSupplyCapTokens', async () => {
         await Promise.all(
           mintedTokenIds.map((tokenId) =>
             context.lsp8CappedSupply.mint(context.accounts.tokenReceiver.address, tokenId),
@@ -86,11 +86,11 @@ export const shouldBehaveLikeLSP8CappedSupply = (
           context.lsp8CappedSupply.mint(context.accounts.tokenReceiver.address, anotherTokenId),
         ).to.be.revertedWithCustomError(
           context.lsp8CappedSupply,
-          "LSP8CappedSupplyCannotMintOverCap",
+          'LSP8CappedSupplyCannotMintOverCap',
         );
       });
 
-      it("should allow minting after burning", async () => {
+      it('should allow minting after burning', async () => {
         await Promise.all(
           mintedTokenIds.map((tokenId) =>
             context.lsp8CappedSupply.mint(context.accounts.tokenReceiver.address, tokenId),

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8CompatibleERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8CompatibleERC721.behaviour.ts
@@ -1,6 +1,6 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
 import {
   LSP8CompatibleERC721Tester,
@@ -20,12 +20,12 @@ import {
   TokenReceiverWithoutLSP1WithERC721ReceivedInvalid__factory,
   TokenReceiverWithoutLSP1WithERC721Received,
   TokenReceiverWithoutLSP1WithERC721Received__factory,
-} from "../../types";
-import { tokenIdAsBytes32 } from "../utils/tokens";
-import { ERC725YDataKeys, INTERFACE_IDS, SupportedStandards } from "../../constants";
+} from '../../types';
+import { tokenIdAsBytes32 } from '../utils/tokens';
+import { ERC725YDataKeys, INTERFACE_IDS, SupportedStandards } from '../../constants';
 
-import type { BytesLike, Contract } from "ethers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
+import type { BytesLike, Contract } from 'ethers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
 export type LSP8CompatibleERC721TestAccounts = {
   owner: SignerWithAddress;
@@ -58,8 +58,8 @@ export type ExpectedError = {
   args: string[];
 };
 
-const mintedTokenId = "10";
-const neverMintedTokenId = "1010110";
+const mintedTokenId = '10';
+const neverMintedTokenId = '1010110';
 
 export const shouldBehaveLikeLSP8CompatibleERC721 = (
   buildContext: () => Promise<LSP8CompatibleERC721TestContext>,
@@ -70,50 +70,50 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     context = await buildContext();
   });
 
-  describe("when checking supported ERC165 interfaces", () => {
-    it("should support ERC721", async () => {
+  describe('when checking supported ERC165 interfaces', () => {
+    it('should support ERC721', async () => {
       expect(await context.lsp8CompatibleERC721.supportsInterface(INTERFACE_IDS.ERC721)).to.equal(
         true,
       );
     });
 
-    it("should support ERC721Metadata", async () => {
+    it('should support ERC721Metadata', async () => {
       expect(
         await context.lsp8CompatibleERC721.supportsInterface(INTERFACE_IDS.ERC721Metadata),
       ).to.equal(true);
     });
   });
 
-  describe("name", () => {
-    it("should allow reading name", async () => {
+  describe('name', () => {
+    it('should allow reading name', async () => {
       // using compatibility getter -> returns(string)
       const nameAsString = await context.lsp8CompatibleERC721.name();
       expect(nameAsString).to.equal(context.deployParams.name);
 
       // using getData -> returns(bytes)
-      const nameAsBytes = await context.lsp8CompatibleERC721["getData(bytes32)"](
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("LSP4TokenName")),
+      const nameAsBytes = await context.lsp8CompatibleERC721['getData(bytes32)'](
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('LSP4TokenName')),
       );
       expect(ethers.utils.toUtf8String(nameAsBytes)).to.equal(context.deployParams.name);
     });
   });
 
-  describe("symbol", () => {
-    it("should allow reading symbol", async () => {
+  describe('symbol', () => {
+    it('should allow reading symbol', async () => {
       // using compatibility getter -> returns(string)
       const symbolAsString = await context.lsp8CompatibleERC721.symbol();
       expect(symbolAsString).to.equal(context.deployParams.symbol);
 
       // using getData -> returns(bytes)
-      const symbolAsBytes = await context.lsp8CompatibleERC721["getData(bytes32)"](
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("LSP4TokenSymbol")),
+      const symbolAsBytes = await context.lsp8CompatibleERC721['getData(bytes32)'](
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('LSP4TokenSymbol')),
       );
       expect(ethers.utils.toUtf8String(symbolAsBytes)).to.equal(context.deployParams.symbol);
     });
   });
 
-  describe("tokenURI", () => {
-    it("should allow reading tokenURI", async () => {
+  describe('tokenURI', () => {
+    it('should allow reading tokenURI', async () => {
       // using compatibility getter -> returns(string)
       const tokenURIAsString = await context.lsp8CompatibleERC721.tokenURI(mintedTokenId);
       // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36 + 2 for prefix = 38
@@ -123,28 +123,28 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       );
 
       // using getData -> returns(bytes)
-      const lsp4MetadataValueAsBytes = await context.lsp8CompatibleERC721["getData(bytes32)"](
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("LSP4Metadata")),
+      const lsp4MetadataValueAsBytes = await context.lsp8CompatibleERC721['getData(bytes32)'](
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('LSP4Metadata')),
       );
       expect(lsp4MetadataValueAsBytes).to.equal(context.deployParams.lsp4MetadataValue);
     });
   });
 
-  describe("ownerOf", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('ownerOf', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(context.lsp8CompatibleERC721.ownerOf(neverMintedTokenId))
-          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NonExistentTokenId')
           .withArgs(tokenIdAsBytes32(neverMintedTokenId));
       });
     });
 
-    describe("when tokenId has been minted", () => {
-      it("should return owner address", async () => {
+    describe('when tokenId has been minted', () => {
+      it('should return owner address', async () => {
         await context.lsp8CompatibleERC721.mint(
           context.accounts.owner.address,
           mintedTokenId,
-          ethers.utils.toUtf8Bytes("mint a token for the owner"),
+          ethers.utils.toUtf8Bytes('mint a token for the owner'),
         );
 
         expect(await context.lsp8CompatibleERC721.ownerOf(mintedTokenId)).to.equal(
@@ -154,36 +154,36 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe("approve", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('approve', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8CompatibleERC721
             .connect(context.accounts.anyone)
             .approve(context.accounts.operator.address, neverMintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NonExistentTokenId')
           .withArgs(tokenIdAsBytes32(neverMintedTokenId));
       });
     });
 
-    describe("when the tokenId has been minted", () => {
+    describe('when the tokenId has been minted', () => {
       beforeEach(async () => {
         await context.lsp8CompatibleERC721.mint(
           context.accounts.owner.address,
           mintedTokenId,
-          ethers.utils.toUtf8Bytes("mint a token for the owner"),
+          ethers.utils.toUtf8Bytes('mint a token for the owner'),
         );
       });
 
-      describe("when caller is not owner of tokenId", () => {
-        it("should revert", async () => {
+      describe('when caller is not owner of tokenId', () => {
+        it('should revert', async () => {
           await expect(
             context.lsp8CompatibleERC721
               .connect(context.accounts.anyone)
               .approve(context.accounts.operator.address, mintedTokenId),
           )
-            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NotTokenOwner")
+            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NotTokenOwner')
             .withArgs(
               context.accounts.owner.address,
               tokenIdAsBytes32(mintedTokenId),
@@ -192,26 +192,26 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         });
       });
 
-      describe("when caller is owner of tokenId", () => {
-        describe("when operator is not the zero address", () => {
-          it("should succeed", async () => {
+      describe('when caller is owner of tokenId', () => {
+        describe('when operator is not the zero address', () => {
+          it('should succeed', async () => {
             const operator = context.accounts.operator.address;
             const tokenId = mintedTokenId;
 
             const tx = await context.lsp8CompatibleERC721.approve(operator, tokenId);
 
             await expect(tx)
-              .to.emit(context.lsp8CompatibleERC721, "AuthorizedOperator")
+              .to.emit(context.lsp8CompatibleERC721, 'AuthorizedOperator')
               .withArgs(operator, context.accounts.owner.address, tokenIdAsBytes32(tokenId));
 
             await expect(tx)
-              .to.emit(context.lsp8CompatibleERC721, "Approval")
+              .to.emit(context.lsp8CompatibleERC721, 'Approval')
               .withArgs(context.accounts.owner.address, operator, ethers.BigNumber.from(tokenId));
           });
         });
 
-        describe("when operator is the zero address", () => {
-          it("should revert", async () => {
+        describe('when operator is the zero address', () => {
+          it('should revert', async () => {
             const operator = ethers.constants.AddressZero;
             const tokenId = mintedTokenId;
 
@@ -219,7 +219,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               context.lsp8CompatibleERC721.approve(operator, tokenId),
             ).to.be.revertedWithCustomError(
               context.lsp8CompatibleERC721,
-              "LSP8CannotUseAddressZeroAsOperator",
+              'LSP8CannotUseAddressZeroAsOperator',
             );
           });
         });
@@ -227,13 +227,13 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe("setApprovalForAll", () => {
+  describe('setApprovalForAll', () => {
     const tokenIds = [
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NFT 1")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NFT 2")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NFT 3")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NFT 4")),
-      ethers.utils.keccak256(ethers.utils.toUtf8Bytes("NFT 5")),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NFT 1')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NFT 2')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NFT 3')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NFT 4')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('NFT 5')),
     ];
 
     beforeEach(async () => {
@@ -254,16 +254,16 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         .setApprovalForAll(context.accounts.operator.address, true);
     });
 
-    describe("when calling setApprovalForAll with true", () => {
-      it("should revert when trying to pass caller address as operator", async () => {
+    describe('when calling setApprovalForAll with true', () => {
+      it('should revert when trying to pass caller address as operator', async () => {
         await expect(
           context.lsp8CompatibleERC721
             .connect(context.accounts.owner)
             .setApprovalForAll(context.accounts.owner.address, true),
-        ).to.be.revertedWith("LSP8CompatibleERC721: approve to caller");
+        ).to.be.revertedWith('LSP8CompatibleERC721: approve to caller');
       });
 
-      it("should have emitted an ApprovalForAll event", async () => {
+      it('should have emitted an ApprovalForAll event', async () => {
         const txParams = {
           to: context.accounts.owner.address,
           tokenId: 5,
@@ -279,12 +279,12 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           .setApprovalForAll(context.accounts.operator.address, true);
 
         expect(tx)
-          .to.emit(context.lsp8CompatibleERC721, "ApprovalForAll")
+          .to.emit(context.lsp8CompatibleERC721, 'ApprovalForAll')
           .withArgs(context.accounts.owner.address, context.accounts.operator.address, true);
       });
 
-      describe("when calling isApprovedForAll", () => {
-        it("should return true for operator", async () => {
+      describe('when calling isApprovedForAll', () => {
+        it('should return true for operator', async () => {
           const result = await context.lsp8CompatibleERC721.isApprovedForAll(
             context.accounts.owner.address,
             context.accounts.operator.address,
@@ -293,7 +293,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           expect(result).to.be.true;
         });
 
-        it("should return false for non-operator", async () => {
+        it('should return false for non-operator', async () => {
           const result = await context.lsp8CompatibleERC721.isApprovedForAll(
             context.accounts.owner.address,
             context.accounts.anyone.address,
@@ -304,7 +304,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       });
     });
 
-    describe("when operator transfer tokenId", () => {
+    describe('when operator transfer tokenId', () => {
       [
         { tokenId: tokenIds[0] },
         { tokenId: tokenIds[1] },
@@ -313,7 +313,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         { tokenId: tokenIds[4] },
       ].forEach((testCase) => {
         describe(`for tokenId ${testCase.tokenId}:`, () => {
-          it("should have transferred successfully with `transferFrom(...)` (changed token owner)", async () => {
+          it('should have transferred successfully with `transferFrom(...)` (changed token owner)', async () => {
             const sender = context.accounts.owner.address;
             const recipient = context.accounts.tokenReceiver.address;
 
@@ -325,7 +325,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             expect(newTokenOwner).to.equal(context.accounts.tokenReceiver.address);
           });
 
-          it("should have emitted a Transfer event", async () => {
+          it('should have emitted a Transfer event', async () => {
             const sender = context.accounts.owner.address;
             const recipient = context.accounts.tokenReceiver.address;
 
@@ -334,18 +334,18 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               .transferFrom(sender, recipient, testCase.tokenId);
 
             expect(tx)
-              .to.emit(context.lsp8CompatibleERC721, "Transfer(address,address,uint256)")
+              .to.emit(context.lsp8CompatibleERC721, 'Transfer(address,address,uint256)')
               .withArgs(sender, recipient, testCase.tokenId);
           });
 
-          it("should have cleared operators array", async () => {
+          it('should have cleared operators array', async () => {
             // add 3 x individual operators per tokenId to test if the operators array is cleared
             // once the tokenId has been transferred by operator that is approvedForAll
             // const operatorsPerTokenIds = getRandomAddresses(1);
             const operatorsPerTokenIdsBefore = [
-              "0xcafecafecafecafecafecafecafecafecafecafe",
-              "0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
-              "0xf00df00df00df00df00df00df00df00df00df00d",
+              '0xcafecafecafecafecafecafecafecafecafecafe',
+              '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+              '0xf00df00df00df00df00df00df00df00df00df00d',
             ];
 
             await context.lsp8CompatibleERC721
@@ -377,7 +377,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       });
     });
 
-    describe("when calling setApprovalForAll with false (removing operator full approval)", () => {
+    describe('when calling setApprovalForAll with false (removing operator full approval)', () => {
       beforeEach(async () => {
         await context.lsp8CompatibleERC721
           .connect(context.accounts.owner)
@@ -391,7 +391,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         { tokenId: tokenIds[3] },
         { tokenId: tokenIds[4] },
       ].forEach((testCase) => {
-        it("should return false when calling isApprovedForAll for operator", async () => {
+        it('should return false when calling isApprovedForAll for operator', async () => {
           const result = await context.lsp8CompatibleERC721.isApprovedForAll(
             context.accounts.owner.address,
             context.accounts.operator.address,
@@ -415,41 +415,41 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 testCase.tokenId,
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NotTokenOperator")
+            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NotTokenOperator')
             .withArgs(tokenIdAsBytes32, context.accounts.operator.address);
         });
       });
     });
   });
 
-  describe("getApproved", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('getApproved', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(context.lsp8CompatibleERC721.getApproved(neverMintedTokenId))
-          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NonExistentTokenId')
           .withArgs(tokenIdAsBytes32(neverMintedTokenId));
       });
     });
 
-    describe("when tokenId has been minted", () => {
+    describe('when tokenId has been minted', () => {
       beforeEach(async () => {
         await context.lsp8CompatibleERC721.mint(
           context.accounts.owner.address,
           mintedTokenId,
-          ethers.utils.toUtf8Bytes("mint a token for the owner"),
+          ethers.utils.toUtf8Bytes('mint a token for the owner'),
         );
       });
 
-      describe("when there have been no approvals for the tokenId", () => {
-        it("should return address(0)", async () => {
+      describe('when there have been no approvals for the tokenId', () => {
+        it('should return address(0)', async () => {
           expect(await context.lsp8CompatibleERC721.getApproved(mintedTokenId)).to.equal(
             ethers.constants.AddressZero,
           );
         });
       });
 
-      describe("when one account has been approved for the tokenId", () => {
-        it("should return the operator address", async () => {
+      describe('when one account has been approved for the tokenId', () => {
+        it('should return the operator address', async () => {
           await context.lsp8CompatibleERC721.approve(
             context.accounts.operator.address,
             tokenIdAsBytes32(mintedTokenId),
@@ -461,8 +461,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         });
       });
 
-      describe("when many context.accounts have been approved for the tokenId", () => {
-        it("should return the last new authorized operator", async () => {
+      describe('when many context.accounts have been approved for the tokenId', () => {
+        it('should return the last new authorized operator', async () => {
           const operatorFirstAndThirdCall = context.accounts.operator.address;
           const operatorSecondCall = context.accounts.anotherOperator.address;
 
@@ -483,13 +483,13 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe("mint", () => {
-    describe("when a token is minted", () => {
-      it("should have expected events", async () => {
+  describe('mint', () => {
+    describe('when a token is minted', () => {
+      it('should have expected events', async () => {
         const txParams = {
           to: context.accounts.owner.address,
           tokenId: mintedTokenId,
-          data: ethers.utils.toUtf8Bytes("mint a token for the owner"),
+          data: ethers.utils.toUtf8Bytes('mint a token for the owner'),
         };
         const operator = context.accounts.owner;
 
@@ -500,7 +500,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         await expect(tx)
           .to.emit(
             context.lsp8CompatibleERC721,
-            "Transfer(address,address,address,bytes32,bool,bytes)",
+            'Transfer(address,address,address,bytes32,bool,bytes)',
           )
           .withArgs(
             operator.address,
@@ -512,7 +512,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           );
 
         await expect(tx)
-          .to.emit(context.lsp8CompatibleERC721, "Transfer(address,address,uint256)")
+          .to.emit(context.lsp8CompatibleERC721, 'Transfer(address,address,uint256)')
           .withArgs(
             ethers.constants.AddressZero,
             txParams.to,
@@ -522,20 +522,20 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe("burn", () => {
-    describe("when a token is burned", () => {
+  describe('burn', () => {
+    describe('when a token is burned', () => {
       beforeEach(async () => {
         await context.lsp8CompatibleERC721.mint(
           context.accounts.owner.address,
           mintedTokenId,
-          ethers.utils.toUtf8Bytes("mint a token for the owner"),
+          ethers.utils.toUtf8Bytes('mint a token for the owner'),
         );
       });
 
-      it("should have expected events", async () => {
+      it('should have expected events', async () => {
         const txParams = {
           tokenId: mintedTokenId,
-          data: ethers.utils.toUtf8Bytes("burn a token from the owner"),
+          data: ethers.utils.toUtf8Bytes('burn a token from the owner'),
         };
         const operator = context.accounts.owner;
 
@@ -546,7 +546,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         await expect(tx)
           .to.emit(
             context.lsp8CompatibleERC721,
-            "Transfer(address,address,address,bytes32,bool,bytes)",
+            'Transfer(address,address,address,bytes32,bool,bytes)',
           )
           .withArgs(
             operator.address,
@@ -557,7 +557,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             ethers.utils.hexlify(txParams.data),
           );
         await expect(tx)
-          .to.emit(context.lsp8CompatibleERC721, "Transfer(address,address,uint256)")
+          .to.emit(context.lsp8CompatibleERC721, 'Transfer(address,address,uint256)')
           .withArgs(
             operator.address,
             ethers.constants.AddressZero,
@@ -567,7 +567,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     });
   });
 
-  describe("transfers", () => {
+  describe('transfers', () => {
     type TestDeployedContracts = {
       tokenReceiverWithLSP1: TokenReceiverWithLSP1;
       tokenReceiverWithoutLSP1: TokenReceiverWithoutLSP1;
@@ -628,7 +628,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       await context.lsp8CompatibleERC721.mint(
         context.accounts.owner.address,
         mintedTokenId,
-        ethers.utils.toUtf8Bytes("mint a token for the owner"),
+        ethers.utils.toUtf8Bytes('mint a token for the owner'),
       );
 
       // setup so we can observe approvals being cleared during transfer tests
@@ -662,7 +662,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       await expect(tx)
         .to.emit(
           context.lsp8CompatibleERC721,
-          "Transfer(address,address,address,bytes32,bool,bytes)",
+          'Transfer(address,address,address,bytes32,bool,bytes)',
         )
         .withArgs(
           operator,
@@ -674,11 +674,11 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         );
 
       await expect(tx)
-        .to.emit(context.lsp8CompatibleERC721, "Transfer(address,address,uint256)")
+        .to.emit(context.lsp8CompatibleERC721, 'Transfer(address,address,uint256)')
         .withArgs(from, to, ethers.BigNumber.from(tokenId));
 
       await expect(tx)
-        .to.emit(context.lsp8CompatibleERC721, "RevokedOperator")
+        .to.emit(context.lsp8CompatibleERC721, 'RevokedOperator')
         .withArgs(context.accounts.operator.address, from, tokenIdAsBytes32(tokenId));
 
       // post-conditions
@@ -722,14 +722,14 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       expect(postOwnerOf).to.equal(preOwnerOf);
     };
 
-    describe("transferFrom", () => {
-      const transferFn = "transferFrom";
+    describe('transferFrom', () => {
+      const transferFn = 'transferFrom';
       const allowNonLSP1Recipient = true;
-      const expectedData = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(""));
+      const expectedData = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(''));
 
-      describe("when the from address is the tokenId owner", () => {
-        describe("when `to` is an EOA", () => {
-          it("should allow transfering the tokenId", async () => {
+      describe('when the from address is the tokenId owner', () => {
+        describe('when `to` is an EOA', () => {
+          it('should allow transfering the tokenId', async () => {
             const txParams = {
               operator: context.accounts.owner.address,
               from: context.accounts.owner.address,
@@ -746,9 +746,9 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           });
         });
 
-        describe("when `to` is a contract", () => {
-          describe("when receiving contract supports LSP1", () => {
-            it("should allow transfering the tokenId", async () => {
+        describe('when `to` is a contract', () => {
+          describe('when receiving contract supports LSP1', () => {
+            it('should allow transfering the tokenId', async () => {
               const txParams = {
                 operator: context.accounts.owner.address,
                 from: context.accounts.owner.address,
@@ -765,8 +765,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             });
           });
 
-          describe("when receiving contract does not support LSP1", () => {
-            it("should allow transfering the tokenId", async () => {
+          describe('when receiving contract does not support LSP1', () => {
+            it('should allow transfering the tokenId', async () => {
               const txParams = {
                 operator: context.accounts.owner.address,
                 from: context.accounts.owner.address,
@@ -785,8 +785,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         });
       });
 
-      describe("when the from address is not the tokenId owner", () => {
-        it("should revert", async () => {
+      describe('when the from address is not the tokenId owner', () => {
+        it('should revert', async () => {
           const txParams = {
             operator: context.accounts.owner.address,
             from: context.accounts.anyone.address,
@@ -800,7 +800,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           await expect(
             context.lsp8CompatibleERC721[transferFn](txParams.from, txParams.to, txParams.tokenId),
           )
-            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NotTokenOwner")
+            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NotTokenOwner')
             .withArgs(
               context.accounts.owner.address,
               tokenIdAsBytes32(txParams.tokenId).toString(),
@@ -814,12 +814,12 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       });
     });
 
-    describe("safeTransferFrom(address,address,uint256)", () => {
-      const transferFn = "safeTransferFrom(address,address,uint256)";
+    describe('safeTransferFrom(address,address,uint256)', () => {
+      const transferFn = 'safeTransferFrom(address,address,uint256)';
 
-      describe("when the from address is the tokenId owner", () => {
-        describe("when `to` is an EOA", () => {
-          it("should pass", async () => {
+      describe('when the from address is the tokenId owner', () => {
+        describe('when `to` is an EOA', () => {
+          it('should pass', async () => {
             const txParams = {
               operator: context.accounts.owner.address,
               from: context.accounts.owner.address,
@@ -827,14 +827,14 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               tokenId: mintedTokenId,
             };
 
-            await transferSuccessScenario(txParams, transferFn, true, "0x");
+            await transferSuccessScenario(txParams, transferFn, true, '0x');
           });
         });
 
-        describe("when `to` is a contract", () => {
-          describe("when the receiving contract supports LSP1", () => {
-            describe("when the receiving contract does not implement `onERC721Received`", () => {
-              it("should fail and revert", async () => {
+        describe('when `to` is a contract', () => {
+          describe('when the receiving contract supports LSP1', () => {
+            describe('when the receiving contract does not implement `onERC721Received`', () => {
+              it('should fail and revert', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithoutERC721Receiver.address,
@@ -842,7 +842,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
@@ -851,8 +851,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               });
             });
 
-            describe("when the receiving contract implements `onERC721Received`", () => {
-              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+            describe('when the receiving contract implements `onERC721Received`', () => {
+              it('should fail if the `onERC721Received` function reverts + bubble up the error', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithERC721ReceivedRevert.address,
@@ -860,17 +860,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected",
+                  'TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected',
                 );
               });
 
-              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+              it('should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithERC721ReceivedInvalid.address,
@@ -878,17 +878,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer",
+                  'LSP8CompatibleERC721: transfer to non ERC721Receiver implementer',
                 );
               });
 
-              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+              it('should pass if the `onERC721Received` function returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -896,14 +896,14 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                   tokenId: mintedTokenId,
                 };
 
-                await transferSuccessScenario(txParams, transferFn, true, "0x");
+                await transferSuccessScenario(txParams, transferFn, true, '0x');
               });
             });
           });
 
-          describe("when the receiving contract does not support LSP1", () => {
-            describe("when the receiving contract does not implement `onERC721Received`", () => {
-              it("should fail and revert", async () => {
+          describe('when the receiving contract does not support LSP1', () => {
+            describe('when the receiving contract does not implement `onERC721Received`', () => {
+              it('should fail and revert', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -912,7 +912,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
@@ -921,8 +921,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               });
             });
 
-            describe("when the receiving contract implements `onERC721Received`", () => {
-              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+            describe('when the receiving contract implements `onERC721Received`', () => {
+              it('should fail if the `onERC721Received` function reverts + bubble up the error', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1WithERC721ReceivedRevert.address,
@@ -930,17 +930,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected",
+                  'TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected',
                 );
               });
 
-              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+              it('should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1WithERC721ReceivedInvalid.address,
@@ -948,17 +948,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer",
+                  'LSP8CompatibleERC721: transfer to non ERC721Receiver implementer',
                 );
               });
 
-              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+              it('should pass if the `onERC721Received` function returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -966,15 +966,15 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                   tokenId: mintedTokenId,
                 };
 
-                await transferSuccessScenario(txParams, transferFn, true, "0x");
+                await transferSuccessScenario(txParams, transferFn, true, '0x');
               });
             });
           });
         });
       });
 
-      describe("when the from address is not the tokenId owner", () => {
-        it("should revert", async () => {
+      describe('when the from address is not the tokenId owner', () => {
+        it('should revert', async () => {
           const txParams = {
             operator: context.accounts.owner.address,
             from: context.accounts.anyone.address,
@@ -988,7 +988,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           await expect(
             context.lsp8CompatibleERC721[transferFn](txParams.from, txParams.to, txParams.tokenId),
           )
-            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NotTokenOwner")
+            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NotTokenOwner')
             .withArgs(
               context.accounts.owner.address,
               tokenIdAsBytes32(txParams.tokenId).toString(),
@@ -1002,15 +1002,15 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
       });
     });
 
-    describe("safeTransferFrom(address,address,uint256,bytes)", () => {
-      const transferFn = "safeTransferFrom(address,address,uint256,bytes)";
+    describe('safeTransferFrom(address,address,uint256,bytes)', () => {
+      const transferFn = 'safeTransferFrom(address,address,uint256,bytes)';
       const expectedData = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(`custom-data-${Date.now()}`),
       );
 
-      describe("when the from address is the tokenId owner", () => {
-        describe("when `to` is an EOA", () => {
-          it("should pass", async () => {
+      describe('when the from address is the tokenId owner', () => {
+        describe('when `to` is an EOA', () => {
+          it('should pass', async () => {
             const txParams = {
               operator: context.accounts.owner.address,
               from: context.accounts.owner.address,
@@ -1023,10 +1023,10 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           });
         });
 
-        describe("when `to` is a contract", () => {
-          describe("when the receiving contract supports LSP1", () => {
-            describe("when the receiving contract does not implement `onERC721Received`", () => {
-              it("should fail and revert", async () => {
+        describe('when `to` is a contract', () => {
+          describe('when the receiving contract supports LSP1', () => {
+            describe('when the receiving contract does not implement `onERC721Received`', () => {
+              it('should fail and revert', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithoutERC721Receiver.address,
@@ -1035,7 +1035,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
@@ -1044,8 +1044,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               });
             });
 
-            describe("when the receiving contract implements `onERC721Received`", () => {
-              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+            describe('when the receiving contract implements `onERC721Received`', () => {
+              it('should fail if the `onERC721Received` function reverts + bubble up the error', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithERC721ReceivedRevert.address,
@@ -1054,17 +1054,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected",
+                  'TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected',
                 );
               });
 
-              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+              it('should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1WithERC721ReceivedInvalid.address,
@@ -1073,17 +1073,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer",
+                  'LSP8CompatibleERC721: transfer to non ERC721Receiver implementer',
                 );
               });
 
-              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+              it('should pass if the `onERC721Received` function returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -1097,9 +1097,9 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
             });
           });
 
-          describe("when the receiving contract does not support LSP1", () => {
-            describe("when the receiving contract does not implement `onERC721Received`", () => {
-              it("should fail and revert", async () => {
+          describe('when the receiving contract does not support LSP1', () => {
+            describe('when the receiving contract does not implement `onERC721Received`', () => {
+              it('should fail and revert', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -1109,7 +1109,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
@@ -1118,8 +1118,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               });
             });
 
-            describe("when the receiving contract implements `onERC721Received`", () => {
-              it("should fail if the `onERC721Received` function reverts + bubble up the error", async () => {
+            describe('when the receiving contract implements `onERC721Received`', () => {
+              it('should fail if the `onERC721Received` function reverts + bubble up the error', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1WithERC721ReceivedRevert.address,
@@ -1128,17 +1128,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected",
+                  'TokenReceiverWithLSP1WithERC721ReceivedRevert: transfer rejected',
                 );
               });
 
-              it("should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value", async () => {
+              it('should fail and revert if the `onERC721Received` function does not returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1WithERC721ReceivedInvalid.address,
@@ -1147,17 +1147,17 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 };
 
                 await expect(
-                  context.lsp8CompatibleERC721["safeTransferFrom(address,address,uint256)"](
+                  context.lsp8CompatibleERC721['safeTransferFrom(address,address,uint256)'](
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
                   ),
                 ).to.be.revertedWith(
-                  "LSP8CompatibleERC721: transfer to non ERC721Receiver implementer",
+                  'LSP8CompatibleERC721: transfer to non ERC721Receiver implementer',
                 );
               });
 
-              it("should pass if the `onERC721Received` function returns the correct bytes4 magic value", async () => {
+              it('should pass if the `onERC721Received` function returns the correct bytes4 magic value', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -1173,8 +1173,8 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
         });
       });
 
-      describe("when the from address is not the tokenId owner", () => {
-        it("should revert", async () => {
+      describe('when the from address is not the tokenId owner', () => {
+        it('should revert', async () => {
           const txParams = {
             operator: context.accounts.owner.address,
             from: context.accounts.anyone.address,
@@ -1194,7 +1194,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               txParams.data,
             ),
           )
-            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, "LSP8NotTokenOwner")
+            .to.be.revertedWithCustomError(context.lsp8CompatibleERC721, 'LSP8NotTokenOwner')
             .withArgs(
               context.accounts.owner.address,
               tokenIdAsBytes32(txParams.tokenId).toString(),
@@ -1225,8 +1225,8 @@ export const shouldInitializeLikeLSP8CompatibleERC721 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered its ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered its ERC165 interface', async () => {
       expect(
         await context.lsp8CompatibleERC721.supportsInterface(
           INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
@@ -1236,9 +1236,9 @@ export const shouldInitializeLikeLSP8CompatibleERC721 = (
       expect(await context.lsp8CompatibleERC721.supportsInterface(INTERFACE_IDS.ERC721Metadata));
     });
 
-    it("should have set expected entries with ERC725Y.setData", async () => {
+    it('should have set expected entries with ERC725Y.setData', async () => {
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8CompatibleERC721, "DataChanged")
+        .to.emit(context.lsp8CompatibleERC721, 'DataChanged')
         .withArgs(
           SupportedStandards.LSP4DigitalAsset.key,
           SupportedStandards.LSP4DigitalAsset.value,
@@ -1247,21 +1247,21 @@ export const shouldInitializeLikeLSP8CompatibleERC721 = (
         await context.lsp8CompatibleERC721.getData(SupportedStandards.LSP4DigitalAsset.key),
       ).to.equal(SupportedStandards.LSP4DigitalAsset.value);
 
-      const nameKey = ERC725YDataKeys.LSP4["LSP4TokenName"];
+      const nameKey = ERC725YDataKeys.LSP4['LSP4TokenName'];
       const expectedNameValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.name),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8CompatibleERC721, "DataChanged")
+        .to.emit(context.lsp8CompatibleERC721, 'DataChanged')
         .withArgs(nameKey, expectedNameValue);
       expect(await context.lsp8CompatibleERC721.getData(nameKey)).to.equal(expectedNameValue);
 
-      const symbolKey = ERC725YDataKeys.LSP4["LSP4TokenSymbol"];
+      const symbolKey = ERC725YDataKeys.LSP4['LSP4TokenSymbol'];
       const expectedSymbolValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.symbol),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8CompatibleERC721, "DataChanged")
+        .to.emit(context.lsp8CompatibleERC721, 'DataChanged')
         .withArgs(symbolKey, expectedSymbolValue);
       expect(await context.lsp8CompatibleERC721.getData(symbolKey)).to.equal(expectedSymbolValue);
     });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8Enumerable.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8Enumerable.behaviour.ts
@@ -1,8 +1,8 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP8EnumerableTester } from "../../types";
+import { LSP8EnumerableTester } from '../../types';
 
 export type LSP8EnumerableTestAccounts = {
   owner: SignerWithAddress;
@@ -35,8 +35,8 @@ export const shouldBehaveLikeLSP8Enumerable = (
     context = await buildContext();
   });
 
-  describe("when no minted tokens", () => {
-    it("should not get token", async () => {
+  describe('when no minted tokens', () => {
+    it('should not get token', async () => {
       const tokenSupply = await context.lsp8Enumerable.totalSupply();
       expect(await context.lsp8Enumerable.tokenAt(tokenSupply)).to.equal(
         ethers.utils.hexZeroPad(ethers.BigNumber.from(0).toHexString(), 32),
@@ -44,10 +44,10 @@ export const shouldBehaveLikeLSP8Enumerable = (
     });
   });
 
-  describe("when minted tokens", () => {
+  describe('when minted tokens', () => {
     const tokenId = ethers.utils.randomBytes(32);
 
-    it("should access by index", async () => {
+    it('should access by index', async () => {
       const tokenSupply = await context.lsp8Enumerable.totalSupply();
       await context.lsp8Enumerable.mint(context.accounts.tokenReceiver.address, tokenId);
       expect(await context.lsp8Enumerable.totalSupply()).to.equal(tokenSupply.add(1));
@@ -56,7 +56,7 @@ export const shouldBehaveLikeLSP8Enumerable = (
       );
     });
 
-    it("should not access by index after removed", async () => {
+    it('should not access by index after removed', async () => {
       const tokenSupply = await context.lsp8Enumerable.totalSupply();
       const anotherTokenId = ethers.utils.randomBytes(32);
       await context.lsp8Enumerable.mint(context.accounts.tokenReceiver.address, tokenId);
@@ -71,7 +71,7 @@ export const shouldBehaveLikeLSP8Enumerable = (
       );
     });
 
-    it("should access by index after removed", async () => {
+    it('should access by index after removed', async () => {
       const tokenSupply = await context.lsp8Enumerable.totalSupply();
       const anotherTokenId = ethers.utils.randomBytes(32);
       await context.lsp8Enumerable.mint(context.accounts.tokenReceiver.address, tokenId);

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -1,8 +1,8 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import type { BytesLike } from "ethers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { BytesLike } from 'ethers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
 
 // types
 import {
@@ -12,13 +12,13 @@ import {
   TokenReceiverWithLSP1__factory,
   TokenReceiverWithoutLSP1,
   TokenReceiverWithoutLSP1__factory,
-} from "../../types";
+} from '../../types';
 
 // helpers
-import { tokenIdAsBytes32 } from "../utils/tokens";
+import { tokenIdAsBytes32 } from '../utils/tokens';
 
 // constants
-import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from "../../constants";
+import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from '../../constants';
 
 export type LSP8TestAccounts = {
   owner: SignerWithAddress;
@@ -61,25 +61,25 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     context = await buildContext();
   });
 
-  describe("when minting tokens", () => {
+  describe('when minting tokens', () => {
     before(async () => {
       await context.lsp8.mint(
         context.accounts.owner.address,
         mintedTokenId,
         true,
-        ethers.utils.toUtf8Bytes("mint a token for the owner"),
+        ethers.utils.toUtf8Bytes('mint a token for the owner'),
       );
 
       expectedTotalSupply++;
     });
 
-    describe("when tokenId has already been minted", () => {
-      it("should revert", async () => {
+    describe('when tokenId has already been minted', () => {
+      it('should revert', async () => {
         const txParams = {
           to: context.accounts.tokenReceiver.address,
           tokenId: mintedTokenId,
           allowNonLSP1Recipient: true,
-          data: "0x",
+          data: '0x',
         };
 
         await expect(
@@ -90,21 +90,21 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             txParams.data,
           ),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8TokenIdAlreadyMinted")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8TokenIdAlreadyMinted')
           .withArgs(txParams.tokenId);
       });
     });
 
-    describe("when tokenId has not been minted", () => {
-      const toBeMintedTokenId = tokenIdAsBytes32("2020202020");
+    describe('when tokenId has not been minted', () => {
+      const toBeMintedTokenId = tokenIdAsBytes32('2020202020');
 
-      describe("when `to` is the zero address", () => {
-        it("should revert", async () => {
+      describe('when `to` is the zero address', () => {
+        it('should revert', async () => {
           const txParams = {
             to: ethers.constants.AddressZero,
             tokenId: toBeMintedTokenId,
             allowNonLSP1Recipient: true,
-            data: "0x",
+            data: '0x',
           };
 
           await expect(
@@ -114,17 +114,17 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               txParams.allowNonLSP1Recipient,
               txParams.data,
             ),
-          ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotSendToAddressZero");
+          ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToAddressZero');
         });
       });
 
-      describe("when `to` is not the zero address", () => {
-        it("should mint the token", async () => {
+      describe('when `to` is not the zero address', () => {
+        it('should mint the token', async () => {
           const txParams = {
             to: context.accounts.tokenReceiver.address,
             tokenId: toBeMintedTokenId,
             allowNonLSP1Recipient: true,
-            data: ethers.utils.toUtf8Bytes("we need more tokens"),
+            data: ethers.utils.toUtf8Bytes('we need more tokens'),
           };
 
           await context.lsp8.mint(
@@ -143,41 +143,41 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("totalSupply", () => {
-    it("should return total token supply", async () => {
+  describe('totalSupply', () => {
+    it('should return total token supply', async () => {
       expect(await context.lsp8.totalSupply()).to.equal(ethers.BigNumber.from(expectedTotalSupply));
     });
   });
 
-  describe("balanceOf", () => {
-    describe("when the given address owns tokens", () => {
-      it("should return the owned token count", async () => {
+  describe('balanceOf', () => {
+    describe('when the given address owns tokens', () => {
+      it('should return the owned token count', async () => {
         expect(await context.lsp8.balanceOf(context.accounts.owner.address)).to.equal(
-          ethers.BigNumber.from("1"),
+          ethers.BigNumber.from('1'),
         );
       });
     });
 
-    describe("when the given address does not own tokens", () => {
-      it("should return zero", async () => {
+    describe('when the given address does not own tokens', () => {
+      it('should return zero', async () => {
         expect(await context.lsp8.balanceOf(context.accounts.anyone.address)).to.equal(
-          ethers.BigNumber.from("0"),
+          ethers.BigNumber.from('0'),
         );
       });
     });
   });
 
-  describe("tokenOwnerOf", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('tokenOwnerOf', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(context.lsp8.tokenOwnerOf(neverMintedTokenId))
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when tokenId has been minted", () => {
-      it("should return owner address", async () => {
+    describe('when tokenId has been minted', () => {
+      it('should return owner address', async () => {
         expect(await context.lsp8.tokenOwnerOf(mintedTokenId)).to.equal(
           context.accounts.owner.address,
         );
@@ -185,56 +185,56 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("tokenIdsOf", () => {
-    describe("when the given address owns some tokens", () => {
-      it("should return the list of owned tokenIds", async () => {
+  describe('tokenIdsOf', () => {
+    describe('when the given address owns some tokens', () => {
+      it('should return the list of owned tokenIds', async () => {
         expect(await context.lsp8.tokenIdsOf(context.accounts.owner.address)).to.be.deep.equal([
           mintedTokenId,
         ]);
       });
     });
 
-    describe("when the given address does not owns some tokens", () => {
-      it("should return an empty list", async () => {
+    describe('when the given address does not owns some tokens', () => {
+      it('should return an empty list', async () => {
         expect(await context.lsp8.tokenIdsOf(context.accounts.anyone.address)).to.be.deep.equal([]);
       });
     });
   });
 
-  describe("authorizeOperator", () => {
-    describe("when tokenId does not exist", () => {
-      it("should revert", async () => {
+  describe('authorizeOperator', () => {
+    describe('when tokenId does not exist', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8.authorizeOperator(context.accounts.operator.address, neverMintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when caller is not owner of tokenId", () => {
-      it("should revert", async () => {
+    describe('when caller is not owner of tokenId', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8
             .connect(context.accounts.anyone)
             .authorizeOperator(context.accounts.operator.address, mintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOwner")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOwner')
           .withArgs(context.accounts.owner.address, mintedTokenId, context.accounts.anyone.address);
       });
     });
 
-    describe("when operator is the token owner", () => {
-      it("should revert", async () => {
+    describe('when operator is the token owner', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8.authorizeOperator(context.accounts.owner.address, mintedTokenId),
-        ).to.be.revertedWithCustomError(context.lsp8, "LSP8TokenOwnerCannotBeOperator");
+        ).to.be.revertedWithCustomError(context.lsp8, 'LSP8TokenOwnerCannotBeOperator');
       });
     });
 
-    describe("when caller is owner of tokenId", () => {
-      describe("when operator is not the zero address", () => {
-        it("should succeed", async () => {
+    describe('when caller is owner of tokenId', () => {
+      describe('when operator is not the zero address', () => {
+        it('should succeed', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
           const tokenId = mintedTokenId;
@@ -242,75 +242,75 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           const tx = await context.lsp8.authorizeOperator(operator, tokenId);
 
           await expect(tx)
-            .to.emit(context.lsp8, "AuthorizedOperator")
+            .to.emit(context.lsp8, 'AuthorizedOperator')
             .withArgs(operator, tokenOwner, tokenId);
 
           expect(await context.lsp8.isOperatorFor(operator, tokenId)).to.be.true;
         });
 
-        describe("when operator is already authorized", () => {
-          it("should revert", async () => {
+        describe('when operator is already authorized', () => {
+          it('should revert', async () => {
             const operator = context.accounts.operator.address;
             const tokenId = mintedTokenId;
 
             await expect(context.lsp8.authorizeOperator(operator, tokenId))
-              .to.be.revertedWithCustomError(context.lsp8, "LSP8OperatorAlreadyAuthorized")
+              .to.be.revertedWithCustomError(context.lsp8, 'LSP8OperatorAlreadyAuthorized')
               .withArgs(operator, tokenId);
           });
         });
 
-        describe("when operator is the zero address", () => {
-          it("should revert", async () => {
+        describe('when operator is the zero address', () => {
+          it('should revert', async () => {
             const operator = ethers.constants.AddressZero;
             const tokenId = mintedTokenId;
 
             await expect(
               context.lsp8.authorizeOperator(operator, tokenId),
-            ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotUseAddressZeroAsOperator");
+            ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotUseAddressZeroAsOperator');
           });
         });
       });
     });
   });
 
-  describe("revokeOperator", () => {
-    describe("when tokenId does not exist", () => {
-      it("should revert", async () => {
+  describe('revokeOperator', () => {
+    describe('when tokenId does not exist', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8.revokeOperator(context.accounts.operator.address, neverMintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when caller is not owner of tokenId", () => {
-      it("should revert", async () => {
+    describe('when caller is not owner of tokenId', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8
             .connect(context.accounts.anyone)
             .authorizeOperator(context.accounts.operator.address, mintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOwner")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOwner')
           .withArgs(context.accounts.owner.address, mintedTokenId, context.accounts.anyone.address);
       });
     });
 
-    describe("when caller is not owner of tokenId", () => {
-      it("should revert", async () => {
+    describe('when caller is not owner of tokenId', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8
             .connect(context.accounts.anyone)
             .revokeOperator(context.accounts.operator.address, mintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOwner")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOwner')
           .withArgs(context.accounts.owner.address, mintedTokenId, context.accounts.anyone.address);
       });
     });
 
-    describe("when caller is owner of tokenId", () => {
-      describe("when operator is not the zero address", () => {
-        it("should succeed", async () => {
+    describe('when caller is owner of tokenId', () => {
+      describe('when operator is not the zero address', () => {
+        it('should succeed', async () => {
           const operator = context.accounts.operator.address;
           const tokenOwner = context.accounts.owner.address;
           const tokenId = mintedTokenId;
@@ -321,7 +321,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           // effects
           const tx = await context.lsp8.revokeOperator(operator, tokenId);
           await expect(tx)
-            .to.emit(context.lsp8, "RevokedOperator")
+            .to.emit(context.lsp8, 'RevokedOperator')
             .withArgs(operator, tokenOwner, tokenId);
 
           // post-conditions
@@ -329,51 +329,51 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         });
       });
 
-      describe("when operator is the zero address", () => {
-        it("should revert", async () => {
+      describe('when operator is the zero address', () => {
+        it('should revert', async () => {
           const operator = ethers.constants.AddressZero;
           const tokenId = mintedTokenId;
 
           await expect(
             context.lsp8.revokeOperator(operator, tokenId),
-          ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotUseAddressZeroAsOperator");
+          ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotUseAddressZeroAsOperator');
         });
       });
 
-      describe("when address provided to revoke is not an existing operator", () => {
-        it("should revert", async () => {
+      describe('when address provided to revoke is not an existing operator', () => {
+        it('should revert', async () => {
           const operator = context.accounts.anyone.address;
           const tokenId = mintedTokenId;
 
           await expect(context.lsp8.revokeOperator(operator, tokenId))
-            .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistingOperator")
+            .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistingOperator')
             .withArgs(operator, tokenId);
         });
       });
     });
   });
 
-  describe("isOperatorFor", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('isOperatorFor', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(
           context.lsp8.isOperatorFor(context.accounts.operator.address, neverMintedTokenId),
         )
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when tokenId has been minted", () => {
-      describe("when operator has not been authorized", () => {
-        it("should return false", async () => {
+    describe('when tokenId has been minted', () => {
+      describe('when operator has not been authorized', () => {
+        it('should return false', async () => {
           expect(await context.lsp8.isOperatorFor(context.accounts.operator.address, mintedTokenId))
             .to.be.false;
         });
       });
 
-      describe("when one account have been authorized for the tokenId", () => {
-        it("should return true", async () => {
+      describe('when one account have been authorized for the tokenId', () => {
+        it('should return true', async () => {
           await context.lsp8.authorizeOperator(context.accounts.operator.address, mintedTokenId);
 
           expect(await context.lsp8.isOperatorFor(context.accounts.operator.address, mintedTokenId))
@@ -381,8 +381,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         });
       });
 
-      describe("when many accounts have been authorized for the tokenId", () => {
-        it("should return true for all operators", async () => {
+      describe('when many accounts have been authorized for the tokenId', () => {
+        it('should return true for all operators', async () => {
           await context.lsp8.authorizeOperator(
             context.accounts.anotherOperator.address,
             mintedTokenId,
@@ -401,24 +401,24 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("getOperatorsOf", () => {
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
+  describe('getOperatorsOf', () => {
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
         await expect(context.lsp8.getOperatorsOf(neverMintedTokenId))
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when tokenId has been minted", () => {
-      after("cleanup operators", async () => {
+    describe('when tokenId has been minted', () => {
+      after('cleanup operators', async () => {
         await context.lsp8.revokeOperator(context.accounts.operator.address, mintedTokenId);
 
         await context.lsp8.revokeOperator(context.accounts.anotherOperator.address, mintedTokenId);
       });
 
-      describe("when operator has not been authorized", () => {
-        before("remove operators", async () => {
+      describe('when operator has not been authorized', () => {
+        before('remove operators', async () => {
           await context.lsp8.revokeOperator(context.accounts.operator.address, mintedTokenId);
 
           await context.lsp8.revokeOperator(
@@ -427,32 +427,32 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           );
         });
 
-        it("should return empty list", async () => {
+        it('should return empty list', async () => {
           expect(await context.lsp8.getOperatorsOf(mintedTokenId)).to.be.deep.equal([]);
         });
       });
 
-      describe("when one account have been authorized for the tokenId", () => {
-        before("authorize 1 x operator", async () => {
+      describe('when one account have been authorized for the tokenId', () => {
+        before('authorize 1 x operator', async () => {
           await context.lsp8.authorizeOperator(context.accounts.operator.address, mintedTokenId);
         });
 
-        it("should return array with 1x operator", async () => {
+        it('should return array with 1x operator', async () => {
           expect(await context.lsp8.getOperatorsOf(mintedTokenId)).to.be.deep.equal([
             context.accounts.operator.address,
           ]);
         });
       });
 
-      describe("when many accounts have been authorized for the tokenId", () => {
-        before("authorize 1+ more operator", async () => {
+      describe('when many accounts have been authorized for the tokenId', () => {
+        before('authorize 1+ more operator', async () => {
           await context.lsp8.authorizeOperator(
             context.accounts.anotherOperator.address,
             mintedTokenId,
           );
         });
 
-        it("should return array with 2x operators", async () => {
+        it('should return array with 2x operators', async () => {
           expect(await context.lsp8.getOperatorsOf(mintedTokenId)).to.be.deep.equal([
             context.accounts.operator.address,
             context.accounts.anotherOperator.address,
@@ -462,7 +462,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("transfers", () => {
+  describe('transfers', () => {
     type HelperContracts = {
       tokenReceiverWithLSP1: TokenReceiverWithLSP1;
       tokenReceiverWithoutLSP1: TokenReceiverWithoutLSP1;
@@ -488,7 +488,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         context.accounts.owner.address,
         mintedTokenId,
         true,
-        ethers.utils.toUtf8Bytes("mint a token for the owner"),
+        ethers.utils.toUtf8Bytes('mint a token for the owner'),
       );
 
       // setup so we can observe operators being cleared during transfer tests
@@ -496,7 +496,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
       await context.lsp8.authorizeOperator(context.accounts.anotherOperator.address, mintedTokenId);
     });
 
-    describe("transfer", () => {
+    describe('transfer', () => {
       type TransferTxParams = {
         from: string;
         to: string;
@@ -533,15 +533,15 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           .connect(operator)
           .transfer(from, to, tokenId, allowNonLSP1Recipient, data);
         await expect(tx)
-          .to.emit(context.lsp8, "Transfer")
+          .to.emit(context.lsp8, 'Transfer')
           .withArgs(operator.address, from, to, tokenId, allowNonLSP1Recipient, data);
 
         await expect(tx)
-          .to.emit(context.lsp8, "RevokedOperator")
+          .to.emit(context.lsp8, 'RevokedOperator')
           .withArgs(context.accounts.operator.address, from, tokenId);
 
         await expect(tx)
-          .to.emit(context.lsp8, "RevokedOperator")
+          .to.emit(context.lsp8, 'RevokedOperator')
           .withArgs(context.accounts.anotherOperator.address, from, tokenId);
 
         // post-conditions
@@ -574,15 +574,15 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           operator = getOperator();
         });
 
-        describe("when using allowNonLSP1Recipient=true", () => {
+        describe('when using allowNonLSP1Recipient=true', () => {
           const allowNonLSP1Recipient = true;
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("doing a transfer with allowNonLSP1Recipient"),
+            ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
           );
 
-          describe("when `to` is an EOA", () => {
-            describe("when `to` is the zero address", () => {
-              it("should revert", async () => {
+          describe('when `to` is an EOA', () => {
+            describe('when `to` is the zero address', () => {
+              it('should revert', async () => {
                 const txParams = {
                   from: context.accounts.owner.address,
                   to: ethers.constants.AddressZero,
@@ -601,11 +601,11 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                       txParams.allowNonLSP1Recipient,
                       txParams.data,
                     ),
-                ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotSendToAddressZero");
+                ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToAddressZero');
               });
             });
 
-            it("should allow transfering the tokenId", async () => {
+            it('should allow transfering the tokenId', async () => {
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
@@ -618,9 +618,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -634,18 +634,18 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                 const packedData = ethers.utils.solidityPack(
-                  ["address", "address", "bytes32", "bytes"],
+                  ['address', 'address', 'bytes32', 'bytes'],
                   [txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
 
                 await expect(tx)
-                  .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                   .withArgs(typeId, packedData);
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -661,7 +661,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
 
           describe("when `from == to` address (= sending to tokenId's owner itself)", () => {
-            it("should revert", async () => {
+            it('should revert', async () => {
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.owner.address,
@@ -680,19 +680,19 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.allowNonLSP1Recipient,
                     txParams.data,
                   ),
-              ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotSendToSelf");
+              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
             });
           });
         });
 
-        describe("when allowNonLSP1Recipient=false", () => {
+        describe('when allowNonLSP1Recipient=false', () => {
           const allowNonLSP1Recipient = false;
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
           );
 
-          describe("when `to` is an EOA", () => {
-            it("should not allow transfering the tokenId", async () => {
+          describe('when `to` is an EOA', () => {
+            it('should not allow transfering the tokenId', async () => {
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
@@ -712,14 +712,14 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.data,
                   ),
               )
-                .to.be.revertedWithCustomError(context.lsp8, "LSP8NotifyTokenReceiverIsEOA")
+                .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotifyTokenReceiverIsEOA')
                 .withArgs(txParams.to);
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -733,18 +733,18 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                 const packedData = ethers.utils.solidityPack(
-                  ["address", "address", "bytes32", "bytes"],
+                  ['address', 'address', 'bytes32', 'bytes'],
                   [txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
 
                 await expect(tx)
-                  .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                   .withArgs(typeId, packedData);
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should not allow transfering the tokenId", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should not allow transfering the tokenId', async () => {
                 const txParams = {
                   operator: context.accounts.owner.address,
                   from: context.accounts.owner.address,
@@ -767,7 +767,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 )
                   .to.be.revertedWithCustomError(
                     context.lsp8,
-                    "LSP8NotifyTokenReceiverContractMissingLSP1Interface",
+                    'LSP8NotifyTokenReceiverContractMissingLSP1Interface',
                   )
                   .withArgs(txParams.to);
               });
@@ -775,7 +775,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
 
           describe("when `from == to` address (= sending to tokenId's owner itself)", () => {
-            it("should revert", async () => {
+            it('should revert', async () => {
               const txParams = {
                 from: context.accounts.owner.address,
                 to: context.accounts.owner.address,
@@ -794,28 +794,28 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.allowNonLSP1Recipient,
                     txParams.data,
                   ),
-              ).to.be.revertedWithCustomError(context.lsp8, "LSP8CannotSendToSelf");
+              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
             });
           });
         });
       };
 
-      describe("when tokenOwner sends tx", () => {
+      describe('when tokenOwner sends tx', () => {
         sendingTransferTransactions(() => context.accounts.owner);
       });
 
-      describe("when operator sends tx", () => {
+      describe('when operator sends tx', () => {
         sendingTransferTransactions(() => context.accounts.operator);
 
-        describe("when the caller is not an operator", () => {
-          it("should revert", async () => {
+        describe('when the caller is not an operator', () => {
+          it('should revert', async () => {
             const operator = context.accounts.anyone;
             const txParams = {
               from: context.accounts.owner.address,
               to: context.accounts.tokenReceiver.address,
               tokenId: mintedTokenId,
               allowNonLSP1Recipient: true,
-              data: "0x",
+              data: '0x',
             };
 
             await expect(
@@ -829,21 +829,21 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   txParams.data,
                 ),
             )
-              .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOperator")
+              .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOperator')
               .withArgs(txParams.tokenId.toString(), operator.address);
           });
         });
       });
 
-      describe("when the from address is incorrect", () => {
-        it("should revert", async () => {
+      describe('when the from address is incorrect', () => {
+        it('should revert', async () => {
           const operator = context.accounts.owner;
           const txParams = {
             from: context.accounts.anyone.address,
             to: context.accounts.tokenReceiver.address,
             tokenId: mintedTokenId,
             allowNonLSP1Recipient: true,
-            data: "0x",
+            data: '0x',
           };
 
           await expect(
@@ -857,20 +857,20 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 txParams.data,
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOwner")
+            .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOwner')
             .withArgs(context.accounts.owner.address, txParams.tokenId.toString(), txParams.from);
         });
       });
 
-      describe("when the given tokenId has not been minted", () => {
-        it("should revert", async () => {
+      describe('when the given tokenId has not been minted', () => {
+        it('should revert', async () => {
           const operator = context.accounts.owner;
           const txParams = {
             from: context.accounts.owner.address,
             to: context.accounts.tokenReceiver.address,
             tokenId: neverMintedTokenId,
             allowNonLSP1Recipient: true,
-            data: "0x",
+            data: '0x',
           };
 
           await expect(
@@ -884,14 +884,14 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 txParams.data,
               ),
           )
-            .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+            .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
             .withArgs(txParams.tokenId.toString());
         });
       });
     });
 
-    describe("transferBatch", () => {
-      const anotherMintedTokenId = tokenIdAsBytes32("5555");
+    describe('transferBatch', () => {
+      const anotherMintedTokenId = tokenIdAsBytes32('5555');
 
       beforeEach(async () => {
         // setup so we can transfer multiple tokenIds during transferBatch test
@@ -899,7 +899,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           context.accounts.owner.address,
           anotherMintedTokenId,
           true,
-          ethers.utils.toUtf8Bytes("mint another token for the owner"),
+          ethers.utils.toUtf8Bytes('mint another token for the owner'),
         );
 
         // setup so we can observe operators being cleared during transferBatch tests
@@ -947,7 +947,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         await Promise.all(
           tokenId.map(async (_, index) => {
             await expect(tx)
-              .to.emit(context.lsp8, "Transfer")
+              .to.emit(context.lsp8, 'Transfer')
               .withArgs(
                 operator.address,
                 from[index],
@@ -957,10 +957,10 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 data[index],
               );
             await expect(tx)
-              .to.emit(context.lsp8, "RevokedOperator")
+              .to.emit(context.lsp8, 'RevokedOperator')
               .withArgs(context.accounts.operator.address, from[index], tokenId[index]);
             await expect(tx)
-              .to.emit(context.lsp8, "RevokedOperator")
+              .to.emit(context.lsp8, 'RevokedOperator')
               .withArgs(context.accounts.anotherOperator.address, from[index], tokenId[index]);
           }),
         );
@@ -1016,14 +1016,14 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           operator = getOperator();
         });
 
-        describe("when allowNonLSP1Recipient=true", () => {
+        describe('when allowNonLSP1Recipient=true', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("doing a transfer with allowNonLSP1Recipient"),
+            ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
           );
 
-          describe("when `to` is an EOA", () => {
-            describe("when `to` is the zero address", () => {
-              it("should revert", async () => {
+          describe('when `to` is an EOA', () => {
+            describe('when `to` is the zero address', () => {
+              it('should revert', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [context.accounts.tokenReceiver.address, ethers.constants.AddressZero],
@@ -1031,7 +1031,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   allowNonLSP1Recipient: [true, true],
                   data: [data, data],
                 };
-                const expectedError = "LSP8CannotSendToAddressZero";
+                const expectedError = 'LSP8CannotSendToAddressZero';
 
                 await transferBatchFailScenario(txParams, operator, {
                   error: expectedError,
@@ -1040,7 +1040,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               });
             });
 
-            it("should allow transfering the tokenId", async () => {
+            it('should allow transfering the tokenId', async () => {
               const txParams = {
                 from: [context.accounts.owner.address, context.accounts.owner.address],
                 to: [
@@ -1056,9 +1056,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1075,9 +1075,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 await Promise.all(
                   txParams.tokenId.map((_, index) => async () => {
                     const typeId =
-                      "0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895";
+                      '0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895';
                     const packedData = ethers.utils.solidityPack(
-                      ["address", "address", "bytes32", "bytes"],
+                      ['address', 'address', 'bytes32', 'bytes'],
                       [
                         txParams.from[index],
                         txParams.to[index],
@@ -1087,15 +1087,15 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     );
 
                     await expect(tx)
-                      .to.emit(helperContracts.tokenReceiverWithLSP1, "UniversalReceiverCalled")
+                      .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
                       .withArgs(typeId, packedData);
                   }),
                 );
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1113,13 +1113,13 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe("when allowNonLSP1Recipient=false", () => {
+        describe('when allowNonLSP1Recipient=false', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
           );
 
-          describe("when `to` is an EOA", () => {
-            it("should not allow transfering the tokenId", async () => {
+          describe('when `to` is an EOA', () => {
+            it('should not allow transfering the tokenId', async () => {
               const txParams = {
                 from: [context.accounts.owner.address, context.accounts.owner.address],
                 to: [
@@ -1130,7 +1130,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 allowNonLSP1Recipient: [false, false],
                 data: [data, data],
               };
-              const expectedError = "LSP8NotifyTokenReceiverIsEOA";
+              const expectedError = 'LSP8NotifyTokenReceiverIsEOA';
 
               await transferBatchFailScenario(txParams, operator, {
                 error: expectedError,
@@ -1139,9 +1139,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             });
           });
 
-          describe("when `to` is a contract", () => {
-            describe("when receiving contract supports LSP1", () => {
-              it("should allow transfering the tokenId", async () => {
+          describe('when `to` is a contract', () => {
+            describe('when receiving contract supports LSP1', () => {
+              it('should allow transfering the tokenId', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1157,8 +1157,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               });
             });
 
-            describe("when receiving contract does not support LSP1", () => {
-              it("should not allow transfering the tokenId", async () => {
+            describe('when receiving contract does not support LSP1', () => {
+              it('should not allow transfering the tokenId', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1169,7 +1169,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   allowNonLSP1Recipient: [false, false],
                   data: [data, data],
                 };
-                const expectedError = "LSP8NotifyTokenReceiverContractMissingLSP1Interface";
+                const expectedError = 'LSP8NotifyTokenReceiverContractMissingLSP1Interface';
 
                 await transferBatchFailScenario(txParams, operator, {
                   error: expectedError,
@@ -1180,13 +1180,13 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe("when allowNonLSP1Recipient is mixed(true/false) respectively", () => {
+        describe('when allowNonLSP1Recipient is mixed(true/false) respectively', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("doing a transfer without allowNonLSP1Recipient"),
+            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
           );
 
-          describe("when `to` is an EOA", () => {
-            it("should revert", async () => {
+          describe('when `to` is an EOA', () => {
+            it('should revert', async () => {
               const txParams = {
                 from: [context.accounts.owner.address, context.accounts.owner.address],
                 to: [
@@ -1197,7 +1197,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 allowNonLSP1Recipient: [true, false],
                 data: [data, data],
               };
-              const expectedError = "LSP8NotifyTokenReceiverIsEOA";
+              const expectedError = 'LSP8NotifyTokenReceiverIsEOA';
 
               await transferBatchFailScenario(txParams, operator, {
                 error: expectedError,
@@ -1206,9 +1206,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             });
           });
 
-          describe("when `to` is a contract", () => {
+          describe('when `to` is a contract', () => {
             describe("when first receiving contract support LSP1 but the second doesn't", () => {
-              it("should allow transfering", async () => {
+              it('should allow transfering', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1220,7 +1220,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   data: [data, data],
                 };
 
-                const expectedError = "LSP8NotifyTokenReceiverContractMissingLSP1Interface";
+                const expectedError = 'LSP8NotifyTokenReceiverContractMissingLSP1Interface';
 
                 await transferBatchFailScenario(txParams, operator, {
                   error: expectedError,
@@ -1229,8 +1229,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               });
             });
 
-            describe("when receiving contract both support LSP1", () => {
-              it("should pass regardless of allowNonLSP1Recipient params", async () => {
+            describe('when receiving contract both support LSP1', () => {
+              it('should pass regardless of allowNonLSP1Recipient params', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1248,16 +1248,16 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe("when the from address is incorrect", () => {
-          it("should revert", async () => {
+        describe('when the from address is incorrect', () => {
+          it('should revert', async () => {
             const txParams = {
               to: [context.accounts.anyone.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId],
               allowNonLSP1Recipient: [true],
-              data: ["0x"],
+              data: ['0x'],
             };
-            const expectedError = "LSP8NotTokenOwner";
+            const expectedError = 'LSP8NotTokenOwner';
 
             await transferBatchFailScenario(txParams, operator, {
               error: expectedError,
@@ -1270,16 +1270,16 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe("when the given tokenId has not been minted", () => {
-          it("should revert", async () => {
+        describe('when the given tokenId has not been minted', () => {
+          it('should revert', async () => {
             const txParams = {
               to: [context.accounts.anyone.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [neverMintedTokenId],
               allowNonLSP1Recipient: [true],
-              data: ["0x"],
+              data: ['0x'],
             };
-            const expectedError = "LSP8NonExistentTokenId";
+            const expectedError = 'LSP8NonExistentTokenId';
 
             await transferBatchFailScenario(txParams, operator, {
               error: expectedError,
@@ -1288,18 +1288,18 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe("when function parameters list length does not match", () => {
-          it("should revert", async () => {
+        describe('when function parameters list length does not match', () => {
+          it('should revert', async () => {
             const validTxParams = {
               from: [context.accounts.owner.address, context.accounts.owner.address],
               to: [context.accounts.tokenReceiver.address, context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId, anotherMintedTokenId],
               allowNonLSP1Recipient: [true],
-              data: ["0x", "0x"],
+              data: ['0x', '0x'],
             };
 
             await Promise.all(
-              ["from", "to", "tokenId", "data"].map(async (arrayParam) => {
+              ['from', 'to', 'tokenId', 'data'].map(async (arrayParam) => {
                 await transferBatchFailScenario(
                   {
                     ...validTxParams,
@@ -1307,7 +1307,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   },
                   operator,
                   {
-                    error: "LSP8InvalidTransferBatch",
+                    error: 'LSP8InvalidTransferBatch',
                     args: [],
                   },
                 );
@@ -1317,24 +1317,24 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         });
       };
 
-      describe("when tokenOwner sends tx", () => {
+      describe('when tokenOwner sends tx', () => {
         sendingTransferBatchTransactions(() => context.accounts.owner);
       });
 
-      describe("when operator sends tx", () => {
+      describe('when operator sends tx', () => {
         sendingTransferBatchTransactions(() => context.accounts.operator);
 
-        describe("when the caller is not an operator", () => {
-          it("should revert", async () => {
+        describe('when the caller is not an operator', () => {
+          it('should revert', async () => {
             const operator = context.accounts.anyone;
             const txParams = {
               to: [context.accounts.owner.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId],
               allowNonLSP1Recipient: [true],
-              data: ["0x"],
+              data: ['0x'],
             };
-            const expectedError = "LSP8NotTokenOperator";
+            const expectedError = 'LSP8NotTokenOperator';
 
             await transferBatchFailScenario(txParams, operator, {
               error: expectedError,
@@ -1346,7 +1346,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("burn", () => {
+  describe('burn', () => {
     beforeEach(async () => {
       context = await buildContext();
 
@@ -1354,65 +1354,65 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         context.accounts.owner.address,
         mintedTokenId,
         true,
-        ethers.utils.toUtf8Bytes("mint a token for the owner"),
+        ethers.utils.toUtf8Bytes('mint a token for the owner'),
       );
     });
 
-    describe("when tokenId has not been minted", () => {
-      it("should revert", async () => {
-        await expect(context.lsp8.burn(neverMintedTokenId, "0x"))
-          .to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId")
+    describe('when tokenId has not been minted', () => {
+      it('should revert', async () => {
+        await expect(context.lsp8.burn(neverMintedTokenId, '0x'))
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId')
           .withArgs(neverMintedTokenId);
       });
     });
 
-    describe("when tokenId has been minted", () => {
-      describe("when caller is not the token owner or an operator", () => {
-        it("should revert", async () => {
-          await expect(context.lsp8.connect(context.accounts.anyone).burn(mintedTokenId, "0x"))
-            .to.be.revertedWithCustomError(context.lsp8, "LSP8NotTokenOperator")
+    describe('when tokenId has been minted', () => {
+      describe('when caller is not the token owner or an operator', () => {
+        it('should revert', async () => {
+          await expect(context.lsp8.connect(context.accounts.anyone).burn(mintedTokenId, '0x'))
+            .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOperator')
             .withArgs(mintedTokenId, context.accounts.anyone.address);
         });
       });
 
-      describe("when caller is the token owner", () => {
-        describe("after burning a tokenId", () => {
-          it("should have decreased the total supply", async () => {
+      describe('when caller is the token owner', () => {
+        describe('after burning a tokenId', () => {
+          it('should have decreased the total supply', async () => {
             const totalSupplyBefore = await context.lsp8.totalSupply();
 
-            await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, "0x");
+            await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, '0x');
 
             const totalSupplyAfter = await context.lsp8.totalSupply();
 
             expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(1));
           });
 
-          it("should have emitted a Transfer event with address(0) as `to` param", async () => {
-            await expect(context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, "0x"))
-              .to.emit(context.lsp8, "Transfer")
+          it('should have emitted a Transfer event with address(0) as `to` param', async () => {
+            await expect(context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, '0x'))
+              .to.emit(context.lsp8, 'Transfer')
               .withArgs(
                 context.accounts.owner.address,
                 context.accounts.owner.address,
                 ethers.constants.AddressZero,
                 mintedTokenId,
                 false,
-                "0x",
+                '0x',
               );
           });
 
-          describe("when calling `tokenOwnerOf(...)` for the burnt tokenId", () => {
-            it("should revert stating tokenId does not exist", async () => {
-              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, "0x");
+          describe('when calling `tokenOwnerOf(...)` for the burnt tokenId', () => {
+            it('should revert stating tokenId does not exist', async () => {
+              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, '0x');
 
               await expect(context.lsp8.tokenOwnerOf(mintedTokenId)).to.be.revertedWithCustomError(
                 context.lsp8,
-                "LSP8NonExistentTokenId",
+                'LSP8NonExistentTokenId',
               );
             });
           });
 
-          describe("when calling `getOperatorsOf(...)` for the burnt tokenId", () => {
-            it("should revert stating tokenId does not exist", async () => {
+          describe('when calling `getOperatorsOf(...)` for the burnt tokenId', () => {
+            it('should revert stating tokenId does not exist', async () => {
               await context.lsp8.authorizeOperator(
                 context.accounts.operator.address,
                 mintedTokenId,
@@ -1430,22 +1430,22 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 context.accounts.anotherOperator.address,
               ]);
 
-              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, "0x");
+              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, '0x');
 
               await expect(
                 context.lsp8.getOperatorsOf(mintedTokenId),
-              ).to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId");
+              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId');
             });
           });
 
-          describe("when calling `tokenIdsOf(...)` with the initial owner address of the burnt token", () => {
-            it("should return a list of tokenIds that does not contain the burnt tokenId", async () => {
+          describe('when calling `tokenIdsOf(...)` with the initial owner address of the burnt token', () => {
+            it('should return a list of tokenIds that does not contain the burnt tokenId', async () => {
               const tokenIdsOfOwnerBefore = await context.lsp8.tokenIdsOf(
                 context.accounts.owner.address,
               );
               expect(tokenIdsOfOwnerBefore).to.contain(mintedTokenId);
 
-              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, "0x");
+              await context.lsp8.connect(context.accounts.owner).burn(mintedTokenId, '0x');
 
               const tokenIdsOfOwnerAfter = await context.lsp8.tokenIdsOf(
                 context.accounts.owner.address,
@@ -1456,48 +1456,48 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         });
       });
 
-      describe("when caller is an operator", () => {
+      describe('when caller is an operator', () => {
         beforeEach(async () => {
           await context.lsp8.authorizeOperator(context.accounts.operator.address, mintedTokenId);
         });
 
-        describe("after burning a tokenId", () => {
-          it("should have decreased the total supply", async () => {
+        describe('after burning a tokenId', () => {
+          it('should have decreased the total supply', async () => {
             const totalSupplyBefore = await context.lsp8.totalSupply();
 
-            await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, "0x");
+            await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, '0x');
 
             const totalSupplyAfter = await context.lsp8.totalSupply();
 
             expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(1));
           });
 
-          it("should have emitted a Transfer event with address(0) as `to` param", async () => {
-            await expect(context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, "0x"))
-              .to.emit(context.lsp8, "Transfer")
+          it('should have emitted a Transfer event with address(0) as `to` param', async () => {
+            await expect(context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, '0x'))
+              .to.emit(context.lsp8, 'Transfer')
               .withArgs(
                 context.accounts.operator.address,
                 context.accounts.owner.address,
                 ethers.constants.AddressZero,
                 mintedTokenId,
                 false,
-                "0x",
+                '0x',
               );
           });
 
-          describe("when calling `tokenOwnerOf(...)` for the burnt tokenId", () => {
-            it("should revert stating tokenId does not exist", async () => {
-              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, "0x");
+          describe('when calling `tokenOwnerOf(...)` for the burnt tokenId', () => {
+            it('should revert stating tokenId does not exist', async () => {
+              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, '0x');
 
               await expect(context.lsp8.tokenOwnerOf(mintedTokenId)).to.be.revertedWithCustomError(
                 context.lsp8,
-                "LSP8NonExistentTokenId",
+                'LSP8NonExistentTokenId',
               );
             });
           });
 
-          describe("when calling `getOperatorsOf(...)` for the burnt tokenId", () => {
-            it("should revert stating tokenId does not exist", async () => {
+          describe('when calling `getOperatorsOf(...)` for the burnt tokenId', () => {
+            it('should revert stating tokenId does not exist', async () => {
               await context.lsp8.authorizeOperator(
                 context.accounts.anotherOperator.address,
                 mintedTokenId,
@@ -1510,22 +1510,22 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 context.accounts.anotherOperator.address,
               ]);
 
-              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, "0x");
+              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, '0x');
 
               await expect(
                 context.lsp8.getOperatorsOf(mintedTokenId),
-              ).to.be.revertedWithCustomError(context.lsp8, "LSP8NonExistentTokenId");
+              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8NonExistentTokenId');
             });
           });
 
-          describe("when calling `tokenIdsOf(...)` with the initial owner address of the burnt token", () => {
-            it("should return a list of tokenIds that does not contain the burnt tokenId", async () => {
+          describe('when calling `tokenIdsOf(...)` with the initial owner address of the burnt token', () => {
+            it('should return a list of tokenIds that does not contain the burnt tokenId', async () => {
               const tokenIdsOfOwnerBefore = await context.lsp8.tokenIdsOf(
                 context.accounts.owner.address,
               );
               expect(tokenIdsOfOwnerBefore).to.contain(mintedTokenId);
 
-              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, "0x");
+              await context.lsp8.connect(context.accounts.operator).burn(mintedTokenId, '0x');
 
               const tokenIdsOfOwnerAfter = await context.lsp8.tokenIdsOf(
                 context.accounts.owner.address,
@@ -1538,7 +1538,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
     });
   });
 
-  describe("transferOwnership", () => {
+  describe('transferOwnership', () => {
     let oldOwner: SignerWithAddress;
     let newOwner: SignerWithAddress;
 
@@ -1548,47 +1548,47 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
       newOwner = context.accounts.anyone;
     });
 
-    it("should not allow non-owners to transfer ownership", async () => {
+    it('should not allow non-owners to transfer ownership', async () => {
       const newOwner = context.accounts.anyone;
       await expect(
         context.lsp8.connect(newOwner).transferOwnership(newOwner.address),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
 
-    it("should transfer ownership of the contract", async () => {
+    it('should transfer ownership of the contract', async () => {
       await context.lsp8.connect(oldOwner).transferOwnership(newOwner.address);
       expect(await context.lsp8.owner()).to.equal(newOwner.address);
     });
 
-    describe("after transferring ownership of the contract", () => {
+    describe('after transferring ownership of the contract', () => {
       beforeEach(async () => {
         context = await buildContext();
 
         await context.lsp8.connect(oldOwner).transferOwnership(newOwner.address);
       });
 
-      it("old owner should not be allowed to use `transferOwnership(..)`", async () => {
+      it('old owner should not be allowed to use `transferOwnership(..)`', async () => {
         const randomAddress = context.accounts.anyone.address;
         await expect(
           context.lsp8.connect(oldOwner).transferOwnership(randomAddress),
-        ).to.be.revertedWith("Ownable: caller is not the owner");
+        ).to.be.revertedWith('Ownable: caller is not the owner');
       });
 
-      it("old owner should not be allowed to use `renounceOwnership(..)`", async () => {
+      it('old owner should not be allowed to use `renounceOwnership(..)`', async () => {
         await expect(context.lsp8.connect(oldOwner).renounceOwnership()).to.be.revertedWith(
-          "Ownable: caller is not the owner",
+          'Ownable: caller is not the owner',
         );
       });
 
-      it("old owner should not be allowed to use `setData(..)`", async () => {
-        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key"));
-        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("value"));
+      it('old owner should not be allowed to use `setData(..)`', async () => {
+        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key'));
+        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('value'));
         await expect(context.lsp8.connect(oldOwner).setData(key, value)).to.be.revertedWith(
-          "Ownable: caller is not the owner",
+          'Ownable: caller is not the owner',
         );
       });
 
-      it("new owner should be allowed to use `transferOwnership(..)`", async () => {
+      it('new owner should be allowed to use `transferOwnership(..)`', async () => {
         const randomAddress = context.accounts.anyone.address;
 
         await context.lsp8.connect(newOwner).transferOwnership(randomAddress);
@@ -1596,15 +1596,15 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         expect(await context.lsp8.owner()).to.equal(randomAddress);
       });
 
-      it("new owner should be allowed to use `renounceOwnership(..)`", async () => {
+      it('new owner should be allowed to use `renounceOwnership(..)`', async () => {
         await context.lsp8.connect(newOwner).renounceOwnership();
 
         expect(await context.lsp8.owner()).to.equal(ethers.constants.AddressZero);
       });
 
-      it("new owner should be allowed to use `setData(..)`", async () => {
-        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("key"));
-        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("value"));
+      it('new owner should be allowed to use `setData(..)`', async () => {
+        const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('key'));
+        const value = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('value'));
         await context.lsp8.connect(newOwner).setData(key, value);
 
         expect(await context.lsp8.getData(key)).to.equal(value);
@@ -1628,22 +1628,22 @@ export const shouldInitializeLikeLSP8 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered the ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered the ERC165 interface', async () => {
       expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC165));
     });
 
-    it("should have registered the ERC725Y interface", async () => {
+    it('should have registered the ERC725Y interface', async () => {
       expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC725Y));
     });
 
-    it("should have registered the LSP8 interface", async () => {
+    it('should have registered the LSP8 interface', async () => {
       expect(await context.lsp8.supportsInterface(INTERFACE_IDS.LSP8IdentifiableDigitalAsset));
     });
 
-    it("should have set expected entries with ERC725Y.setData", async () => {
+    it('should have set expected entries with ERC725Y.setData', async () => {
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8, "DataChanged")
+        .to.emit(context.lsp8, 'DataChanged')
         .withArgs(
           SupportedStandards.LSP4DigitalAsset.key,
           SupportedStandards.LSP4DigitalAsset.value,
@@ -1652,21 +1652,21 @@ export const shouldInitializeLikeLSP8 = (
         SupportedStandards.LSP4DigitalAsset.value,
       );
 
-      const nameKey = ERC725YDataKeys.LSP4["LSP4TokenName"];
+      const nameKey = ERC725YDataKeys.LSP4['LSP4TokenName'];
       const expectedNameValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.name),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8, "DataChanged")
+        .to.emit(context.lsp8, 'DataChanged')
         .withArgs(nameKey, expectedNameValue);
       expect(await context.lsp8.getData(nameKey)).to.equal(expectedNameValue);
 
-      const symbolKey = ERC725YDataKeys.LSP4["LSP4TokenSymbol"];
+      const symbolKey = ERC725YDataKeys.LSP4['LSP4TokenSymbol'];
       const expectedSymbolValue = ethers.utils.hexlify(
         ethers.utils.toUtf8Bytes(context.deployParams.symbol),
       );
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp8, "DataChanged")
+        .to.emit(context.lsp8, 'DataChanged')
         .withArgs(symbolKey, expectedSymbolValue);
       expect(await context.lsp8.getData(symbolKey)).to.equal(expectedSymbolValue);
     });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
@@ -1,17 +1,17 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   LSP8Mintable,
   UniversalProfile,
   LSP6KeyManager,
   UniversalReceiverDelegateTokenReentrant__factory,
-} from "../../types";
+} from '../../types';
 
-import { setupProfileWithKeyManagerWithURD } from "../utils/fixtures";
+import { setupProfileWithKeyManagerWithURD } from '../utils/fixtures';
 
-import { PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES, CALLTYPE } from "../../constants";
-import { combineAllowedCalls, combinePermissions } from "../utils/helpers";
+import { PERMISSIONS, ERC725YDataKeys, OPERATION_TYPES, CALLTYPE } from '../../constants';
+import { combineAllowedCalls, combinePermissions } from '../utils/helpers';
 
 export type LSP8MintableTestAccounts = {
   owner: SignerWithAddress;
@@ -45,8 +45,8 @@ export const shouldBehaveLikeLSP8Mintable = (
     context = await buildContext();
   });
 
-  describe("when owner minting tokens", () => {
-    it("total supply should have increased", async () => {
+  describe('when owner minting tokens', () => {
+    it('total supply should have increased', async () => {
       const randomTokenId = ethers.utils.randomBytes(32);
 
       const preMintTotalSupply = await context.lsp8Mintable.totalSupply();
@@ -55,14 +55,14 @@ export const shouldBehaveLikeLSP8Mintable = (
         context.accounts.tokenReceiver.address,
         randomTokenId,
         true, // beneficiary is an EOA, so we need to allowNonLSP1Recipient minting
-        "0x",
+        '0x',
       );
 
       let postMintTotalSupply = await context.lsp8Mintable.totalSupply();
       expect(postMintTotalSupply).to.equal(preMintTotalSupply.add(1));
     });
 
-    it("tokenReceiver balance should have increased", async () => {
+    it('tokenReceiver balance should have increased', async () => {
       const tokenReceiverBalance = await context.lsp8Mintable.balanceOf(
         context.accounts.tokenReceiver.address,
       );
@@ -71,8 +71,8 @@ export const shouldBehaveLikeLSP8Mintable = (
     });
   });
 
-  describe("when non-owner minting tokens", () => {
-    it("should revert", async () => {
+  describe('when non-owner minting tokens', () => {
+    it('should revert', async () => {
       const randomTokenId = ethers.utils.randomBytes(32);
 
       // use any other account
@@ -81,12 +81,12 @@ export const shouldBehaveLikeLSP8Mintable = (
       await expect(
         context.lsp8Mintable
           .connect(nonOwner)
-          .mint(context.accounts.tokenReceiver.address, randomTokenId, true, "0x"),
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+          .mint(context.accounts.tokenReceiver.address, randomTokenId, true, '0x'),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
     });
   });
 
-  describe("when owner try to re-enter function through the UniversalReceiverDelegate", () => {
+  describe('when owner try to re-enter function through the UniversalReceiverDelegate', () => {
     let universalProfile;
     let lsp6KeyManager;
 
@@ -104,11 +104,11 @@ export const shouldBehaveLikeLSP8Mintable = (
         context.accounts.profileOwner,
       ).deploy();
 
-      const setDataPayload = universalProfile.interface.encodeFunctionData("setDataBatch", [
+      const setDataPayload = universalProfile.interface.encodeFunctionData('setDataBatch', [
         [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             URDTokenReentrant.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             URDTokenReentrant.address.substring(2),
           ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
         ],
@@ -117,8 +117,8 @@ export const shouldBehaveLikeLSP8Mintable = (
           combineAllowedCalls(
             [CALLTYPE.CALL],
             [context.lsp8Mintable.address],
-            ["0xffffffff"],
-            ["0xffffffff"],
+            ['0xffffffff'],
+            ['0xffffffff'],
           ),
           URDTokenReentrant.address,
         ],
@@ -126,25 +126,25 @@ export const shouldBehaveLikeLSP8Mintable = (
 
       await lsp6KeyManager.connect(context.accounts.profileOwner).execute(setDataPayload);
     });
-    it("should pass", async () => {
+    it('should pass', async () => {
       const randomTokenId = ethers.utils.randomBytes(32);
       const secondRandomTokenId = ethers.utils.randomBytes(32);
 
-      const reentrantMintPayload = context.lsp8Mintable.interface.encodeFunctionData("mint", [
+      const reentrantMintPayload = context.lsp8Mintable.interface.encodeFunctionData('mint', [
         universalProfile.address,
         secondRandomTokenId,
         false,
-        "0x",
+        '0x',
       ]);
 
-      const mintPayload = context.lsp8Mintable.interface.encodeFunctionData("mint", [
+      const mintPayload = context.lsp8Mintable.interface.encodeFunctionData('mint', [
         universalProfile.address,
         randomTokenId,
         false,
         reentrantMintPayload,
       ]);
 
-      const executePayload = universalProfile.interface.encodeFunctionData("execute", [
+      const executePayload = universalProfile.interface.encodeFunctionData('execute', [
         OPERATION_TYPES.CALL,
         context.lsp8Mintable.address,
         0,

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8CappedSupplyInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8CappedSupplyInit.test.ts
@@ -1,24 +1,24 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { LSP8CappedSupplyInitTester__factory } from "../../../types";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { LSP8CappedSupplyInitTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8CappedSupply,
   LSP8CappedSupplyTestContext,
   getNamedAccounts,
-} from "../LSP8CappedSupply.behaviour";
+} from '../LSP8CappedSupply.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP8CappedSupplyInit with proxy", () => {
+describe('LSP8CappedSupplyInit with proxy', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 capped supply - deployed with proxy",
-      symbol: "CAP",
+      name: 'LSP8 capped supply - deployed with proxy',
+      symbol: 'CAP',
       newOwner: accounts.owner.address,
-      tokenSupplyCap: ethers.BigNumber.from("2"),
+      tokenSupplyCap: ethers.BigNumber.from('2'),
     };
     const lsp8CappedSupplyInit = await new LSP8CappedSupplyInitTester__factory(
       accounts.owner,
@@ -30,7 +30,7 @@ describe("LSP8CappedSupplyInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP8CappedSupplyTestContext) => {
-    return context.lsp8CappedSupply["initialize(string,string,address,uint256)"](
+    return context.lsp8CappedSupply['initialize(string,string,address,uint256)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
@@ -38,14 +38,14 @@ describe("LSP8CappedSupplyInit with proxy", () => {
     );
   };
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP8CappedSupplyTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8(async () => {
         const { lsp8CappedSupply: lsp8, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -58,16 +58,16 @@ describe("LSP8CappedSupplyInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8CappedSupply(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8CompatibleERC721Init.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8CompatibleERC721Init.test.ts
@@ -1,35 +1,35 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
 import {
   LSP8CompatibleERC721InitTester__factory,
   LSP8CompatibleERC721MintableInit__factory,
-} from "../../../types";
+} from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP8CompatibleERC721,
   shouldInitializeLikeLSP8CompatibleERC721,
   LSP8CompatibleERC721TestContext,
-} from "../LSP8CompatibleERC721.behaviour";
+} from '../LSP8CompatibleERC721.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP8CompatibleERC721Init with proxy", () => {
+describe('LSP8CompatibleERC721Init with proxy', () => {
   const buildTestContext = async (): Promise<LSP8CompatibleERC721TestContext> => {
     const accounts = await getNamedAccounts();
 
-    const tokenUriHex = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("ipfs://some-cid"));
+    const tokenUriHex = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('ipfs://some-cid'));
     const tokenUriHash = ethers.utils.keccak256(tokenUriHex);
-    const hashSig = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("keccak256(utf8)"));
+    const hashSig = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('keccak256(utf8)'));
     const lsp4MetadataValue = `${hashSig.slice(0, 10)}${tokenUriHash.replace(
       /^0x/,
-      "",
-    )}${tokenUriHex.replace(/^0x/, "")}`;
+      '',
+    )}${tokenUriHex.replace(/^0x/, '')}`;
 
     const deployParams = {
-      name: "LSP8 - deployed with constructor",
-      symbol: "NFT",
+      name: 'LSP8 - deployed with constructor',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
       lsp4MetadataValue,
     };
@@ -47,7 +47,7 @@ describe("LSP8CompatibleERC721Init with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP8CompatibleERC721TestContext) => {
-    return context.lsp8CompatibleERC721["initialize(string,string,address,bytes)"](
+    return context.lsp8CompatibleERC721['initialize(string,string,address,bytes)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
@@ -55,8 +55,8 @@ describe("LSP8CompatibleERC721Init with proxy", () => {
     );
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("LSP8CompatibleERC721Init: prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('LSP8CompatibleERC721Init: prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp8CompatibilityForERC721TesterInit =
@@ -65,16 +65,16 @@ describe("LSP8CompatibleERC721Init with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp8CompatibilityForERC721TesterInit["initialize(string,string,address,bytes)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp8CompatibilityForERC721TesterInit['initialize(string,string,address,bytes)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
-          "0x",
+          '0x',
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
 
-    it("LSP8CompatibleERC721MintableInit: prevent any address from calling the initialize(...) function on the implementation", async () => {
+    it('LSP8CompatibleERC721MintableInit: prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp8CompatibleERC721MintableInit = await new LSP8CompatibleERC721MintableInit__factory(
@@ -84,23 +84,23 @@ describe("LSP8CompatibleERC721Init with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp8CompatibleERC721MintableInit["initialize(string,string,address)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp8CompatibleERC721MintableInit['initialize(string,string,address)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP8CompatibleERC721TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8CompatibleERC721(async () => {
         const { lsp8CompatibleERC721, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -113,16 +113,16 @@ describe("LSP8CompatibleERC721Init with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8CompatibleERC721(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8EnumerableInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8EnumerableInit.test.ts
@@ -1,21 +1,21 @@
-import { expect } from "chai";
-import { LSP8EnumerableInitTester, LSP8EnumerableInitTester__factory } from "../../../types";
+import { expect } from 'chai';
+import { LSP8EnumerableInitTester, LSP8EnumerableInitTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8Enumerable,
   LSP8EnumerableTestContext,
   getNamedAccounts,
-} from "../LSP8Enumerable.behaviour";
+} from '../LSP8Enumerable.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP8EnumerableInit with proxy", () => {
+describe('LSP8EnumerableInit with proxy', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 Enumerable - deployed with proxy",
-      symbol: "LSP8 NMRBL",
+      name: 'LSP8 Enumerable - deployed with proxy',
+      symbol: 'LSP8 NMRBL',
       newOwner: accounts.owner.address,
     };
 
@@ -29,21 +29,21 @@ describe("LSP8EnumerableInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP8EnumerableTestContext) => {
-    return context.lsp8Enumerable["initialize(string,string,address)"](
+    return context.lsp8Enumerable['initialize(string,string,address)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
     );
   };
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP8EnumerableTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8(async () => {
         const { lsp8Enumerable: lsp8, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -55,16 +55,16 @@ describe("LSP8EnumerableInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8Enumerable(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8IdentifiableDigitalAssetInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8IdentifiableDigitalAssetInit.test.ts
@@ -1,28 +1,28 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP8InitTester__factory, LSP8IdentifiableDigitalAsset } from "../../../types";
+import { LSP8InitTester__factory, LSP8IdentifiableDigitalAsset } from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP8,
   shouldInitializeLikeLSP8,
   LSP8TestContext,
-} from "../LSP8IdentifiableDigitalAsset.behaviour";
+} from '../LSP8IdentifiableDigitalAsset.behaviour';
 
 import {
   LS4DigitalAssetMetadataTestContext,
   shouldBehaveLikeLSP4DigitalAssetMetadata,
-} from "../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour";
+} from '../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP8IdentifiableDigitalAssetInit with proxy", () => {
+describe('LSP8IdentifiableDigitalAssetInit with proxy', () => {
   const buildTestContext = async (): Promise<LSP8TestContext> => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 - deployed with constructor",
-      symbol: "NFT",
+      name: 'LSP8 - deployed with constructor',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
     };
 
@@ -50,31 +50,31 @@ describe("LSP8IdentifiableDigitalAssetInit with proxy", () => {
     };
 
   const initializeProxy = async (context: LSP8TestContext) => {
-    return context.lsp8["initialize(string,string,address)"](
+    return context.lsp8['initialize(string,string,address)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
     );
   };
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP8TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    it("should revert when initializing with address(0) as owner", async () => {
+    it('should revert when initializing with address(0) as owner', async () => {
       await expect(
-        context.lsp8["initialize(string,string,address)"](
+        context.lsp8['initialize(string,string,address)'](
           context.deployParams.name,
           context.deployParams.symbol,
           ethers.constants.AddressZero,
         ),
-      ).to.be.revertedWith("Ownable: new owner is the zero address");
+      ).to.be.revertedWith('Ownable: new owner is the zero address');
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8(async () => {
         const { lsp8, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -87,22 +87,22 @@ describe("LSP8IdentifiableDigitalAssetInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP4DigitalAssetMetadata(async () => {
       let lsp4Context = await buildLSP4DigitalAssetMetadataTestContext();
 
-      await lsp4Context.contract["initialize(string,string,address)"](
-        "LSP8 - deployed with proxy",
-        "NFT",
+      await lsp4Context.contract['initialize(string,string,address)'](
+        'LSP8 - deployed with proxy',
+        'NFT',
         lsp4Context.deployParams.owner.address,
       );
 

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
@@ -1,22 +1,22 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { LSP8MintableInit, LSP8MintableInit__factory } from "../../../types";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { LSP8MintableInit, LSP8MintableInit__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8Mintable,
   LSP8MintableTestContext,
   getNamedAccounts,
-} from "../LSP8Mintable.behaviour";
+} from '../LSP8Mintable.behaviour';
 
-import { deployProxy } from "../../utils/fixtures";
+import { deployProxy } from '../../utils/fixtures';
 
-describe("LSP8MintableInit with proxy", () => {
+describe('LSP8MintableInit with proxy', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 Mintable - deployed with proxy",
-      symbol: "MNTBL",
+      name: 'LSP8 Mintable - deployed with proxy',
+      symbol: 'MNTBL',
       newOwner: accounts.owner.address,
     };
 
@@ -31,15 +31,15 @@ describe("LSP8MintableInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP8MintableTestContext) => {
-    return context.lsp8Mintable["initialize(string,string,address)"](
+    return context.lsp8Mintable['initialize(string,string,address)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
     );
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp8Mintable = await new LSP8MintableInit__factory(accounts[0]).deploy();
@@ -47,23 +47,23 @@ describe("LSP8MintableInit with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp8Mintable["initialize(string,string,address)"](
-          "XXXXXXXXXXX",
-          "XXX",
+        lsp8Mintable['initialize(string,string,address)'](
+          'XXXXXXXXXXX',
+          'XXX',
           randomCaller.address,
         ),
-      ).to.be.revertedWith("Initializable: contract is already initialized");
+      ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP8MintableTestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8(async () => {
         const { lsp8Mintable: lsp8, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -76,16 +76,16 @@ describe("LSP8MintableInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8Mintable(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8CappedSupply.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8CappedSupply.test.ts
@@ -1,22 +1,22 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
-import { LSP8CappedSupplyTester__factory } from "../../../types";
+import { LSP8CappedSupplyTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8CappedSupply,
   LSP8CappedSupplyTestContext,
   getNamedAccounts,
-} from "../LSP8CappedSupply.behaviour";
+} from '../LSP8CappedSupply.behaviour';
 
-describe("LSP8CappedSupply with constructor", () => {
+describe('LSP8CappedSupply with constructor', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 capped supply - deployed with constructor",
-      symbol: "CAP",
+      name: 'LSP8 capped supply - deployed with constructor',
+      symbol: 'CAP',
       newOwner: accounts.owner.address,
-      tokenSupplyCap: ethers.BigNumber.from("2"),
+      tokenSupplyCap: ethers.BigNumber.from('2'),
     };
     const lsp8CappedSupply = await new LSP8CappedSupplyTester__factory(accounts.owner).deploy(
       deployParams.name,
@@ -28,7 +28,7 @@ describe("LSP8CappedSupply with constructor", () => {
     return { accounts, lsp8CappedSupply, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP8CappedSupplyTestContext;
 
     before(async () => {
@@ -46,7 +46,7 @@ describe("LSP8CappedSupply with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8CappedSupply(buildTestContext);
   });
 });

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8CompatibleERC721.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8CompatibleERC721.test.ts
@@ -1,29 +1,29 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
-import { LSP8CompatibleERC721Tester__factory } from "../../../types";
+import { LSP8CompatibleERC721Tester__factory } from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP8CompatibleERC721,
   shouldInitializeLikeLSP8CompatibleERC721,
   LSP8CompatibleERC721TestContext,
-} from "../LSP8CompatibleERC721.behaviour";
+} from '../LSP8CompatibleERC721.behaviour';
 
-describe("LSP8CompatibleERC721 with constructor", () => {
+describe('LSP8CompatibleERC721 with constructor', () => {
   const buildTestContext = async (): Promise<LSP8CompatibleERC721TestContext> => {
     const accounts = await getNamedAccounts();
 
-    const tokenUriHex = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("ipfs://some-cid"));
+    const tokenUriHex = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('ipfs://some-cid'));
     const tokenUriHash = ethers.utils.keccak256(tokenUriHex);
-    const hashSig = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("keccak256(utf8)"));
+    const hashSig = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('keccak256(utf8)'));
     const lsp4MetadataValue = `${hashSig.slice(0, 10)}${tokenUriHash.replace(
       /^0x/,
-      "",
-    )}${tokenUriHex.replace(/^0x/, "")}`;
+      '',
+    )}${tokenUriHex.replace(/^0x/, '')}`;
 
     const deployParams = {
-      name: "Compat for ERC721",
-      symbol: "NFT",
+      name: 'Compat for ERC721',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
       lsp4MetadataValue,
     };
@@ -40,14 +40,14 @@ describe("LSP8CompatibleERC721 with constructor", () => {
     return { accounts, lsp8CompatibleERC721, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP8CompatibleERC721TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP8CompatibleERC721(async () => {
         const { lsp8CompatibleERC721, deployParams } = context;
 
@@ -60,7 +60,7 @@ describe("LSP8CompatibleERC721 with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8CompatibleERC721(buildTestContext);
   });
 });

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Enumerable.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Enumerable.test.ts
@@ -1,19 +1,19 @@
-import { LSP8EnumerableTester, LSP8EnumerableTester__factory } from "../../../types";
+import { LSP8EnumerableTester, LSP8EnumerableTester__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8Enumerable,
   LSP8EnumerableTestContext,
   getNamedAccounts,
-} from "../LSP8Enumerable.behaviour";
+} from '../LSP8Enumerable.behaviour';
 
-describe("LSP8Enumerable with constructor", () => {
+describe('LSP8Enumerable with constructor', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
 
     const deployParams = {
-      name: "LSP8 Enumerable - deployed with constructor",
-      symbol: "LSP8 NMRBL",
+      name: 'LSP8 Enumerable - deployed with constructor',
+      symbol: 'LSP8 NMRBL',
       newOwner: accounts.owner.address,
     };
 
@@ -24,7 +24,7 @@ describe("LSP8Enumerable with constructor", () => {
     return { accounts, lsp8Enumerable, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP8EnumerableTestContext;
 
     before(async () => {
@@ -41,7 +41,7 @@ describe("LSP8Enumerable with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8Enumerable(buildTestContext);
   });
 });

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8IdentifiableDigitalAsset.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8IdentifiableDigitalAsset.test.ts
@@ -1,26 +1,26 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { LSP8Tester__factory, LSP8IdentifiableDigitalAsset } from "../../../types";
+import { LSP8Tester__factory, LSP8IdentifiableDigitalAsset } from '../../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP8,
   shouldInitializeLikeLSP8,
   LSP8TestContext,
-} from "../LSP8IdentifiableDigitalAsset.behaviour";
+} from '../LSP8IdentifiableDigitalAsset.behaviour';
 
 import {
   LS4DigitalAssetMetadataTestContext,
   shouldBehaveLikeLSP4DigitalAssetMetadata,
-} from "../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour";
+} from '../../LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.behaviour';
 
-describe("LSP8IdentifiableDigitalAsset with constructor", () => {
+describe('LSP8IdentifiableDigitalAsset with constructor', () => {
   const buildTestContext = async (): Promise<LSP8TestContext> => {
     const accounts = await getNamedAccounts();
     const deployParams = {
-      name: "LSP8 - deployed with constructor",
-      symbol: "NFT",
+      name: 'LSP8 - deployed with constructor',
+      symbol: 'NFT',
       newOwner: accounts.owner.address,
     };
     const lsp8 = await new LSP8Tester__factory(accounts.owner).deploy(
@@ -48,13 +48,13 @@ describe("LSP8IdentifiableDigitalAsset with constructor", () => {
       };
     };
 
-  describe("when deploying the contract", () => {
-    it("should revert when deploying with address(0) as owner", async () => {
+  describe('when deploying the contract', () => {
+    it('should revert when deploying with address(0) as owner', async () => {
       const accounts = await ethers.getSigners();
 
       const deployParams = {
-        name: "LSP8 - deployed with constructor",
-        symbol: "NFT",
+        name: 'LSP8 - deployed with constructor',
+        symbol: 'NFT',
         newOwner: ethers.constants.AddressZero,
       };
 
@@ -64,10 +64,10 @@ describe("LSP8IdentifiableDigitalAsset with constructor", () => {
           deployParams.symbol,
           ethers.constants.AddressZero,
         ),
-      ).to.be.revertedWith("Ownable: new owner is the zero address");
+      ).to.be.revertedWith('Ownable: new owner is the zero address');
     });
 
-    describe("once the contract was deployed", () => {
+    describe('once the contract was deployed', () => {
       let context: LSP8TestContext;
 
       before(async () => {
@@ -86,7 +86,7 @@ describe("LSP8IdentifiableDigitalAsset with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP4DigitalAssetMetadata(buildLSP4DigitalAssetMetadataTestContext);
     shouldBehaveLikeLSP8(buildTestContext);
   });

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
@@ -1,19 +1,19 @@
-import { LSP8Mintable, LSP8Mintable__factory } from "../../../types";
+import { LSP8Mintable, LSP8Mintable__factory } from '../../../types';
 
-import { shouldInitializeLikeLSP8 } from "../LSP8IdentifiableDigitalAsset.behaviour";
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
 import {
   shouldBehaveLikeLSP8Mintable,
   LSP8MintableTestContext,
   getNamedAccounts,
-} from "../LSP8Mintable.behaviour";
+} from '../LSP8Mintable.behaviour';
 
-describe("LSP8Mintable with constructor", () => {
+describe('LSP8Mintable with constructor', () => {
   const buildTestContext = async () => {
     const accounts = await getNamedAccounts();
 
     const deployParams = {
-      name: "LSP8 Mintable - deployed with constructor",
-      symbol: "LSP8 MNTBL",
+      name: 'LSP8 Mintable - deployed with constructor',
+      symbol: 'LSP8 MNTBL',
       newOwner: accounts.owner.address,
     };
 
@@ -26,7 +26,7 @@ describe("LSP8Mintable with constructor", () => {
     return { accounts, lsp8Mintable, deployParams };
   };
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP8MintableTestContext;
 
     before(async () => {
@@ -44,7 +44,7 @@ describe("LSP8Mintable with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP8Mintable(buildTestContext);
   });
 });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -1,7 +1,7 @@
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import type { TransactionResponse } from "@ethersproject/abstract-provider";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
+import { expect } from 'chai';
 
 // types
 import {
@@ -12,13 +12,13 @@ import {
   UniversalReceiverDelegateVaultReentrantA__factory,
   UniversalReceiverDelegateVaultReentrantB__factory,
   UniversalReceiverDelegateVaultMalicious__factory,
-} from "../../types";
+} from '../../types';
 
 // helpers
-import { ARRAY_LENGTH, abiCoder, combineAllowedCalls } from "../utils/helpers";
+import { ARRAY_LENGTH, abiCoder, combineAllowedCalls } from '../utils/helpers';
 
 // fixtures
-import { callPayload } from "../utils/fixtures";
+import { callPayload } from '../utils/fixtures';
 
 // constants
 import {
@@ -29,8 +29,8 @@ import {
   OPERATION_TYPES,
   LSP1_TYPE_IDS,
   CALLTYPE,
-} from "../../constants";
-import { BigNumber } from "ethers";
+} from '../../constants';
+import { BigNumber } from 'ethers';
 
 export type LSP9TestAccounts = {
   owner: SignerWithAddress;
@@ -66,10 +66,10 @@ export const shouldBehaveLikeLSP9 = (
     context = await buildContext(100);
   });
 
-  describe("when testing setting data", () => {
-    it("owner should be able to setData", async () => {
-      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("some data key"));
-      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value"));
+  describe('when testing setting data', () => {
+    it('owner should be able to setData', async () => {
+      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('some data key'));
+      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value'));
 
       await context.lsp9Vault.connect(context.accounts.owner).setData(dataKey, dataValue);
 
@@ -78,12 +78,12 @@ export const shouldBehaveLikeLSP9 = (
     });
 
     it("non-owner shouldn't be able to setData", async () => {
-      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("some data key"));
-      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value"));
+      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('some data key'));
+      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value'));
 
       await expect(
         context.lsp9Vault.connect(context.accounts.random).setData(dataKey, dataValue),
-      ).to.be.revertedWith("Only Owner or reentered Universal Receiver Delegate allowed");
+      ).to.be.revertedWith('Only Owner or reentered Universal Receiver Delegate allowed');
     });
 
     it("UniversalReceiverDelegate shouldn't be able to setData in a call not passing by the universalReceiver", async () => {
@@ -98,17 +98,17 @@ export const shouldBehaveLikeLSP9 = (
           lsp1UniversalReceiverDelegateVaultSetter.address,
         );
 
-      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("some data key"));
-      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value"));
+      const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('some data key'));
+      const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value'));
 
       await expect(
         lsp1UniversalReceiverDelegateVaultSetter
           .connect(context.accounts.anyone)
           .universalReceiver(context.lsp9Vault.address, dataKey, dataValue),
-      ).to.be.revertedWith("Only Owner or reentered Universal Receiver Delegate allowed");
+      ).to.be.revertedWith('Only Owner or reentered Universal Receiver Delegate allowed');
     });
 
-    it("Main UniversalReceiverDelegate A should be able to setData in a universalReceiver reentrant call", async () => {
+    it('Main UniversalReceiverDelegate A should be able to setData in a universalReceiver reentrant call', async () => {
       // setting UniversalReceiverDelegate that setData
       const lsp1UniversalReceiverDelegateVaultReentrantA =
         await new UniversalReceiverDelegateVaultReentrantA__factory(
@@ -126,7 +126,7 @@ export const shouldBehaveLikeLSP9 = (
       const data = ethers.utils.hexlify(ethers.utils.randomBytes(64));
 
       const resultBefore = await context.lsp9Vault.getData(data.substring(0, 66));
-      expect(resultBefore).to.equal("0x");
+      expect(resultBefore).to.equal('0x');
 
       await context.lsp9Vault.connect(context.accounts.anyone).universalReceiver(typeId, data);
 
@@ -134,10 +134,10 @@ export const shouldBehaveLikeLSP9 = (
       // and the value "aabbccdd" as data value, check the UniversalReceiverDelegateVaultReentrant A contract in helpers
 
       const resultAfter = await context.lsp9Vault.getData(data.substring(0, 66));
-      expect(resultAfter).to.equal("0xaabbccdd");
+      expect(resultAfter).to.equal('0xaabbccdd');
     });
 
-    it("Mapped UniversalReceiverDelegate B should be able to setData in a universalReceiver reentrant call", async () => {
+    it('Mapped UniversalReceiverDelegate B should be able to setData in a universalReceiver reentrant call', async () => {
       // setting UniversalReceiverDelegate that setData
       const lsp1UniversalReceiverDelegateVaultReentrantB =
         await new UniversalReceiverDelegateVaultReentrantB__factory(
@@ -156,7 +156,7 @@ export const shouldBehaveLikeLSP9 = (
 
       const resultBefore = await context.lsp9Vault.getData(data.substring(0, 66));
 
-      expect(resultBefore).to.equal("0x");
+      expect(resultBefore).to.equal('0x');
 
       await context.lsp9Vault.connect(context.accounts.anyone).universalReceiver(typeId, data);
 
@@ -164,10 +164,10 @@ export const shouldBehaveLikeLSP9 = (
       // and the value "ddccbbaa" as data value, check the UniversalReceiverDelegateVaultReentrant B contract in helpers
 
       const resultAfter = await context.lsp9Vault.getData(data.substring(0, 66));
-      expect(resultAfter).to.equal("0xddccbbaa");
+      expect(resultAfter).to.equal('0xddccbbaa');
     });
 
-    describe("when setting LSP1, LSP6, LSP17 dataKeys", () => {
+    describe('when setting LSP1, LSP6, LSP17 dataKeys', () => {
       before(async () => {
         // setting UniversalReceiverDelegate that setData
         const lsp1UniversalReceiverDelegateVaultMalicious =
@@ -182,25 +182,25 @@ export const shouldBehaveLikeLSP9 = (
             lsp1UniversalReceiverDelegateVaultMalicious.address,
           );
       });
-      describe("when testing LSP1 Keys", () => {
-        describe("when the owner is setting data", () => {
-          describe("using setData", () => {
-            it("should pass", async () => {
+      describe('when testing LSP1 Keys', () => {
+        describe('when the owner is setting data', () => {
+          describe('using setData', () => {
+            it('should pass', async () => {
               const key =
                 ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
                 ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
 
-              const value = "0xaabbccdd";
+              const value = '0xaabbccdd';
 
               await context.lsp9Vault.connect(context.accounts.owner).setData(key, value);
 
-              const result = await context.lsp9Vault.callStatic["getData(bytes32)"](key);
+              const result = await context.lsp9Vault.callStatic['getData(bytes32)'](key);
               expect(result).to.equal(value);
             });
           });
 
-          describe("using setData Array", () => {
-            it("should pass", async () => {
+          describe('using setData Array', () => {
+            it('should pass', async () => {
               const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
               const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
 
@@ -222,66 +222,66 @@ export const shouldBehaveLikeLSP9 = (
           });
         });
 
-        describe("when the URD is setting data", () => {
-          describe("using setData", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData"]);
+        describe('when the URD is setting data', () => {
+          describe('using setData', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData']);
 
-              const data = "0x00"; // To set MappedUniversalReceiverDelegate Key
+              const data = '0x00'; // To set MappedUniversalReceiverDelegate Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
                 .withArgs(
-                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix + "00".repeat(20),
+                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix + '00'.repeat(20),
                 );
             });
           });
-          describe("using setData Array", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData[]"]);
+          describe('using setData Array', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData[]']);
 
-              const data = "0x00"; // To set MappedUniversalReceiverDelegate Key
+              const data = '0x00'; // To set MappedUniversalReceiverDelegate Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
                 .withArgs(
-                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix + "00".repeat(20),
+                  ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix + '00'.repeat(20),
                 );
             });
           });
         });
       });
 
-      describe("when testing LSP6 Keys", () => {
-        describe("when the owner is setting data", () => {
-          describe("using setData", () => {
-            it("should pass", async () => {
+      describe('when testing LSP6 Keys', () => {
+        describe('when the owner is setting data', () => {
+          describe('using setData', () => {
+            it('should pass', async () => {
               const key =
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                 ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
 
-              const value = "0xaabbccdd";
+              const value = '0xaabbccdd';
 
               await context.lsp9Vault.connect(context.accounts.owner).setData(key, value);
 
-              const result = await context.lsp9Vault.callStatic["getData(bytes32)"](key);
+              const result = await context.lsp9Vault.callStatic['getData(bytes32)'](key);
               expect(result).to.equal(value);
             });
           });
 
-          describe("using setData Array", () => {
-            it("should pass", async () => {
+          describe('using setData Array', () => {
+            it('should pass', async () => {
               const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
               const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
 
               const key2 =
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                 ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
 
               const value2 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
@@ -298,57 +298,57 @@ export const shouldBehaveLikeLSP9 = (
           });
         });
 
-        describe("when the URD is setting data", () => {
-          describe("using setData", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData"]);
+        describe('when the URD is setting data', () => {
+          describe('using setData', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData']);
 
-              const data = "0x01"; // To set LSP6Permission Key
+              const data = '0x01'; // To set LSP6Permission Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
-                .withArgs(ERC725YDataKeys.LSP6.AddressPermissionsPrefix + "00".repeat(26));
+                .withArgs(ERC725YDataKeys.LSP6.AddressPermissionsPrefix + '00'.repeat(26));
             });
           });
-          describe("using setData Array", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData[]"]);
+          describe('using setData Array', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData[]']);
 
-              const data = "0x01"; // To set LSP6Permission Key
+              const data = '0x01'; // To set LSP6Permission Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
-                .withArgs(ERC725YDataKeys.LSP6.AddressPermissionsPrefix + "00".repeat(26));
+                .withArgs(ERC725YDataKeys.LSP6.AddressPermissionsPrefix + '00'.repeat(26));
             });
           });
         });
       });
 
-      describe("when testing LSP17 Keys", () => {
-        describe("when the owner is setting data", () => {
-          describe("using setData", () => {
-            it("should pass", async () => {
+      describe('when testing LSP17 Keys', () => {
+        describe('when the owner is setting data', () => {
+          describe('using setData', () => {
+            it('should pass', async () => {
               const key =
                 ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
                 ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
 
-              const value = "0xaabbccdd";
+              const value = '0xaabbccdd';
 
               await context.lsp9Vault.connect(context.accounts.owner).setData(key, value);
 
-              const result = await context.lsp9Vault.callStatic["getData(bytes32)"](key);
+              const result = await context.lsp9Vault.callStatic['getData(bytes32)'](key);
               expect(result).to.equal(value);
             });
           });
 
-          describe("using setData Array", () => {
-            it("should pass", async () => {
+          describe('using setData Array', () => {
+            it('should pass', async () => {
               const key1 = ethers.utils.hexlify(ethers.utils.randomBytes(32));
               const value1 = ethers.utils.hexlify(ethers.utils.randomBytes(5));
 
@@ -370,46 +370,46 @@ export const shouldBehaveLikeLSP9 = (
           });
         });
 
-        describe("when the URD is setting data", () => {
-          describe("using setData", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData"]);
+        describe('when the URD is setting data', () => {
+          describe('using setData', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData']);
 
-              const data = "0x02"; // To set LSP17Extension Key
+              const data = '0x02'; // To set LSP17Extension Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
-                .withArgs(ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + "00".repeat(20));
+                .withArgs(ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + '00'.repeat(20));
             });
           });
-          describe("using setData Array", () => {
-            it("should revert", async () => {
-              const typeId = ethers.utils.solidityKeccak256(["string"], ["setData[]"]);
+          describe('using setData Array', () => {
+            it('should revert', async () => {
+              const typeId = ethers.utils.solidityKeccak256(['string'], ['setData[]']);
 
-              const data = "0x02"; // To set LSP17Extension Key
+              const data = '0x02'; // To set LSP17Extension Key
 
               await expect(context.lsp9Vault.universalReceiver(typeId, data))
                 .to.be.revertedWithCustomError(
                   context.lsp9Vault,
-                  "LSP1DelegateNotAllowedToSetDataKey",
+                  'LSP1DelegateNotAllowedToSetDataKey',
                 )
-                .withArgs(ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + "00".repeat(20));
+                .withArgs(ERC725YDataKeys.LSP17.LSP17ExtensionPrefix + '00'.repeat(20));
             });
           });
         });
       });
     });
 
-    describe("when setting a data key with a value less than 256 bytes", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value less than 256 bytes', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(200));
 
         await expect(context.lsp9Vault.setData(key, value))
-          .to.emit(context.lsp9Vault, "DataChanged")
+          .to.emit(context.lsp9Vault, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.lsp9Vault.getData(key);
@@ -417,13 +417,13 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe("when setting a data key with a value more than 256 bytes", () => {
-      it("should emit DataChanged event with only the first 256 bytes of the value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value more than 256 bytes', () => {
+      it('should emit DataChanged event with only the first 256 bytes of the value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
         await expect(context.lsp9Vault.setData(key, value))
-          .to.emit(context.lsp9Vault, "DataChanged")
+          .to.emit(context.lsp9Vault, 'DataChanged')
           .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
         const result = await context.lsp9Vault.getData(key);
@@ -431,8 +431,8 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe("when calling the contract without any value or data", () => {
-      it("should pass and not emit the ValueReceived event", async () => {
+    describe('when calling the contract without any value or data', () => {
+      it('should pass and not emit the ValueReceived event', async () => {
         const sender = context.accounts.anyone;
         const amount = 0;
 
@@ -447,13 +447,13 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe("when setting a data key with a value exactly 256 bytes long", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value exactly 256 bytes long', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(256));
 
         await expect(context.lsp9Vault.setData(key, value))
-          .to.emit(context.lsp9Vault, "DataChanged")
+          .to.emit(context.lsp9Vault, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.lsp9Vault.getData(key);
@@ -461,12 +461,12 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe("When sending value to setData", () => {
-      it("should revert when sending value to setData(..)", async () => {
-        let value = ethers.utils.parseEther("2");
+    describe('When sending value to setData', () => {
+      it('should revert when sending value to setData(..)', async () => {
+        let value = ethers.utils.parseEther('2');
         const txParams = {
-          dataKey: ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"]),
-          dataValue: "0xaabbccdd",
+          dataKey: ethers.utils.solidityKeccak256(['string'], ['FirstDataKey']),
+          dataValue: '0xaabbccdd',
         };
 
         await expect(
@@ -475,14 +475,14 @@ export const shouldBehaveLikeLSP9 = (
             .setData(txParams.dataKey, txParams.dataValue, {
               value: value,
             }),
-        ).to.be.revertedWithCustomError(context.lsp9Vault, "ERC725Y_MsgValueDisallowed");
+        ).to.be.revertedWithCustomError(context.lsp9Vault, 'ERC725Y_MsgValueDisallowed');
       });
 
-      it("should revert when sending value to setData(..) Array", async () => {
-        let value = ethers.utils.parseEther("2");
+      it('should revert when sending value to setData(..) Array', async () => {
+        let value = ethers.utils.parseEther('2');
         const txParams = {
-          dataKey: [ethers.utils.solidityKeccak256(["string"], ["FirstDataKey"])],
-          dataValue: ["0xaabbccdd"],
+          dataKey: [ethers.utils.solidityKeccak256(['string'], ['FirstDataKey'])],
+          dataValue: ['0xaabbccdd'],
         };
 
         await expect(
@@ -491,39 +491,39 @@ export const shouldBehaveLikeLSP9 = (
             .setDataBatch(txParams.dataKey, txParams.dataValue, {
               value: value,
             }),
-        ).to.be.revertedWithCustomError(context.lsp9Vault, "ERC725Y_MsgValueDisallowed");
+        ).to.be.revertedWithCustomError(context.lsp9Vault, 'ERC725Y_MsgValueDisallowed');
       });
     });
   });
 
-  describe("when testing execute(...)", () => {
-    describe("when executing operation (4) DELEGATECALL", () => {
-      it("should revert with unknow operation type custom error", async () => {
+  describe('when testing execute(...)', () => {
+    describe('when executing operation (4) DELEGATECALL', () => {
+      it('should revert with unknow operation type custom error', async () => {
         await expect(
           context.lsp9Vault.execute(
             OPERATION_TYPES.DELEGATECALL,
             context.accounts.random.address,
             0,
-            "0x",
+            '0x',
           ),
         )
-          .to.be.revertedWithCustomError(context.universalProfile, "ERC725X_UnknownOperationType")
+          .to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType')
           .withArgs(OPERATION_TYPES.DELEGATECALL);
       });
     });
   });
 
-  describe("when using vault with UniversalProfile", () => {
-    describe("when transferring ownership of the vault to the universalProfile", () => {
+  describe('when using vault with UniversalProfile', () => {
+    describe('when transferring ownership of the vault to the universalProfile', () => {
       before(async () => {
         await context.lsp9Vault
           .connect(context.accounts.owner)
           .transferOwnership(context.universalProfile.address);
 
         let acceptOwnershipSelector =
-          context.universalProfile.interface.getSighash("acceptOwnership");
+          context.universalProfile.interface.getSighash('acceptOwnership');
 
-        let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           context.lsp9Vault.address,
           0,
@@ -533,15 +533,15 @@ export const shouldBehaveLikeLSP9 = (
         await context.lsp6KeyManager.connect(context.accounts.owner).execute(executePayload);
       });
 
-      it("should register lsp10 keys of the vault on the profile", async () => {
-        const arrayLength = await context.universalProfile.callStatic["getData(bytes32)"](
-          ERC725YDataKeys.LSP10["LSP10Vaults[]"].length,
+      it('should register lsp10 keys of the vault on the profile', async () => {
+        const arrayLength = await context.universalProfile.callStatic['getData(bytes32)'](
+          ERC725YDataKeys.LSP10['LSP10Vaults[]'].length,
         );
         expect(arrayLength).to.equal(ARRAY_LENGTH.ONE);
       });
     });
 
-    describe("when using batchCalls function", () => {
+    describe('when using batchCalls function', () => {
       before(async () => {
         await context.accounts.friend.sendTransaction({
           value: 1000,
@@ -549,41 +549,41 @@ export const shouldBehaveLikeLSP9 = (
         });
       });
 
-      describe("when non-owner is calling", () => {
-        it("shoud revert", async () => {
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+      describe('when non-owner is calling', () => {
+        it('shoud revert', async () => {
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
-          let setDataPayload = context.lsp9Vault.interface.encodeFunctionData("setData", [
+          let setDataPayload = context.lsp9Vault.interface.encodeFunctionData('setData', [
             key,
             value,
           ]);
 
           await expect(
             context.lsp9Vault.connect(context.accounts.random).batchCalls([setDataPayload]),
-          ).to.be.revertedWith("Only Owner or reentered Universal Receiver Delegate allowed");
+          ).to.be.revertedWith('Only Owner or reentered Universal Receiver Delegate allowed');
         });
       });
 
-      describe("when the owner is calling", () => {
-        describe("when executing one function", () => {
-          describe("setData", () => {
-            it("should pass", async () => {
-              let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+      describe('when the owner is calling', () => {
+        describe('when executing one function', () => {
+          describe('setData', () => {
+            it('should pass', async () => {
+              let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
               let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
-              let setDataPayload = context.lsp9Vault.interface.encodeFunctionData("setData", [
+              let setDataPayload = context.lsp9Vault.interface.encodeFunctionData('setData', [
                 key,
                 value,
               ]);
 
               const multiCallPayload = context.lsp9Vault.interface.encodeFunctionData(
-                "batchCalls",
+                'batchCalls',
                 [[setDataPayload]],
               );
 
               const executePayloadUP = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [0, context.lsp9Vault.address, 0, multiCallPayload],
               );
 
@@ -596,23 +596,23 @@ export const shouldBehaveLikeLSP9 = (
             });
           });
 
-          describe("execute", () => {
-            it("should pass", async () => {
+          describe('execute', () => {
+            it('should pass', async () => {
               let amount = 20;
-              let executePayload = context.lsp9Vault.interface.encodeFunctionData("execute", [
+              let executePayload = context.lsp9Vault.interface.encodeFunctionData('execute', [
                 0,
                 context.accounts.random.address,
                 amount,
-                "0x",
+                '0x',
               ]);
 
               const multiCallPayload = context.lsp9Vault.interface.encodeFunctionData(
-                "batchCalls",
+                'batchCalls',
                 [[executePayload]],
               );
 
               const executePayloadUP = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [0, context.lsp9Vault.address, 0, multiCallPayload],
               );
 
@@ -626,27 +626,27 @@ export const shouldBehaveLikeLSP9 = (
           });
         });
 
-        describe("when executing several functions", () => {
-          describe("When transfering lyx, setting data, transferring ownership", () => {
-            it("should pass", async () => {
+        describe('when executing several functions', () => {
+          describe('When transfering lyx, setting data, transferring ownership', () => {
+            it('should pass', async () => {
               let amount = 20;
-              let executePayload = context.lsp9Vault.interface.encodeFunctionData("execute", [
+              let executePayload = context.lsp9Vault.interface.encodeFunctionData('execute', [
                 0,
                 context.accounts.random.address,
                 amount,
-                "0x",
+                '0x',
               ]);
 
-              let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("A new key"));
+              let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('A new key'));
               let value = ethers.utils.hexlify(ethers.utils.randomBytes(10));
 
-              let setDataPayload = context.lsp9Vault.interface.encodeFunctionData("setData", [
+              let setDataPayload = context.lsp9Vault.interface.encodeFunctionData('setData', [
                 key,
                 value,
               ]);
 
               let transferOwnershipPayload = context.lsp9Vault.interface.encodeFunctionData(
-                "transferOwnership",
+                'transferOwnership',
                 [context.accounts.anyone.address],
               );
 
@@ -655,12 +655,12 @@ export const shouldBehaveLikeLSP9 = (
               );
 
               const multiCallPayload = context.lsp9Vault.interface.encodeFunctionData(
-                "batchCalls",
+                'batchCalls',
                 [[executePayload, setDataPayload, transferOwnershipPayload]],
               );
 
               const executePayloadUP = context.universalProfile.interface.encodeFunctionData(
-                "execute",
+                'execute',
                 [0, context.lsp9Vault.address, 0, multiCallPayload],
               );
 
@@ -683,14 +683,14 @@ export const shouldBehaveLikeLSP9 = (
       });
     });
 
-    describe("when restricitng address to only talk to the vault", () => {
+    describe('when restricitng address to only talk to the vault', () => {
       before(async () => {
         let friendPermissions = PERMISSIONS.CALL;
-        const payload = context.universalProfile.interface.encodeFunctionData("setDataBatch", [
+        const payload = context.universalProfile.interface.encodeFunctionData('setDataBatch', [
           [
-            ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
               context.accounts.friend.address.substring(2),
-            ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
               context.accounts.friend.address.substring(2),
           ],
           [
@@ -699,8 +699,8 @@ export const shouldBehaveLikeLSP9 = (
               // TODO: is the bit permission CALL in the allowed call enough for this test?
               [CALLTYPE.CALL],
               [context.lsp9Vault.address],
-              ["0xffffffff"],
-              ["0xffffffff"],
+              ['0xffffffff'],
+              ['0xffffffff'],
             ),
           ],
         ]);
@@ -708,11 +708,11 @@ export const shouldBehaveLikeLSP9 = (
         await context.lsp6KeyManager.connect(context.accounts.owner).execute(payload);
       });
 
-      it("should allow friend to talk to the vault", async () => {
-        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("some data key"));
-        const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value"));
+      it('should allow friend to talk to the vault', async () => {
+        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('some data key'));
+        const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value'));
 
-        const payload = context.lsp9Vault.interface.encodeFunctionData("setData", [
+        const payload = context.lsp9Vault.interface.encodeFunctionData('setData', [
           dataKey,
           dataValue,
         ]);
@@ -724,11 +724,11 @@ export const shouldBehaveLikeLSP9 = (
         expect(res).to.equal(dataValue);
       });
 
-      it("should fail when friend is interacting with other contracts", async () => {
-        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("some data key"));
-        const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("some value"));
+      it('should fail when friend is interacting with other contracts', async () => {
+        const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('some data key'));
+        const dataValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('some value'));
 
-        const payload = context.universalProfile.interface.encodeFunctionData("setData", [
+        const payload = context.universalProfile.interface.encodeFunctionData('setData', [
           dataKey,
           dataValue,
         ]);
@@ -742,75 +742,75 @@ export const shouldBehaveLikeLSP9 = (
               callPayload(context.universalProfile, context.universalProfile.address, payload),
             ),
         )
-          .to.be.revertedWithCustomError(context.lsp6KeyManager, "NotAllowedCall")
+          .to.be.revertedWithCustomError(context.lsp6KeyManager, 'NotAllowedCall')
           .withArgs(
             context.accounts.friend.address,
             disallowedAddress,
-            context.universalProfile.interface.getSighash("setData"),
+            context.universalProfile.interface.getSighash('setData'),
           );
       });
     });
 
-    describe("when transferring ownership of the vault", () => {
+    describe('when transferring ownership of the vault', () => {
       before(async () => {
         context = await buildContext();
       });
 
-      it("should emit UniversalReceiver event", async () => {
+      it('should emit UniversalReceiver event', async () => {
         const transferOwnership = context.lsp9Vault
           .connect(context.accounts.owner)
           .transferOwnership(context.universalProfile.address);
 
         await expect(transferOwnership)
-          .to.emit(context.universalProfile, "UniversalReceiver")
+          .to.emit(context.universalProfile, 'UniversalReceiver')
           .withArgs(
             context.lsp9Vault.address,
             0,
             LSP1_TYPE_IDS.LSP9OwnershipTransferStarted,
-            "0x",
+            '0x',
             abiCoder.encode(
-              ["bytes", "bytes"],
-              [ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")), "0x"],
+              ['bytes', 'bytes'],
+              [ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')), '0x'],
             ),
           );
       });
     });
   });
 
-  describe("when using the batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` function", () => {
-    describe("when specifying `msg.value`", () => {
-      it("should emit a `ValueReceived` event", async () => {
+  describe('when using the batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` function', () => {
+    describe('when specifying `msg.value`', () => {
+      it('should emit a `ValueReceived` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts.friend.address,
           context.accounts.random.address,
           context.accounts.anyone.address,
         ];
-        const values = Array(3).fill(ethers.BigNumber.from("1"));
-        const datas = Array(3).fill("0x");
+        const values = Array(3).fill(ethers.BigNumber.from('1'));
+        const datas = Array(3).fill('0x');
 
-        const msgValue = ethers.utils.parseEther("10");
+        const msgValue = ethers.utils.parseEther('10');
 
         const tx = await context.lsp9Vault.executeBatch(operationsType, recipients, values, datas, {
           value: msgValue,
         });
 
         await expect(tx)
-          .to.emit(context.lsp9Vault, "ValueReceived")
+          .to.emit(context.lsp9Vault, 'ValueReceived')
           .withArgs(context.deployParams.newOwner, msgValue);
       });
     });
 
-    describe("when NOT sending any `msg.value`", () => {
-      it("should NOT emit a `ValueReceived` event", async () => {
+    describe('when NOT sending any `msg.value`', () => {
+      it('should NOT emit a `ValueReceived` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts.friend.address,
           context.accounts.random.address,
           context.accounts.anyone.address,
         ];
-        const values = Array(3).fill(ethers.BigNumber.from("1"));
-        const datas = Array(3).fill("0x");
+        const values = Array(3).fill(ethers.BigNumber.from('1'));
+        const datas = Array(3).fill('0x');
 
         const msgValue = 0;
 
@@ -818,7 +818,7 @@ export const shouldBehaveLikeLSP9 = (
           value: msgValue,
         });
 
-        await expect(tx).to.not.emit(context.lsp9Vault, "ValueReceived");
+        await expect(tx).to.not.emit(context.lsp9Vault, 'ValueReceived');
       });
     });
   });
@@ -839,45 +839,45 @@ export const shouldInitializeLikeLSP9 = (
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should have registered the ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should have registered the ERC165 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC165);
       expect(result).to.be.true;
     });
 
-    it("should have registered the ERC725X interface", async () => {
+    it('should have registered the ERC725X interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725X);
       expect(result).to.be.true;
     });
 
-    it("should have registered the ERC725Y interface", async () => {
+    it('should have registered the ERC725Y interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725Y);
       expect(result).to.be.true;
     });
 
-    it("should have registered the LSP9 interface", async () => {
+    it('should have registered the LSP9 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP9Vault);
       expect(result).to.be.true;
     });
 
-    it("should have registered the LSP1 interface", async () => {
+    it('should have registered the LSP1 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP1UniversalReceiver);
       expect(result).to.be.true;
     });
 
-    it("should support LSP14Ownable2Step interface", async () => {
+    it('should support LSP14Ownable2Step interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP14Ownable2Step);
       expect(result).to.be.true;
     });
 
-    it("should support LSP17Extendable interface", async () => {
+    it('should support LSP17Extendable interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP17Extendable);
       expect(result).to.be.true;
     });
 
-    it("should have set expected entries with ERC725Y.setData", async () => {
+    it('should have set expected entries with ERC725Y.setData', async () => {
       await expect(context.initializeTransaction)
-        .to.emit(context.lsp9Vault, "DataChanged")
+        .to.emit(context.lsp9Vault, 'DataChanged')
         .withArgs(SupportedStandards.LSP9Vault.key, SupportedStandards.LSP9Vault.value);
       expect(await context.lsp9Vault.getData(SupportedStandards.LSP9Vault.key)).to.equal(
         SupportedStandards.LSP9Vault.value,

--- a/tests/LSP9Vault/LSP9Vault.test.ts
+++ b/tests/LSP9Vault/LSP9Vault.test.ts
@@ -1,30 +1,30 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
 import {
   LSP14TestContext,
   shouldBehaveLikeLSP14,
-} from "../LSP14Ownable2Step/LSP14Ownable2Step.behaviour";
+} from '../LSP14Ownable2Step/LSP14Ownable2Step.behaviour';
 
-import { LSP9Vault__factory, UniversalProfile, LSP6KeyManager } from "../../types";
+import { LSP9Vault__factory, UniversalProfile, LSP6KeyManager } from '../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP9,
   shouldInitializeLikeLSP9,
   LSP9TestContext,
-} from "./LSP9Vault.behaviour";
+} from './LSP9Vault.behaviour';
 
 import {
   LSP17TestContext,
   shouldBehaveLikeLSP17,
-} from "../LSP17ContractExtension/LSP17Extendable.behaviour";
+} from '../LSP17ContractExtension/LSP17Extendable.behaviour';
 
-import { setupProfileWithKeyManagerWithURD } from "../utils/fixtures";
-import { provider } from "../utils/helpers";
-import { BigNumber } from "ethers";
+import { setupProfileWithKeyManagerWithURD } from '../utils/fixtures';
+import { provider } from '../utils/helpers';
+import { BigNumber } from 'ethers';
 
-describe("LSP9Vault with constructor", () => {
+describe('LSP9Vault with constructor', () => {
   const buildTestContext = async (initialFunding?: number): Promise<LSP9TestContext> => {
     const accounts = await getNamedAccounts();
     const deployParams = {
@@ -61,7 +61,7 @@ describe("LSP9Vault with constructor", () => {
       value: initialFunding,
     });
 
-    const onlyOwnerRevertString = "Only Owner or reentered Universal Receiver Delegate allowed";
+    const onlyOwnerRevertString = 'Only Owner or reentered Universal Receiver Delegate allowed';
 
     return {
       accounts,
@@ -83,7 +83,7 @@ describe("LSP9Vault with constructor", () => {
 
   [{ initialFunding: undefined }, { initialFunding: 0 }, { initialFunding: 5 }].forEach(
     (testCase) => {
-      describe("when deploying the contract with or without value", () => {
+      describe('when deploying the contract with or without value', () => {
         let context: LSP9TestContext;
 
         before(async () => {
@@ -98,8 +98,8 @@ describe("LSP9Vault with constructor", () => {
     },
   );
 
-  describe("when deploying the contract", () => {
-    describe("when initializing the contract", () => {
+  describe('when deploying the contract', () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP9(async () => {
         let context = await buildTestContext();
         const { lsp9Vault, deployParams } = context;
@@ -113,7 +113,7 @@ describe("LSP9Vault with constructor", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP9(buildTestContext);
     shouldBehaveLikeLSP14(buildLSP14TestContext);
     shouldBehaveLikeLSP17(buildLSP17TestContext);

--- a/tests/LSP9Vault/LSP9VaultInit.test.ts
+++ b/tests/LSP9Vault/LSP9VaultInit.test.ts
@@ -1,35 +1,35 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
 import {
   LSP14TestContext,
   shouldBehaveLikeLSP14,
-} from "../LSP14Ownable2Step/LSP14Ownable2Step.behaviour";
+} from '../LSP14Ownable2Step/LSP14Ownable2Step.behaviour';
 
 import {
   LSP9Vault__factory,
   LSP9VaultInit__factory,
   UniversalProfile,
   LSP6KeyManager,
-} from "../../types";
+} from '../../types';
 
 import {
   getNamedAccounts,
   shouldBehaveLikeLSP9,
   shouldInitializeLikeLSP9,
   LSP9TestContext,
-} from "./LSP9Vault.behaviour";
+} from './LSP9Vault.behaviour';
 
 import {
   LSP17TestContext,
   shouldBehaveLikeLSP17,
-} from "../LSP17ContractExtension/LSP17Extendable.behaviour";
+} from '../LSP17ContractExtension/LSP17Extendable.behaviour';
 
-import { deployProxy, setupProfileWithKeyManagerWithURD } from "../utils/fixtures";
-import { provider } from "../utils/helpers";
-import { BigNumber } from "ethers";
+import { deployProxy, setupProfileWithKeyManagerWithURD } from '../utils/fixtures';
+import { provider } from '../utils/helpers';
+import { BigNumber } from 'ethers';
 
-describe("LSP9VaultInit with proxy", () => {
+describe('LSP9VaultInit with proxy', () => {
   const buildTestContext = async (
     initialFunding?: number | BigNumber,
   ): Promise<LSP9TestContext> => {
@@ -75,13 +75,13 @@ describe("LSP9VaultInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP9TestContext) => {
-    return context.lsp9Vault["initialize(address)"](context.deployParams.newOwner, {
+    return context.lsp9Vault['initialize(address)'](context.deployParams.newOwner, {
       value: context.deployParams.initialFunding,
     });
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 
       const lsp9VaultInit = await new LSP9VaultInit__factory(accounts[0]).deploy();
@@ -89,19 +89,19 @@ describe("LSP9VaultInit with proxy", () => {
       const randomCaller = accounts[1];
 
       await expect(lsp9VaultInit.initialize(randomCaller.address)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe("when deploying the contract as proxy", () => {
+  describe('when deploying the contract as proxy', () => {
     let context: LSP9TestContext;
 
     before(async () => {
       context = await buildTestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP9(async () => {
         const { lsp9Vault, deployParams } = context;
         const initializeTransaction = await initializeProxy(context);
@@ -114,16 +114,16 @@ describe("LSP9VaultInit with proxy", () => {
       });
     });
 
-    describe("when calling initialize more than once", () => {
-      it("should revert", async () => {
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
         await expect(initializeProxy(context)).to.be.revertedWith(
-          "Initializable: contract is already initialized",
+          'Initializable: contract is already initialized',
         );
       });
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP9(() =>
       buildTestContext().then(async (context) => {
         await initializeProxy(context);
@@ -137,7 +137,7 @@ describe("LSP9VaultInit with proxy", () => {
       let accounts = await ethers.getSigners();
       await initializeProxy(context);
 
-      const onlyOwnerRevertString = "Only Owner or reentered Universal Receiver Delegate allowed";
+      const onlyOwnerRevertString = 'Only Owner or reentered Universal Receiver Delegate allowed';
 
       return {
         accounts: accounts,
@@ -150,7 +150,7 @@ describe("LSP9VaultInit with proxy", () => {
     shouldBehaveLikeLSP17(async () => {
       let fallbackExtensionContext = await buildLSP17TestContext();
 
-      await fallbackExtensionContext.contract["initialize(address)"](
+      await fallbackExtensionContext.contract['initialize(address)'](
         fallbackExtensionContext.deployParams.owner.address,
       );
 

--- a/tests/Mocks/ABIEncoder.test.ts
+++ b/tests/Mocks/ABIEncoder.test.ts
@@ -1,9 +1,9 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { ABIEncoder, ABIEncoder__factory } from "../../types";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { ABIEncoder, ABIEncoder__factory } from '../../types';
 
-describe("ABI Encoder Contract", () => {
+describe('ABI Encoder Contract', () => {
   let accounts: SignerWithAddress[];
   let contract: ABIEncoder;
 
@@ -24,146 +24,146 @@ describe("ABI Encoder Contract", () => {
     return gasUsed.toNumber();
   };
 
-  describe("Checking the encoding works", () => {
-    it("Encoding empty bytes", async () => {
+  describe('Checking the encoding works', () => {
+    it('Encoding empty bytes', async () => {
       const txParams = {
-        a: "0x",
-        b: "0x",
+        a: '0x',
+        b: '0x',
       };
 
       await verifyResult(txParams.a, txParams.b);
     });
 
-    it("Encoding one empty bytes with non empty bytes", async () => {
+    it('Encoding one empty bytes with non empty bytes', async () => {
       const txParams = {
-        a: "0xaabbccdd",
-        b: "0x",
+        a: '0xaabbccdd',
+        b: '0x',
       };
 
       await verifyResult(txParams.a, txParams.b);
     });
 
-    it("Encoding non empty bytes with non empty bytes", async () => {
+    it('Encoding non empty bytes with non empty bytes', async () => {
       const txParams = {
-        a: "0xaabbccdd",
-        b: "0xaabbccdd",
+        a: '0xaabbccdd',
+        b: '0xaabbccdd',
       };
 
       await verifyResult(txParams.a, txParams.b);
     });
   });
 
-  describe("Checking the gas cost", () => {
-    describe("General cases", () => {
-      it("Encoding small amount of bytes in one param", async () => {
+  describe('Checking the gas cost', () => {
+    describe('General cases', () => {
+      it('Encoding small amount of bytes in one param', async () => {
         const txParams = {
-          a: "0xaabbccdd",
-          b: "0x",
+          a: '0xaabbccdd',
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding larger amount of bytes in one param", async () => {
+      it('Encoding larger amount of bytes in one param', async () => {
         const txParams = {
-          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
-          b: "0x",
+          a: '0xaabbccddaabbccddaabbccddaabbccddaabbccdd',
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding very large amount of bytes in one param", async () => {
+      it('Encoding very large amount of bytes in one param', async () => {
         const txParams = {
-          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
-          b: "0x",
+          a: '0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd',
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding small amount of bytes in both param", async () => {
+      it('Encoding small amount of bytes in both param', async () => {
         const txParams = {
-          a: "0xaabbccdd",
-          b: "0xaabbccdd",
+          a: '0xaabbccdd',
+          b: '0xaabbccdd',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding larger amount of bytes in both param", async () => {
+      it('Encoding larger amount of bytes in both param', async () => {
         const txParams = {
-          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
-          b: "0xaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          a: '0xaabbccddaabbccddaabbccddaabbccddaabbccdd',
+          b: '0xaabbccddaabbccddaabbccddaabbccddaabbccdd',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding very large amount of bytes in both param", async () => {
+      it('Encoding very large amount of bytes in both param', async () => {
         const txParams = {
-          a: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
-          b: "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd",
+          a: '0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd',
+          b: '0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
     });
 
-    describe("LSP1 Specific Cases", () => {
-      it("Encoding URD response when typeId out of scope with empty bytes", async () => {
+    describe('LSP1 Specific Cases', () => {
+      it('Encoding URD response when typeId out of scope with empty bytes', async () => {
         const txParams = {
-          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: typeId out of scope")),
-          b: "0x",
+          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding URD response when owner is not a KM with empty bytes", async () => {
+      it('Encoding URD response when owner is not a KM with empty bytes', async () => {
         const txParams = {
           a: ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("LSP1: account owner is not a LSP6KeyManager"),
+            ethers.utils.toUtf8Bytes('LSP1: account owner is not a LSP6KeyManager'),
           ),
-          b: "0x",
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding URD response when asset already exist with empty bytes", async () => {
+      it('Encoding URD response when asset already exist with empty bytes', async () => {
         const txParams = {
           a: ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes("LSP1: asset received is already registered"),
+            ethers.utils.toUtf8Bytes('LSP1: asset received is already registered'),
           ),
-          b: "0x",
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding URD response when asset is not registered with empty bytes", async () => {
+      it('Encoding URD response when asset is not registered with empty bytes', async () => {
         const txParams = {
-          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: asset sent is not registered")),
-          b: "0x",
+          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: asset sent is not registered')),
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding URD response when full balance was not sent with empty bytes", async () => {
+      it('Encoding URD response when full balance was not sent with empty bytes', async () => {
         const txParams = {
-          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes("LSP1: full balance is not sent")),
-          b: "0x",
+          a: ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: full balance is not sent')),
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);
       });
 
-      it("Encoding URD response when the data is successfully set with empty bytes", async () => {
+      it('Encoding URD response when the data is successfully set with empty bytes', async () => {
         const txParams = {
-          a: "0x",
-          b: "0x",
+          a: '0x',
+          b: '0x',
         };
 
         const result = await checkGasCost(txParams.a, txParams.b);

--- a/tests/Mocks/AddressRegistry.test.ts
+++ b/tests/Mocks/AddressRegistry.test.ts
@@ -1,6 +1,6 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   AddressRegistry,
   AddressRegistryRequiresERC725,
@@ -8,9 +8,9 @@ import {
   AddressRegistry__factory,
   UniversalProfile,
   UniversalProfile__factory,
-} from "../../types";
+} from '../../types';
 
-describe("Address Registry contracts", () => {
+describe('Address Registry contracts', () => {
   let addressRegistry: AddressRegistry;
   let accounts: SignerWithAddress[];
 
@@ -19,20 +19,20 @@ describe("Address Registry contracts", () => {
     addressRegistry = await new AddressRegistry__factory(accounts[1]).deploy();
   });
 
-  describe("AddressRegistry", () => {
-    it("add address", async () => {
+  describe('AddressRegistry', () => {
+    it('add address', async () => {
       await addressRegistry.addAddress(accounts[1].address);
       expect(await addressRegistry.getAddress(0)).to.equal(accounts[1].address);
     });
 
-    it("add same address", async () => {
+    it('add same address', async () => {
       expect(await addressRegistry.containsAddress(accounts[1].address)).to.be.true;
 
       await addressRegistry.addAddress(accounts[1].address);
       expect(await addressRegistry.getAddress(0)).to.equal(accounts[1].address);
     });
 
-    it("should add and remove address", async () => {
+    it('should add and remove address', async () => {
       await addressRegistry.addAddress(accounts[4].address);
       expect(await addressRegistry.containsAddress(accounts[4].address)).to.be.true;
 
@@ -40,23 +40,23 @@ describe("Address Registry contracts", () => {
       expect(await addressRegistry.containsAddress(accounts[4].address)).to.be.false;
     });
 
-    it("should give the right count", async () => {
-      expect(await addressRegistry.length()).to.equal("1");
+    it('should give the right count', async () => {
+      expect(await addressRegistry.length()).to.equal('1');
       // add new entry
       await addressRegistry.addAddress(accounts[2].address);
-      expect(await addressRegistry.length()).to.equal("2");
+      expect(await addressRegistry.length()).to.equal('2');
     });
 
-    it("get correct index", async () => {
-      expect(await addressRegistry.getIndex(accounts[1].address)).to.equal("0");
-      expect(await addressRegistry.getIndex(accounts[2].address)).to.equal("1");
+    it('get correct index', async () => {
+      expect(await addressRegistry.getIndex(accounts[1].address)).to.equal('0');
+      expect(await addressRegistry.getIndex(accounts[2].address)).to.equal('1');
 
       await expect(addressRegistry.getIndex(accounts[4].address)).to.be.revertedWith(
-        "EnumerableSet: Index not found",
+        'EnumerableSet: Index not found',
       );
     });
 
-    it("can list all values of the registry", async () => {
+    it('can list all values of the registry', async () => {
       let length = await (await addressRegistry.length()).toNumber();
       let values = [];
 
@@ -67,16 +67,16 @@ describe("Address Registry contracts", () => {
       expect(values).to.deep.equal([accounts[1].address, accounts[2].address]);
     });
 
-    it("can get all raw values in one call", async () => {
+    it('can get all raw values in one call', async () => {
       expect(await addressRegistry.getAllRawValues()).to.deep.equal([
-        "0x000000000000000000000000" + accounts[1].address.replace("0x", "").toLowerCase(),
-        "0x000000000000000000000000" + accounts[2].address.replace("0x", "").toLowerCase(),
+        '0x000000000000000000000000' + accounts[1].address.replace('0x', '').toLowerCase(),
+        '0x000000000000000000000000' + accounts[2].address.replace('0x', '').toLowerCase(),
       ]);
     });
   });
 
   // Require ERC725
-  describe("AddressRegistryRequiresERC725", () => {
+  describe('AddressRegistryRequiresERC725', () => {
     let addressRegistryRequireERC725: AddressRegistryRequiresERC725,
       account: UniversalProfile,
       owner: SignerWithAddress;
@@ -89,8 +89,8 @@ describe("Address Registry contracts", () => {
       ).deploy();
     });
 
-    it("add address", async () => {
-      let abi = addressRegistryRequireERC725.interface.encodeFunctionData("addAddress", [
+    it('add address', async () => {
+      let abi = addressRegistryRequireERC725.interface.encodeFunctionData('addAddress', [
         account.address,
       ]);
 
@@ -100,13 +100,13 @@ describe("Address Registry contracts", () => {
       expect(await addressRegistryRequireERC725.getAddress(0)).to.equal(account.address);
     });
 
-    it("external account adds address", async () => {
+    it('external account adds address', async () => {
       await addressRegistryRequireERC725.connect(accounts[5]).addAddress(account.address);
       expect(await addressRegistryRequireERC725.getAddress(0)).to.equal(account.address);
     });
 
-    it("remove address", async () => {
-      let abi = addressRegistryRequireERC725.interface.encodeFunctionData("removeAddress", [
+    it('remove address', async () => {
+      let abi = addressRegistryRequireERC725.interface.encodeFunctionData('removeAddress', [
         account.address,
       ]);
 
@@ -114,7 +114,7 @@ describe("Address Registry contracts", () => {
       expect(await addressRegistryRequireERC725.containsAddress(account.address)).to.equal(false);
     });
 
-    it("should fail if called by a regular address", async () => {
+    it('should fail if called by a regular address', async () => {
       // simply reverts as no ERC165 is detected
       await expect(addressRegistryRequireERC725.addAddress(accounts[5].address)).to.be.reverted;
     });

--- a/tests/Mocks/EIP191Signer.ts
+++ b/tests/Mocks/EIP191Signer.ts
@@ -1,17 +1,17 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 import {
   EIP191SignerTester__factory,
   UniversalProfile__factory,
   LSP6KeyManager__factory,
-} from "../../types";
+} from '../../types';
 
-describe("EIP191Signer", () => {
-  describe("when using `toDataWithIntendedValidator(...)`", () => {
-    it("should return the same hash than the EIP191Signer library", async () => {
-      const data = "example";
+describe('EIP191Signer', () => {
+  describe('when using `toDataWithIntendedValidator(...)`', () => {
+    it('should return the same hash than the EIP191Signer library', async () => {
+      const data = 'example';
 
       const accounts = await ethers.getSigners();
       const owner = accounts[0];

--- a/tests/Mocks/ERC165Interfaces.test.ts
+++ b/tests/Mocks/ERC165Interfaces.test.ts
@@ -1,15 +1,15 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   CalculateLSPInterfaces,
   CalculateLSPInterfaces__factory,
   CalculateERCInterfaces,
   CalculateERCInterfaces__factory,
-} from "../../types";
+} from '../../types';
 
 // utils
-import { INTERFACE_IDS } from "../../constants";
+import { INTERFACE_IDS } from '../../constants';
 
 /**
  * @dev these tests check that the ERC165 interface IDs stored in `constant.ts`
@@ -20,7 +20,7 @@ import { INTERFACE_IDS } from "../../constants";
  *      - the file `constants.ts` always hold correct values (since it is part of the npm package)
  *      - tests that use or check for these interface IDs rely on correct values
  */
-describe("Calculate LSP interfaces", () => {
+describe('Calculate LSP interfaces', () => {
   let accounts: SignerWithAddress[];
   let contract: CalculateLSPInterfaces;
 
@@ -29,68 +29,68 @@ describe("Calculate LSP interfaces", () => {
     contract = await new CalculateLSPInterfaces__factory(accounts[0]).deploy();
   });
 
-  it("LSP0", async () => {
+  it('LSP0', async () => {
     const result = await contract.calculateInterfaceLSP0();
     expect(result).to.equal(INTERFACE_IDS.LSP0ERC725Account);
   });
 
-  it("LSP1", async () => {
+  it('LSP1', async () => {
     const result = await contract.calculateInterfaceLSP1();
     expect(result).to.equal(INTERFACE_IDS.LSP1UniversalReceiver);
   });
 
-  it("LSP6", async () => {
+  it('LSP6', async () => {
     const result = await contract.calculateInterfaceLSP6KeyManager();
     expect(result).to.equal(INTERFACE_IDS.LSP6KeyManager);
   });
 
-  it("LSP7", async () => {
+  it('LSP7', async () => {
     const result = await contract.calculateInterfaceLSP7();
     expect(result).to.equal(INTERFACE_IDS.LSP7DigitalAsset);
   });
 
-  it("LSP8", async () => {
+  it('LSP8', async () => {
     const result = await contract.calculateInterfaceLSP8();
     expect(result).to.equal(INTERFACE_IDS.LSP8IdentifiableDigitalAsset);
   });
 
-  it("LSP9", async () => {
+  it('LSP9', async () => {
     const result = await contract.calculateInterfaceLSP9();
     expect(result).to.equal(INTERFACE_IDS.LSP9Vault);
   });
 
-  it("LSP11", async () => {
+  it('LSP11', async () => {
     const result = await contract.calculateInterfaceLSP11();
     expect(result).to.equal(INTERFACE_IDS.LSP11BasicSocialRecovery);
   });
 
-  it("LSP14", async () => {
+  it('LSP14', async () => {
     const result = await contract.calculateInterfaceLSP14();
     expect(result).to.equal(INTERFACE_IDS.LSP14Ownable2Step);
   });
 
-  it("LSP17Extendable", async () => {
+  it('LSP17Extendable', async () => {
     const result = await contract.calculateInterfaceLSP17Extendable();
     expect(result).to.equal(INTERFACE_IDS.LSP17Extendable);
   });
 
-  it("LSP17Extension", async () => {
+  it('LSP17Extension', async () => {
     const result = await contract.calculateInterfaceLSP17Extension();
     expect(result).to.equal(INTERFACE_IDS.LSP17Extension);
   });
 
-  it("LSP20CallVerification", async () => {
+  it('LSP20CallVerification', async () => {
     const result = await contract.calculateInterfaceLSP20CallVerification();
     expect(result).to.equal(INTERFACE_IDS.LSP20CallVerification);
   });
 
-  it("LSP20CallVerifier", async () => {
+  it('LSP20CallVerifier', async () => {
     const result = await contract.calculateInterfaceLSP20CallVerifier();
     expect(result).to.equal(INTERFACE_IDS.LSP20CallVerifier);
   });
 });
 
-describe("Calculate ERC interfaces", () => {
+describe('Calculate ERC interfaces', () => {
   let accounts: SignerWithAddress[];
   let contract: CalculateERCInterfaces;
 
@@ -99,37 +99,37 @@ describe("Calculate ERC interfaces", () => {
     contract = await new CalculateERCInterfaces__factory(accounts[0]).deploy();
   });
 
-  it("ERC20", async () => {
+  it('ERC20', async () => {
     const result = await contract.calculateInterfaceERC20();
     expect(result).to.equal(INTERFACE_IDS.ERC20);
   });
 
-  it("ERC223", async () => {
+  it('ERC223', async () => {
     const result = await contract.calculateInterfaceERC223();
     expect(result).to.equal(INTERFACE_IDS.ERC223);
   });
 
-  it("ERC721", async () => {
+  it('ERC721', async () => {
     const result = await contract.calculateInterfaceERC721();
     expect(result).to.equal(INTERFACE_IDS.ERC721);
   });
 
-  it("ERC721Metadata", async () => {
+  it('ERC721Metadata', async () => {
     const result = await contract.calculateInterfaceERC721Metadata();
     expect(result).to.equal(INTERFACE_IDS.ERC721Metadata);
   });
 
-  it("ERC777", async () => {
+  it('ERC777', async () => {
     const result = await contract.calculateInterfaceERC777();
     expect(result).to.equal(INTERFACE_IDS.ERC777);
   });
 
-  it("ERC1155", async () => {
+  it('ERC1155', async () => {
     const result = await contract.calculateInterfaceERC1155();
     expect(result).to.equal(INTERFACE_IDS.ERC1155);
   });
 
-  it("ERC1271", async () => {
+  it('ERC1271', async () => {
     const result = await contract.calculateInterfaceERC1271();
     expect(result).to.equal(INTERFACE_IDS.ERC1271);
   });

--- a/tests/Mocks/KeyManagerExecutionCosts.test.ts
+++ b/tests/Mocks/KeyManagerExecutionCosts.test.ts
@@ -1,7 +1,7 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 
-import { UniversalProfile__factory, LSP6KeyManager__factory, UniversalProfile } from "../../types";
+import { UniversalProfile__factory, LSP6KeyManager__factory, UniversalProfile } from '../../types';
 import {
   ALL_PERMISSIONS,
   ERC725YDataKeys,
@@ -9,22 +9,22 @@ import {
   PERMISSIONS,
   INTERFACE_IDS,
   CALLTYPE,
-} from "../../constants";
+} from '../../constants';
 
-import { LSP6TestContext } from "../utils/context";
+import { LSP6TestContext } from '../utils/context';
 import {
   abiCoder,
   provider,
   combinePermissions,
   combineAllowedCalls,
   combineCallTypes,
-} from "../utils/helpers";
+} from '../utils/helpers';
 
-import { setupKeyManager } from "../utils/fixtures";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { setupKeyManager } from '../utils/fixtures';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-describe("Key Manager gas cost interactions", () => {
-  describe("when using LSP6KeyManager with constructor", () => {
+describe('Key Manager gas cost interactions', () => {
+  describe('when using LSP6KeyManager with constructor', () => {
     const buildLSP6TestContext = async (): Promise<LSP6TestContext> => {
       const accounts = await ethers.getSigners();
       const owner = accounts[0];
@@ -35,7 +35,7 @@ describe("Key Manager gas cost interactions", () => {
       return { accounts, owner, universalProfile, keyManager };
     };
 
-    describe("after deploying the contract", () => {
+    describe('after deploying the contract', () => {
       let context: LSP6TestContext;
 
       let restrictedToOneAddress: SignerWithAddress,
@@ -54,15 +54,15 @@ describe("Key Manager gas cost interactions", () => {
         );
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             restrictedToOneAddress.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             restrictedToOneAddressAndStandard.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             restrictedToOneAddress.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
             restrictedToOneAddressAndStandard.address.substring(2),
         ];
 
@@ -74,13 +74,13 @@ describe("Key Manager gas cost interactions", () => {
             [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
             [contractImplementsERC1271.address],
             [INTERFACE_IDS.ERC1271],
-            ["0xffffffff"],
+            ['0xffffffff'],
           ),
           combineAllowedCalls(
             [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
             [contractImplementsERC1271.address],
-            ["0xffffffff"],
-            ["0xffffffff"],
+            ['0xffffffff'],
+            ['0xffffffff'],
           ),
         ];
 
@@ -88,21 +88,21 @@ describe("Key Manager gas cost interactions", () => {
 
         await context.owner.sendTransaction({
           to: context.universalProfile.address,
-          value: ethers.utils.parseEther("10"),
+          value: ethers.utils.parseEther('10'),
         });
       });
 
-      describe("display gas cost", () => {
-        it("when caller has any allowed address and standard allowed", async () => {
+      describe('display gas cost', () => {
+        it('when caller has any allowed address and standard allowed', async () => {
           let initialAccountBalance = await provider.getBalance(contractImplementsERC1271.address);
 
           let transferLyxPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
+            'execute',
             [
               OPERATION_TYPES.CALL,
               contractImplementsERC1271.address,
-              ethers.utils.parseEther("1"),
-              "0x",
+              ethers.utils.parseEther('1'),
+              '0x',
             ],
           );
 
@@ -111,7 +111,7 @@ describe("Key Manager gas cost interactions", () => {
           let receipt = await tx.wait();
 
           console.log(
-            "gas cost LYX transfer - everything allowed: ",
+            'gas cost LYX transfer - everything allowed: ',
             ethers.BigNumber.from(receipt.gasUsed).toNumber(),
           );
 
@@ -120,14 +120,14 @@ describe("Key Manager gas cost interactions", () => {
         });
       });
 
-      it("when caller has only 1 x allowed address allowed", async () => {
+      it('when caller has only 1 x allowed address allowed', async () => {
         let initialAccountBalance = await provider.getBalance(contractImplementsERC1271.address);
 
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           contractImplementsERC1271.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
         let tx = await context.keyManager
@@ -137,7 +137,7 @@ describe("Key Manager gas cost interactions", () => {
         let receipt = await tx.wait();
 
         console.log(
-          "gas cost LYX transfer - with 1 x allowed address: ",
+          'gas cost LYX transfer - with 1 x allowed address: ',
           ethers.BigNumber.from(receipt.gasUsed).toNumber(),
         );
 
@@ -145,14 +145,14 @@ describe("Key Manager gas cost interactions", () => {
         expect(newAccountBalance).to.be.greaterThan(initialAccountBalance);
       });
 
-      it("when caller has only 1 x allowed address + 1 x allowed standard allowed", async () => {
+      it('when caller has only 1 x allowed address + 1 x allowed standard allowed', async () => {
         let initialAccountBalance = await provider.getBalance(contractImplementsERC1271.address);
 
-        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let transferLyxPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           contractImplementsERC1271.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
         let tx = await context.keyManager
@@ -162,7 +162,7 @@ describe("Key Manager gas cost interactions", () => {
         let receipt = await tx.wait();
 
         console.log(
-          "gas cost LYX transfer - with 1 x allowed address + 1 x allowed standard: ",
+          'gas cost LYX transfer - with 1 x allowed address + 1 x allowed standard: ',
           ethers.BigNumber.from(receipt.gasUsed).toNumber(),
         );
 

--- a/tests/Mocks/NFTStorage.test.ts
+++ b/tests/Mocks/NFTStorage.test.ts
@@ -1,13 +1,13 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-const keccak256 = require("keccak256");
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { NFTStorageMerkle, NFTStorageMerkle__factory } from "../../types";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+const keccak256 = require('keccak256');
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { NFTStorageMerkle, NFTStorageMerkle__factory } from '../../types';
 
-const { MerkleTree } = require("merkletreejs");
+const { MerkleTree } = require('merkletreejs');
 
-describe("NFTStorageMerkle", () => {
-  describe("Testing Merkle Tree", () => {
+describe('NFTStorageMerkle', () => {
+  describe('Testing Merkle Tree', () => {
     let accounts: SignerWithAddress[];
     let owner, nftList;
 
@@ -35,18 +35,18 @@ describe("NFTStorageMerkle", () => {
       merkletree = new MerkleTree(leaves, keccak256, { sortPairs: true });
     });
 
-    it("Should return 8 for leaves count", () => {
+    it('Should return 8 for leaves count', () => {
       let count = merkletree.getHexLeaves().length;
       expect(count).to.equal(8);
     });
 
-    it("Keccak256 hash should match for the first NFT address", async () => {
+    it('Keccak256 hash should match for the first NFT address', async () => {
       let firstNFT = merkletree.getHexLeaves()[0];
 
       expect(firstNFT).to.equal(ethers.utils.keccak256(nftList[0]));
     });
 
-    it("Should verify the proof in the smart contract", async () => {
+    it('Should verify the proof in the smart contract', async () => {
       let root = merkletree.getHexRoot();
       let leaf = merkletree.getHexLeaves()[3];
       let proof = merkletree.getHexProof(leaf);

--- a/tests/Reentrancy/LSP20/ERC725XBatchExecuteToERC725XExecute.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XBatchExecuteToERC725XExecute.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
+import { BigNumber, BytesLike } from 'ethers';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -23,10 +23,10 @@ import {
   changeUniversalReceiverDelegateTestCases,
   // Functions
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
-import { LSP20ReentrantContract__factory } from "../../../types";
-import { Interface } from "ethers/lib/utils";
+import { LSP20ReentrantContract__factory } from '../../../types';
+import { Interface } from 'ethers/lib/utils';
 
 export const testERC725XBatchExecuteToERC725XExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -37,17 +37,17 @@ export const testERC725XBatchExecuteToERC725XExecute = (
   let reentrantContractInterface: Interface;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
     reentrantContractInterface = new LSP20ReentrantContract__factory().interface;
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "TRANSFERVALUE",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'TRANSFERVALUE',
       ]);
     });
 
@@ -55,10 +55,10 @@ export const testERC725XBatchExecuteToERC725XExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -70,14 +70,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -88,12 +88,12 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         context.universalProfile
           .connect(reentrancyContext.caller)
           .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -102,7 +102,7 @@ export const testERC725XBatchExecuteToERC725XExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.universalProfile
         .connect(reentrancyContext.caller)
@@ -110,22 +110,22 @@ export const testERC725XBatchExecuteToERC725XExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.reentrantContract.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "SETDATA",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'SETDATA',
       ]);
     });
 
@@ -133,10 +133,10 @@ export const testERC725XBatchExecuteToERC725XExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -148,14 +148,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -166,12 +166,12 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         context.universalProfile
           .connect(reentrancyContext.caller)
           .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -182,26 +182,26 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         .connect(reentrancyContext.caller)
         .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]);
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "ADDCONTROLLER",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'ADDCONTROLLER',
       ]);
     });
 
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -213,14 +213,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -232,10 +232,10 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -243,19 +243,19 @@ export const testERC725XBatchExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "EDITPERMISSIONS",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'EDITPERMISSIONS',
       ]);
     });
 
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -267,14 +267,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -286,9 +286,9 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -296,19 +296,19 @@ export const testERC725XBatchExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "ADDUNIVERSALRECEIVERDELEGATE",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'ADDUNIVERSALRECEIVERDELEGATE',
       ]);
     });
 
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -320,14 +320,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -350,19 +350,19 @@ export const testERC725XBatchExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let reentrantCall: BytesLike;
 
     before(async () => {
-      reentrantCall = reentrantContractInterface.encodeFunctionData("callThatReenters", [
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+      reentrantCall = reentrantContractInterface.encodeFunctionData('callThatReenters', [
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
       ]);
     });
 
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -374,14 +374,14 @@ export const testERC725XBatchExecuteToERC725XExecute = (
             .connect(reentrancyContext.caller)
             .executeBatch([0], [reentrancyContext.reentrantContract.address], [0], [reentrantCall]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -396,7 +396,7 @@ export const testERC725XBatchExecuteToERC725XExecute = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP20/ERC725XExecuteToERC725XExecute.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XExecuteToERC725XExecute.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
+import { BigNumber, BytesLike } from 'ethers';
 
 // constants
-import { ALL_PERMISSIONS, ERC725YDataKeys } from "../../../constants";
+import { ALL_PERMISSIONS, ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -23,8 +23,8 @@ import {
   changeUniversalReceiverDelegateTestCases,
   // Functions
   loadTestCase,
-} from "./reentrancyHelpers";
-import { LSP20ReentrantContract__factory } from "../../../types";
+} from './reentrancyHelpers';
+import { LSP20ReentrantContract__factory } from '../../../types';
 
 export const testERC725XExecuteToERC725XExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -34,11 +34,11 @@ export const testERC725XExecuteToERC725XExecute = (
   let reentrancyContext: ReentrancyContext;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -48,8 +48,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["TRANSFERVALUE"],
+        'callThatReenters',
+        ['TRANSFERVALUE'],
       );
 
       executeCalldata = {
@@ -64,10 +64,10 @@ export const testERC725XExecuteToERC725XExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -84,14 +84,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -107,12 +107,12 @@ export const testERC725XExecuteToERC725XExecute = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -121,7 +121,7 @@ export const testERC725XExecuteToERC725XExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.universalProfile
         .connect(reentrancyContext.caller)
@@ -134,17 +134,17 @@ export const testERC725XExecuteToERC725XExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.reentrantContract.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -154,8 +154,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["SETDATA"],
+        'callThatReenters',
+        ['SETDATA'],
       );
 
       executeCalldata = {
@@ -170,10 +170,10 @@ export const testERC725XExecuteToERC725XExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -190,14 +190,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -213,12 +213,12 @@ export const testERC725XExecuteToERC725XExecute = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -234,14 +234,14 @@ export const testERC725XExecuteToERC725XExecute = (
           executeCalldata.data,
         );
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -251,8 +251,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["ADDCONTROLLER"],
+        'callThatReenters',
+        ['ADDCONTROLLER'],
       );
 
       executeCalldata = {
@@ -266,7 +266,7 @@ export const testERC725XExecuteToERC725XExecute = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -283,14 +283,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -307,7 +307,7 @@ export const testERC725XExecuteToERC725XExecute = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
@@ -316,7 +316,7 @@ export const testERC725XExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -326,8 +326,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["EDITPERMISSIONS"],
+        'callThatReenters',
+        ['EDITPERMISSIONS'],
       );
 
       executeCalldata = {
@@ -341,7 +341,7 @@ export const testERC725XExecuteToERC725XExecute = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -358,14 +358,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -382,9 +382,9 @@ export const testERC725XExecuteToERC725XExecute = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -392,7 +392,7 @@ export const testERC725XExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -402,8 +402,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["ADDUNIVERSALRECEIVERDELEGATE"],
+        'callThatReenters',
+        ['ADDUNIVERSALRECEIVERDELEGATE'],
       );
 
       executeCalldata = {
@@ -417,7 +417,7 @@ export const testERC725XExecuteToERC725XExecute = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -434,14 +434,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -469,7 +469,7 @@ export const testERC725XExecuteToERC725XExecute = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let executeCalldata: {
       operationType: number;
       to: string;
@@ -479,8 +479,8 @@ export const testERC725XExecuteToERC725XExecute = (
 
     before(async () => {
       const reentrantCall = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-        "callThatReenters",
-        ["CHANGEUNIVERSALRECEIVERDELEGATE"],
+        'callThatReenters',
+        ['CHANGEUNIVERSALRECEIVERDELEGATE'],
       );
 
       executeCalldata = {
@@ -494,7 +494,7 @@ export const testERC725XExecuteToERC725XExecute = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -511,14 +511,14 @@ export const testERC725XExecuteToERC725XExecute = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -538,7 +538,7 @@ export const testERC725XExecuteToERC725XExecute = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP20/ERC725XExecuteToLSP6BatchExecuteRelayCall.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XExecuteToLSP6BatchExecuteRelayCall.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
-import { SingleReentrancyRelayer__factory } from "../../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { SingleReentrancyRelayer__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys, OPERATION_TYPES } from "../../../constants";
+import { ERC725YDataKeys, OPERATION_TYPES } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   // Functions
   generateBatchRelayPayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -41,11 +41,11 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
   };
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
 
     const reentrantCall = new SingleReentrancyRelayer__factory().interface.encodeFunctionData(
-      "relayCallThatReenters",
+      'relayCallThatReenters',
       [context.keyManager.address],
     );
 
@@ -57,12 +57,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     };
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -74,10 +74,10 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -94,14 +94,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -117,12 +117,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -131,7 +131,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.universalProfile
         .connect(reentrancyContext.caller)
@@ -144,22 +144,22 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.batchReentarncyRelayer.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "SETDATA",
+        'SETDATA',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -171,10 +171,10 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -191,14 +191,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -214,12 +214,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -235,19 +235,19 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
           executeCalldata.data,
         );
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -258,7 +258,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -275,14 +275,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -299,10 +299,10 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -310,12 +310,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -326,7 +326,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -343,14 +343,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -367,9 +367,9 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -377,12 +377,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -393,7 +393,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -410,14 +410,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -445,12 +445,12 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -461,7 +461,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -478,14 +478,14 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -505,7 +505,7 @@ export const testERC725XExecuteToLSP6BatchExecuteRelayCall = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP20/ERC725XExecuteToLSP6ExecuteRelayCall.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XExecuteToLSP6ExecuteRelayCall.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
-import { SingleReentrancyRelayer__factory } from "../../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { SingleReentrancyRelayer__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys, OPERATION_TYPES } from "../../../constants";
+import { ERC725YDataKeys, OPERATION_TYPES } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   // Functions
   generateSingleRelayPayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testERC725XExecuteToLSP6ExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -41,11 +41,11 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
   };
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
 
     const reentrantCall = new SingleReentrancyRelayer__factory().interface.encodeFunctionData(
-      "relayCallThatReenters",
+      'relayCallThatReenters',
       [context.keyManager.address],
     );
 
@@ -57,12 +57,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     };
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -74,10 +74,10 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -94,14 +94,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -117,12 +117,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -131,7 +131,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.universalProfile
         .connect(reentrancyContext.caller)
@@ -144,22 +144,22 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.singleReentarncyRelayer.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "SETDATA",
+        'SETDATA',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -171,10 +171,10 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -191,14 +191,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -214,12 +214,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
             executeCalldata.value,
             executeCalldata.data,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -235,19 +235,19 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
           executeCalldata.data,
         );
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -258,7 +258,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -275,14 +275,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -299,10 +299,10 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -310,12 +310,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -326,7 +326,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -343,14 +343,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -367,9 +367,9 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -377,12 +377,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -393,7 +393,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -410,14 +410,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -445,12 +445,12 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -461,7 +461,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -478,14 +478,14 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
               executeCalldata.data,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -505,7 +505,7 @@ export const testERC725XExecuteToLSP6ExecuteRelayCall = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
@@ -1,34 +1,34 @@
 // types
-import { BigNumber } from "ethers";
+import { BigNumber } from 'ethers';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { buildReentrancyContext } from "./reentrancyHelpers";
+import { LSP6TestContext } from '../../utils/context';
+import { buildReentrancyContext } from './reentrancyHelpers';
 
 // tests
-import { testERC725XExecuteToERC725XExecute } from "./ERC725XExecuteToERC725XExecute.test";
-import { testERC725XExecuteToLSP6ExecuteRelayCall } from "./ERC725XExecuteToLSP6ExecuteRelayCall.test";
+import { testERC725XExecuteToERC725XExecute } from './ERC725XExecuteToERC725XExecute.test';
+import { testERC725XExecuteToLSP6ExecuteRelayCall } from './ERC725XExecuteToLSP6ExecuteRelayCall.test';
 
-import { testERC725XBatchExecuteToERC725XExecute } from "./ERC725XBatchExecuteToERC725XExecute.test";
-import { testERC725XExecuteToLSP6BatchExecuteRelayCall } from "./ERC725XExecuteToLSP6BatchExecuteRelayCall.test";
+import { testERC725XBatchExecuteToERC725XExecute } from './ERC725XBatchExecuteToERC725XExecute.test';
+import { testERC725XExecuteToLSP6BatchExecuteRelayCall } from './ERC725XExecuteToLSP6BatchExecuteRelayCall.test';
 
 export const shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
-  describe("first call through `execute(bytes)`, second call through `execute(bytes)`", () => {
+  describe('first call through `execute(bytes)`, second call through `execute(bytes)`', () => {
     testERC725XExecuteToERC725XExecute(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `execute(bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`", () => {
+  describe('first call through `execute(bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`', () => {
     testERC725XExecuteToLSP6ExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 
   // This tests will be enabled when we allow `ERC725X.execute(uint256[],address[],uint256[],bytes[])` in the LSP6.execute(bytes)
-  describe.skip("first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`", () => {
+  describe.skip('first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`', () => {
     testERC725XBatchExecuteToERC725XExecute(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `ERC725X.execute(bytes)`, second call through `LSP6.executeRelayCall(bytes[],uint256[],uint256[],bytes[])`", () => {
+  describe('first call through `ERC725X.execute(bytes)`, second call through `LSP6.executeRelayCall(bytes[],uint256[],uint256[],bytes[])`', () => {
     testERC725XExecuteToLSP6BatchExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 };

--- a/tests/Reentrancy/LSP20/reentrancyHelpers.ts
+++ b/tests/Reentrancy/LSP20/reentrancyHelpers.ts
@@ -1,8 +1,8 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
 // types
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber, BytesLike, Wallet } from "ethers";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { BigNumber, BytesLike, Wallet } from 'ethers';
 import {
   LSP20ReentrantContract__factory,
   LSP20ReentrantContract,
@@ -13,13 +13,13 @@ import {
   SingleReentrancyRelayer__factory,
   BatchReentrancyRelayer__factory,
   UniversalProfile__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, CALLTYPE } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, CALLTYPE } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -28,8 +28,8 @@ import {
   LOCAL_PRIVATE_KEYS,
   signLSP6ExecuteRelayCall,
   encodeCompactBytesArray,
-} from "../../utils/helpers";
-import { setupKeyManager } from "../../utils/fixtures";
+} from '../../utils/helpers';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // Complex permission as it has AllowedCalls
 export type TransferValueTestCase = {
@@ -70,232 +70,232 @@ export type ReentrancyContext = {
 export const transferValueTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedCalls: false,
-      missingPermission: "TRANSFERVALUE",
+      missingPermission: 'TRANSFERVALUE',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedCalls: true,
-      missingPermission: "TRANSFERVALUE",
+      missingPermission: 'TRANSFERVALUE',
     },
     {
-      permissionsText: "TRANSFERVALUE",
+      permissionsText: 'TRANSFERVALUE',
       permissions: PERMISSIONS.TRANSFERVALUE,
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "TRANSFERVALUE",
+      permissionsText: 'TRANSFERVALUE',
       permissions: PERMISSIONS.TRANSFERVALUE,
       allowedCalls: true,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   NoCallsAllowed: {
-    permissionsText: "REENTRANCY, TRANSFERVALUE",
+    permissionsText: 'REENTRANCY, TRANSFERVALUE',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.TRANSFERVALUE),
     allowedCalls: false,
-    missingPermission: "",
+    missingPermission: '',
   },
   ValidCase: {
-    permissionsText: "REENTRANCY, TRANSFERVALUE",
+    permissionsText: 'REENTRANCY, TRANSFERVALUE',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.TRANSFERVALUE),
     allowedCalls: true,
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const setDataTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedERC725YDataKeys: false,
-      missingPermission: "SETDATA",
+      missingPermission: 'SETDATA',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedERC725YDataKeys: true,
-      missingPermission: "SETDATA",
+      missingPermission: 'SETDATA',
     },
     {
-      permissionsText: "SETDATA",
+      permissionsText: 'SETDATA',
       permissions: PERMISSIONS.SETDATA,
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "SETDATA",
+      permissionsText: 'SETDATA',
       permissions: PERMISSIONS.SETDATA,
       allowedERC725YDataKeys: true,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   NoERC725YDataKeysAllowed: {
-    permissionsText: "REENTRANCY, SETDATA",
+    permissionsText: 'REENTRANCY, SETDATA',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.SETDATA),
     allowedERC725YDataKeys: false,
-    missingPermission: "",
+    missingPermission: '',
   },
   ValidCase: {
-    permissionsText: "REENTRANCY, SETDATA",
+    permissionsText: 'REENTRANCY, SETDATA',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.SETDATA),
     allowedERC725YDataKeys: true,
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const addPermissionsTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "ADDCONTROLLER",
+      missingPermission: 'ADDCONTROLLER',
     },
     {
-      permissionsText: "ADDCONTROLLER",
+      permissionsText: 'ADDCONTROLLER',
       permissions: PERMISSIONS.ADDCONTROLLER,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, ADDCONTROLLER",
+    permissionsText: 'REENTRANCY, ADDCONTROLLER',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.ADDCONTROLLER),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const editPermissionsTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "EDITPERMISSIONS",
+      missingPermission: 'EDITPERMISSIONS',
     },
     {
-      permissionsText: "EDITPERMISSIONS",
+      permissionsText: 'EDITPERMISSIONS',
       permissions: PERMISSIONS.EDITPERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, EDITPERMISSIONS",
+    permissionsText: 'REENTRANCY, EDITPERMISSIONS',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.EDITPERMISSIONS),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const addUniversalReceiverDelegateTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "ADDUNIVERSALRECEIVERDELEGATE",
+      missingPermission: 'ADDUNIVERSALRECEIVERDELEGATE',
     },
     {
-      permissionsText: "ADDUNIVERSALRECEIVERDELEGATE",
+      permissionsText: 'ADDUNIVERSALRECEIVERDELEGATE',
       permissions: PERMISSIONS.ADDUNIVERSALRECEIVERDELEGATE,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE",
+    permissionsText: 'REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE',
     permissions: combinePermissions(
       PERMISSIONS.REENTRANCY,
       PERMISSIONS.ADDUNIVERSALRECEIVERDELEGATE,
     ),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const changeUniversalReceiverDelegateTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "CHANGEUNIVERSALRECEIVERDELEGATE",
+      missingPermission: 'CHANGEUNIVERSALRECEIVERDELEGATE',
     },
     {
-      permissionsText: "CHANGEUNIVERSALRECEIVERDELEGATE",
+      permissionsText: 'CHANGEUNIVERSALRECEIVERDELEGATE',
       permissions: PERMISSIONS.CHANGEUNIVERSALRECEIVERDELEGATE,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE",
+    permissionsText: 'REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE',
     permissions: combinePermissions(
       PERMISSIONS.REENTRANCY,
       PERMISSIONS.CHANGEUNIVERSALRECEIVERDELEGATE,
     ),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
@@ -308,7 +308,7 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
 
   const reentrantContract = await new LSP20ReentrantContract__factory(owner).deploy(
     newControllerAddress,
-    ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")),
+    ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')),
     newURDAddress,
   );
 
@@ -318,11 +318,11 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
   const batchReentarncyRelayer = await new BatchReentrancyRelayer__factory(owner).deploy();
 
   const permissionKeys = [
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + owner.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + owner.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
   ];
 
   const permissionValues = [
@@ -332,22 +332,22 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
       // allow controller to call the 3 x addresses listed below
       [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
       [reentrantContract.address, singleReentarncyRelayer.address, batchReentarncyRelayer.address],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
     ),
     PERMISSIONS.CALL,
     combineAllowedCalls(
       // allow controller to call the 3 x addresses listed below
       [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
       [reentrantContract.address, singleReentarncyRelayer.address, batchReentarncyRelayer.address],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
     ),
   ];
 
   await setupKeyManager(context, permissionKeys, permissionValues);
 
-  const randomLSP1TypeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId"));
+  const randomLSP1TypeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId'));
 
   return {
     owner,
@@ -408,48 +408,48 @@ export const generateSingleRelayPayload = async (
 ) => {
   let payload: BytesLike;
   switch (payloadType) {
-    case "TRANSFERVALUE":
-      payload = universalProfile.interface.encodeFunctionData("execute", [
+    case 'TRANSFERVALUE':
+      payload = universalProfile.interface.encodeFunctionData('execute', [
         0,
         reentrancyRelayer.address,
-        ethers.utils.parseEther("1"),
-        "0x",
+        ethers.utils.parseEther('1'),
+        '0x',
       ]);
       break;
-    case "SETDATA":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
-        ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+    case 'SETDATA':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
       ]);
       break;
-    case "ADDCONTROLLER":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x0000000000000000000000000000000000000000000000000000000000000010",
+    case 'ADDCONTROLLER':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x0000000000000000000000000000000000000000000000000000000000000010',
       ]);
       break;
-    case "EDITPERMISSIONS":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x",
+    case 'EDITPERMISSIONS':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x',
       ]);
       break;
-    case "ADDUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'ADDUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
         newURDAddress,
       ]);
       break;
-    case "CHANGEUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'CHANGEUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
-        "0x",
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
+        '0x',
       ]);
       break;
     default:
-      payload = "0x";
+      payload = '0x';
       break;
   }
 
@@ -481,48 +481,48 @@ export const generateBatchRelayPayload = async (
 ) => {
   let payload: BytesLike;
   switch (payloadType) {
-    case "TRANSFERVALUE":
-      payload = universalProfile.interface.encodeFunctionData("execute", [
+    case 'TRANSFERVALUE':
+      payload = universalProfile.interface.encodeFunctionData('execute', [
         0,
         reentrancyRelayer.address,
-        ethers.utils.parseEther("1"),
-        "0x",
+        ethers.utils.parseEther('1'),
+        '0x',
       ]);
       break;
-    case "SETDATA":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
-        ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+    case 'SETDATA':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
       ]);
       break;
-    case "ADDCONTROLLER":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x0000000000000000000000000000000000000000000000000000000000000010",
+    case 'ADDCONTROLLER':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x0000000000000000000000000000000000000000000000000000000000000010',
       ]);
       break;
-    case "EDITPERMISSIONS":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x",
+    case 'EDITPERMISSIONS':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x',
       ]);
       break;
-    case "ADDUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'ADDUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
         newURDAddress,
       ]);
       break;
-    case "CHANGEUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'CHANGEUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
-        "0x",
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
+        '0x',
       ]);
       break;
     default:
-      payload = "0x";
+      payload = '0x';
       break;
   }
 
@@ -555,11 +555,11 @@ export const generateExecutePayload = (
   payloadType: string,
 ) => {
   const reentrantPayload = new LSP20ReentrantContract__factory().interface.encodeFunctionData(
-    "callThatReenters",
+    'callThatReenters',
     [keyManagerAddress, payloadType],
   );
 
-  const executePayload = new UniversalProfile__factory().interface.encodeFunctionData("execute", [
+  const executePayload = new UniversalProfile__factory().interface.encodeFunctionData('execute', [
     0,
     reentrantContractAddress,
     0,
@@ -580,10 +580,10 @@ export const loadTestCase = async (
   let permissionValues: BytesLike[];
 
   switch (payloadType) {
-    case "TRANSFERVALUE": {
+    case 'TRANSFERVALUE': {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + reentrantAddress.substring(2),
       ];
 
       permissionValues = [
@@ -593,17 +593,17 @@ export const loadTestCase = async (
               // TODO: is the call permission enough here for this test?
               [CALLTYPE.VALUE],
               [valueReceiverAddress],
-              ["0xffffffff"],
-              ["0xffffffff"],
+              ['0xffffffff'],
+              ['0xffffffff'],
             )
-          : "0x",
+          : '0x',
       ];
       break;
     }
-    case "SETDATA": {
+    case 'SETDATA': {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           reentrantAddress.substring(2),
       ];
 
@@ -611,15 +611,15 @@ export const loadTestCase = async (
         testCase.permissions,
         (testCase as SetDataTestCase).allowedERC725YDataKeys
           ? encodeCompactBytesArray([
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
             ])
-          : "0x",
+          : '0x',
       ];
       break;
     }
     default: {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
       ];
 
       permissionValues = [testCase.permissions];
@@ -627,7 +627,7 @@ export const loadTestCase = async (
   }
 
   const permissionsPayload = new UniversalProfile__factory().interface.encodeFunctionData(
-    "setDataBatch",
+    'setDataBatch',
     [permissionKeys, permissionValues],
   );
   await context.keyManager.connect(context.owner).execute(permissionsPayload);

--- a/tests/Reentrancy/LSP6/LSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP6/LSP6Reentrancy.test.ts
@@ -1,19 +1,19 @@
-import { expect } from "chai";
-import { BigNumber, ethers } from "ethers";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { expect } from 'chai';
+import { BigNumber, ethers } from 'ethers';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
-import { buildReentrancyContext } from "./reentrancyHelpers";
+import { LSP6TestContext } from '../../utils/context';
+import { buildReentrancyContext } from './reentrancyHelpers';
 
 // tests
-import { testSingleExecuteToSingleExecute } from "./SingleExecuteToSingleExecute.test";
-import { testSingleExecuteRelayCallToSingleExecute } from "./SingleExecuteRelayCallToSingleExecute.test";
-import { testSingleExecuteToSingleExecuteRelayCall } from "./SingleExecuteToSingleExecuteRelayCall.test";
-import { testSingleExecuteRelayCallToSingleExecuteRelayCall } from "./SingleExecuteRelayCallToSingleExecuteRelayCall.test";
-import { testSingleExecuteToBatchExecute } from "./SingleExecuteToBatchExecute.test";
-import { testSingleExecuteToBatchExecuteRelayCall } from "./SingleExecuteToBatchExecuteRelayCall.test";
+import { testSingleExecuteToSingleExecute } from './SingleExecuteToSingleExecute.test';
+import { testSingleExecuteRelayCallToSingleExecute } from './SingleExecuteRelayCallToSingleExecute.test';
+import { testSingleExecuteToSingleExecuteRelayCall } from './SingleExecuteToSingleExecuteRelayCall.test';
+import { testSingleExecuteRelayCallToSingleExecuteRelayCall } from './SingleExecuteRelayCallToSingleExecuteRelayCall.test';
+import { testSingleExecuteToBatchExecute } from './SingleExecuteToBatchExecute.test';
+import { testSingleExecuteToBatchExecuteRelayCall } from './SingleExecuteToBatchExecuteRelayCall.test';
 
 import {
   ALL_PERMISSIONS,
@@ -23,7 +23,7 @@ import {
   LSP6_VERSION,
   OPERATION_TYPES,
   PERMISSIONS,
-} from "../../../constants";
+} from '../../../constants';
 
 import {
   combineAllowedCalls,
@@ -32,7 +32,7 @@ import {
   encodeCompactBytesArray,
   LOCAL_PRIVATE_KEYS,
   provider,
-} from "../../utils/helpers";
+} from '../../utils/helpers';
 
 import {
   Reentrancy,
@@ -42,14 +42,14 @@ import {
   SecondToCallLSP6,
   FirstToCallLSP6,
   UniversalReceiverDelegateDataUpdater__factory,
-} from "../../../types";
+} from '../../../types';
 
-import { setupKeyManager } from "../../utils/fixtures";
+import { setupKeyManager } from '../../utils/fixtures';
 
 export const shouldBehaveLikeLSP6ReentrancyScenarios = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
-  describe("Basic Reentrancy Scenarios", () => {
+  describe('Basic Reentrancy Scenarios', () => {
     let context: LSP6TestContext;
 
     let signer: SignerWithAddress, relayer: SignerWithAddress, attacker: SignerWithAddress;
@@ -68,9 +68,9 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + context.owner.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
       ];
 
       const permissionValues = [
@@ -83,8 +83,8 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
             combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL),
           ],
           [signer.address, ethers.constants.AddressZero],
-          ["0xffffffff", "0xffffffff"],
-          ["0xffffffff", "0xffffffff"],
+          ['0xffffffff', '0xffffffff'],
+          ['0xffffffff', '0xffffffff'],
         ),
       ];
 
@@ -93,23 +93,23 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
       // Fund Universal Profile with some LYXe
       await context.owner.sendTransaction({
         to: context.universalProfile.address,
-        value: ethers.utils.parseEther("10"),
+        value: ethers.utils.parseEther('10'),
       });
     });
 
-    describe("when sending LYX to a contract", () => {
-      it("Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant receive() function.", async () => {
+    describe('when sending LYX to a contract', () => {
+      it('Permissions should prevent ReEntrancy and stop malicious contract with a re-entrant receive() function.', async () => {
         // the Universal Profile wants to send 1 x LYX from its UP to another smart contract
         // we assume the UP owner is not aware that some malicious code is present
         // in the fallback function of the target (= recipient) contract
-        let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           maliciousContract.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
-        let executePayload = context.keyManager.interface.encodeFunctionData("execute", [
+        let executePayload = context.keyManager.interface.encodeFunctionData('execute', [
           transferPayload,
         ]);
         // load the malicious payload, that will be executed in the receive function
@@ -123,8 +123,8 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         // at this point, the malicious contract receive function try to drain funds by re-entering the KeyManager
         // this should not be possible since it does not have the permission `REENTRANCY`
         await expect(context.keyManager.connect(context.owner).execute(transferPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(maliciousContract.address, "REENTRANCY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(maliciousContract.address, 'REENTRANCY');
 
         let newAccountBalance = await provider.getBalance(context.universalProfile.address);
         let newAttackerContractBalance = await provider.getBalance(maliciousContract.address);
@@ -133,24 +133,24 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         expect(newAttackerContractBalance).to.equal(initialAttackerContractBalance);
       });
 
-      describe("when calling via `executeRelayCall(...)`", () => {
+      describe('when calling via `executeRelayCall(...)`', () => {
         const channelId = 0;
 
-        it("Replay Attack should fail because of invalid nonce", async () => {
+        it('Replay Attack should fail because of invalid nonce', async () => {
           let nonce = await context.keyManager.callStatic.getNonce(signer.address, channelId);
 
           const validityTimestamps = 0;
 
           let executeRelayCallPayload = context.universalProfile.interface.encodeFunctionData(
-            "execute",
-            [OPERATION_TYPES.CALL, signer.address, ethers.utils.parseEther("1"), "0x"],
+            'execute',
+            [OPERATION_TYPES.CALL, signer.address, ethers.utils.parseEther('1'), '0x'],
           );
 
           const HARDHAT_CHAINID = 31337;
           let valueToSend = 0;
 
           let encodedMessage = ethers.utils.solidityPack(
-            ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+            ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
               LSP6_VERSION,
               HARDHAT_CHAINID,
@@ -182,45 +182,45 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
               .connect(relayer)
               .executeRelayCall(signature, nonce, validityTimestamps, executeRelayCallPayload),
           )
-            .to.be.revertedWithCustomError(context.keyManager, "InvalidRelayNonce")
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidRelayNonce')
             .withArgs(signer.address, nonce, signature);
         });
       });
     });
 
-    describe("when reentering execute function", () => {
-      it("should revert if reentered from a random address", async () => {
-        let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+    describe('when reentering execute function', () => {
+      it('should revert if reentered from a random address', async () => {
+        let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           maliciousContract.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
-        let executePayload = context.keyManager.interface.encodeFunctionData("execute", [
+        let executePayload = context.keyManager.interface.encodeFunctionData('execute', [
           transferPayload,
         ]);
 
         await maliciousContract.loadPayload(executePayload);
 
         await expect(context.keyManager.connect(context.owner).execute(transferPayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-          .withArgs(maliciousContract.address, "REENTRANCY");
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+          .withArgs(maliciousContract.address, 'REENTRANCY');
       });
 
-      it("should pass when reentered by URD and the URD has REENTRANCY permission", async () => {
+      it('should pass when reentered by URD and the URD has REENTRANCY permission', async () => {
         const URDDummy = await new Reentrancy__factory(context.owner).deploy(
           context.keyManager.address,
         );
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [
             [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                 URDDummy.address.substring(2),
-              ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
                 URDDummy.address.substring(2),
             ],
             [
@@ -229,8 +229,8 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
               combineAllowedCalls(
                 [combineCallTypes(CALLTYPE.VALUE, CALLTYPE.CALL)],
                 [URDDummy.address],
-                ["0xffffffff"],
-                ["0xffffffff"],
+                ['0xffffffff'],
+                ['0xffffffff'],
               ),
             ],
           ],
@@ -238,14 +238,14 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
 
         await context.keyManager.connect(context.owner).execute(setDataPayload);
 
-        let transferPayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        let transferPayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           URDDummy.address,
-          ethers.utils.parseEther("1"),
-          "0x",
+          ethers.utils.parseEther('1'),
+          '0x',
         ]);
 
-        let executePayload = context.keyManager.interface.encodeFunctionData("execute", [
+        let executePayload = context.keyManager.interface.encodeFunctionData('execute', [
           transferPayload,
         ]);
 
@@ -259,31 +259,31 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         let newAccountBalance = await provider.getBalance(context.universalProfile.address);
         let newAttackerContractBalance = await provider.getBalance(URDDummy.address);
 
-        expect(newAccountBalance).to.equal(initialAccountBalance.sub(ethers.utils.parseEther("2")));
+        expect(newAccountBalance).to.equal(initialAccountBalance.sub(ethers.utils.parseEther('2')));
         expect(newAttackerContractBalance).to.equal(
-          initialAttackerContractBalance.add(ethers.utils.parseEther("2")),
+          initialAttackerContractBalance.add(ethers.utils.parseEther('2')),
         );
       });
 
-      it("should allow the URD to use `setData(..)` through the LSP6", async () => {
+      it('should allow the URD to use `setData(..)` through the LSP6', async () => {
         const universalReceiverDelegateDataUpdater =
           await new UniversalReceiverDelegateDataUpdater__factory(context.owner).deploy();
 
         const randomHardcodedKey = ethers.utils.keccak256(
-          ethers.utils.toUtf8Bytes("some random data key"),
+          ethers.utils.toUtf8Bytes('some random data key'),
         );
         const randomHardcodedValue = ethers.utils.hexlify(
-          ethers.utils.toUtf8Bytes("some random text for the data value"),
+          ethers.utils.toUtf8Bytes('some random text for the data value'),
         );
 
         const setDataPayload = context.universalProfile.interface.encodeFunctionData(
-          "setDataBatch",
+          'setDataBatch',
           [
             [
               ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
-              ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                 universalReceiverDelegateDataUpdater.address.substring(2),
-              ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
                 universalReceiverDelegateDataUpdater.address.substring(2),
             ],
             [
@@ -297,15 +297,15 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         await context.keyManager.connect(context.owner).execute(setDataPayload);
 
         const universalReceiverDelegatePayload =
-          universalReceiverDelegateDataUpdater.interface.encodeFunctionData("universalReceiver", [
+          universalReceiverDelegateDataUpdater.interface.encodeFunctionData('universalReceiver', [
             LSP1_TYPE_IDS.LSP7Tokens_SenderNotification,
-            "0xcafecafecafecafe",
+            '0xcafecafecafecafe',
           ]);
 
-        const executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+        const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
           OPERATION_TYPES.CALL,
           universalReceiverDelegateDataUpdater.address,
-          ethers.utils.parseEther("0"),
+          ethers.utils.parseEther('0'),
           universalReceiverDelegatePayload,
         ]);
 
@@ -317,7 +317,7 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
       });
     });
 
-    describe("when chaining reentrancy", () => {
+    describe('when chaining reentrancy', () => {
       let firstReentrant: FirstToCallLSP6;
       let secondReentrant: SecondToCallLSP6;
 
@@ -331,11 +331,11 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         );
 
         const permissionKeys = [
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             context.owner.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             firstReentrant.address.substring(2),
-          ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+          ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             secondReentrant.address.substring(2),
         ];
 
@@ -348,27 +348,27 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
         await setupKeyManager(context, permissionKeys, permissionValues);
       });
 
-      describe("when executing reentrant calls from two different contracts", () => {
-        describe("when the firstReentrant execute its first reentrant call to the UniversalProfile successfully", () => {
-          describe("when the secondReentrant is not granted REENTRANCY Permission", () => {
-            it("shoul fail stating that the caller (secondReentrant) is not authorised (no reentrancy permission)", async () => {
-              let firstTargetSelector = firstReentrant.interface.encodeFunctionData("firstTarget");
+      describe('when executing reentrant calls from two different contracts', () => {
+        describe('when the firstReentrant execute its first reentrant call to the UniversalProfile successfully', () => {
+          describe('when the secondReentrant is not granted REENTRANCY Permission', () => {
+            it('shoul fail stating that the caller (secondReentrant) is not authorised (no reentrancy permission)', async () => {
+              let firstTargetSelector = firstReentrant.interface.encodeFunctionData('firstTarget');
 
               let payload = context.universalProfile.interface.encodeFunctionData(
-                "execute(uint256,address,uint256,bytes)",
+                'execute(uint256,address,uint256,bytes)',
                 [OPERATION_TYPES.CALL, firstReentrant.address, 0, firstTargetSelector],
               );
 
               await expect(context.keyManager.connect(context.owner).execute(payload))
-                .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
-                .withArgs(secondReentrant.address, "REENTRANCY");
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(secondReentrant.address, 'REENTRANCY');
             });
           });
 
-          describe("when the secondReentrant is granted REENTRANCY Permission", () => {
+          describe('when the secondReentrant is granted REENTRANCY Permission', () => {
             before(async () => {
               const permissionKeys = [
-                ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+                ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
                   secondReentrant.address.substring(2),
               ];
 
@@ -379,21 +379,21 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
               await setupKeyManager(context, permissionKeys, permissionValues);
             });
 
-            it("should pass and setData from the second reentrantCall on the UniversalProfile correctly", async () => {
-              let firstTargetSelector = firstReentrant.interface.encodeFunctionData("firstTarget");
+            it('should pass and setData from the second reentrantCall on the UniversalProfile correctly', async () => {
+              let firstTargetSelector = firstReentrant.interface.encodeFunctionData('firstTarget');
 
               let payload = context.universalProfile.interface.encodeFunctionData(
-                "execute(uint256,address,uint256,bytes)",
+                'execute(uint256,address,uint256,bytes)',
                 [OPERATION_TYPES.CALL, firstReentrant.address, 0, firstTargetSelector],
               );
 
               await context.keyManager.connect(context.owner).execute(payload);
 
-              let result = await context.universalProfile["getData(bytes32)"](
+              let result = await context.universalProfile['getData(bytes32)'](
                 ethers.constants.HashZero,
               );
 
-              expect(result).to.equal("0xaabbccdd");
+              expect(result).to.equal('0xaabbccdd');
             });
           });
         });
@@ -401,27 +401,27 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
     });
   });
 
-  describe("first call through `execute(bytes)`, second call through `execute(bytes)`", () => {
+  describe('first call through `execute(bytes)`, second call through `execute(bytes)`', () => {
     testSingleExecuteToSingleExecute(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `executeRelayCall(bytes,uint256,bytes)`, second call through `execute(bytes)`", () => {
+  describe('first call through `executeRelayCall(bytes,uint256,bytes)`, second call through `execute(bytes)`', () => {
     testSingleExecuteRelayCallToSingleExecute(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `execute(bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`", () => {
+  describe('first call through `execute(bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`', () => {
     testSingleExecuteToSingleExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `executeRelayCall(bytes,uint256,bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`", () => {
+  describe('first call through `executeRelayCall(bytes,uint256,bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`', () => {
     testSingleExecuteRelayCallToSingleExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`", () => {
+  describe('first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`', () => {
     testSingleExecuteToBatchExecute(buildContext, buildReentrancyContext);
   });
 
-  describe("first call through `execute(bytes)`, second call through `executeRelayCall(bytes[],uint256[],uint256[],bytes[])`", () => {
+  describe('first call through `execute(bytes)`, second call through `executeRelayCall(bytes[],uint256[],uint256[],bytes[])`', () => {
     testSingleExecuteToBatchExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 };

--- a/tests/Reentrancy/LSP6/SingleExecuteRelayCallToSingleExecute.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteRelayCallToSingleExecute.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
+import { BigNumber, BytesLike } from 'ethers';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   generateRelayCall,
   generateExecutePayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteRelayCallToSingleExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -35,11 +35,11 @@ export const testSingleExecuteRelayCallToSingleExecute = (
   let reentrancyContext: ReentrancyContext;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -50,7 +50,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
       );
 
       relayCallParams = await generateRelayCall(
@@ -64,10 +64,10 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -84,14 +84,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -107,12 +107,12 @@ export const testSingleExecuteRelayCallToSingleExecute = (
             relayCallParams.validityTimestamps,
             relayCallParams.payload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -121,7 +121,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager
         .connect(reentrancyContext.caller)
@@ -134,17 +134,17 @@ export const testSingleExecuteRelayCallToSingleExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.reentrantContract.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -155,7 +155,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "SETDATA",
+        'SETDATA',
       );
 
       relayCallParams = await generateRelayCall(
@@ -169,10 +169,10 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -189,14 +189,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -212,12 +212,12 @@ export const testSingleExecuteRelayCallToSingleExecute = (
             relayCallParams.validityTimestamps,
             relayCallParams.payload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -233,14 +233,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
           relayCallParams.payload,
         );
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -251,7 +251,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
       );
 
       relayCallParams = await generateRelayCall(
@@ -264,7 +264,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -281,14 +281,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -305,10 +305,10 @@ export const testSingleExecuteRelayCallToSingleExecute = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -316,7 +316,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -327,7 +327,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
       );
 
       relayCallParams = await generateRelayCall(
@@ -340,7 +340,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -357,14 +357,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -381,9 +381,9 @@ export const testSingleExecuteRelayCallToSingleExecute = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -391,7 +391,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -402,7 +402,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
       );
 
       relayCallParams = await generateRelayCall(
@@ -415,7 +415,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -432,14 +432,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -467,7 +467,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -478,7 +478,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
       const executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
       );
 
       relayCallParams = await generateRelayCall(
@@ -491,7 +491,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -508,14 +508,14 @@ export const testSingleExecuteRelayCallToSingleExecute = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -535,7 +535,7 @@ export const testSingleExecuteRelayCallToSingleExecute = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/SingleExecuteRelayCallToSingleExecuteRelayCall.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteRelayCallToSingleExecuteRelayCall.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
-import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from "../../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -26,7 +26,7 @@ import {
   generateRelayCall,
   generateSingleRelayPayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -37,14 +37,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
   let executePayload: BytesLike;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
 
     const reentrantCallPayload =
-      new SingleReentrancyRelayer__factory().interface.encodeFunctionData("relayCallThatReenters", [
+      new SingleReentrancyRelayer__factory().interface.encodeFunctionData('relayCallThatReenters', [
         context.keyManager.address,
       ]);
-    executePayload = new UniversalProfile__factory().interface.encodeFunctionData("execute", [
+    executePayload = new UniversalProfile__factory().interface.encodeFunctionData('execute', [
       0,
       reentrancyContext.singleReentarncyRelayer.address,
       0,
@@ -52,7 +52,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     ]);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -69,7 +69,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -81,10 +81,10 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -101,14 +101,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -124,12 +124,12 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
             relayCallParams.validityTimestamps,
             relayCallParams.payload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -138,7 +138,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager
         .connect(reentrancyContext.caller)
@@ -151,17 +151,17 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.singleReentarncyRelayer.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -178,7 +178,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "SETDATA",
+        'SETDATA',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -190,10 +190,10 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -210,14 +210,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -233,12 +233,12 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
             relayCallParams.validityTimestamps,
             relayCallParams.payload,
           ),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -254,14 +254,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
           relayCallParams.payload,
         );
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -278,7 +278,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -289,7 +289,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -306,14 +306,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -330,10 +330,10 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -341,7 +341,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -358,7 +358,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -369,7 +369,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -386,14 +386,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -410,9 +410,9 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
         );
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -420,7 +420,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -437,7 +437,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -448,7 +448,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -465,14 +465,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -500,7 +500,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let relayCallParams: {
       signature: BytesLike;
       nonce: BigNumber;
@@ -517,7 +517,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -528,7 +528,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -545,14 +545,14 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
               relayCallParams.payload,
             ),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -572,7 +572,7 @@ export const testSingleExecuteRelayCallToSingleExecuteRelayCall = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/SingleExecuteToBatchExecute.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteToBatchExecute.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
+import { BigNumber, BytesLike } from 'ethers';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -24,7 +24,7 @@ import {
   // Functions
   generateExecutePayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteToBatchExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -34,17 +34,17 @@ export const testSingleExecuteToBatchExecute = (
   let reentrancyContext: ReentrancyContext;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
       );
     });
 
@@ -52,10 +52,10 @@ export const testSingleExecuteToBatchExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -65,14 +65,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -81,12 +81,12 @@ export const testSingleExecuteToBatchExecute = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -95,7 +95,7 @@ export const testSingleExecuteToBatchExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager
         .connect(reentrancyContext.caller)
@@ -103,23 +103,23 @@ export const testSingleExecuteToBatchExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.reentrantContract.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "SETDATA",
+        'SETDATA',
       );
     });
 
@@ -127,10 +127,10 @@ export const testSingleExecuteToBatchExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -140,14 +140,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -156,12 +156,12 @@ export const testSingleExecuteToBatchExecute = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -172,27 +172,27 @@ export const testSingleExecuteToBatchExecute = (
         .connect(reentrancyContext.caller)
         .executeBatch([0], [executePayload]);
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
       );
     });
 
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -202,14 +202,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -221,10 +221,10 @@ export const testSingleExecuteToBatchExecute = (
         .executeBatch([0], [executePayload]);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -232,20 +232,20 @@ export const testSingleExecuteToBatchExecute = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
       );
     });
 
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -255,14 +255,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -274,9 +274,9 @@ export const testSingleExecuteToBatchExecute = (
         .executeBatch([0], [executePayload]);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -284,20 +284,20 @@ export const testSingleExecuteToBatchExecute = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
       );
     });
 
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -307,14 +307,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -337,20 +337,20 @@ export const testSingleExecuteToBatchExecute = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
       );
     });
 
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -360,14 +360,14 @@ export const testSingleExecuteToBatchExecute = (
         await expect(
           context.keyManager.connect(reentrancyContext.caller).executeBatch([0], [executePayload]),
         )
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -382,7 +382,7 @@ export const testSingleExecuteToBatchExecute = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/SingleExecuteToBatchExecuteRelayCall.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteToBatchExecuteRelayCall.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
-import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from "../../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   // Functions
   generateBatchRelayPayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteToBatchExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -36,14 +36,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
   let executePayload: BytesLike;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
 
     const reentrantCallPayload =
-      new SingleReentrancyRelayer__factory().interface.encodeFunctionData("relayCallThatReenters", [
+      new SingleReentrancyRelayer__factory().interface.encodeFunctionData('relayCallThatReenters', [
         context.keyManager.address,
       ]);
-    executePayload = new UniversalProfile__factory().interface.encodeFunctionData("execute", [
+    executePayload = new UniversalProfile__factory().interface.encodeFunctionData('execute', [
       0,
       reentrancyContext.batchReentarncyRelayer.address,
       0,
@@ -51,12 +51,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     ]);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -68,10 +68,10 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -79,14 +79,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -95,12 +95,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -109,28 +109,28 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.batchReentarncyRelayer.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "SETDATA",
+        'SETDATA',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -142,10 +142,10 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -153,14 +153,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -169,12 +169,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -183,19 +183,19 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -206,7 +206,7 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -214,14 +214,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -231,10 +231,10 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -242,12 +242,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -258,7 +258,7 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -266,14 +266,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -283,9 +283,9 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -293,12 +293,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -309,7 +309,7 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -317,14 +317,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -345,12 +345,12 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     before(async () => {
       await generateBatchRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.batchReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -361,7 +361,7 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -369,14 +369,14 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -389,7 +389,7 @@ export const testSingleExecuteToBatchExecuteRelayCall = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/SingleExecuteToSingleExecute.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteToSingleExecute.test.ts
@@ -1,14 +1,14 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
+import { BigNumber, BytesLike } from 'ethers';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -24,7 +24,7 @@ import {
   // Functions
   generateExecutePayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteToSingleExecute = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -34,17 +34,17 @@ export const testSingleExecuteToSingleExecute = (
   let reentrancyContext: ReentrancyContext;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
       );
     });
 
@@ -52,10 +52,10 @@ export const testSingleExecuteToSingleExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -63,14 +63,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -79,12 +79,12 @@ export const testSingleExecuteToSingleExecute = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -93,29 +93,29 @@ export const testSingleExecuteToSingleExecute = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.reentrantContract.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "SETDATA",
+        'SETDATA',
       );
     });
 
@@ -123,10 +123,10 @@ export const testSingleExecuteToSingleExecute = (
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -134,14 +134,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant contract has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantContract.address,
@@ -150,12 +150,12 @@ export const testSingleExecuteToSingleExecute = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -164,27 +164,27 @@ export const testSingleExecuteToSingleExecute = (
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
       );
     });
 
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -192,14 +192,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -209,10 +209,10 @@ export const testSingleExecuteToSingleExecute = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -220,20 +220,20 @@ export const testSingleExecuteToSingleExecute = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
       );
     });
 
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -241,14 +241,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -258,9 +258,9 @@ export const testSingleExecuteToSingleExecute = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -268,20 +268,20 @@ export const testSingleExecuteToSingleExecute = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
       );
     });
 
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -289,14 +289,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -317,20 +317,20 @@ export const testSingleExecuteToSingleExecute = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     let executePayload: BytesLike;
     before(async () => {
       executePayload = generateExecutePayload(
         context.keyManager.address,
         reentrancyContext.reentrantContract.address,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
       );
     });
 
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant contract has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantContract.address,
@@ -338,14 +338,14 @@ export const testSingleExecuteToSingleExecute = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantContract.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant contract has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantContract.address,
@@ -358,7 +358,7 @@ export const testSingleExecuteToSingleExecute = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/SingleExecuteToSingleExecuteRelayCall.test.ts
+++ b/tests/Reentrancy/LSP6/SingleExecuteToSingleExecuteRelayCall.test.ts
@@ -1,15 +1,15 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
 
 //types
-import { BigNumber, BytesLike } from "ethers";
-import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from "../../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { SingleReentrancyRelayer__factory, UniversalProfile__factory } from '../../../types';
 
 // constants
-import { ERC725YDataKeys } from "../../../constants";
+import { ERC725YDataKeys } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -25,7 +25,7 @@ import {
   // Functions
   generateSingleRelayPayload,
   loadTestCase,
-} from "./reentrancyHelpers";
+} from './reentrancyHelpers';
 
 export const testSingleExecuteToSingleExecuteRelayCall = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
@@ -36,14 +36,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
   let executePayload: BytesLike;
 
   before(async () => {
-    context = await buildContext(ethers.utils.parseEther("10"));
+    context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
 
     const reentrantCallPayload =
-      new SingleReentrancyRelayer__factory().interface.encodeFunctionData("relayCallThatReenters", [
+      new SingleReentrancyRelayer__factory().interface.encodeFunctionData('relayCallThatReenters', [
         context.keyManager.address,
       ]);
-    executePayload = new UniversalProfile__factory().interface.encodeFunctionData("execute", [
+    executePayload = new UniversalProfile__factory().interface.encodeFunctionData('execute', [
       0,
       reentrancyContext.singleReentarncyRelayer.address,
       0,
@@ -51,12 +51,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     ]);
   });
 
-  describe("when reentering and transferring value", () => {
+  describe('when reentering and transferring value', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -68,10 +68,10 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedCalls - ${
-        testCase.allowedCalls ? "YES" : "NO"
+        testCase.allowedCalls ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "TRANSFERVALUE",
+          'TRANSFERVALUE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -79,14 +79,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & NO AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.NoCallsAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -95,12 +95,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoCallsAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoCallsAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, TRANSFERVALUE & AllowedCalls', async () => {
       await loadTestCase(
-        "TRANSFERVALUE",
+        'TRANSFERVALUE',
         transferValueTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -109,28 +109,28 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("10"));
+      ).to.equal(ethers.utils.parseEther('10'));
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       expect(
         await context.universalProfile.provider.getBalance(context.universalProfile.address),
-      ).to.equal(ethers.utils.parseEther("9"));
+      ).to.equal(ethers.utils.parseEther('9'));
 
       expect(
         await context.universalProfile.provider.getBalance(
           reentrancyContext.singleReentarncyRelayer.address,
         ),
-      ).to.equal(ethers.utils.parseEther("1"));
+      ).to.equal(ethers.utils.parseEther('1'));
     });
   });
 
-  describe("when reentering and setting data", () => {
+  describe('when reentering and setting data', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "SETDATA",
+        'SETDATA',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -142,10 +142,10 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${
         testCase.permissionsText
       }; MISSING - ${testCase.missingPermission}; AllowedERC725YDataKeys - ${
-        testCase.allowedERC725YDataKeys ? "YES" : "NO"
+        testCase.allowedERC725YDataKeys ? 'YES' : 'NO'
       }`, async () => {
         await loadTestCase(
-          "SETDATA",
+          'SETDATA',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -153,14 +153,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys", async () => {
+    it('should revert if the reentrant signer has the following permissions: REENTRANCY, SETDATA & NO AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.NoERC725YDataKeysAllowed,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -169,12 +169,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
 
       await expect(
         context.keyManager.connect(reentrancyContext.caller).execute(executePayload),
-      ).to.be.revertedWithCustomError(context.keyManager, "NoERC725YDataKeysAllowed");
+      ).to.be.revertedWithCustomError(context.keyManager, 'NoERC725YDataKeysAllowed');
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, SETDATA & AllowedERC725YDataKeys', async () => {
       await loadTestCase(
-        "SETDATA",
+        'SETDATA',
         setDataTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -183,19 +183,19 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
 
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
-      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
-      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed"));
+      const hardcodedKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
+      const hardcodedValue = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed'));
 
       expect(await context.universalProfile.getData(hardcodedKey)).to.equal(hardcodedValue);
     });
   });
 
-  describe("when reentering and adding permissions", () => {
+  describe('when reentering and adding permissions', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -206,7 +206,7 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     addPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDCONTROLLER",
+          'ADDCONTROLLER',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -214,14 +214,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDCONTROLLER', async () => {
       await loadTestCase(
-        "ADDCONTROLLER",
+        'ADDCONTROLLER',
         addPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -231,10 +231,10 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
       const hardcodedPermissionValue =
-        "0x0000000000000000000000000000000000000000000000000000000000000010";
+        '0x0000000000000000000000000000000000000000000000000000000000000010';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -242,12 +242,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing permissions", () => {
+  describe('when reentering and changing permissions', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -258,7 +258,7 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     editPermissionsTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "EDITPERMISSIONS",
+          'EDITPERMISSIONS',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -266,14 +266,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, EDITPERMISSIONS', async () => {
       await loadTestCase(
-        "EDITPERMISSIONS",
+        'EDITPERMISSIONS',
         editPermissionsTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -283,9 +283,9 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
       await context.keyManager.connect(reentrancyContext.caller).execute(executePayload);
 
       const hardcodedPermissionKey =
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         reentrancyContext.newControllerAddress.substring(2);
-      const hardcodedPermissionValue = "0x";
+      const hardcodedPermissionValue = '0x';
 
       expect(await context.universalProfile.getData(hardcodedPermissionKey)).to.equal(
         hardcodedPermissionValue,
@@ -293,12 +293,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and adding URD", () => {
+  describe('when reentering and adding URD', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -309,7 +309,7 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     addUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "ADDUNIVERSALRECEIVERDELEGATE",
+          'ADDUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -317,14 +317,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "ADDUNIVERSALRECEIVERDELEGATE",
+        'ADDUNIVERSALRECEIVERDELEGATE',
         addUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -345,12 +345,12 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     });
   });
 
-  describe("when reentering and changing URD", () => {
+  describe('when reentering and changing URD', () => {
     before(async () => {
       await generateSingleRelayPayload(
         context.universalProfile,
         context.keyManager,
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         reentrancyContext.singleReentarncyRelayer,
         reentrancyContext.reentrantSigner,
         reentrancyContext.newControllerAddress,
@@ -361,7 +361,7 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
     changeUniversalReceiverDelegateTestCases.NotAuthorised.forEach((testCase) => {
       it(`should revert if the reentrant signer has the following permission set: PRESENT - ${testCase.permissionsText}; MISSING - ${testCase.missingPermission};`, async () => {
         await loadTestCase(
-          "CHANGEUNIVERSALRECEIVERDELEGATE",
+          'CHANGEUNIVERSALRECEIVERDELEGATE',
           testCase,
           context,
           reentrancyContext.reentrantSigner.address,
@@ -369,14 +369,14 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         );
 
         await expect(context.keyManager.connect(reentrancyContext.caller).execute(executePayload))
-          .to.be.revertedWithCustomError(context.keyManager, "NotAuthorised")
+          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
           .withArgs(reentrancyContext.reentrantSigner.address, testCase.missingPermission);
       });
     });
 
-    it("should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE", async () => {
+    it('should pass if the reentrant signer has the following permissions: REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE', async () => {
       await loadTestCase(
-        "CHANGEUNIVERSALRECEIVERDELEGATE",
+        'CHANGEUNIVERSALRECEIVERDELEGATE',
         changeUniversalReceiverDelegateTestCases.ValidCase,
         context,
         reentrancyContext.reentrantSigner.address,
@@ -389,7 +389,7 @@ export const testSingleExecuteToSingleExecuteRelayCall = (
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
         reentrancyContext.randomLSP1TypeId.substring(2, 42);
 
-      const hardcodedLSP1Value = "0x";
+      const hardcodedLSP1Value = '0x';
 
       expect(await context.universalProfile.getData(hardcodedLSP1Key)).to.equal(
         hardcodedLSP1Value.toLowerCase(),

--- a/tests/Reentrancy/LSP6/reentrancyHelpers.ts
+++ b/tests/Reentrancy/LSP6/reentrancyHelpers.ts
@@ -1,8 +1,8 @@
-import { ethers } from "hardhat";
+import { ethers } from 'hardhat';
 
 //types
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber, BytesLike, Wallet } from "ethers";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { BigNumber, BytesLike, Wallet } from 'ethers';
 import {
   ReentrantContract__factory,
   ReentrantContract,
@@ -13,13 +13,13 @@ import {
   SingleReentrancyRelayer__factory,
   BatchReentrancyRelayer__factory,
   UniversalProfile__factory,
-} from "../../../types";
+} from '../../../types';
 
 // constants
-import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, CALLTYPE } from "../../../constants";
+import { ERC725YDataKeys, ALL_PERMISSIONS, PERMISSIONS, CALLTYPE } from '../../../constants';
 
 // setup
-import { LSP6TestContext } from "../../utils/context";
+import { LSP6TestContext } from '../../utils/context';
 
 // helpers
 import {
@@ -28,8 +28,8 @@ import {
   LOCAL_PRIVATE_KEYS,
   signLSP6ExecuteRelayCall,
   encodeCompactBytesArray,
-} from "../../utils/helpers";
-import { setupKeyManager } from "../../utils/fixtures";
+} from '../../utils/helpers';
+import { setupKeyManager } from '../../utils/fixtures';
 
 // Complex permission as it has AllowedCalls
 export type TransferValueTestCase = {
@@ -70,232 +70,232 @@ export type ReentrancyContext = {
 export const transferValueTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedCalls: false,
-      missingPermission: "TRANSFERVALUE",
+      missingPermission: 'TRANSFERVALUE',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedCalls: true,
-      missingPermission: "TRANSFERVALUE",
+      missingPermission: 'TRANSFERVALUE',
     },
     {
-      permissionsText: "TRANSFERVALUE",
+      permissionsText: 'TRANSFERVALUE',
       permissions: PERMISSIONS.TRANSFERVALUE,
       allowedCalls: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "TRANSFERVALUE",
+      permissionsText: 'TRANSFERVALUE',
       permissions: PERMISSIONS.TRANSFERVALUE,
       allowedCalls: true,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   NoCallsAllowed: {
-    permissionsText: "REENTRANCY, TRANSFERVALUE",
+    permissionsText: 'REENTRANCY, TRANSFERVALUE',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.TRANSFERVALUE),
     allowedCalls: false,
-    missingPermission: "",
+    missingPermission: '',
   },
   ValidCase: {
-    permissionsText: "REENTRANCY, TRANSFERVALUE",
+    permissionsText: 'REENTRANCY, TRANSFERVALUE',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.TRANSFERVALUE),
     allowedCalls: true,
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const setDataTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedERC725YDataKeys: false,
-      missingPermission: "SETDATA",
+      missingPermission: 'SETDATA',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
       allowedERC725YDataKeys: true,
-      missingPermission: "SETDATA",
+      missingPermission: 'SETDATA',
     },
     {
-      permissionsText: "SETDATA",
+      permissionsText: 'SETDATA',
       permissions: PERMISSIONS.SETDATA,
       allowedERC725YDataKeys: false,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "SETDATA",
+      permissionsText: 'SETDATA',
       permissions: PERMISSIONS.SETDATA,
       allowedERC725YDataKeys: true,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   NoERC725YDataKeysAllowed: {
-    permissionsText: "REENTRANCY, SETDATA",
+    permissionsText: 'REENTRANCY, SETDATA',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.SETDATA),
     allowedERC725YDataKeys: false,
-    missingPermission: "",
+    missingPermission: '',
   },
   ValidCase: {
-    permissionsText: "REENTRANCY, SETDATA",
+    permissionsText: 'REENTRANCY, SETDATA',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.SETDATA),
     allowedERC725YDataKeys: true,
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const addPermissionsTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "ADDCONTROLLER",
+      missingPermission: 'ADDCONTROLLER',
     },
     {
-      permissionsText: "ADDCONTROLLER",
+      permissionsText: 'ADDCONTROLLER',
       permissions: PERMISSIONS.ADDCONTROLLER,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, ADDCONTROLLER",
+    permissionsText: 'REENTRANCY, ADDCONTROLLER',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.ADDCONTROLLER),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const editPermissionsTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "EDITPERMISSIONS",
+      missingPermission: 'EDITPERMISSIONS',
     },
     {
-      permissionsText: "EDITPERMISSIONS",
+      permissionsText: 'EDITPERMISSIONS',
       permissions: PERMISSIONS.EDITPERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, EDITPERMISSIONS",
+    permissionsText: 'REENTRANCY, EDITPERMISSIONS',
     permissions: combinePermissions(PERMISSIONS.REENTRANCY, PERMISSIONS.EDITPERMISSIONS),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const addUniversalReceiverDelegateTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "ADDUNIVERSALRECEIVERDELEGATE",
+      missingPermission: 'ADDUNIVERSALRECEIVERDELEGATE',
     },
     {
-      permissionsText: "ADDUNIVERSALRECEIVERDELEGATE",
+      permissionsText: 'ADDUNIVERSALRECEIVERDELEGATE',
       permissions: PERMISSIONS.ADDUNIVERSALRECEIVERDELEGATE,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE",
+    permissionsText: 'REENTRANCY, ADDUNIVERSALRECEIVERDELEGATE',
     permissions: combinePermissions(
       PERMISSIONS.REENTRANCY,
       PERMISSIONS.ADDUNIVERSALRECEIVERDELEGATE,
     ),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
 export const changeUniversalReceiverDelegateTestCases = {
   NotAuthorised: [
     {
-      permissionsText: "NO Permissions",
-      permissions: "0x",
-      missingPermission: "REENTRANCY",
+      permissionsText: 'NO Permissions',
+      permissions: '0x',
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "ALL_PERMISSIONS",
+      permissionsText: 'ALL_PERMISSIONS',
       permissions: ALL_PERMISSIONS,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
     {
-      permissionsText: "REENTRANCY",
+      permissionsText: 'REENTRANCY',
       permissions: PERMISSIONS.REENTRANCY,
-      missingPermission: "CHANGEUNIVERSALRECEIVERDELEGATE",
+      missingPermission: 'CHANGEUNIVERSALRECEIVERDELEGATE',
     },
     {
-      permissionsText: "CHANGEUNIVERSALRECEIVERDELEGATE",
+      permissionsText: 'CHANGEUNIVERSALRECEIVERDELEGATE',
       permissions: PERMISSIONS.CHANGEUNIVERSALRECEIVERDELEGATE,
-      missingPermission: "REENTRANCY",
+      missingPermission: 'REENTRANCY',
     },
   ],
   ValidCase: {
-    permissionsText: "REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE",
+    permissionsText: 'REENTRANCY, CHANGEUNIVERSALRECEIVERDELEGATE',
     permissions: combinePermissions(
       PERMISSIONS.REENTRANCY,
       PERMISSIONS.CHANGEUNIVERSALRECEIVERDELEGATE,
     ),
-    missingPermission: "",
+    missingPermission: '',
   },
 };
 
@@ -308,7 +308,7 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
 
   const reentrantContract = await new ReentrantContract__factory(owner).deploy(
     newControllerAddress,
-    ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")),
+    ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')),
     newURDAddress,
   );
 
@@ -318,11 +318,11 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
   const batchReentarncyRelayer = await new BatchReentrancyRelayer__factory(owner).deploy();
 
   const permissionKeys = [
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + owner.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + caller.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + caller.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + signer.address.substring(2),
-    ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + signer.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + owner.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + caller.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + caller.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
+    ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
   ];
 
   const permissionValues = [
@@ -332,22 +332,22 @@ export const buildReentrancyContext = async (context: LSP6TestContext) => {
       // allow controller to call the 3 x addresses listed below
       [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
       [reentrantContract.address, singleReentarncyRelayer.address, batchReentarncyRelayer.address],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
     ),
     PERMISSIONS.CALL,
     combineAllowedCalls(
       // allow controller to call the 3 x addresses listed below
       [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
       [reentrantContract.address, singleReentarncyRelayer.address, batchReentarncyRelayer.address],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
-      ["0xffffffff", "0xffffffff", "0xffffffff"],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
+      ['0xffffffff', '0xffffffff', '0xffffffff'],
     ),
   ];
 
   await setupKeyManager(context, permissionKeys, permissionValues);
 
-  const randomLSP1TypeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId"));
+  const randomLSP1TypeId = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId'));
 
   return {
     owner,
@@ -408,48 +408,48 @@ export const generateSingleRelayPayload = async (
 ) => {
   let payload: BytesLike;
   switch (payloadType) {
-    case "TRANSFERVALUE":
-      payload = universalProfile.interface.encodeFunctionData("execute", [
+    case 'TRANSFERVALUE':
+      payload = universalProfile.interface.encodeFunctionData('execute', [
         0,
         reentrancyRelayer.address,
-        ethers.utils.parseEther("1"),
-        "0x",
+        ethers.utils.parseEther('1'),
+        '0x',
       ]);
       break;
-    case "SETDATA":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
-        ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+    case 'SETDATA':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
       ]);
       break;
-    case "ADDCONTROLLER":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x0000000000000000000000000000000000000000000000000000000000000010",
+    case 'ADDCONTROLLER':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x0000000000000000000000000000000000000000000000000000000000000010',
       ]);
       break;
-    case "EDITPERMISSIONS":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x",
+    case 'EDITPERMISSIONS':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x',
       ]);
       break;
-    case "ADDUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'ADDUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
         newURDAddress,
       ]);
       break;
-    case "CHANGEUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'CHANGEUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
-        "0x",
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
+        '0x',
       ]);
       break;
     default:
-      payload = "0x";
+      payload = '0x';
       break;
   }
 
@@ -481,48 +481,48 @@ export const generateBatchRelayPayload = async (
 ) => {
   let payload: BytesLike;
   switch (payloadType) {
-    case "TRANSFERVALUE":
-      payload = universalProfile.interface.encodeFunctionData("execute", [
+    case 'TRANSFERVALUE':
+      payload = universalProfile.interface.encodeFunctionData('execute', [
         0,
         reentrancyRelayer.address,
-        ethers.utils.parseEther("1"),
-        "0x",
+        ethers.utils.parseEther('1'),
+        '0x',
       ]);
       break;
-    case "SETDATA":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
-        ethers.utils.hexlify(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+    case 'SETDATA':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
+        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
       ]);
       break;
-    case "ADDCONTROLLER":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x0000000000000000000000000000000000000000000000000000000000000010",
+    case 'ADDCONTROLLER':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x0000000000000000000000000000000000000000000000000000000000000010',
       ]);
       break;
-    case "EDITPERMISSIONS":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + newControllerAddress.substring(2),
-        "0x",
+    case 'EDITPERMISSIONS':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + newControllerAddress.substring(2),
+        '0x',
       ]);
       break;
-    case "ADDUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'ADDUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
         newURDAddress,
       ]);
       break;
-    case "CHANGEUNIVERSALRECEIVERDELEGATE":
-      payload = universalProfile.interface.encodeFunctionData("setData", [
+    case 'CHANGEUNIVERSALRECEIVERDELEGATE':
+      payload = universalProfile.interface.encodeFunctionData('setData', [
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegatePrefix +
-          ethers.utils.keccak256(ethers.utils.toUtf8Bytes("RandomLSP1TypeId")).substring(2, 42),
-        "0x",
+          ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomLSP1TypeId')).substring(2, 42),
+        '0x',
       ]);
       break;
     default:
-      payload = "0x";
+      payload = '0x';
       break;
   }
 
@@ -555,11 +555,11 @@ export const generateExecutePayload = (
   payloadType: string,
 ) => {
   const reentrantPayload = new ReentrantContract__factory().interface.encodeFunctionData(
-    "callThatReenters",
+    'callThatReenters',
     [keyManagerAddress, payloadType],
   );
 
-  const executePayload = new UniversalProfile__factory().interface.encodeFunctionData("execute", [
+  const executePayload = new UniversalProfile__factory().interface.encodeFunctionData('execute', [
     0,
     reentrantContractAddress,
     0,
@@ -580,10 +580,10 @@ export const loadTestCase = async (
   let permissionValues: BytesLike[];
 
   switch (payloadType) {
-    case "TRANSFERVALUE": {
+    case 'TRANSFERVALUE': {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedCalls"] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + reentrantAddress.substring(2),
       ];
 
       permissionValues = [
@@ -593,17 +593,17 @@ export const loadTestCase = async (
               // TODO: is the call permission enough here for this test?
               [CALLTYPE.VALUE],
               [valueReceiverAddress],
-              ["0xffffffff"],
-              ["0xffffffff"],
+              ['0xffffffff'],
+              ['0xffffffff'],
             )
-          : "0x",
+          : '0x',
       ];
       break;
     }
-    case "SETDATA": {
+    case 'SETDATA': {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:AllowedERC725YDataKeys"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
           reentrantAddress.substring(2),
       ];
 
@@ -611,15 +611,15 @@ export const loadTestCase = async (
         testCase.permissions,
         (testCase as SetDataTestCase).allowedERC725YDataKeys
           ? encodeCompactBytesArray([
-              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("SomeRandomTextUsed")),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('SomeRandomTextUsed')),
             ])
-          : "0x",
+          : '0x',
       ];
       break;
     }
     default: {
       permissionKeys = [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + reentrantAddress.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + reentrantAddress.substring(2),
       ];
 
       permissionValues = [testCase.permissions];
@@ -627,7 +627,7 @@ export const loadTestCase = async (
   }
 
   const permissionsPayload = new UniversalProfile__factory().interface.encodeFunctionData(
-    "setDataBatch",
+    'setDataBatch',
     [permissionKeys, permissionValues],
   );
   await context.keyManager.connect(context.owner).execute(permissionsPayload);

--- a/tests/Reentrancy/Reentrancy.test.ts
+++ b/tests/Reentrancy/Reentrancy.test.ts
@@ -1,14 +1,14 @@
-import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
 
-import { UniversalProfile__factory, LSP6KeyManager__factory } from "../../types";
+import { UniversalProfile__factory, LSP6KeyManager__factory } from '../../types';
 
-import { LSP6TestContext } from "../utils/context";
+import { LSP6TestContext } from '../utils/context';
 
-import { shouldBehaveLikeLSP6ReentrancyScenarios } from "./LSP6/LSP6Reentrancy.test";
-import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from "./LSP20/LSP20WithLSP6Reentrancy.test";
+import { shouldBehaveLikeLSP6ReentrancyScenarios } from './LSP6/LSP6Reentrancy.test';
+import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from './LSP20/LSP20WithLSP6Reentrancy.test';
 
-describe("Reentrancy scenarios with constructor", () => {
+describe('Reentrancy scenarios with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
     const owner = accounts[0];
@@ -22,11 +22,11 @@ describe("Reentrancy scenarios with constructor", () => {
     return { accounts, owner, universalProfile, keyManager, initialFunding };
   };
 
-  describe("when testing Reentrancy scenarios for LSP6", () => {
+  describe('when testing Reentrancy scenarios for LSP6', () => {
     shouldBehaveLikeLSP6ReentrancyScenarios(buildTestContext);
   });
 
-  describe("when testing Reentrancy scenarios for LSP20 + LSP6", () => {
+  describe('when testing Reentrancy scenarios for LSP20 + LSP6', () => {
     shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios(buildTestContext);
   });
 });

--- a/tests/Reentrancy/ReentrancyInit.test.ts
+++ b/tests/Reentrancy/ReentrancyInit.test.ts
@@ -1,15 +1,15 @@
-import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
 
-import { UniversalProfileInit__factory, LSP6KeyManagerInit__factory } from "../../types";
+import { UniversalProfileInit__factory, LSP6KeyManagerInit__factory } from '../../types';
 
-import { deployProxy } from "../utils/fixtures";
-import { LSP6TestContext } from "../utils/context";
+import { deployProxy } from '../utils/fixtures';
+import { LSP6TestContext } from '../utils/context';
 
-import { shouldBehaveLikeLSP6ReentrancyScenarios } from "./LSP6/LSP6Reentrancy.test";
-import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from "./LSP20/LSP20WithLSP6Reentrancy.test";
+import { shouldBehaveLikeLSP6ReentrancyScenarios } from './LSP6/LSP6Reentrancy.test';
+import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from './LSP20/LSP20WithLSP6Reentrancy.test';
 
-describe("Reentrancy scenarios with proxy", () => {
+describe('Reentrancy scenarios with proxy', () => {
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
     const owner = accounts[0];
@@ -26,16 +26,16 @@ describe("Reentrancy scenarios with proxy", () => {
   };
 
   const initializeProxies = async (context: LSP6TestContext) => {
-    await context.universalProfile["initialize(address)"](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.owner.address, {
       value: context.initialFunding,
     });
 
-    await context.keyManager["initialize(address)"](context.universalProfile.address);
+    await context.keyManager['initialize(address)'](context.universalProfile.address);
 
     return context;
   };
 
-  describe("when testing Reentrancy scenarios for LSP6", () => {
+  describe('when testing Reentrancy scenarios for LSP6', () => {
     shouldBehaveLikeLSP6ReentrancyScenarios(async (initialFunding?: BigNumber) => {
       let context = await buildProxyTestContext(initialFunding);
       await initializeProxies(context);
@@ -43,7 +43,7 @@ describe("Reentrancy scenarios with proxy", () => {
     });
   });
 
-  describe("when testing Reentrancy scenarios for LSP20 + LSP6", () => {
+  describe('when testing Reentrancy scenarios for LSP20 + LSP6', () => {
     shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios(async (initialFunding?: BigNumber) => {
       let context = await buildProxyTestContext(initialFunding);
       await initializeProxies(context);

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -1,16 +1,16 @@
-import { expect } from "chai";
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // types
 import {
   UniversalProfile,
   GenericExecutor__factory,
   ERC1271MaliciousMock__factory,
-} from "../types";
+} from '../types';
 
 // helpers
-import { getRandomAddresses } from "./utils/helpers";
+import { getRandomAddresses } from './utils/helpers';
 
 // constants
 import {
@@ -19,7 +19,7 @@ import {
   INTERFACE_IDS,
   OPERATION_TYPES,
   SupportedStandards,
-} from "../constants";
+} from '../constants';
 
 export type LSP3TestContext = {
   accounts: SignerWithAddress[];
@@ -36,14 +36,14 @@ export const shouldBehaveLikeLSP3 = (
     context = await buildContext(100);
   });
 
-  describe("when using `isValidSignature()` from ERC1271", () => {
+  describe('when using `isValidSignature()` from ERC1271', () => {
     afterEach(async () => {
       context = await buildContext(100);
     });
-    it("should verify signature from owner", async () => {
+    it('should verify signature from owner', async () => {
       const signer = context.deployParams.owner;
 
-      const dataToSign = "0xcafecafe";
+      const dataToSign = '0xcafecafe';
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
@@ -51,10 +51,10 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
     });
 
-    it("should return fail value when verifying signature from non-owner", async () => {
+    it('should return fail value when verifying signature from non-owner', async () => {
       const signer = context.accounts[1];
 
-      const dataToSign = "0xcafecafe";
+      const dataToSign = '0xcafecafe';
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
@@ -72,11 +72,11 @@ export const shouldBehaveLikeLSP3 = (
         .transferOwnership(genericExecutor.address);
 
       const acceptOwnershipPayload =
-        context.universalProfile.interface.encodeFunctionData("acceptOwnership");
+        context.universalProfile.interface.encodeFunctionData('acceptOwnership');
 
       await genericExecutor.call(context.universalProfile.address, 0, acceptOwnershipPayload);
 
-      const dataToSign = "0xcafecafe";
+      const dataToSign = '0xcafecafe';
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
@@ -96,7 +96,7 @@ export const shouldBehaveLikeLSP3 = (
         .transferOwnership(maliciousERC1271Wallet.address);
 
       const acceptOwnershipPayload =
-        context.universalProfile.interface.encodeFunctionData("acceptOwnership");
+        context.universalProfile.interface.encodeFunctionData('acceptOwnership');
 
       await maliciousERC1271Wallet.call(
         context.universalProfile.address,
@@ -104,7 +104,7 @@ export const shouldBehaveLikeLSP3 = (
         acceptOwnershipPayload,
       );
 
-      const dataToSign = "0xcafecafe";
+      const dataToSign = '0xcafecafe';
       const messageHash = ethers.utils.hashMessage(dataToSign);
       const signature = await signer.signMessage(dataToSign);
 
@@ -112,39 +112,39 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
     });
 
-    it("should return failValue when providing an invalid length signature", async () => {
-      const data = "0xcafecafe";
+    it('should return failValue when providing an invalid length signature', async () => {
+      const data = '0xcafecafe';
       const messageHash = ethers.utils.hashMessage(data);
-      const signature = "0xbadbadbadb";
+      const signature = '0xbadbadbadb';
 
       const result = await context.universalProfile.isValidSignature(messageHash, signature);
       expect(result).to.equal(ERC1271_VALUES.FAIL_VALUE);
     });
   });
 
-  describe("when interacting with the ERC725Y storage", () => {
+  describe('when interacting with the ERC725Y storage', () => {
     let lsp12IssuedAssetsKeys = [
-      ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index + "00000000000000000000000000000000",
-      ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index + "00000000000000000000000000000001",
+      ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index + '00000000000000000000000000000000',
+      ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index + '00000000000000000000000000000001',
     ];
 
     let lsp12IssuedAssetsValues = [
-      "0xd94353d9b005b3c0a9da169b768a31c57844e490",
-      "0xdaea594e385fc724449e3118b2db7e86dfba1826",
+      '0xd94353d9b005b3c0a9da169b768a31c57844e490',
+      '0xdaea594e385fc724449e3118b2db7e86dfba1826',
     ];
 
-    it("should set the 3 x keys for a basic UP setup => `LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`", async () => {
+    it('should set the 3 x keys for a basic UP setup => `LSP3Profile`, `LSP12IssuedAssets[]` and `LSP1UniversalReceiverDelegate`', async () => {
       let keys = [
         ERC725YDataKeys.LSP3.LSP3Profile,
-        ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length,
+        ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].length,
         ...lsp12IssuedAssetsKeys,
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
       ];
       let values = [
-        "0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178",
-        "0x0000000000000000000000000000000000000000000000000000000000000002",
+        '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178',
+        '0x0000000000000000000000000000000000000000000000000000000000000002',
         ...lsp12IssuedAssetsValues,
-        "0x1183790f29be3cdfd0a102862fea1a4a30b3adab",
+        '0x1183790f29be3cdfd0a102862fea1a4a30b3adab',
       ];
 
       await context.universalProfile.setDataBatch(keys, values);
@@ -153,7 +153,7 @@ export const shouldBehaveLikeLSP3 = (
       expect(result).to.eql(values);
     });
 
-    it("should add +10 more LSP12IssuedAssets[]", async () => {
+    it('should add +10 more LSP12IssuedAssets[]', async () => {
       let newIssuedAssets = getRandomAddresses(10);
 
       const expectedKeysLength = lsp12IssuedAssetsKeys.length + newIssuedAssets.length;
@@ -163,7 +163,7 @@ export const shouldBehaveLikeLSP3 = (
         let hexIndex = ethers.utils.hexlify(lsp12IssuedAssetsKeys.length);
 
         lsp12IssuedAssetsKeys.push(
-          ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index +
+          ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index +
             ethers.utils.hexZeroPad(hexIndex, 16).substring(2),
         );
 
@@ -174,7 +174,7 @@ export const shouldBehaveLikeLSP3 = (
 
       let keys = [
         ...lsp12IssuedAssetsKeys,
-        ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length, // update array length
+        ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].length, // update array length
       ];
 
       let values = [
@@ -189,11 +189,11 @@ export const shouldBehaveLikeLSP3 = (
     });
 
     for (let ii = 1; ii <= 8; ii++) {
-      it("should add +1 LSP12IssuedAssets", async () => {
+      it('should add +1 LSP12IssuedAssets', async () => {
         let hexIndex = ethers.utils.hexlify(lsp12IssuedAssetsKeys.length + 1);
 
         lsp12IssuedAssetsKeys.push(
-          ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].index +
+          ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].index +
             ethers.utils.hexZeroPad(hexIndex, 16).substring(2),
         );
 
@@ -201,7 +201,7 @@ export const shouldBehaveLikeLSP3 = (
 
         let keys = [
           ...lsp12IssuedAssetsKeys,
-          ERC725YDataKeys.LSP12["LSP12IssuedAssets[]"].length, // update array length
+          ERC725YDataKeys.LSP12['LSP12IssuedAssets[]'].length, // update array length
         ];
 
         let values = [
@@ -216,13 +216,13 @@ export const shouldBehaveLikeLSP3 = (
       });
     }
 
-    describe("when setting a data key with a value less than 256 bytes", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value less than 256 bytes', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(200));
 
         await expect(context.universalProfile.setData(key, value))
-          .to.emit(context.universalProfile, "DataChanged")
+          .to.emit(context.universalProfile, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.universalProfile.getData(key);
@@ -230,13 +230,13 @@ export const shouldBehaveLikeLSP3 = (
       });
     });
 
-    describe("when setting a data key with a value more than 256 bytes", () => {
-      it("should emit DataChanged event with only the first 256 bytes of the value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value more than 256 bytes', () => {
+      it('should emit DataChanged event with only the first 256 bytes of the value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
         await expect(context.universalProfile.setData(key, value))
-          .to.emit(context.universalProfile, "DataChanged")
+          .to.emit(context.universalProfile, 'DataChanged')
           .withArgs(key, ethers.utils.hexDataSlice(value, 0, 256));
 
         const result = await context.universalProfile.getData(key);
@@ -244,13 +244,13 @@ export const shouldBehaveLikeLSP3 = (
       });
     });
 
-    describe("when setting a data key with a value exactly 256 bytes long", () => {
-      it("should emit DataChanged event with the whole data value", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when setting a data key with a value exactly 256 bytes long', () => {
+      it('should emit DataChanged event with the whole data value', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(256));
 
         await expect(context.universalProfile.setData(key, value))
-          .to.emit(context.universalProfile, "DataChanged")
+          .to.emit(context.universalProfile, 'DataChanged')
           .withArgs(key, value);
 
         const result = await context.universalProfile.getData(key);
@@ -258,11 +258,11 @@ export const shouldBehaveLikeLSP3 = (
       });
     });
 
-    describe("when sending value while setting data", () => {
-      describe("when calling setData(..)", () => {
-        it("should pass and emit the ValueReceived event", async () => {
-          let msgValue = ethers.utils.parseEther("2");
-          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when sending value while setting data', () => {
+      describe('when calling setData(..)', () => {
+        it('should pass and emit the ValueReceived event', async () => {
+          let msgValue = ethers.utils.parseEther('2');
+          let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
           let value = ethers.utils.hexlify(ethers.utils.randomBytes(256));
 
           await expect(
@@ -270,7 +270,7 @@ export const shouldBehaveLikeLSP3 = (
               .connect(context.accounts[0])
               .setData(key, value, { value: msgValue }),
           )
-            .to.emit(context.universalProfile, "ValueReceived")
+            .to.emit(context.universalProfile, 'ValueReceived')
             .withArgs(context.accounts[0].address, msgValue);
 
           const result = await context.universalProfile.getData(key);
@@ -278,10 +278,10 @@ export const shouldBehaveLikeLSP3 = (
         });
       });
 
-      describe("when calling setData(..) Array", () => {
-        it("should pass and emit the ValueReceived event", async () => {
-          let msgValue = ethers.utils.parseEther("2");
-          let key = [ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"))];
+      describe('when calling setData(..) Array', () => {
+        it('should pass and emit the ValueReceived event', async () => {
+          let msgValue = ethers.utils.parseEther('2');
+          let key = [ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'))];
           let value = [ethers.utils.hexlify(ethers.utils.randomBytes(256))];
 
           await expect(
@@ -289,7 +289,7 @@ export const shouldBehaveLikeLSP3 = (
               .connect(context.accounts[0])
               .setDataBatch(key, value, { value: msgValue }),
           )
-            .to.emit(context.universalProfile, "ValueReceived")
+            .to.emit(context.universalProfile, 'ValueReceived')
             .withArgs(context.accounts[0].address, msgValue);
 
           const result = await context.universalProfile.getDataBatch(key);
@@ -299,8 +299,8 @@ export const shouldBehaveLikeLSP3 = (
     });
   });
 
-  describe("when calling the contract without any value or data", () => {
-    it("should pass and not emit the ValueReceived event", async () => {
+  describe('when calling the contract without any value or data', () => {
+    it('should pass and not emit the ValueReceived event', async () => {
       const sender = context.accounts[0];
       const amount = 0;
 
@@ -315,10 +315,10 @@ export const shouldBehaveLikeLSP3 = (
     });
   });
 
-  describe("when sending native tokens to the contract", () => {
-    it("should emit the right ValueReceived event", async () => {
+  describe('when sending native tokens to the contract', () => {
+    it('should emit the right ValueReceived event', async () => {
       const sender = context.accounts[0];
-      const amount = ethers.utils.parseEther("5");
+      const amount = ethers.utils.parseEther('5');
 
       await expect(
         sender.sendTransaction({
@@ -326,13 +326,13 @@ export const shouldBehaveLikeLSP3 = (
           value: amount,
         }),
       )
-        .to.emit(context.universalProfile, "ValueReceived")
+        .to.emit(context.universalProfile, 'ValueReceived')
         .withArgs(sender.address, amount);
     });
 
-    it("should allow to send a random payload as well, and emit the ValueReceived event", async () => {
+    it('should allow to send a random payload as well, and emit the ValueReceived event', async () => {
       const sender = context.accounts[0];
-      const amount = ethers.utils.parseEther("5");
+      const amount = ethers.utils.parseEther('5');
 
       // The payload must be prepended with bytes4(0) to be interpreted as graffiti
       // and not as a function selector
@@ -340,42 +340,42 @@ export const shouldBehaveLikeLSP3 = (
         sender.sendTransaction({
           to: context.universalProfile.address,
           value: amount,
-          data: "0x00000000aabbccdd",
+          data: '0x00000000aabbccdd',
         }),
       )
-        .to.emit(context.universalProfile, "ValueReceived")
+        .to.emit(context.universalProfile, 'ValueReceived')
         .withArgs(sender.address, amount);
     });
   });
 
-  describe("when sending a random payload, without any value", () => {
-    it("should execute the fallback function, but not emit the ValueReceived event", async () => {
+  describe('when sending a random payload, without any value', () => {
+    it('should execute the fallback function, but not emit the ValueReceived event', async () => {
       // The payload must be prepended with bytes4(0) to be interpreted as graffiti
       // and not as a function selector
       let tx = await context.accounts[0].sendTransaction({
         to: context.universalProfile.address,
         value: 0,
-        data: "0x00000000aabbccdd",
+        data: '0x00000000aabbccdd',
       });
 
       // check that no event was emitted
-      await expect(tx).to.not.emit(context.universalProfile, "ValueReceived");
+      await expect(tx).to.not.emit(context.universalProfile, 'ValueReceived');
     });
   });
 
-  describe("when using the batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` function", () => {
-    describe("when specifying `msg.value`", () => {
-      it("should emit a `ValueReceived` event", async () => {
+  describe('when using the batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` function', () => {
+    describe('when specifying `msg.value`', () => {
+      it('should emit a `ValueReceived` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts[1].address,
           context.accounts[2].address,
           context.accounts[3].address,
         ];
-        const values = Array(3).fill(ethers.BigNumber.from("1"));
-        const datas = Array(3).fill("0x");
+        const values = Array(3).fill(ethers.BigNumber.from('1'));
+        const datas = Array(3).fill('0x');
 
-        const msgValue = ethers.utils.parseEther("10");
+        const msgValue = ethers.utils.parseEther('10');
 
         const tx = await context.universalProfile.executeBatch(
           operationsType,
@@ -386,21 +386,21 @@ export const shouldBehaveLikeLSP3 = (
         );
 
         await expect(tx)
-          .to.emit(context.universalProfile, "ValueReceived")
+          .to.emit(context.universalProfile, 'ValueReceived')
           .withArgs(context.deployParams.owner.address, msgValue);
       });
     });
 
-    describe("when NOT sending any `msg.value`", () => {
-      it("should NOT emit a `ValueReceived` event", async () => {
+    describe('when NOT sending any `msg.value`', () => {
+      it('should NOT emit a `ValueReceived` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts[1].address,
           context.accounts[2].address,
           context.accounts[3].address,
         ];
-        const values = Array(3).fill(ethers.BigNumber.from("1"));
-        const datas = Array(3).fill("0x");
+        const values = Array(3).fill(ethers.BigNumber.from('1'));
+        const datas = Array(3).fill('0x');
 
         const msgValue = 0;
 
@@ -412,18 +412,18 @@ export const shouldBehaveLikeLSP3 = (
           { value: msgValue },
         );
 
-        await expect(tx).to.not.emit(context.universalProfile, "ValueReceived");
+        await expect(tx).to.not.emit(context.universalProfile, 'ValueReceived');
       });
     });
   });
 
-  describe("when using batchCalls function", () => {
-    describe("when non-owner is calling", () => {
-      it("shoud revert", async () => {
-        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+  describe('when using batchCalls function', () => {
+    describe('when non-owner is calling', () => {
+      it('shoud revert', async () => {
+        let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
         let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
-        let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+        let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
           key,
           value,
         ]);
@@ -431,19 +431,19 @@ export const shouldBehaveLikeLSP3 = (
         await expect(
           context.universalProfile.connect(context.accounts[4]).batchCalls([setDataPayload]),
         )
-          .to.be.revertedWithCustomError(context.universalProfile, "LSP20InvalidMagicValue")
-          .withArgs(false, "0x");
+          .to.be.revertedWithCustomError(context.universalProfile, 'LSP20InvalidMagicValue')
+          .withArgs(false, '0x');
       });
     });
 
-    describe("when the owner is calling", () => {
-      describe("when executing one function", () => {
-        describe("setData", () => {
-          it("should pass", async () => {
-            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Key"));
+    describe('when the owner is calling', () => {
+      describe('when executing one function', () => {
+        describe('setData', () => {
+          it('should pass', async () => {
+            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Key'));
             let value = ethers.utils.hexlify(ethers.utils.randomBytes(500));
 
-            let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -457,14 +457,14 @@ export const shouldBehaveLikeLSP3 = (
           });
         });
 
-        describe("execute", () => {
-          it("should pass", async () => {
+        describe('execute', () => {
+          it('should pass', async () => {
             let amount = 20;
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               0,
               context.accounts[4].address,
               amount,
-              "0x",
+              '0x',
             ]);
 
             await expect(() =>
@@ -479,27 +479,27 @@ export const shouldBehaveLikeLSP3 = (
         });
       });
 
-      describe("when executing several functions", () => {
-        describe("When transfering lyx, setting data, transferring ownership", () => {
-          it("should pass", async () => {
+      describe('when executing several functions', () => {
+        describe('When transfering lyx, setting data, transferring ownership', () => {
+          it('should pass', async () => {
             let amount = 20;
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               0,
               context.accounts[5].address,
               amount,
-              "0x",
+              '0x',
             ]);
 
-            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("A new key"));
+            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('A new key'));
             let value = ethers.utils.hexlify(ethers.utils.randomBytes(10));
 
-            let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
 
             let transferOwnershipPayload = context.universalProfile.interface.encodeFunctionData(
-              "transferOwnership",
+              'transferOwnership',
               [context.accounts[8].address],
             );
 
@@ -525,20 +525,20 @@ export const shouldBehaveLikeLSP3 = (
           });
         });
 
-        describe("When setting data and transferring value in staticcall operation", () => {
-          it("should revert", async () => {
+        describe('When setting data and transferring value in staticcall operation', () => {
+          it('should revert', async () => {
             let amount = 100;
-            let executePayload = context.universalProfile.interface.encodeFunctionData("execute", [
+            let executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
               3,
               context.accounts[5].address,
               amount,
-              "0x",
+              '0x',
             ]);
 
-            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another key"));
+            let key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Another key'));
             let value = ethers.utils.hexlify(ethers.utils.randomBytes(10));
 
-            let setDataPayload = context.universalProfile.interface.encodeFunctionData("setData", [
+            let setDataPayload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
               value,
             ]);
@@ -549,7 +549,7 @@ export const shouldBehaveLikeLSP3 = (
                 .batchCalls([setDataPayload, executePayload]),
             ).to.be.revertedWithCustomError(
               context.universalProfile,
-              "ERC725X_MsgValueDisallowedInStaticCall",
+              'ERC725X_MsgValueDisallowedInStaticCall',
             );
           });
         });
@@ -565,56 +565,56 @@ export const shouldInitializeLikeLSP3 = (buildContext: () => Promise<LSP3TestCon
     context = await buildContext();
   });
 
-  describe("when the contract was initialized", () => {
-    it("should support ERC165 interface", async () => {
+  describe('when the contract was initialized', () => {
+    it('should support ERC165 interface', async () => {
       const result = await context.universalProfile.supportsInterface(INTERFACE_IDS.ERC165);
       expect(result).to.be.true;
     });
 
-    it("should support ERC1271 interface", async () => {
+    it('should support ERC1271 interface', async () => {
       const result = await context.universalProfile.supportsInterface(INTERFACE_IDS.ERC1271);
       expect(result).to.be.true;
     });
 
-    it("should support ERC725X interface", async () => {
+    it('should support ERC725X interface', async () => {
       const result = await context.universalProfile.supportsInterface(INTERFACE_IDS.ERC725X);
       expect(result).to.be.true;
     });
 
-    it("should support ERC725Y interface", async () => {
+    it('should support ERC725Y interface', async () => {
       const result = await context.universalProfile.supportsInterface(INTERFACE_IDS.ERC725Y);
       expect(result).to.be.true;
     });
 
-    it("should support LSP0 (ERC725Account) interface", async () => {
+    it('should support LSP0 (ERC725Account) interface', async () => {
       const result = await context.universalProfile.supportsInterface(
         INTERFACE_IDS.LSP0ERC725Account,
       );
       expect(result).to.be.true;
     });
 
-    it("should support LSP1 interface", async () => {
+    it('should support LSP1 interface', async () => {
       const result = await context.universalProfile.supportsInterface(
         INTERFACE_IDS.LSP1UniversalReceiver,
       );
       expect(result).to.be.true;
     });
 
-    it("should support LSP14Ownable2Step interface", async () => {
+    it('should support LSP14Ownable2Step interface', async () => {
       const result = await context.universalProfile.supportsInterface(
         INTERFACE_IDS.LSP14Ownable2Step,
       );
       expect(result).to.be.true;
     });
 
-    it("should support LSP17Extendable interface", async () => {
+    it('should support LSP17Extendable interface', async () => {
       const result = await context.universalProfile.supportsInterface(
         INTERFACE_IDS.LSP17Extendable,
       );
       expect(result).to.be.true;
     });
 
-    it("should support LSP20CallVerification interface", async () => {
+    it('should support LSP20CallVerification interface', async () => {
       const result = await context.universalProfile.supportsInterface(
         INTERFACE_IDS.LSP20CallVerification,
       );

--- a/tests/UniversalProfile.test.ts
+++ b/tests/UniversalProfile.test.ts
@@ -1,35 +1,35 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
-import { UniversalProfile__factory, UniversalReceiverTester__factory } from "../types";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { UniversalProfile__factory, UniversalReceiverTester__factory } from '../types';
 
 import {
   LSP1TestContext,
   shouldBehaveLikeLSP1,
-} from "./LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour";
+} from './LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour';
 
 import {
   LSP17TestContext,
   shouldBehaveLikeLSP17,
-} from "./LSP17ContractExtension/LSP17Extendable.behaviour";
+} from './LSP17ContractExtension/LSP17Extendable.behaviour';
 
 import {
   LSP20TestContext,
   shouldBehaveLikeLSP20,
-} from "./LSP20CallVerification/LSP20CallVerification.behaviour";
+} from './LSP20CallVerification/LSP20CallVerification.behaviour';
 
 import {
   LSP3TestContext,
   shouldInitializeLikeLSP3,
   shouldBehaveLikeLSP3,
-} from "./UniversalProfile.behaviour";
-import { provider } from "./utils/helpers";
-import { BigNumber } from "ethers";
+} from './UniversalProfile.behaviour';
+import { provider } from './utils/helpers';
+import { BigNumber } from 'ethers';
 import {
   LSP14CombinedWithLSP20TestContext,
   shouldBehaveLikeLSP14WithLSP20,
-} from "./LSP20CallVerification/LSP20WithLSP14.behaviour";
+} from './LSP20CallVerification/LSP20WithLSP14.behaviour';
 
-describe("UniversalProfile with constructor", () => {
+describe('UniversalProfile with constructor', () => {
   const buildLSP3TestContext = async (initialFunding?: number): Promise<LSP3TestContext> => {
     const accounts = await ethers.getSigners();
     const deployParams = {
@@ -72,7 +72,7 @@ describe("UniversalProfile with constructor", () => {
       { value: initialFunding },
     );
 
-    const onlyOwnerRevertString = "Ownable: caller is not the owner";
+    const onlyOwnerRevertString = 'Ownable: caller is not the owner';
 
     return { accounts, contract, deployParams, onlyOwnerRevertString };
   };
@@ -103,7 +103,7 @@ describe("UniversalProfile with constructor", () => {
 
   [{ initialFunding: undefined }, { initialFunding: 0 }, { initialFunding: 5 }].forEach(
     (testCase) => {
-      describe("when deploying the contract with or without value", () => {
+      describe('when deploying the contract with or without value', () => {
         let context: LSP3TestContext;
 
         before(async () => {
@@ -118,19 +118,19 @@ describe("UniversalProfile with constructor", () => {
     },
   );
 
-  describe("when deploying the contract", () => {
+  describe('when deploying the contract', () => {
     let context: LSP3TestContext;
 
     before(async () => {
       context = await buildLSP3TestContext();
     });
 
-    describe("when initializing the contract", () => {
+    describe('when initializing the contract', () => {
       shouldInitializeLikeLSP3(async () => context);
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP3(buildLSP3TestContext);
     shouldBehaveLikeLSP1(buildLSP1TestContext);
     shouldBehaveLikeLSP14WithLSP20(buildLSP14WithLSP20TestContext);

--- a/tests/UniversalProfileInit.test.ts
+++ b/tests/UniversalProfileInit.test.ts
@@ -1,40 +1,40 @@
-import { ethers } from "hardhat";
-import { expect } from "chai";
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
 import {
   LSP0ERC725Account,
   UniversalProfileInit__factory,
   UniversalReceiverTester__factory,
-} from "../types";
-import { deployProxy } from "./utils/fixtures";
+} from '../types';
+import { deployProxy } from './utils/fixtures';
 
 import {
   LSP1TestContext,
   shouldBehaveLikeLSP1,
-} from "./LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour";
+} from './LSP1UniversalReceiver/LSP1UniversalReceiver.behaviour';
 
 import {
   LSP17TestContext,
   shouldBehaveLikeLSP17,
-} from "./LSP17ContractExtension/LSP17Extendable.behaviour";
+} from './LSP17ContractExtension/LSP17Extendable.behaviour';
 
 import {
   LSP20TestContext,
   shouldBehaveLikeLSP20,
-} from "./LSP20CallVerification/LSP20CallVerification.behaviour";
+} from './LSP20CallVerification/LSP20CallVerification.behaviour';
 
 import {
   LSP3TestContext,
   shouldInitializeLikeLSP3,
   shouldBehaveLikeLSP3,
-} from "./UniversalProfile.behaviour";
-import { provider } from "./utils/helpers";
-import { BigNumber } from "ethers";
+} from './UniversalProfile.behaviour';
+import { provider } from './utils/helpers';
+import { BigNumber } from 'ethers';
 import {
   LSP14CombinedWithLSP20TestContext,
   shouldBehaveLikeLSP14WithLSP20,
-} from "./LSP20CallVerification/LSP20WithLSP14.behaviour";
+} from './LSP20CallVerification/LSP20WithLSP14.behaviour';
 
-describe("UniversalProfileInit with proxy", () => {
+describe('UniversalProfileInit with proxy', () => {
   let universalProfileInit;
   let accounts;
 
@@ -57,7 +57,7 @@ describe("UniversalProfileInit with proxy", () => {
   };
 
   const initializeProxy = async (context: LSP3TestContext) => {
-    return context.universalProfile["initialize(address)"](context.deployParams.owner.address, {
+    return context.universalProfile['initialize(address)'](context.deployParams.owner.address, {
       value: context.deployParams.initialFunding,
     });
   };
@@ -86,7 +86,7 @@ describe("UniversalProfileInit with proxy", () => {
 
     const universalProfile = universalProfileInit.attach(universalProfileProxy);
 
-    const onlyOwnerRevertString = "Ownable: caller is not the owner";
+    const onlyOwnerRevertString = 'Ownable: caller is not the owner';
 
     return {
       accounts,
@@ -123,19 +123,19 @@ describe("UniversalProfileInit with proxy", () => {
     return { accounts, universalProfile: universalProfile, deployParams };
   };
 
-  describe("when deploying the base implementation contract", () => {
-    it("prevent any address from calling the initialize(...) function on the implementation", async () => {
+  describe('when deploying the base implementation contract', () => {
+    it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const randomCaller = accounts[1];
 
       await expect(universalProfileInit.initialize(randomCaller.address)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
   [{ initialFunding: undefined }, { initialFunding: 0 }, { initialFunding: 5 }].forEach(
     (testCase) => {
-      describe("when deploying + intializing the proxy contract with or without value", () => {
+      describe('when deploying + intializing the proxy contract with or without value', () => {
         it(`should have initialized with the correct funding amount (${testCase.initialFunding})`, async () => {
           let context = await buildLSP3TestContext(testCase.initialFunding);
           await initializeProxy(context);
@@ -146,18 +146,18 @@ describe("UniversalProfileInit with proxy", () => {
     },
   );
 
-  describe("when calling `initialize(...)` more than once", () => {
-    it("should revert", async () => {
+  describe('when calling `initialize(...)` more than once', () => {
+    it('should revert', async () => {
       let context = await buildLSP3TestContext();
       await initializeProxy(context);
 
       await expect(initializeProxy(context)).to.be.revertedWith(
-        "Initializable: contract is already initialized",
+        'Initializable: contract is already initialized',
       );
     });
   });
 
-  describe("when deploying + initializing the proxy contract", () => {
+  describe('when deploying + initializing the proxy contract', () => {
     shouldInitializeLikeLSP3(async () => {
       let context = await buildLSP3TestContext();
       await initializeProxy(context);
@@ -165,7 +165,7 @@ describe("UniversalProfileInit with proxy", () => {
     });
   });
 
-  describe("when testing deployed contract", () => {
+  describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP3(async (initialFunding?: number) => {
       let context = await buildLSP3TestContext(initialFunding);
       await initializeProxy(context);

--- a/tests/utils/context.ts
+++ b/tests/utils/context.ts
@@ -1,6 +1,6 @@
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { BigNumber } from "ethers";
-import { KeyManagerInternalTester, LSP6KeyManager, UniversalProfile } from "../../types";
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { BigNumber } from 'ethers';
+import { KeyManagerInternalTester, LSP6KeyManager, UniversalProfile } from '../../types';
 
 export type LSP6TestContext = {
   accounts: SignerWithAddress[];

--- a/tests/utils/deploy.ts
+++ b/tests/utils/deploy.ts
@@ -1,11 +1,11 @@
-import { ethers } from "hardhat";
-import { Contract, ContractTransaction } from "ethers";
+import { ethers } from 'hardhat';
+import { Contract, ContractTransaction } from 'ethers';
 
 export async function getDeploymentCost(contractOrTransaction: Contract | ContractTransaction) {
   let gasUsed: number;
   let receipt: any;
 
-  if ("deployTransaction" in contractOrTransaction) {
+  if ('deployTransaction' in contractOrTransaction) {
     receipt = await contractOrTransaction.deployTransaction.wait();
   } else {
     receipt = await contractOrTransaction.wait();

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -1,17 +1,17 @@
-import { ethers } from "hardhat";
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
   LSP1UniversalReceiverDelegateUP__factory,
   LSP6KeyManager__factory,
   UniversalProfile__factory,
-} from "../../types";
+} from '../../types';
 
-import { PERMISSIONS, ERC725YDataKeys, ALL_PERMISSIONS } from "../../constants";
+import { PERMISSIONS, ERC725YDataKeys, ALL_PERMISSIONS } from '../../constants';
 
 // helpers
-import { combinePermissions } from "../utils/helpers";
-import { LSP6TestContext, LSP6InternalsTestContext } from "./context";
+import { combinePermissions } from '../utils/helpers';
+import { LSP6TestContext, LSP6InternalsTestContext } from './context';
 
 /**
  * Deploy a proxy contract, referencing to baseContractAddress via delegateCall
@@ -29,11 +29,11 @@ export async function deployProxy(
    * The first 10 x hex opcodes copy the runtime code into memory and return it.
    */
   const eip1167RuntimeCodeTemplate =
-    "0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3";
+    '0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3';
 
   // deploy proxy contract
   let proxyBytecode = eip1167RuntimeCodeTemplate.replace(
-    "bebebebebebebebebebebebebebebebebebebebe",
+    'bebebebebebebebebebebebebebebebebebebebe',
     baseContractAddress.substr(2),
   );
   let tx = await deployer.sendTransaction({
@@ -54,7 +54,7 @@ export async function setupKeyManager(
       // required to set owner permission so that it can acceptOwnership(...) via the KeyManager
       // otherwise, the KeyManager will flag the calling owner as not having the permission CHANGEOWNER
       // when trying to setup the KeyManager
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + _context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + _context.owner.address.substring(2),
       ..._dataKeys,
     ],
     [ALL_PERMISSIONS, ..._dataValues],
@@ -64,7 +64,7 @@ export async function setupKeyManager(
     .connect(_context.owner)
     .transferOwnership(_context.keyManager.address);
 
-  let payload = _context.universalProfile.interface.getSighash("acceptOwnership");
+  let payload = _context.universalProfile.interface.getSighash('acceptOwnership');
 
   await _context.keyManager.connect(_context.owner).execute(payload);
 }
@@ -78,7 +78,7 @@ export async function setupKeyManagerHelper(
     .connect(_context.owner)
     .setDataBatch(
       [
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           _context.owner.address.substring(2),
         ..._permissionsKeys,
       ],
@@ -89,7 +89,7 @@ export async function setupKeyManagerHelper(
     .connect(_context.owner)
     .transferOwnership(_context.keyManagerInternalTester.address);
 
-  let payload = _context.universalProfile.interface.getSighash("acceptOwnership");
+  let payload = _context.universalProfile.interface.getSighash('acceptOwnership');
 
   await _context.keyManagerInternalTester.connect(_context.owner).execute(payload);
 }
@@ -109,11 +109,11 @@ export async function setupProfileWithKeyManagerWithURD(EOA: SignerWithAddress) 
     .connect(EOA)
     .setDataBatch(
       [
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000000",
-        ERC725YDataKeys.LSP6["AddressPermissions[]"].index + "00000000000000000000000000000001",
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + EOA.address.substring(2),
-        ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] +
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000000',
+        ERC725YDataKeys.LSP6['AddressPermissions[]'].index + '00000000000000000000000000000001',
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + EOA.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           lsp1universalReceiverDelegateUP.address.substring(2),
         ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate,
       ],
@@ -129,13 +129,13 @@ export async function setupProfileWithKeyManagerWithURD(EOA: SignerWithAddress) 
 
   await universalProfile.connect(EOA).transferOwnership(lsp6KeyManager.address);
 
-  const claimOwnershipPayload = universalProfile.interface.getSighash("acceptOwnership");
+  const claimOwnershipPayload = universalProfile.interface.getSighash('acceptOwnership');
 
   await lsp6KeyManager.connect(EOA).execute(claimOwnershipPayload);
 
   await EOA.sendTransaction({
     to: universalProfile.address,
-    value: ethers.utils.parseEther("10"),
+    value: ethers.utils.parseEther('10'),
   });
   return [universalProfile, lsp6KeyManager, lsp1universalReceiverDelegateUP];
 }
@@ -150,8 +150,8 @@ export async function grantLSP11PermissionViaKeyManager(
   lsp6KeyManager,
   addressToGrant,
 ) {
-  const rawPermissionArrayLength = await universalProfile.callStatic["getData(bytes32)"](
-    ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
+  const rawPermissionArrayLength = await universalProfile.callStatic['getData(bytes32)'](
+    ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
   );
 
   let permissionArrayLength = ethers.BigNumber.from(rawPermissionArrayLength).toNumber();
@@ -167,11 +167,11 @@ export async function grantLSP11PermissionViaKeyManager(
   // to add a new controller key with some new permissions
   const lsp11SocialRecoveryPermissions = PERMISSIONS.ADDCONTROLLER;
 
-  const payload = universalProfile.interface.encodeFunctionData("setDataBatch", [
+  const payload = universalProfile.interface.encodeFunctionData('setDataBatch', [
     [
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].length,
-      ERC725YDataKeys.LSP6["AddressPermissions[]"].index + rawPermissionArrayLength.substring(2),
-      ERC725YDataKeys.LSP6["AddressPermissions:Permissions"] + addressToGrant.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].length,
+      ERC725YDataKeys.LSP6['AddressPermissions[]'].index + rawPermissionArrayLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + addressToGrant.substring(2),
     ],
     [newRawPermissionArrayLength, addressToGrant, lsp11SocialRecoveryPermissions],
   ]);
@@ -182,7 +182,7 @@ export async function grantLSP11PermissionViaKeyManager(
  * Returns the payload of Call operation with 0 value
  */
 export function callPayload(from: any, to: string, abi: string) {
-  let payload = from.interface.encodeFunctionData("execute", [0, to, 0, abi]);
+  let payload = from.interface.encodeFunctionData('execute', [0, to, 0, abi]);
   return payload;
 }
 
@@ -195,21 +195,21 @@ export async function getLSP5MapAndArrayKeysValue(account, token) {
     ethers.utils.hexConcat([ERC725YDataKeys.LSP5.LSP5ReceivedAssetsMap, token.address]),
   );
 
-  const indexInHex = "0x" + mapValue.substr(10, mapValue.length);
+  const indexInHex = '0x' + mapValue.substr(10, mapValue.length);
   const interfaceId = mapValue.substr(0, 10);
 
   const indexInNumber = ethers.BigNumber.from(indexInHex).toNumber();
   const rawIndexInArray = ethers.utils.hexZeroPad(ethers.utils.hexValue(indexInNumber), 16);
 
   const elementInArrayKey = ethers.utils.hexConcat([
-    ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].index,
+    ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].index,
     rawIndexInArray,
   ]);
 
-  let arrayKey = ERC725YDataKeys.LSP5["LSP5ReceivedAssets[]"].length;
+  let arrayKey = ERC725YDataKeys.LSP5['LSP5ReceivedAssets[]'].length;
   let [arrayLength, elementAddress] = await account.getDataBatch([arrayKey, elementInArrayKey]);
 
-  if (elementAddress != "0x") {
+  if (elementAddress != '0x') {
     elementAddress = ethers.utils.getAddress(elementAddress);
   }
   return [indexInNumber, interfaceId, arrayLength, elementAddress];

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -1,19 +1,19 @@
-import { BigNumber, BytesLike } from "ethers";
-import { ethers } from "hardhat";
-import { LSP6KeyManager } from "../../types";
+import { BigNumber, BytesLike } from 'ethers';
+import { ethers } from 'hardhat';
+import { LSP6KeyManager } from '../../types';
 
 // constants
-import { LSP6_VERSION } from "../../constants";
-import { EIP191Signer } from "@lukso/eip191-signer.js";
+import { LSP6_VERSION } from '../../constants';
+import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 export const abiCoder = ethers.utils.defaultAbiCoder;
 export const provider = ethers.provider;
 
-export const AddressOffset = "000000000000000000000000";
-export const EMPTY_PAYLOAD = "0x";
+export const AddressOffset = '000000000000000000000000';
+export const EMPTY_PAYLOAD = '0x';
 
 export const LSP1_HOOK_PLACEHOLDER =
-  "0xffffffffffffffff0000000000000000aaaaaaaaaaaaaaaa1111111111111111";
+  '0xffffffffffffffff0000000000000000aaaaaaaaaaaaaaaa1111111111111111';
 
 /**
  * Private keys for the accounts used in the tests.
@@ -24,27 +24,27 @@ export const LSP1_HOOK_PLACEHOLDER =
  *          Any funds sent to them on Mainnet or any other live network WILL BE LOST.
  */
 export const LOCAL_PRIVATE_KEYS = {
-  ACCOUNT0: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-  ACCOUNT1: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-  ACCOUNT2: "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
-  ACCOUNT3: "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
-  ACCOUNT4: "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
-  ACCOUNT5: "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
-  ACCOUNT6: "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
-  ACCOUNT7: "0x030ab56c9834360e1c0dba6b9a955b6e127f3166cda462c2472f67e1ba773053",
+  ACCOUNT0: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+  ACCOUNT1: '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+  ACCOUNT2: '0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a',
+  ACCOUNT3: '0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6',
+  ACCOUNT4: '0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a',
+  ACCOUNT5: '0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba',
+  ACCOUNT6: '0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e',
+  ACCOUNT7: '0x030ab56c9834360e1c0dba6b9a955b6e127f3166cda462c2472f67e1ba773053',
 };
 
 // bytes32 arraylength
 export const ARRAY_LENGTH = {
-  ZERO: "0x00000000000000000000000000000000",
-  ONE: "0x00000000000000000000000000000001",
-  TWO: "0x00000000000000000000000000000002",
-  THREE: "0x00000000000000000000000000000003",
-  FOUR: "0x00000000000000000000000000000004",
-  FIVE: "0x00000000000000000000000000000005",
-  SIX: "0x00000000000000000000000000000006",
-  SEVEN: "0x00000000000000000000000000000007",
-  EIGHT: "0x00000000000000000000000000000008",
+  ZERO: '0x00000000000000000000000000000000',
+  ONE: '0x00000000000000000000000000000001',
+  TWO: '0x00000000000000000000000000000002',
+  THREE: '0x00000000000000000000000000000003',
+  FOUR: '0x00000000000000000000000000000004',
+  FIVE: '0x00000000000000000000000000000005',
+  SIX: '0x00000000000000000000000000000006',
+  SEVEN: '0x00000000000000000000000000000007',
+  EIGHT: '0x00000000000000000000000000000008',
 };
 
 export function getRandomAddresses(count: Number): string[] {
@@ -82,7 +82,7 @@ export function combineCallTypes(..._callTypes: string[]) {
 }
 
 export function encodeCompactBytesArray(inputKeys: BytesLike[]) {
-  let compactBytesArray = "0x";
+  let compactBytesArray = '0x';
   for (let i = 0; i < inputKeys.length; i++) {
     compactBytesArray +=
       ethers.utils
@@ -98,10 +98,10 @@ export function decodeCompactBytes(compactBytesArray: BytesLike) {
   let keysToExport: BytesLike[] = [];
   while (pointer < compactBytesArray.length) {
     const length = ethers.BigNumber.from(
-      "0x" + compactBytesArray.toString().substring(pointer, pointer + 4),
+      '0x' + compactBytesArray.toString().substring(pointer, pointer + 4),
     ).toNumber();
     keysToExport.push(
-      "0x" + compactBytesArray.toString().substring(pointer + 4, pointer + 2 * (length + 2)),
+      '0x' + compactBytesArray.toString().substring(pointer + 4, pointer + 2 * (length + 2)),
     );
 
     pointer += 2 * (length + 2);
@@ -115,7 +115,7 @@ export function combineAllowedCalls(
   _allowedStandards: string[],
   _allowedFunctions: string[],
 ) {
-  let result: string = "0x0020";
+  let result: string = '0x0020';
 
   for (let ii = 0; ii < _allowedStandards.length; ii++) {
     // remove "0x" prefixes
@@ -127,7 +127,7 @@ export function combineAllowedCalls(
     result = result + allowedInteractions + allowedAddress + allowedStandard + allowedFunction;
 
     if (ii != _allowedStandards.length - 1) {
-      result = result + "0020";
+      result = result + '0020';
     }
   }
 
@@ -162,7 +162,7 @@ export async function signLSP6ExecuteRelayCall(
   };
 
   let encodedMessage = ethers.utils.solidityPack(
-    ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
+    ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
     [
       signedMessageParams.lsp6Version,
       signedMessageParams.chainId,

--- a/tests/utils/tokens.ts
+++ b/tests/utils/tokens.ts
@@ -1,5 +1,5 @@
-import * as ethers from "ethers";
-import type { BigNumberish, BytesLike } from "ethers";
+import * as ethers from 'ethers';
+import type { BigNumberish, BytesLike } from 'ethers';
 
 export const tokenIdAsBytes32 = (tokenId: BigNumberish): BytesLike => {
   return ethers.utils.hexZeroPad(ethers.BigNumber.from(tokenId).toHexString(), 32);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,35 +1,35 @@
 // vite.config.js
-import { defineConfig } from "vite";
-import Checker from "vite-plugin-checker";
-import esbuild from "rollup-plugin-esbuild";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from 'vite';
+import Checker from 'vite-plugin-checker';
+import esbuild from 'rollup-plugin-esbuild';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   plugins: [
     tsconfigPaths({
-      projects: ["./tsconfig.module.json"],
+      projects: ['./tsconfig.module.json'],
     }),
     Checker({ typescript: true }),
   ],
   build: {
-    target: "esnext",
+    target: 'esnext',
     lib: {
       entry: {
-        constants: "./constants.ts",
+        constants: './constants.ts',
       },
-      formats: ["es", "cjs"],
+      formats: ['es', 'cjs'],
     },
     minify: false,
     rollupOptions: {
       output: {
-        entryFileNames: "[name].[format].js",
-        chunkFileNames: "[name].[format].js",
-        assetFileNames: "[name].[ext]",
+        entryFileNames: '[name].[format].js',
+        chunkFileNames: '[name].[format].js',
+        assetFileNames: '[name].[ext]',
       },
-      external: ["peer-dependency"],
+      external: ['peer-dependency'],
       plugins: [
         esbuild({
-          target: "esnext",
+          target: 'esnext',
         }),
       ],
     },


### PR DESCRIPTION
# What does this PR introduce?

## 🎨 Style

- setup `.prettierrc` to use single quotes for strings in JS/TS files.

> See this article for the reason why we should opt for single quotes: https://www.w3docs.com/snippets/javascript/when-to-use-double-or-single-quotes-in-javascript.html#:~:text=Generally%2C%20there%20is%20no%20difference,%3A%20%5C'%20or%20%5C%E2%80%9D.

- Run prettier on all the files to format JS/TS files with single quotes.

## 🤖 CI

- use npm command in CI to check for prettier code formatting.


<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run linter` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
