### PR TITLE
refactor: mark relay call signature as used

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -245,3 +245,10 @@ error RelayCallExpired();
  * @dev reverts when the address of the Key Manager is being set as extensions for lsp20 functions
  */
 error KeyManagerCannotBeSetAsExtensionForLSP20Functions();
+
+/**
+ * @dev reverts when trying to use the same arguments with a different signature.
+ * @notice Cannot use the same arguments twice! Encoded message: `encodedMessage`
+ * @param encodedMessageHash The hash of the [EIP-191] signed data.
+ */
+error CannotReplayTheRelayCall(bytes32 encodedMessageHash);


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

## ♻️ Refactor

After investigating the way signatures are stored in [`Safe.sol`](https://github.com/safe-global/safe-contracts/blob/d2dfe316ff24162159ee48b05dd6827cf95f06db/contracts/Safe.sol#L67-L68), it turns out that they have a [`signMessage(...)`](https://github.com/safe-global/safe-contracts/blob/d2dfe316ff24162159ee48b05dd6827cf95f06db/contracts/libraries/SignMessageLib.sol#L22) function which marks a signature as approved signature. That further is checked in [`isValidSignature(...)`](https://github.com/safe-global/safe-contracts/blob/d2dfe316ff24162159ee48b05dd6827cf95f06db/contracts/handler/CompatibilityFallbackHandler.sol#L34) which requires that a signature to be approved.

With this said, they don't quite have the same purpose as in our case. We need to store signatures in order to not allow double use while they store signatures that are approved. In our case we cannot use [`signMessage(...)`](https://github.com/safe-global/safe-contracts/blob/d2dfe316ff24162159ee48b05dd6827cf95f06db/contracts/libraries/SignMessageLib.sol#L22) as it will block gas-less execution and will require for someone to have gas in order to approve a signature. We need an approach that does not break the ux behind relay calls.

I took the liberty to implement it in the following way:
- Before executing a relay call, we check that the signature is marked as unused (0) in the `signedMessages` mapping.
- After executing a relay call successfully we mark the signature as used (1) in the `signedMessages` mapping.

That would 100% not allow any signature to be used twice.



<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
