### PR TITLE
fix: (C4#124) delete `pendingOwner` on final ownership renounce 

### DIFF
--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -63,9 +63,12 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
     /**
      * @inheritdoc ILSP14Ownable2Step
      */
-    function transferOwnership(
-        address newOwner
-    ) public virtual override(OwnableUnset, ILSP14Ownable2Step) onlyOwner {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override(OwnableUnset, ILSP14Ownable2Step)
+        onlyOwner
+    {
         _transferOwnership(newOwner);
 
         address currentOwner = owner();
@@ -175,6 +178,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
 
         _setOwner(address(0));
         delete _renounceOwnershipStartedAt;
+        delete _pendingOwner;
         emit OwnershipRenounced();
     }
 }

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -63,12 +63,9 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
     /**
      * @inheritdoc ILSP14Ownable2Step
      */
-    function transferOwnership(address newOwner)
-        public
-        virtual
-        override(OwnableUnset, ILSP14Ownable2Step)
-        onlyOwner
-    {
+    function transferOwnership(
+        address newOwner
+    ) public virtual override(OwnableUnset, ILSP14Ownable2Step) onlyOwner {
         _transferOwnership(newOwner);
 
         address currentOwner = owner();


### PR DESCRIPTION
# What does this PR introduce?

- Deleting _pendingOwner when renounceOwnership() is called for a second time as well:

## 🐛 Bug

As `_pendingOwner` is only deleted in the first call to renounceOwnership(), an owner could regain ownership of the account after the second call to renounceOwnership() by doing the following:

- Call renounceOwnership() for the first time to initiate the process.
- Using execute(), perform a delegate call that overwrites _pendingOwner to his own address.
- Call renounceOwnership() again to set the owner to address(0).

As _pendingOwner is still set to the owner's address, he can call acceptOwnership() at anytime to regain ownership of the account.

### PR Checklist


- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
