### PR TITLE
fix: (C4 #13) use bitwise `OR` / `|` to avoid combining two permissions twice

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -185,11 +185,11 @@ library LSP6Utils {
     function combinePermissions(
         bytes32[] memory permissions
     ) internal pure returns (bytes32) {
-        uint256 result = 0;
+        bytes32 result;
         for (uint256 i = 0; i < permissions.length; i++) {
-            result += uint256(permissions[i]);
+            result |= permissions[i];
         }
-        return bytes32(result);
+        return result;
     }
 
     /**

--- a/tests/foundry/LSP6KeyManager/LSP6RestrictedController.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6RestrictedController.t.sol
@@ -1,0 +1,71 @@
+pragma solidity ^0.8.13;
+
+import "../../../contracts/LSP6KeyManager/LSP6KeyManager.sol";
+import "../../../contracts/LSP0ERC725Account/LSP0ERC725Account.sol";
+import "../../../contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol";
+import "../../../contracts/LSP6KeyManager/LSP6Constants.sol";
+import "../GasTests/UniversalProfileTestsHelper.sol";
+
+import {NotAuthorised} from "../../../contracts/LSP6KeyManager/LSP6Errors.sol";
+
+import {
+    OPERATION_4_DELEGATECALL
+} from "@erc725/smart-contracts/contracts/constants.sol";
+
+contract LSP6RestrictedController is UniversalProfileTestsHelper {
+    LSP0ERC725Account public mainUniversalProfile;
+    LSP6KeyManager public keyManagerMainUP;
+    address public mainUniversalProfileOwner;
+    address public combineController;
+
+    function setUp() public {
+        mainUniversalProfileOwner = vm.addr(1);
+        vm.label(mainUniversalProfileOwner, "mainUniversalProfileOwner");
+        combineController = vm.addr(10);
+        vm.label(combineController, "combineController");
+        mainUniversalProfile = new LSP0ERC725Account(mainUniversalProfileOwner);
+
+        // deploy LSP6KeyManager
+        keyManagerMainUP = new LSP6KeyManager(address(mainUniversalProfile));
+        transferOwnership(
+            mainUniversalProfile,
+            mainUniversalProfileOwner,
+            address(keyManagerMainUP)
+        );
+    }
+
+    function testFail_evenWhenPermissionsGivenTwice() public {
+        bytes32[] memory ownerPermissions = new bytes32[](3);
+        ownerPermissions[0] = _PERMISSION_DEPLOY;
+        ownerPermissions[1] = _PERMISSION_DEPLOY;
+        givePermissionsToController(
+            mainUniversalProfile,
+            combineController,
+            address(keyManagerMainUP),
+            ownerPermissions
+        );
+        bytes32 controllerPermissionDataKey = LSP2Utils
+            .generateMappingWithGroupingKey(
+                _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
+                bytes20(combineController)
+            );
+        bytes32 controllerPermissions = bytes32(
+            mainUniversalProfile.getData(controllerPermissionDataKey)
+        );
+
+        // CHECK that granting permission `DEPLOY` twice should not result in granting permission `SUPER_SETDATA`
+        // - _PERMISSION_DEPLOY        = 0x0000000000000000000000000000000000000000000000000000000000010000;
+        // - _PERMISSION_SUPER_SETDATA = 0x0000000000000000000000000000000000000000000000000000000000020000;
+        assert(controllerPermissions == _PERMISSION_DEPLOY);
+
+        vm.prank(combineController);
+
+        // This should revert as the controller is only allowed to setData but only deploy contracts
+        mainUniversalProfile.setData(
+            bytes32(
+                0xcafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe
+            ),
+            hex"deadbeef"
+        );
+    }
+}

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -338,32 +338,66 @@ contract LSP6UtilsTests is Test {
     }
 
     function testCombinePermissions(
-        uint64 firstPermission,
-        uint64 secondPermission,
-        uint64 thirdPermission,
-        uint64 fourthPermission
+        bytes32 firstPermission,
+        bytes32 secondPermission,
+        bytes32 thirdPermission,
+        bytes32 fourthPermission
     ) public pure {
-        uint256 totalPermissions = uint256(firstPermission) +
-            uint256(secondPermission) +
-            uint256(thirdPermission) +
-            uint256(fourthPermission);
-        bytes32 totalPermissionsBytes32 = bytes32(totalPermissions);
+        bytes32 combinedPermissions = firstPermission |
+            secondPermission |
+            thirdPermission |
+            fourthPermission;
 
-        bytes32[] memory combinePermissions = new bytes32[](4);
-        combinePermissions[0] = bytes32(uint256(firstPermission));
-        combinePermissions[1] = bytes32(uint256(secondPermission));
-        combinePermissions[2] = bytes32(uint256(thirdPermission));
-        combinePermissions[3] = bytes32(uint256(fourthPermission));
+        bytes32[] memory permissionsList = new bytes32[](4);
+        permissionsList[0] = firstPermission;
+        permissionsList[1] = secondPermission;
+        permissionsList[2] = thirdPermission;
+        permissionsList[3] = fourthPermission;
 
         assert(
-            totalPermissionsBytes32 ==
-                LSP6Utils.combinePermissions(combinePermissions)
+            combinedPermissions == LSP6Utils.combinePermissions(permissionsList)
         );
+    }
+
+    function testCombinePermissionsWithSamePermissionListedTwice() public pure {
+        bytes32[] memory permissionsList = new bytes32[](2);
+
+        permissionsList[0] = _PERMISSION_STATICCALL;
+        permissionsList[1] = _PERMISSION_STATICCALL;
+
+        // CHECK that if the same permission is mentioned twice in the array param, it results
+        // in the same permission and not something else
+        assert(
+            LSP6Utils.combinePermissions(permissionsList) ==
+                _PERMISSION_STATICCALL
+        );
+    }
+
+    function testCombinePermissionsWithMultiplePermissionListedMultipleTimes()
+        public
+        pure
+    {
+        bytes32[] memory permissionsList = new bytes32[](7);
+
+        permissionsList[0] = _PERMISSION_STATICCALL;
+        permissionsList[1] = _PERMISSION_STATICCALL;
+        permissionsList[2] = _PERMISSION_TRANSFERVALUE;
+        permissionsList[3] = _PERMISSION_TRANSFERVALUE;
+        permissionsList[4] = _PERMISSION_TRANSFERVALUE;
+        permissionsList[5] = _PERMISSION_SETDATA;
+        permissionsList[6] = _PERMISSION_SIGN;
+
+        bytes32 expectedResult = _PERMISSION_STATICCALL |
+            _PERMISSION_TRANSFERVALUE |
+            _PERMISSION_SETDATA |
+            _PERMISSION_SIGN;
+
+        assert(LSP6Utils.combinePermissions(permissionsList) == expectedResult);
     }
 
     function testHasPermissionShouldReturnTrueToAllRegularPermission(
         uint256 randomNumber
-    ) public view {
+    ) public pure {
         // number between 1 and 17 (number of permissions with non regulars)
         uint8 numberOfPermissions = uint8((randomNumber % 18) + 1);
 


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug Fix

The function `combinePermissions` adds permission together into a final combined value.
If the same permission is added twice, then this will result in a new and different permission.
For example adding `_PERMISSION_STATICCALL` twice results in `_PERMISSION_SUPER_DELEGATECALL`.

- Fix the bug by using bitwise `OR` / `|` inside the function.
- Add a set of Foundry tests to test the function `combinePermissions` + re-use the Foundry test used as a PoC in the issue **sligthly modified to test for revert**.

### PR Checklist

- [x] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`