### PR TITLE
fix: (C4 #139) refactor `_fallbackLSP17Extendable` function to enable to run code after it is called + prevent potential solc bug "storage write removal"

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -64,6 +64,7 @@ jobs:
             "lsp9init",
             "lsp11",
             "lsp11init",
+            "lsp17",
             "lsp20",
             "lsp20init",
             "lsp23",

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -805,23 +805,18 @@ abstract contract LSP0ERC725AccountCore is
         if (extension == address(0))
             revert NoExtensionFoundForFunctionSelector(msg.sig);
 
-        bytes memory calldataWithCallerInfos = abi.encodePacked(
-            callData,
-            msg.sender,
-            msg.value
-        );
-
         (bool success, bytes memory result) = extension.call(
-            calldataWithCallerInfos
+            abi.encodePacked(callData, msg.sender, msg.value)
         );
 
         if (success) {
             return result;
         } else {
-            // `result` -> first word in memory where the length of `result` is stored
-            // `add(result, 32)` -> next word in memory is where the `result` data starts
+            // `mload(result)` -> offset in memory where `result.length` is located
+            // `add(result, 32)` -> offset in memory where `result` data starts
             assembly {
-                revert(add(result, 32), mload(result))
+                let resultdata_size := mload(result)
+                revert(add(result, 32), resultdata_size)
             }
         }
     }

--- a/contracts/LSP17ContractExtension/LSP17Extendable.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extendable.sol
@@ -93,23 +93,20 @@ abstract contract LSP17Extendable is ERC165 {
         if (extension == address(0))
             revert NoExtensionFoundForFunctionSelector(msg.sig);
 
-        bytes memory calldataWithCallerInfos = abi.encodePacked(
-            callData,
-            msg.sender,
-            msg.value
-        );
-
         (bool success, bytes memory result) = extension.call(
-            calldataWithCallerInfos
+            abi.encodePacked(callData, msg.sender, msg.value)
         );
 
         if (success) {
             return result;
         } else {
-            // `result` -> first word in memory where the length of `result` is stored
-            // `add(result, 32)` -> next word in memory is where the `result` data starts
+            // `mload(result)` -> offset in memory where `result.length` is located
+            // `add(result, 32)` -> offset in memory where `result` data starts
+            // solhint-disable no-inline-assembly
+            /// @solidity memory-safe-assembly
             assembly {
-                revert(add(result, 32), mload(result))
+                let resultdata_size := mload(result)
+                revert(add(result, 32), resultdata_size)
             }
         }
     }

--- a/contracts/Mocks/FallbackExtensions/RevertErrorsTestExtension.sol
+++ b/contracts/Mocks/FallbackExtensions/RevertErrorsTestExtension.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @dev This contract is used only for testing purposes
+ */
+contract RevertErrorsTestExtension {
+    error SomeCustomError(address someAddress);
+
+    function revertWithCustomError() public view {
+        revert SomeCustomError(msg.sender);
+    }
+
+    function revertWithErrorString() public pure {
+        revert("some error message");
+    }
+
+    function revertWithPanicError() public pure {
+        uint256 number = 2;
+
+        // trigger an arithmetic underflow.
+        // this should trigger a error of type `Panic(uint256)`
+        // with error code 17 (0x11) --> Panic(0x11)
+        number -= 10;
+    }
+
+    function revertWithNoErrorData() public pure {
+        // solhint-disable reason-string
+        revert();
+    }
+}

