### PR TITLE
chore: prepare release 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.10.3](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.10.2...v0.10.3) (2023-07-20)
+
+### Bug Fixes
+
+- Repair problem in package.json where require/import was swapped. Add in export of package.json ([4e38d39](https://github.com/lukso-network/lsp-smart-contracts/commit/4e38d39a82ef0e53cd5fcd4bbc5b0e4d4454993d))
+
 ## [0.10.2](https://github.com/lukso-network/lsp-smart-contracts/compare/v0.10.1...v0.10.2) (2023-06-13)
 
 ### Refactor

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukso/lsp-smart-contracts",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukso/lsp-smart-contracts",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "The reference implementation for universal profiles smart contracts",
   "directories": {
     "test": "test"


### PR DESCRIPTION
# What does this PR introduce?

This PR prepare for a patch release of the smart contracts package that include a bug fix for importing values from the `constants.es.js` or `constants.cjs.js`. See #633 for details.

- Bump version in `package.json` from `0.10.2` to `0.10.3`.
- Add details of release and commits references in `CHANGELOG.md`.
