### PR TITLE
refactor!: add LSP20 in calculation of LSP0 interface ID

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -24,7 +24,7 @@ export const INTERFACE_IDS = {
   ERC1155: '0xd9b67a26',
   ERC725X: '0x7545acac',
   ERC725Y: '0x629aa694',
-  LSP0ERC725Account: '0x3e89ad98',
+  LSP0ERC725Account: '0x24871b3d',
   LSP1UniversalReceiver: '0x6bb56a14',
   LSP6KeyManager: '0x38bb3cdb',
   LSP7DigitalAsset: '0xda1f85e4',

--- a/contracts/LSP0ERC725Account/LSP0Constants.sol
+++ b/contracts/LSP0ERC725Account/LSP0Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP0 = 0x3e89ad98;
+bytes4 constant _INTERFACEID_LSP0 = 0x24871b3d;
 bytes4 constant _INTERFACEID_ERC1271 = 0x1626ba7e;
 
 // ERC1271 - Standard Signature Validation

--- a/contracts/Mocks/ERC165Interfaces.sol
+++ b/contracts/Mocks/ERC165Interfaces.sol
@@ -91,7 +91,8 @@ contract CalculateLSPInterfaces {
             type(IERC1271).interfaceId ^
             type(ILSP1).interfaceId ^
             calculateInterfaceLSP14() ^
-            calculateInterfaceLSP17Extendable();
+            calculateInterfaceLSP17Extendable() ^
+            calculateInterfaceLSP20CallVerification();
 
         require(
             interfaceId == _INTERFACEID_LSP0,


### PR DESCRIPTION
# What does this PR introduce?

## :warning: BREAKING CHANGE

Add LSP20 in calculation of LSP0 interface.

The interface ID of LSP0 changed from `0x3e89ad98` to -> `0x24871b3d`