--- a/contracts/Mocks/LSP17ExtendableTester.sol
+++ b/contracts/Mocks/LSP17ExtendableTester.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {LSP17Extendable} from "../LSP17ContractExtension/LSP17Extendable.sol";
+
+/**
+ * @dev This contract is used only for testing purposes
+ */
+contract LSP17ExtendableTester is LSP17Extendable {
+    mapping(bytes4 => address) internal _extensions;
+
+    string internal _someStorageData;
+    string internal _anotherStorageData;
+
+    // This `receive()` function is just put there to disable the following solc compiler warning:
+    //
+    // "This contract has a payable fallback function, but no receive ether function.
+    // Consider adding a receive ether function."
+    receive() external payable {}
+
+    // solhint-disable no-complex-fallback
+    fallback() external payable {
+        // CHECK we can update the contract's storage BEFORE calling an extension
+        setStorageData("updated BEFORE calling `_fallbackLSP17Extendable`");
+
+        _fallbackLSP17Extendable(msg.data);
+
+        // CHECK we can update the contract's storage AFTER calling an extension
+        setAnotherStorageData(
+            "updated AFTER calling `_fallbackLSP17Extendable`"
+        );
+    }
+
+    function getExtension(
+        bytes4 functionSelector
+    ) public view returns (address) {
+        return _getExtension(functionSelector);
+    }
+
+    function setExtension(
+        bytes4 functionSelector,
+        address extensionContract
+    ) public {
+        _extensions[functionSelector] = extensionContract;
+    }
+
+    function getStorageData() public view returns (string memory) {
+        return _someStorageData;
+    }
+
+    function setStorageData(string memory newData) public {
+        _someStorageData = newData;
+    }
+
+    function getAnotherStorageData() public view returns (string memory) {
+        return _anotherStorageData;
+    }
+
+    function setAnotherStorageData(string memory newData) public {
+        _anotherStorageData = newData;
+    }
+
+    function _getExtension(
+        bytes4 functionSelector
+    ) internal view override returns (address) {
+        return _extensions[functionSelector];
+    }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test:lsp9init": "hardhat test --no-compile tests/LSP9Vault/LSP9VaultInit.test.ts",
     "test:lsp11": "hardhat test --no-compile tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.test.ts",
     "test:lsp11init": "hardhat test --no-compile tests/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryInit.test.ts",
+    "test:lsp17": "hardhat test --no-compile tests/LSP17ContractExtension/LSP17Extendable.test.ts",
     "test:lsp20": "hardhat test --no-compile tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts",
     "test:lsp20init": "hardhat test --no-compile tests/LSP20CallVerification/LSP6/LSP20WithLSP6Init.test.ts",
     "test:lsp23": "hardhat test --no-compile tests/LSP23LinkedContractsDeployment/LSP23LinkedContractsDeployment.test.ts",

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -265,7 +265,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   .withArgs(checkMsgVariableFunctionSelector);
               });
 
