### PR TITLE
fix: (C4 #120) inheritance of `LSP8Burnable` + add tests to check LSP4 Metadata is set correctly on deployment + initialization

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol
@@ -2,17 +2,19 @@
 pragma solidity ^0.8.4;
 
 import {
-    LSP8IdentifiableDigitalAsset
-} from "../LSP8IdentifiableDigitalAsset.sol";
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 // errors
 import {LSP8NotTokenOperator} from "../LSP8Errors.sol";
 
 /**
- * @dev LSP8 extension (standard version) that allows token holders to destroy both
+ * @dev LSP8 extension (proxy version) that allows token holders to destroy both
  * their own tokens and those that they have an allowance for as an operator.
  */
-abstract contract LSP8Burnable is LSP8IdentifiableDigitalAsset {
+abstract contract LSP8BurnableInitAbstract is
+    LSP8IdentifiableDigitalAssetInitAbstract
+{
     function burn(bytes32 tokenId, bytes memory data) public virtual {
         if (!_isOperatorOrOwner(msg.sender, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, msg.sender);

--- a/contracts/Mocks/Tokens/LSP8BurnableInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8BurnableInitTester.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+// modules
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8BurnableInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol";
+
+contract LSP8BurnableInitTester is LSP8BurnableInitAbstract {
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_
+    ) public virtual initializer {
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
+            name_,
+            symbol_,
+            newOwner_
+        );
+    }
+}

--- a/contracts/Mocks/Tokens/LSP8BurnableTester.sol
+++ b/contracts/Mocks/Tokens/LSP8BurnableTester.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+// modules
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+import {
+    LSP8Burnable
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol";
+
+contract LSP8BurnableTester is LSP8Burnable {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_
+    ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_) {}
+}

--- a/contracts/Mocks/Tokens/LSP8InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8InitTester.sol
@@ -7,12 +7,12 @@ import {
     LSP8IdentifiableDigitalAssetInitAbstract
 } from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
 import {
-    LSP8Burnable
-} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol";
+    LSP8BurnableInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol";
 
 contract LSP8InitTester is
     LSP8IdentifiableDigitalAssetInitAbstract,
-    LSP8Burnable
+    LSP8BurnableInitAbstract
 {
     function initialize(
         string memory name,

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8BurnableInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8BurnableInit.test.ts
@@ -1,0 +1,75 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import { LSP8BurnableInitTester, LSP8BurnableInitTester__factory } from '../../../types';
+
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
+
+import { deployProxy } from '../../utils/fixtures';
+
+type LSP8BurnableInitTestContext = {
+  accounts: SignerWithAddress[];
+  lsp8Burnable: LSP8BurnableInitTester;
+  deployParams: {
+    name: string;
+    symbol: string;
+    newOwner: string;
+  };
+};
+
+describe('LSP8BurnableInit with proxy', () => {
+  const buildTestContext = async () => {
+    const accounts = await ethers.getSigners();
+    const deployParams = {
+      name: 'LSP8 Burnable - deployed with constructor',
+      symbol: 'BRN',
+      newOwner: accounts[0].address,
+    };
+
+    const lsp8BurnableImplementation = await new LSP8BurnableInitTester__factory(
+      accounts[0],
+    ).deploy();
+    const lsp8BurnableProxy = await deployProxy(lsp8BurnableImplementation.address, accounts[0]);
+    const lsp8Burnable = lsp8BurnableImplementation.attach(lsp8BurnableProxy);
+
+    return { accounts, lsp8Burnable, deployParams };
+  };
+
+  const initializeProxy = async (context: LSP8BurnableInitTestContext) => {
+    return context.lsp8Burnable.initialize(
+      context.deployParams.name,
+      context.deployParams.symbol,
+      context.deployParams.newOwner,
+    );
+  };
+
+  describe('when deploying the contract as proxy', () => {
+    let context: LSP8BurnableInitTestContext;
+
+    before(async () => {
+      context = await buildTestContext();
+    });
+
+    describe('when initializing the contract', () => {
+      shouldInitializeLikeLSP8(async () => {
+        const { lsp8Burnable: lsp8, deployParams } = context;
+        const initializeTransaction = await initializeProxy(context);
+
+        return {
+          lsp8,
+          deployParams,
+          initializeTransaction,
+        };
+      });
+    });
+
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
+        await expect(initializeProxy(context)).to.be.revertedWith(
+          'Initializable: contract is already initialized',
+        );
+      });
+    });
+  });
+});

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Burnable.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Burnable.test.ts
@@ -1,0 +1,53 @@
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import { LSP8BurnableTester, LSP8BurnableTester__factory } from '../../../types';
+
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
+
+type LSP8BurnableTestContext = {
+  accounts: SignerWithAddress[];
+  lsp8Burnable: LSP8BurnableTester;
+  deployParams: {
+    name: string;
+    symbol: string;
+    newOwner: string;
+  };
+};
+
+describe('LSP8Burnable with constructor', () => {
+  const buildTestContext = async () => {
+    const accounts = await ethers.getSigners();
+    const deployParams = {
+      name: 'LSP8 Burnable - deployed with constructor',
+      symbol: 'BRN',
+      newOwner: accounts[0].address,
+    };
+
+    const lsp8Burnable = await new LSP8BurnableTester__factory(accounts[0]).deploy(
+      deployParams.name,
+      deployParams.symbol,
+      deployParams.newOwner,
+    );
+
+    return { accounts, lsp8Burnable, deployParams };
+  };
+
+  describe('when deploying the contract', () => {
+    let context: LSP8BurnableTestContext;
+
+    before(async () => {
+      context = await buildTestContext();
+    });
+
+    shouldInitializeLikeLSP8(async () => {
+      const { lsp8Burnable: lsp8, deployParams } = context;
+
+      return {
+        lsp8,
+        deployParams,
+        initializeTransaction: context.lsp8Burnable.deployTransaction,
+      };
+    });
+  });
+});


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug Fix

### Bug Description

The `LSP8Burnable` contract inherits from `LSP8IdentifiableDigitalAssetCore`:

```solidity
abstract contract LSP8Burnable is LSP8IdentifiableDigitalAssetCore {
```

However, LSP8 extensions are supposed to inherit `LSP8IdentifiableDigitalAsset` instead. This can be inferred by looking at `LSP8CappedSupply.sol`

```solidity
abstract contract LSP8CappedSupply is LSP8IdentifiableDigitalAsset {
```

Additionally, the `LSP8BurnableInitAbstract.sol` file is missing in the repository.

### Impact

As `LSP8Burnable` does not inherit `LSP8IdentifiableDigitalAsset`, a developer who implements his LSP8 token using `LSP8Burnable` will face the following issues:

- All functionality from `LSP4DigitalAssetMetadata` will be unavailable.
= As `LSP8Burnable` does not contain a `supportsInterface()` function, it will be incompatible with contracts that use [ERC-165](https://eips.ethereum.org/EIPS/eip-165).

### Fixes

- Fix the inheritance of LSP8Burnable, so that it inherits from LSP4
- Created proxy version `LSP8BurnableInitAbstract`
- Add tests to ensure LSP4 Metadata is set when deploying or initializing a contract that inherit from the `LSP8Burnable` / `LSP8BurnableInitAbstract` extension token contracts.

### PR Checklist

- [x] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`