### PR TITLE
refactor!: change event name from VerifiedCalled to PermissionsVerified in LSP6

### DIFF
--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -18,7 +18,7 @@ interface ILSP6KeyManager is
      * @param value The amount of native token to be transferred in the calldata payload.
      * @param selector The bytes4 function of the function that was executed on the linked {target}
      */
-    event VerifiedCall(
+    event PermissionsVerified(
         address indexed signer,
         uint256 indexed value,
         bytes4 indexed selector

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -298,7 +298,7 @@ abstract contract LSP6KeyManagerCore is
             bool isReentrantCall = _nonReentrantBefore(isSetData, caller);
 
             _verifyPermissions(caller, msgValue, data);
-            emit VerifiedCall(caller, msgValue, bytes4(data));
+            emit PermissionsVerified(caller, msgValue, bytes4(data));
 
             // if it's a setData call, do not invoke the `lsp20VerifyCallResult(..)` function
             return
@@ -363,7 +363,7 @@ abstract contract LSP6KeyManagerCore is
         bool isReentrantCall = _nonReentrantBefore(isSetData, msg.sender);
 
         _verifyPermissions(msg.sender, msgValue, payload);
-        emit VerifiedCall(msg.sender, msgValue, bytes4(payload));
+        emit PermissionsVerified(msg.sender, msgValue, bytes4(payload));
 
         bytes memory result = _executePayload(msgValue, payload);
 
@@ -429,7 +429,7 @@ abstract contract LSP6KeyManagerCore is
         }
 
         _verifyPermissions(signer, msgValue, payload);
-        emit VerifiedCall(signer, msgValue, bytes4(payload));
+        emit PermissionsVerified(signer, msgValue, bytes4(payload));
 
         bytes memory result = _executePayload(msgValue, payload);
 

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
@@ -205,7 +205,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             await expect(tx).to.not.be.reverted;
 
             expect(tx)
-              .to.emit(context.keyManager, 'VerifiedCall')
+              .to.emit(context.keyManager, 'PermissionsVerified')
               .withArgs(addressCanMakeCallWithAllowedCalls.address, 0, '0x00000000');
           });
         });

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -259,7 +259,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               );
 
             expect(tx)
-              .to.emit(context.keyManager, 'VerifiedCall')
+              .to.emit(context.keyManager, 'PermissionsVerified')
               .withArgs(
                 context.accounts[1].address,
                 signedMessageParams.msgValue,


### PR DESCRIPTION
# What does this PR introduce?

## :warning: BREAKING CHANGE

Change event name from `VerifiedCalled` to `PermissionsVerified` in LSP6 specs.