-              it('should pass even if passed a different value from the msg.value', async () => {
+              it('should revert with NoExtensionFoundForFunctionSelector, even if passed a different value from the msg.value', async () => {
                 const sender = context.accounts[0];
                 const supposedValue = 200;
                 const checkMsgVariableFunctionSignature =
@@ -667,6 +667,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             .connect(context.deployParams.owner)
             .setData(bytes1ZeroPaddedExtensionHandlerKey, revertFallbackExtension.address);
         });
+
         it('should pass even if there is an extension for it that reverts', async () => {
           await expect(
             context.accounts[0].sendTransaction({
@@ -677,7 +678,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
         });
       });
 
-      describe('when calling with a payload preprended with 4 bytes of 0', () => {
+      describe('when calling with a payload prepended with 4 bytes of 0', () => {
         describe('when no extension is set for bytes4(0)', () => {
           describe('when the payload is `0x00000000`', () => {
             describe('with sending value', () => {
@@ -694,6 +695,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   .withArgs(context.accounts[0].address, amountSent);
               });
             });
+
             describe('without sending value', () => {
               it('should pass', async () => {
                 await expect(
@@ -705,6 +707,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
               });
             });
           });
+
           describe("when the payload is `0x00000000` + some random data ('graffiti')", () => {
             describe('with sending value', () => {
               it('should pass and emit ValueReceived value', async () => {
@@ -726,6 +729,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                   .withArgs(context.accounts[0].address, amountSent);
               });
             });
+
             describe('without sending value', () => {
               it('should pass', async () => {
                 const graffiti =
@@ -744,6 +748,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
             });
           });
         });
+
         describe('when there is an extension set for bytes4(0)', () => {
           describe('when setting an extension that reverts', () => {
             let revertFallbackExtension: RevertFallbackExtension;
@@ -762,6 +767,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 .connect(context.deployParams.owner)
                 .setData(bytes1ZeroPaddedExtensionHandlerKey, revertFallbackExtension.address);
             });
+
             describe('when the payload is `0x00000000`', () => {
               it('should revert', async () => {
                 await expect(
@@ -772,6 +778,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                 ).to.be.reverted;
               });
             });
+
             describe("when the payload is `0x00000000` + some random data ('graffiti')", () => {
               it('should revert', async () => {
                 const graffiti =
@@ -801,7 +808,7 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
           token = await new RequireCallbackToken__factory(context.accounts[0]).deploy();
         });
 
-        describe('when minitng to the account', () => {
+        describe('when minting to the account', () => {
           describe('before setting the onERC721ReceivedExtension', () => {
             it('should fail since onERC721Received is not implemented', async () => {
               await expect(token.mint(context.contract.address)).to.be.reverted;

--- a/tests/LSP17ContractExtension/LSP17Extendable.test.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.test.ts
@@ -1,0 +1,144 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import {
+  LSP17ExtendableTester,
+  LSP17ExtendableTester__factory,
+  EmitEventExtension,
+  EmitEventExtension__factory,
+  RevertErrorsTestExtension,
+  RevertErrorsTestExtension__factory,
+} from '../../types';
+
+describe('LSP17Extendable - Basic Implementation', () => {
+  let accounts;
+
+  let lsp17Implementation: LSP17ExtendableTester;
+  let exampleExtension: EmitEventExtension;
+  let errorsExtension: RevertErrorsTestExtension;
+
+  const selectorWithExtension =
+    EmitEventExtension__factory.createInterface().getSighash('emitEvent');
+  const selectorWithNoExtension = '0xdeadbeef';
+
+  // selectors to test that errors are bubbled up to the contract
+  const revertErrorsExtensionInterface = RevertErrorsTestExtension__factory.createInterface();
+
+  const selectorRevertCustomError =
+    revertErrorsExtensionInterface.getSighash('revertWithCustomError');
+
+  const selectorRevertErrorString =
+    revertErrorsExtensionInterface.getSighash('revertWithErrorString');
+
+  const selectorRevertPanicError =
+    revertErrorsExtensionInterface.getSighash('revertWithPanicError');
+
+  const selectorRevertNoErrorData =
+    revertErrorsExtensionInterface.getSighash('revertWithNoErrorData');
+
+  before('setup', async () => {
+    accounts = await ethers.getSigners();
+
+    lsp17Implementation = await new LSP17ExtendableTester__factory(accounts[0]).deploy();
+    exampleExtension = await new EmitEventExtension__factory(accounts[0]).deploy();
+    errorsExtension = await new RevertErrorsTestExtension__factory(accounts[0]).deploy();
+
+    await lsp17Implementation.setExtension(selectorWithExtension, exampleExtension.address);
+
+    await lsp17Implementation.setExtension(selectorRevertCustomError, errorsExtension.address);
+    await lsp17Implementation.setExtension(selectorRevertErrorString, errorsExtension.address);
+    await lsp17Implementation.setExtension(selectorRevertPanicError, errorsExtension.address);
+    await lsp17Implementation.setExtension(selectorRevertNoErrorData, errorsExtension.address);
+  });
+
+  // make sure storage is cleared before running each test
+  afterEach(async () => {
+    await lsp17Implementation.setStorageData('0x');
+    await lsp17Implementation.setAnotherStorageData('0x');
+  });
+
+  describe('when there is no extension set', () => {
+    it('should revert with error `NoExtensionFoundForFunctionSelector', async () => {
+      await expect(
+        accounts[0].sendTransaction({
+          to: lsp17Implementation.address,
+          data: selectorWithNoExtension,
+        }),
+      ).to.be.revertedWithCustomError(lsp17Implementation, 'NoExtensionFoundForFunctionSelector');
+    });
+  });
+
+  describe('when there is an extension set', () => {
+    describe('if the extension does not revert', () => {
+      it('should pass and not revert', async () => {
+        await expect(
+          accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorWithExtension,
+          }),
+        ).to.emit(exampleExtension, 'EventEmittedInExtension');
+      });
+
+      describe('if there is any code logic that run after extension was called', () => {
+        it("should have updated the contract's storage after the fallback LSP17 function ran", async () => {
+          const storageBefore = await lsp17Implementation.getStorageData();
+          expect(storageBefore).to.equal('0x');
+
+          const anotherStorageBefore = await lsp17Implementation.getAnotherStorageData();
+          expect(anotherStorageBefore).to.equal('0x');
+
+          await accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorWithExtension,
+          });
+
+          const storageAfter = await lsp17Implementation.getStorageData();
+          expect(storageAfter).to.equal('updated BEFORE calling `_fallbackLSP17Extendable`');
+
+          const anotherStorageAfter = await lsp17Implementation.getAnotherStorageData();
+          expect(anotherStorageAfter).to.equal('updated AFTER calling `_fallbackLSP17Extendable`');
+        });
+      });
+    });
+
+    describe('if the extension revert', () => {
+      it('should bubble up custom errors', async () => {
+        await expect(
+          accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorRevertCustomError,
+          }),
+        )
+          .to.be.revertedWithCustomError(errorsExtension, 'SomeCustomError')
+          .withArgs(lsp17Implementation.address);
+      });
+
+      it('should bubble up revert errors string', async () => {
+        await expect(
+          accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorRevertErrorString,
+          }),
+        ).to.be.revertedWith('some error message');
+      });
+
+      it('should bubble up Panic type errors with their code', async () => {
+        await expect(
+          accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorRevertPanicError,
+          }),
+        ).to.be.revertedWithPanic('0x11' || 17);
+      });
+
+      it('should not bubble up anything with empty error data (`revert()`)', async () => {
+        await expect(
+          accounts[0].sendTransaction({
+            to: lsp17Implementation.address,
+            data: selectorRevertNoErrorData,
+          }),
+        ).to.be.reverted;
+      });
+    });
+  });
+});


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug

Currently, the function in LSP17 `_fallbackLSP17Extendable` does not allow to run any code logic after this function is called, because it uses the low level opcode `return()` in assembly. 
This restrict some potential customization through inheritance, when one want to run some custom code logic after this function is being called.

This PR refactor this function:
- in LSP17 to take a parameter.
- in LSP0 + LSP9 to move from the following `fallback` syntax:

```solidity
fallback() external payable {
    // ...
}
```

To the new following `fallback` syntax (available in all `0.8.x` versions of Solidity).

```solidity
fallback(bytes calldata data) external payable returns (bytes memory) {
   // ...
}
```

By removing assembly, , the function can be overriden to be called via `super._fallbackLSP17Extendable(...)` and run any code after.

> **Note:** this refactoring also helps to prevent potential storage removal bug from the Solidity compiler, if projects inherit the LSP17 contract and compile their contract with a version from 0.8.13 to 0.8.16 (where the bug is present). See Solidity blog for more infos: https://soliditylang.org/blog/2022/09/08/storage-write-removal-before-conditional-termination/

## 🧪 Tests

Created new test suite `LSP17Extendable.test.ts` to test the basic functionalities of LSP17 and this new refactoring.
Tests include checking that storage write works as expected both **before** and **after** the `_fallbackLSP17Extension()` function is called.

Also added tests to ensure different type of revert reason strings are bubble up.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
