### PR TITLE
docs: improve ERC725 Natspec comments + add auto-generated docs

### DIFF
--- a/docs/contracts/ERC725/ERC725.md
+++ b/docs/contracts/ERC725/ERC725.md
@@ -1,0 +1,937 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# ERC725
+
+:::info Standard Specifications
+
+[`ERC-725`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md)
+
+:::
+:::info Solidity implementation
+
+[`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+
+:::
+
+> ERC725 bundle
+
+Bundles ERC725X and ERC725Y together into one smart contract. This implementation does not have by default a:
+
+- `receive() external payable {}`
+
+- or `fallback() external payable {}`
+
+## Public Methods
+
+Public methods are accessible externally from users, allowing interaction with this function from dApps or other smart contracts.
+When marked as 'public', a method can be called both externally and internally, on the other hand, when marked as 'external', a method can only be called externally.
+
+### constructor
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#constructor)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+
+:::
+
+```solidity
+constructor(address newOwner);
+```
+
+_Sets the owner of the contract_
+
+#### Parameters
+
+| Name       |   Type    | Description               |
+| ---------- | :-------: | ------------------------- |
+| `newOwner` | `address` | the owner of the contract |
+
+<br/>
+
+### execute
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#execute)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `execute(uint256,address,uint256,bytes)`
+- Function selector: `0x44c028fe`
+
+:::
+
+```solidity
+function execute(
+  uint256 operationType,
+  address target,
+  uint256 value,
+  bytes data
+) external payable returns (bytes);
+```
+
+Generic executor function to:
+
+- send native tokens to any address.
+
+- interact with any contract by passing an abi-encoded function call in the `data` parameter.
+
+- deploy a contract by providing its creation bytecode in the `data` parameter. Requirements:
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `value` SHOULD be 0.
+
+- `target` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
+
+#### Parameters
+
+| Name            |   Type    | Description                                                                                           |
+| --------------- | :-------: | ----------------------------------------------------------------------------------------------------- |
+| `operationType` | `uint256` | The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4          |
+| `target`        | `address` | The address of the EOA or smart contract. (unused if a contract is created via operation type 1 or 2) |
+| `value`         | `uint256` | The amount of native tokens to transfer (in Wei)                                                      |
+| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy                                     |
+
+#### Returns
+
+| Name |  Type   | Description |
+| ---- | :-----: | ----------- |
+| `0`  | `bytes` | -           |
+
+<br/>
+
+### executeBatch
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#executebatch)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `executeBatch(uint256[],address[],uint256[],bytes[])`
+- Function selector: `0x31858452`
+
+:::
+
+```solidity
+function executeBatch(
+  uint256[] operationsType,
+  address[] targets,
+  uint256[] values,
+  bytes[] datas
+) external payable returns (bytes[]);
+```
+
+Generic batch executor function to:
+
+- send native tokens to any address.
+
+- interact with any contract by passing an abi-encoded function call in the `datas` parameter.
+
+- deploy a contract by providing its creation bytecode in the `datas` parameter. Requirements:
+
+- The length of the parameters provided MUST be equal
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `values` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `values` SHOULD be 0.
+
+- `targets` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
+
+#### Parameters
+
+| Name             |    Type     | Description                                                                                                 |
+| ---------------- | :---------: | ----------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The list of operations type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4       |
+| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2). |
+| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei)                                                       |
+| `datas`          |  `bytes[]`  | The list of call data, or the creation bytecode of the contract to deploy                                   |
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `bytes[]` | -           |
+
+<br/>
+
+### getData
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#getdata)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `getData(bytes32)`
+- Function selector: `0x54f6127f`
+
+:::
+
+```solidity
+function getData(bytes32 dataKey) external view returns (bytes dataValue);
+```
+
+_Gets singular data at a given `dataKey`_
+
+#### Parameters
+
+| Name      |   Type    | Description                     |
+| --------- | :-------: | ------------------------------- |
+| `dataKey` | `bytes32` | The key which value to retrieve |
+
+#### Returns
+
+| Name        |  Type   | Description                |
+| ----------- | :-----: | -------------------------- |
+| `dataValue` | `bytes` | The data stored at the key |
+
+<br/>
+
+### getDataBatch
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#getdatabatch)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `getDataBatch(bytes32[])`
+- Function selector: `0xdedff9c6`
+
+:::
+
+```solidity
+function getDataBatch(
+  bytes32[] dataKeys
+) external view returns (bytes[] dataValues);
+```
+
+_Gets array of data for multiple given keys_
+
+#### Parameters
+
+| Name       |    Type     | Description                                |
+| ---------- | :---------: | ------------------------------------------ |
+| `dataKeys` | `bytes32[]` | The array of keys which values to retrieve |
+
+#### Returns
+
+| Name         |   Type    | Description                               |
+| ------------ | :-------: | ----------------------------------------- |
+| `dataValues` | `bytes[]` | The array of data stored at multiple keys |
+
+<br/>
+
+### owner
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#owner)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `owner()`
+- Function selector: `0x8da5cb5b`
+
+:::
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the address of the current owner.
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `address` | -           |
+
+<br/>
+
+### renounceOwnership
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#renounceownership)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `renounceOwnership()`
+- Function selector: `0x715018a6`
+
+:::
+
+```solidity
+function renounceOwnership() external nonpayable;
+```
+
+Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.
+
+<br/>
+
+### setData
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#setdata)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `setData(bytes32,bytes)`
+- Function selector: `0x7f23690c`
+
+:::
+
+```solidity
+function setData(bytes32 dataKey, bytes dataValue) external payable;
+```
+
+_Sets singular data for a given `dataKey`_
+
+#### Parameters
+
+| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
+| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
+| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+
+<br/>
+
+### setDataBatch
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#setdatabatch)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `setDataBatch(bytes32[],bytes[])`
+- Function selector: `0x97902421`
+
+:::
+
+```solidity
+function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
+```
+
+Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+
+0. Emits a [`DataChanged`](#datachanged) event.
+
+#### Parameters
+
+| Name         |    Type     | Description                              |
+| ------------ | :---------: | ---------------------------------------- |
+| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
+| `dataValues` |  `bytes[]`  | The array of values to set               |
+
+<br/>
+
+### supportsInterface
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#supportsinterface)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name          |   Type   | Description |
+| ------------- | :------: | ----------- |
+| `interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+### transferOwnership
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#transferownership)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Function signature: `transferOwnership(address)`
+- Function selector: `0xf2fde38b`
+
+:::
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable;
+```
+
+Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.
+
+#### Parameters
+
+| Name       |   Type    | Description |
+| ---------- | :-------: | ----------- |
+| `newOwner` | `address` | -           |
+
+<br/>
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_checkOwner
+
+```solidity
+function _checkOwner() internal view;
+```
+
+Throws if the sender is not the owner.
+
+<br/>
+
+### \_setOwner
+
+```solidity
+function _setOwner(address newOwner) internal nonpayable;
+```
+
+Changes the owner if `newOwner` and oldOwner are different
+This pattern is useful in inheritance.
+
+<br/>
+
+### \_execute
+
+```solidity
+function _execute(
+  uint256 operationType,
+  address target,
+  uint256 value,
+  bytes data
+) internal nonpayable returns (bytes);
+```
+
+check the `operationType` provided and perform the associated low-level opcode.
+see `IERC725X.execute(uint256,address,uint256,bytes)`.
+
+<br/>
+
+### \_executeBatch
+
+```solidity
+function _executeBatch(
+  uint256[] operationsType,
+  address[] targets,
+  uint256[] values,
+  bytes[] datas
+) internal nonpayable returns (bytes[]);
+```
+
+same as `_execute` but for batch execution
+see `IERC725X,execute(uint256[],address[],uint256[],bytes[])`
+
+<br/>
+
+### \_executeCall
+
+```solidity
+function _executeCall(
+  address target,
+  uint256 value,
+  bytes data
+) internal nonpayable returns (bytes result);
+```
+
+perform low-level call (operation type = 0)
+
+#### Parameters
+
+| Name     |   Type    | Description                           |
+| -------- | :-------: | ------------------------------------- |
+| `target` | `address` | The address on which call is executed |
+| `value`  | `uint256` | The value to be sent with the call    |
+| `data`   |  `bytes`  | The data to be sent with the call     |
+
+#### Returns
+
+| Name     |  Type   | Description            |
+| -------- | :-----: | ---------------------- |
+| `result` | `bytes` | The data from the call |
+
+<br/>
+
+### \_executeStaticCall
+
+```solidity
+function _executeStaticCall(
+  address target,
+  bytes data
+) internal nonpayable returns (bytes result);
+```
+
+perform low-level staticcall (operation type = 3)
+
+#### Parameters
+
+| Name     |   Type    | Description                                 |
+| -------- | :-------: | ------------------------------------------- |
+| `target` | `address` | The address on which staticcall is executed |
+| `data`   |  `bytes`  | The data to be sent with the staticcall     |
+
+#### Returns
+
+| Name     |  Type   | Description                           |
+| -------- | :-----: | ------------------------------------- |
+| `result` | `bytes` | The data returned from the staticcall |
+
+<br/>
+
+### \_executeDelegateCall
+
+```solidity
+function _executeDelegateCall(
+  address target,
+  bytes data
+) internal nonpayable returns (bytes result);
+```
+
+perform low-level delegatecall (operation type = 4)
+
+#### Parameters
+
+| Name     |   Type    | Description                                   |
+| -------- | :-------: | --------------------------------------------- |
+| `target` | `address` | The address on which delegatecall is executed |
+| `data`   |  `bytes`  | The data to be sent with the delegatecall     |
+
+#### Returns
+
+| Name     |  Type   | Description                             |
+| -------- | :-----: | --------------------------------------- |
+| `result` | `bytes` | The data returned from the delegatecall |
+
+<br/>
+
+### \_deployCreate
+
+```solidity
+function _deployCreate(
+  uint256 value,
+  bytes creationCode
+) internal nonpayable returns (bytes newContract);
+```
+
+deploy a contract using the CREATE opcode (operation type = 1)
+
+#### Parameters
+
+| Name           |   Type    | Description                                                                        |
+| -------------- | :-------: | ---------------------------------------------------------------------------------- |
+| `value`        | `uint256` | The value to be sent to the contract created                                       |
+| `creationCode` |  `bytes`  | The contract creation bytecode to deploy appended with the constructor argument(s) |
+
+#### Returns
+
+| Name          |  Type   | Description                                  |
+| ------------- | :-----: | -------------------------------------------- |
+| `newContract` | `bytes` | The address of the contract created as bytes |
+
+<br/>
+
+### \_deployCreate2
+
+```solidity
+function _deployCreate2(
+  uint256 value,
+  bytes creationCode
+) internal nonpayable returns (bytes newContract);
+```
+
+deploy a contract using the CREATE2 opcode (operation type = 2)
+
+#### Parameters
+
+| Name           |   Type    | Description                                                                                           |
+| -------------- | :-------: | ----------------------------------------------------------------------------------------------------- |
+| `value`        | `uint256` | The value to be sent to the contract created                                                          |
+| `creationCode` |  `bytes`  | The contract creation bytecode to deploy appended with the constructor argument(s) and a bytes32 salt |
+
+#### Returns
+
+| Name          |  Type   | Description                                  |
+| ------------- | :-----: | -------------------------------------------- |
+| `newContract` | `bytes` | The address of the contract created as bytes |
+
+<br/>
+
+### \_getData
+
+```solidity
+function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
+```
+
+<br/>
+
+### \_setData
+
+```solidity
+function _setData(bytes32 dataKey, bytes dataValue) internal nonpayable;
+```
+
+<br/>
+
+## Events
+
+### ContractCreated
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#contractcreated)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Event signature: `ContractCreated(uint256,address,uint256,bytes32)`
+- Event topic hash: `0xa1fb700aaee2ae4a2ff6f91ce7eba292f89c2f5488b8ec4c5c5c8150692595c3`
+
+:::
+
+```solidity
+event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
+```
+
+_Emitted when deploying a contract_
+
+Emitted whenever a contract is created
+
+#### Parameters
+
+| Name                            |   Type    | Description                                                                    |
+| ------------------------------- | :-------: | ------------------------------------------------------------------------------ |
+| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (CREATE or CREATE2)                     |
+| `contractAddress` **`indexed`** | `address` | The created contract address                                                   |
+| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract address |
+| `salt`                          | `bytes32` | -                                                                              |
+
+<br/>
+
+### DataChanged
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#datachanged)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Event signature: `DataChanged(bytes32,bytes)`
+- Event topic hash: `0xece574603820d07bc9b91f2a932baadf4628aabcb8afba49776529c14a6104b2`
+
+:::
+
+```solidity
+event DataChanged(bytes32 indexed dataKey, bytes dataValue);
+```
+
+_Emitted when data at a key is changed_
+
+#### Parameters
+
+| Name                    |   Type    | Description                          |
+| ----------------------- | :-------: | ------------------------------------ |
+| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
+| `dataValue`             |  `bytes`  | The data value to set                |
+
+<br/>
+
+### Executed
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#executed)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Event signature: `Executed(uint256,address,uint256,bytes4)`
+- Event topic hash: `0x4810874456b8e6487bd861375cf6abd8e1c8bb5858c8ce36a86a04dabfac199e`
+
+:::
+
+```solidity
+event Executed(uint256 indexed operationType, address indexed target, uint256 indexed value, bytes4 selector);
+```
+
+_Emitted when calling an address (EOA or contract)_
+
+#### Parameters
+
+| Name                          |   Type    | Description                                                                                      |
+| ----------------------------- | :-------: | ------------------------------------------------------------------------------------------------ |
+| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `to` address (CALL, STATICALL or DELEGATECALL)        |
+| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2). |
+| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred with the call (in Wei)                                   |
+| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call                           |
+
+<br/>
+
+### OwnershipTransferred
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#ownershiptransferred)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Event signature: `OwnershipTransferred(address,address)`
+- Event topic hash: `0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0`
+
+:::
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+```
+
+#### Parameters
+
+| Name                          |   Type    | Description |
+| ----------------------------- | :-------: | ----------- |
+| `previousOwner` **`indexed`** | `address` | -           |
+| `newOwner` **`indexed`**      | `address` | -           |
+
+<br/>
+
+## Errors
+
+### ERC725X_ContractDeploymentFailed
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_contractdeploymentfailed)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_ContractDeploymentFailed()`
+- Error hash: `0x0b07489b`
+
+:::
+
+```solidity
+error ERC725X_ContractDeploymentFailed();
+```
+
+reverts when contract deployment via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` failed. whether using operation type 1 (CREATE) or 2 (CREATE2).
+
+<br/>
+
+### ERC725X_CreateOperationsRequireEmptyRecipientAddress
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_createoperationsrequireemptyrecipientaddress)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_CreateOperationsRequireEmptyRecipientAddress()`
+- Error hash: `0x3041824a`
+
+:::
+
+```solidity
+error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
+```
+
+reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` whether using operation type 1 (CREATE) or 2 (CREATE2).
+
+<br/>
+
+### ERC725X_ExecuteParametersEmptyArray
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_executeparametersemptyarray)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_ExecuteParametersEmptyArray()`
+- Error hash: `0xe9ad2b5f`
+
+:::
+
+```solidity
+error ERC725X_ExecuteParametersEmptyArray();
+```
+
+reverts when one of the array parameter provided to `executeBatch(uint256[],address[],uint256[],bytes[]) is an empty array
+
+<br/>
+
+### ERC725X_ExecuteParametersLengthMismatch
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_executeparameterslengthmismatch)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_ExecuteParametersLengthMismatch()`
+- Error hash: `0x3ff55f4d`
+
+:::
+
+```solidity
+error ERC725X_ExecuteParametersLengthMismatch();
+```
+
+reverts when there is not the same number of operation, to addresses, value, and data.
+
+<br/>
+
+### ERC725X_InsufficientBalance
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_insufficientbalance)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_InsufficientBalance(uint256,uint256)`
+- Error hash: `0x0df9a8f8`
+
+:::
+
+```solidity
+error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
+```
+
+reverts when trying to send more native tokens `value` than available in current `balance`.
+
+#### Parameters
+
+| Name      |   Type    | Description                                                                              |
+| --------- | :-------: | ---------------------------------------------------------------------------------------- |
+| `balance` | `uint256` | the balance of the ERC725X contract.                                                     |
+| `value`   | `uint256` | the amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
+
+<br/>
+
+### ERC725X_MsgValueDisallowedInDelegateCall
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_msgvaluedisallowedindelegatecall)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_MsgValueDisallowedInDelegateCall()`
+- Error hash: `0x5ac83135`
+
+:::
+
+```solidity
+error ERC725X_MsgValueDisallowedInDelegateCall();
+```
+
+the `value` parameter (= sending native tokens) is not allowed when making a delegatecall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because msg.value is persisting.
+
+<br/>
+
+### ERC725X_MsgValueDisallowedInStaticCall
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_msgvaluedisallowedinstaticcall)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_MsgValueDisallowedInStaticCall()`
+- Error hash: `0x72f2bc6a`
+
+:::
+
+```solidity
+error ERC725X_MsgValueDisallowedInStaticCall();
+```
+
+the `value` parameter (= sending native tokens) is not allowed when making a staticcall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because sending native tokens is a state changing operation.
+
+<br/>
+
+### ERC725X_NoContractBytecodeProvided
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_nocontractbytecodeprovided)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_NoContractBytecodeProvided()`
+- Error hash: `0xb81cd8d9`
+
+:::
+
+```solidity
+error ERC725X_NoContractBytecodeProvided();
+```
+
+reverts when no contract bytecode was provided as parameter when trying to deploy a contract via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
+
+<br/>
+
+### ERC725X_UnknownOperationType
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725x_unknownoperationtype)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725X_UnknownOperationType(uint256)`
+- Error hash: `0x7583b3bc`
+
+:::
+
+```solidity
+error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
+```
+
+reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
+
+#### Parameters
+
+| Name                    |   Type    | Description |
+| ----------------------- | :-------: | ----------- |
+| `operationTypeProvided` | `uint256` | -           |
+
+<br/>
+
+### ERC725Y_DataKeysValuesEmptyArray
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y_datakeysvaluesemptyarray)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725Y_DataKeysValuesEmptyArray()`
+- Error hash: `0x97da5f95`
+
+:::
+
+```solidity
+error ERC725Y_DataKeysValuesEmptyArray();
+```
+
+reverts when one of the array parameter provided to `setDataBatch` is an empty array
+
+<br/>
+
+### ERC725Y_DataKeysValuesLengthMismatch
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y_datakeysvalueslengthmismatch)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725Y_DataKeysValuesLengthMismatch()`
+- Error hash: `0x3bcc8979`
+
+:::
+
+```solidity
+error ERC725Y_DataKeysValuesLengthMismatch();
+```
+
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+
+<br/>
+
+### ERC725Y_MsgValueDisallowed
+
+:::note References
+
+- Specification details: [**ERC-725**](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-725.md#erc725y_msgvaluedisallowed)
+- Solidity implementation: [`ERC725.sol`](https://github.com/ERC725Alliance/ERC725/blob/main/implementations/contracts/ERC725.sol)
+- Error signature: `ERC725Y_MsgValueDisallowed()`
+- Error hash: `0xf36ba737`
+
+:::
+
+```solidity
+error ERC725Y_MsgValueDisallowed();
+```
+
+reverts when sending value to the `setData(..)` functions
+
+<br/>


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

Add auto-generated docs for `ERC725` smart contracts under a folder `docs/ERC725/ERC725.md`.

## Build

- update filepath in dodoc config + adjust helper scripts