### PR TITLE
chore: remove `Create2Factory` from code coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,3 +1,3 @@
 module.exports = {
-  skipFiles: ['Mocks', 'Legacy'],
+  skipFiles: ['Mocks', 'Legacy', 'Create2Factory'],
 };


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build + 🤖 CI

Remove the `Create2Factory` contract from the contracts used to generate the code coverage stats. This Factory is not used anymore and is legacy, giving a wrong indication of the actual code coverage.

<img width="835" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/cee262b6-491a-47f7-919d-35f001b2b428">
