### PR TITLE
ci: use `hardhat compile` command to generate build

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci
 
       - name: 🏗️ Build contract artifacts
-        run: npm run build --if-present
+        run: npx hardhat compile
 
       - name: 🧪 Run Benchmark tests
         run: npm run test:benchmark

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -29,7 +29,7 @@ jobs:
 
       # This will also generate the Typechain types used by the Chai tests
       - name: 🏗️ Build contract artifacts
-        run: npm run build --if-present
+        run: npx hardhat compile
 
       - name: 📤 cache dependencies + build
         uses: actions/cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
 
       # This will also generate the Typechain types used by the Chai tests
       - name: Build contract artifacts
-        run: npm run build --if-present
+        run: npx hardhat compile
 
       - name: Run tests with coverage
         run: npm run test:coverage

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -28,7 +28,7 @@ jobs:
 
       # This will also generate the Typechain types used by the Chai tests
       - name: Build contract artifacts
-        run: npm run build --if-present
+        run: npx hardhat compile
 
       - name: cache dependencies + build
         uses: actions/cache@v2

--- a/.github/workflows/foundry-tests.yml
+++ b/.github/workflows/foundry-tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: NPM build
-        run: npm run build --if-present
+        run: npx hardhat compile
 
       - name: Run Foundry tests
         run: npm run test:foundry

--- a/.github/workflows/publish-npm-artifact.yml
+++ b/.github/workflows/publish-npm-artifact.yml
@@ -26,7 +26,7 @@ jobs:
       # This will also generate the Typechain types used by the Chai tests
       - name: Build and Test
         run: |
-          npm run build --if-present
+          npx hardhat compile
           npm run test
 
       - name: Publish


### PR DESCRIPTION
# What does this PR introduce?

## 🤖 CI

Replace CI commands from `npm run build` to `npx hardhat compile`.

This is to fix the error that occurs at random when generating the contracts artifacts + generating the docs at the same time.

https://github.com/lukso-network/lsp-smart-contracts/actions/runs/5335783332/jobs/9685846728

### PR Checklist

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
