### PR TITLE
refactor!: create basic `LSP1UniversalReceiver` implementation to be used through inheritance

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -11,9 +11,6 @@ import {
 // libraries
 import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {
-    ERC165Checker
-} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {LSP1Utils} from "../LSP1UniversalReceiver/LSP1Utils.sol";
 import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
@@ -24,6 +21,9 @@ import {ERC725XCore} from "@erc725/smart-contracts/contracts/ERC725XCore.sol";
 import {
     OwnableUnset
 } from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
+import {
+    LSP1UniversalReceiver
+} from "../LSP1UniversalReceiver/LSP1UniversalReceiver.sol";
 import {LSP14Ownable2Step} from "../LSP14Ownable2Step/LSP14Ownable2Step.sol";
 import {LSP17Extendable} from "../LSP17ContractExtension/LSP17Extendable.sol";
 import {
@@ -41,11 +41,7 @@ import {
     _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
     _TYPEID_LSP0_OwnershipTransferred_RecipientNotification
 } from "../LSP0ERC725Account/LSP0Constants.sol";
-import {
-    _INTERFACEID_LSP1,
-    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
-    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
-} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+import {_INTERFACEID_LSP1} from "../LSP1UniversalReceiver/LSP1Constants.sol";
 import {_INTERFACEID_LSP14} from "../LSP14Ownable2Step/LSP14Constants.sol";
 
 import {
@@ -98,14 +94,13 @@ abstract contract LSP0ERC725AccountCore is
     ERC725YCore,
     IERC1271,
     ILSP0ERC725Account,
-    ILSP1UniversalReceiver,
+    LSP1UniversalReceiver,
     LSP14Ownable2Step,
     LSP17Extendable,
     LSP20CallVerification
 {
-    using ERC165Checker for address;
-    using LSP1Utils for address;
     using Address for address;
+    using LSP1Utils for address;
 
     /**
      * @dev Executed:
@@ -460,82 +455,11 @@ abstract contract LSP0ERC725AccountCore is
     function universalReceiver(
         bytes32 typeId,
         bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    ) public payable virtual override returns (bytes memory returnedValues) {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }
-
-        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY}
-        bytes memory lsp1DelegateValue = _getData(
-            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
-        );
-        bytes memory resultDefaultDelegate;
-
-        if (lsp1DelegateValue.length >= 20) {
-            address universalReceiverDelegate = address(
-                bytes20(lsp1DelegateValue)
-            );
-
-            // Checking LSP1 InterfaceId support
-            if (
-                universalReceiverDelegate.supportsERC165InterfaceUnchecked(
-                    _INTERFACEID_LSP1
-                )
-            ) {
-                // calling {universalReceiver} function on URD appending the caller and the value sent
-                resultDefaultDelegate = universalReceiverDelegate
-                    .callUniversalReceiverWithCallerInfos(
-                        typeId,
-                        receivedData,
-                        msg.sender,
-                        msg.value
-                    );
-            }
-        }
-
-        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
-        bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
-            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
-            bytes20(typeId)
-        );
-
-        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
-        bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
-        bytes memory resultTypeIdDelegate;
-
-        if (lsp1TypeIdDelegateValue.length >= 20) {
-            address universalReceiverDelegate = address(
-                bytes20(lsp1TypeIdDelegateValue)
-            );
-
-            // Checking LSP1 InterfaceId support
-            if (
-                universalReceiverDelegate.supportsERC165InterfaceUnchecked(
-                    _INTERFACEID_LSP1
-                )
-            ) {
-                // calling {universalReceiver} function on URD appending the caller and the value sent
-                resultTypeIdDelegate = universalReceiverDelegate
-                    .callUniversalReceiverWithCallerInfos(
-                        typeId,
-                        receivedData,
-                        msg.sender,
-                        msg.value
-                    );
-            }
-        }
-
-        returnedValues = abi.encode(
-            resultDefaultDelegate,
-            resultTypeIdDelegate
-        );
-        emit UniversalReceiver(
-            msg.sender,
-            msg.value,
-            typeId,
-            receivedData,
-            returnedValues
-        );
+        return super.universalReceiver(typeId, receivedData);
     }
 
     /**

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiver.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {
+    ILSP1UniversalReceiver
+} from "../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+
+// modules
+import {ERC725YCore} from "@erc725/smart-contracts/contracts/ERC725YCore.sol";
+
+// libraries
+import {
+    ERC165Checker
+} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {LSP1Utils} from "../LSP1UniversalReceiver/LSP1Utils.sol";
+import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
+
+// constants
+import {
+    _INTERFACEID_LSP1,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
+} from "../LSP1UniversalReceiver/LSP1Constants.sol";
+
+abstract contract LSP1UniversalReceiver is ERC725YCore, ILSP1UniversalReceiver {
+    using ERC165Checker for address;
+    using LSP1Utils for address;
+
+    function universalReceiver(
+        bytes32 typeId,
+        bytes calldata receivedData
+    ) public payable virtual returns (bytes memory returnedValues) {
+        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY}
+        bytes memory lsp1DelegateValue = _getData(
+            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY
+        );
+        bytes memory resultDefaultDelegate;
+
+        if (lsp1DelegateValue.length >= 20) {
+            address universalReceiverDelegate = address(
+                bytes20(lsp1DelegateValue)
+            );
+
+            // Checking LSP1 InterfaceId support
+            if (
+                universalReceiverDelegate.supportsERC165InterfaceUnchecked(
+                    _INTERFACEID_LSP1
+                )
+            ) {
+                // calling {universalReceiver} function on URD appending the caller and the value sent
+                resultDefaultDelegate = universalReceiverDelegate
+                    .callUniversalReceiverWithCallerInfos(
+                        typeId,
+                        receivedData,
+                        msg.sender,
+                        msg.value
+                    );
+            }
+        }
+
+        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
+        bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
+            _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+            bytes20(typeId)
+        );
+
+        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
+        bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
+        bytes memory resultTypeIdDelegate;
+
+        if (lsp1TypeIdDelegateValue.length >= 20) {
+            address universalReceiverDelegate = address(
+                bytes20(lsp1TypeIdDelegateValue)
+            );
+
+            // Checking LSP1 InterfaceId support
+            if (
+                universalReceiverDelegate.supportsERC165InterfaceUnchecked(
+                    _INTERFACEID_LSP1
+                )
+            ) {
+                // calling {universalReceiver} function on URD appending the caller and the value sent
+                resultTypeIdDelegate = universalReceiverDelegate
+                    .callUniversalReceiverWithCallerInfos(
+                        typeId,
+                        receivedData,
+                        msg.sender,
+                        msg.value
+                    );
+            }
+        }
+
+        returnedValues = abi.encode(
+            resultDefaultDelegate,
+            resultTypeIdDelegate
+        );
+        emit UniversalReceiver(
+            msg.sender,
+            msg.value,
+            typeId,
+            receivedData,
+            returnedValues
+        );
+    }
+}


### PR DESCRIPTION
# What does this PR introduce?

Create a basic implementation of `LSP1UniversalReceiver` that implements the core logic of the `universalReceiver(...)` function present in `LSP0Core` and `LSP9Core`.

This aims to:
- avoid duplication in both code base of LSP0 and LSP9
- provide composability for projects that want to implement LSP1 only (they can simply inherit the contract).
