### PR TITLE
test: resolve `.skip` and `TODOs` tests in LSP6 + LSP7

### DIFF
--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1.sol
@@ -15,8 +15,6 @@ import {
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract TokenReceiverWithLSP1 is ERC165Storage, ILSP1UniversalReceiver {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     constructor() {
         _registerInterface(_INTERFACEID_LSP1);
     }
@@ -25,7 +23,7 @@ contract TokenReceiverWithLSP1 is ERC165Storage, ILSP1UniversalReceiver {
         bytes32 typeId,
         bytes memory data
     ) external payable override returns (bytes memory returnValue) {
-        emit UniversalReceiverCalled(typeId, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, "");
 
         return "thanks for calling";
     }

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721Received.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721Received.sol
@@ -22,8 +22,6 @@ contract TokenReceiverWithLSP1WithERC721Received is
     ILSP1UniversalReceiver,
     ERC721Holder
 {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     constructor() {
         _registerInterface(_INTERFACEID_LSP1);
     }
@@ -36,7 +34,7 @@ contract TokenReceiverWithLSP1WithERC721Received is
         bytes32 typeId,
         bytes memory data
     ) external payable override returns (bytes memory returnValue) {
-        emit UniversalReceiverCalled(typeId, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, "");
 
         return "thanks for calling";
     }

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedInvalid.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedInvalid.sol
@@ -22,8 +22,6 @@ contract TokenReceiverWithLSP1WithERC721ReceivedInvalid is
     ILSP1UniversalReceiver,
     ERC721Holder
 {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     constructor() {
         _registerInterface(_INTERFACEID_LSP1);
     }
@@ -36,7 +34,7 @@ contract TokenReceiverWithLSP1WithERC721ReceivedInvalid is
         bytes32 typeId,
         bytes memory data
     ) external payable override returns (bytes memory returnValue) {
-        emit UniversalReceiverCalled(typeId, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, "");
 
         return "thanks for calling";
     }

--- a/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedRevert.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithLSP1WithERC721ReceivedRevert.sol
@@ -22,8 +22,6 @@ contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
     ILSP1UniversalReceiver,
     ERC721Holder
 {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     constructor() {
         _registerInterface(_INTERFACEID_LSP1);
     }
@@ -36,7 +34,7 @@ contract TokenReceiverWithLSP1WithERC721ReceivedRevert is
         bytes32 typeId,
         bytes memory data
     ) external payable override returns (bytes memory returnValue) {
-        emit UniversalReceiverCalled(typeId, data);
+        emit UniversalReceiver(msg.sender, msg.value, typeId, data, "");
 
         return "thanks for calling";
     }

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721Received.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721Received.sol
@@ -10,8 +10,6 @@ import {
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract TokenReceiverWithoutLSP1WithERC721Received is ERC721Holder {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     receive() external payable {}
 
     fallback() external payable {}

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedInvalid.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedInvalid.sol
@@ -10,8 +10,6 @@ import {
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract TokenReceiverWithoutLSP1WithERC721ReceivedInvalid is ERC721Holder {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     receive() external payable {}
 
     fallback() external payable {}

--- a/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedRevert.sol
+++ b/contracts/Mocks/Tokens/TokenReceiverWithoutLSP1WithERC721ReceivedRevert.sol
@@ -10,8 +10,6 @@ import {
 import {_INTERFACEID_LSP1} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
 contract TokenReceiverWithoutLSP1WithERC721ReceivedRevert is ERC721Holder {
-    event UniversalReceiverCalled(bytes32 typeId, bytes data);
-
     receive() external payable {}
 
     fallback() external payable {}

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
@@ -21,11 +21,6 @@ describe('LSP20 + LSP6 with constructor', () => {
     return { accounts, owner, universalProfile, keyManager, initialFunding };
   };
 
-  describe('when deploying the contract', () => {
-    // TODO: add tests to ensure LSP20 interface is registered.
-    // on LSP6 or LSP0?
-  });
-
   describe('when testing deployed contract', () => {
     shouldBehaveLikeLSP6(buildTestContext);
   });

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedCalls.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/SetAllowedCalls.test.ts
@@ -191,50 +191,48 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should fail with NotAuthorised -> beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          [
-            '0xcafecafecafecafecafecafecafecafecafecafe',
-            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.VALUE, CALLTYPE.VALUE],
+            [
+              '0xcafecafecafecafecafecafecafecafecafecafe',
+              '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-      });
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should fail with NotAuthorised -> beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          [
-            '0xcafecafecafecafecafecafecafecafecafecafe',
-            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.VALUE, CALLTYPE.VALUE],
+            [
+              '0xcafecafecafecafecafecafecafecafecafecafe',
+              '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
       });
 
       it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
@@ -365,54 +363,52 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          [
-            '0xcafecafecafecafecafecafecafecafecafecafe',
-            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.VALUE, CALLTYPE.VALUE],
+            [
+              '0xcafecafecafecafecafecafecafecafecafecafe',
+              '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
-      });
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 40 x 0 bytes set initially as allowed addresses', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should pass when address had 40 x 0 bytes set initially as allowed addresses', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          [
-            '0xcafecafecafecafecafecafecafecafecafecafe',
-            '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.VALUE, CALLTYPE.VALUE],
+            [
+              '0xcafecafecafecafecafecafecafecafecafecafe',
+              '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
       });
 
       describe('when changing the list of allowed calls from existing ANY:<address>:ANY to an invalid value', () => {
@@ -537,50 +533,48 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // Even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.VALUE, CALLTYPE.VALUE],
-          ['0xffffffff', '0xffffffff'],
-          ['0xcafecafe', '0xca11ca11'],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.VALUE, CALLTYPE.VALUE],
+            ['0xffffffff', '0xffffffff'],
+            ['0xcafecafe', '0xca11ca11'],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-      });
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xcafecafe', '0xca11ca11'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xcafecafe', '0xca11ca11'],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
       });
 
       it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
@@ -707,54 +701,52 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // Even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xcafecafe', '0xbeefbeef'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xcafecafe', '0xbeefbeef'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
-      });
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 40 x 0 bytes set initially as allowed functions', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should pass when address had 40 x 0 bytes set initially as allowed functions', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          ['0xffffffff', '0xffffffff'],
-          ['0xcafecafe', '0xbeefbeef'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            ['0xffffffff', '0xffffffff'],
+            ['0xcafecafe', '0xbeefbeef'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
       });
 
       describe('when changing the list of selectors in allowed calls from existing ANY:ANY:<selector> to an invalid value', () => {
@@ -899,64 +891,62 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
           .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // Even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should fail with NotAuthorised -> when beneficiary had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          [
-            INTERFACE_IDS.LSP7DigitalAsset,
-            INTERFACE_IDS.ERC20,
-            INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
-            INTERFACE_IDS.ERC721,
-          ],
-          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            [
+              INTERFACE_IDS.LSP7DigitalAsset,
+              INTERFACE_IDS.ERC20,
+              INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
+              INTERFACE_IDS.ERC721,
+            ],
+            ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-      });
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should fail with NotAuthorised -> when beneficiary had 40 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          [
-            INTERFACE_IDS.LSP7DigitalAsset,
-            INTERFACE_IDS.ERC20,
-            INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
-            INTERFACE_IDS.ERC721,
-          ],
-          ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            [
+              INTERFACE_IDS.LSP7DigitalAsset,
+              INTERFACE_IDS.ERC20,
+              INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
+              INTERFACE_IDS.ERC721,
+            ],
+            ['0xffffffff', '0xffffffff', '0xffffffff', '0xffffffff'],
+          );
 
-        await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
-          .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-          .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          await expect(context.universalProfile.connect(canOnlyAddController).setData(key, value))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+        });
       });
 
       it('should pass when beneficiary had no values set under AddressPermissions:AllowedCalls:... + setting a valid bytes28[CompactBytesArray]', async () => {
@@ -1102,54 +1092,52 @@ export const shouldBehaveLikeSetAllowedCalls = (buildContext: () => Promise<LSP6
         expect(result).to.equal(value);
       });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero32Bytes.address.substring(2);
+      // Even if the controller had some 00 bytes set as allowed calls, it is not considered as it does not have any allowed calls set
+      // but rather that its allowed calls are "disabled"
+      describe('when beneficiary (= controller) had 00 bytes set initially as allowed calls (e.g: allowed calls disabled)', () => {
+        it('should pass when address had 32 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero32Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
-      });
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
 
-      /**
-       * TODO: this test pass but behaviour when some zero bytes are stored must be clarified.
-       */
-      it.skip('should pass when address had 40 x 0 bytes set initially as allowed calls', async () => {
-        const key =
-          ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          zero40Bytes.address.substring(2);
+        it('should pass when address had 40 x 0 bytes set initially as allowed calls', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+            zero40Bytes.address.substring(2);
 
-        const value = combineAllowedCalls(
-          [CALLTYPE.CALL, CALLTYPE.CALL],
-          [
-            '0xffffffffffffffffffffffffffffffffffffffff',
-            '0xffffffffffffffffffffffffffffffffffffffff',
-          ],
-          [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
-          ['0xffffffff', '0xffffffff'],
-        );
+          const value = combineAllowedCalls(
+            [CALLTYPE.CALL, CALLTYPE.CALL],
+            [
+              '0xffffffffffffffffffffffffffffffffffffffff',
+              '0xffffffffffffffffffffffffffffffffffffffff',
+            ],
+            [INTERFACE_IDS.LSP7DigitalAsset, INTERFACE_IDS.ERC20],
+            ['0xffffffff', '0xffffffff'],
+          );
 
-        await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
+          await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
-        // prettier-ignore
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
+          // prettier-ignore
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
       });
 
       describe('when changing the list of interface IDs in allowed calls <standard>:ANY:ANY to an invalid value', () => {

--- a/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
@@ -38,19 +38,11 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
-      // TODO: why the allowed calls for this controller are set twice? duplicate?
-      ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
     ];
 
     const permissionsValues = [
       ALL_PERMISSIONS,
       PERMISSIONS.CALL,
-      combineAllowedCalls(
-        [CALLTYPE.CALL],
-        [targetContract.address],
-        ['0xffffffff'],
-        ['0xffffffff'],
-      ),
       combineAllowedCalls(
         [CALLTYPE.CALL],
         [targetContract.address],

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -75,7 +75,7 @@ export const testAllowedCallsInternals = (
       });
 
       it('should return `false` if there are just 2 x length bytes but not followed by the value (the allowed calls)', async () => {
-        const allowedCalls = '0x001c';
+        const allowedCalls = '0x0020';
         const result = await context.keyManagerInternalTester.isCompactBytesArrayOfAllowedCalls(
           allowedCalls,
         );
@@ -566,19 +566,7 @@ export const testAllowedCallsInternals = (
   });
 
   describe("testing 'zero bytes' stored under AddressPermission:AllowedCalls:<address>", () => {
-    type ControllersContext = {
-      noBytes: SignerWithAddress;
-      oneZeroByte: SignerWithAddress;
-      tenZeroBytes: SignerWithAddress;
-      twentyZeroBytes: SignerWithAddress;
-      thirtyTwoZeroBytes: SignerWithAddress;
-      fourtyZeroBytes: SignerWithAddress;
-      sixtyFourZeroBytes: SignerWithAddress;
-      hundredZeroBytes: SignerWithAddress;
-    };
-
     const zeroBytesValues = [
-      '0x',
       '0x' + '00'.repeat(1),
       '0x' + '00'.repeat(10),
       '0x' + '00'.repeat(20),
@@ -588,43 +576,48 @@ export const testAllowedCallsInternals = (
       '0x' + '00'.repeat(100),
     ];
 
-    let controller: ControllersContext;
+    let controllers: { description: string; account: SignerWithAddress }[];
 
     before(async () => {
       context = await buildContext();
 
-      controller = {
-        noBytes: context.accounts[1],
-        oneZeroByte: context.accounts[2],
-        tenZeroBytes: context.accounts[3],
-        twentyZeroBytes: context.accounts[4],
-        thirtyTwoZeroBytes: context.accounts[5],
-        fourtyZeroBytes: context.accounts[6],
-        sixtyFourZeroBytes: context.accounts[7],
-        hundredZeroBytes: context.accounts[8],
-      };
+      controllers = [
+        { description: 'noBytes', account: context.accounts[1] },
+        { description: 'oneZeroByte', account: context.accounts[2] },
+        { description: 'tenZeroBytes', account: context.accounts[3] },
+        { description: 'twentyZeroBytes', account: context.accounts[4] },
+        { description: 'thirtyTwoZeroBytes', account: context.accounts[5] },
+        { description: 'fourtyZeroBytes', account: context.accounts[6] },
+        { description: 'sixtyFourZeroBytes', account: context.accounts[7] },
+        { description: 'hundredZeroBytes', account: context.accounts[8] },
+      ];
 
       const permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
-        ...Object.values(controller).map(
+        ...Object.values(controllers).map(
           (controller) =>
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            controller.address.substring(2),
+            controller.account.address.substring(2),
         ),
-        ...Object.values(controller).map(
+        ...Object.values(controllers).map(
           (controller) =>
             ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-            controller.address.substring(2),
+            controller.account.address.substring(2),
         ),
       ];
 
       let permissionValues = [ALL_PERMISSIONS];
 
-      for (let ii = 0; ii < Object.values(controller).length; ii++) {
+      for (let ii = 0; ii < Object.values(controllers).length; ii++) {
         permissionValues.push(combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE));
       }
 
+      // set the AllowedCalls to zero bytes for the first test to test for `NoCallsAllowed` error
+      permissionValues.push('0x');
+
       permissionValues = permissionValues.concat(zeroBytesValues);
+
+      console.log(permissionValues);
 
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
@@ -642,121 +635,53 @@ export const testAllowedCallsInternals = (
         randomData,
       ]);
 
-      describe('should revert with `NoAllowedCall` error', () => {
-        it(`noBytes -> ${zeroBytesValues[0]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(controller.noBytes.address, payload),
-          ).to.be.reverted;
-        });
-
-        it(`oneZeroByte -> ${zeroBytesValues[1]}`, async () => {
+      describe('should revert with `NoCallsAllowed` error', () => {
+        it(`when AllowedCalls contain noBytes -> 0x`, async () => {
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
-              controller.oneZeroByte.address,
+              controllers[0].account.address,
               payload,
             ),
-          ).to.be.reverted;
-        });
-
-        it(`tenZeroBytes -> ${zeroBytesValues[2]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.tenZeroBytes.address,
-              payload,
-            ),
-          ).to.be.reverted;
-        });
-
-        it(`twentyZeroBytes -> ${zeroBytesValues[3]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.twentyZeroBytes.address,
-              payload,
-            ),
-          ).to.be.reverted;
+          ).to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NoCallsAllowed');
         });
       });
 
-      /**
-       * TODO: define the new behaviour when some empty zero bytes 0x00 are stored under `AddressPermissions:AllowedCalls:<address>`
-       */
-      describe('should revert with NotAllowedCall(...) error for:', () => {
-        it.skip(`thirtyTwoZeroBytes -> ${zeroBytesValues[4]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.thirtyTwoZeroBytes.address,
-              payload,
-            ),
-          )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
-            .withArgs(
-              controller.thirtyTwoZeroBytes.address,
-              ethers.utils.getAddress(randomAddress),
-              randomData,
-            );
-        });
+      describe('should revert with `InvalidEncodedAllowedCalls` error', () => {
+        zeroBytesValues.forEach((testCase, index) => {
+          // count number of bytes (without the `0x` prefix)
+          const numberOfZeroBytes = testCase.substring(2).length / 2;
 
-        it.skip(`fourtyZeroBytes -> ${zeroBytesValues[5]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.fourtyZeroBytes.address,
-              randomAddress,
-            ),
-          )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
-            .withArgs(
-              controller.fourtyZeroBytes.address,
-              ethers.utils.getAddress(randomAddress),
-              randomData,
-            );
-        });
-
-        it.skip(`sixtyFourZeroBytes -> ${zeroBytesValues[6]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.sixtyFourZeroBytes.address,
-              randomAddress,
-            ),
-          )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedAddress')
-            .withArgs(
-              controller.sixtyFourZeroBytes.address,
-              ethers.utils.getAddress(randomAddress),
-            );
-        });
-
-        it.skip(`hundredZeroBytes -> ${zeroBytesValues[7]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.hundredZeroBytes.address,
-              randomAddress,
-            ),
-          )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedAddress')
-            .withArgs(controller.hundredZeroBytes.address, ethers.utils.getAddress(randomAddress));
+          it(`when AllowedCalls contain ${numberOfZeroBytes} x 0x00 bytes -> ${testCase}`, async () => {
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedCall(
+                controllers[index + 1].account.address,
+                payload,
+              ),
+            )
+              .to.be.revertedWithCustomError(
+                context.keyManagerInternalTester,
+                'InvalidEncodedAllowedCalls',
+              )
+              .withArgs(testCase);
+          });
         });
       });
     });
   });
 
-  describe('testing random values under the key `AddressPermissions:AllowedCalls:<address>`', () => {
-    type ControllersContext = {
-      multipleOf29Bytes: SignerWithAddress;
-      shortBytes: SignerWithAddress;
-      longBytes: SignerWithAddress;
-    };
+  describe('testing multiple of 34 x `0x00` bytes values set under the CompactBytesArray of `AddressPermissions:AllowedCalls:<address>`', () => {
+    let context: LSP6InternalsTestContext;
 
-    const randomValues = [
-      '0x001c00000000000000000000000000000000000000000000000000000000001c00000000000000000000000000000000000000000000000000000000',
-      '0xaabbccdd',
-      '0x1234567890abcdef1234567890abcdef1234',
+    const allowedCallsValues = [
+      '0x00200000000000000000000000000000000000000000000000000000000000000000',
+      '0x0020000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000',
+      '0x002000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000',
     ];
 
     const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
     const randomData = '0xaabbccdd';
 
     let payload: string;
-    let controller: ControllersContext;
 
     before(async () => {
       context = await buildContext();
@@ -768,26 +693,20 @@ export const testAllowedCallsInternals = (
         randomData,
       ]);
 
-      controller = {
-        multipleOf29Bytes: context.accounts[1],
-        shortBytes: context.accounts[2],
-        longBytes: context.accounts[3],
-      };
-
       const permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          controller.multipleOf29Bytes.address.substring(2),
+          context.accounts[1].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          controller.shortBytes.address.substring(2),
+          context.accounts[2].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          controller.longBytes.address.substring(2),
+          context.accounts[3].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          controller.multipleOf29Bytes.address.substring(2),
+          context.accounts[1].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          controller.shortBytes.address.substring(2),
+          context.accounts[2].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-          controller.longBytes.address.substring(2),
+          context.accounts[3].address.substring(2),
       ];
 
       let permissionValues = [
@@ -797,48 +716,29 @@ export const testAllowedCallsInternals = (
         combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
       ];
 
-      permissionValues = permissionValues.concat(randomValues);
+      permissionValues = permissionValues.concat(allowedCallsValues);
 
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
     describe('`verifyAllowedCall(...)`', () => {
       describe('should revert with NotAllowedCall(...) error for:', () => {
-        // this test is invalid
-        it.skip(`multipleOf29Bytes -> ${randomValues[0]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.multipleOf29Bytes.address,
-              payload,
-            ),
-          )
-            .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
-            .withArgs(
-              controller.multipleOf29Bytes.address,
-              ethers.utils.getAddress(randomAddress),
-              randomData,
-            );
-        });
-      });
-
-      describe('should revert', () => {
-        it(`shortBytes -> ${randomValues[1]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.shortBytes.address,
-              payload,
-            ),
-          ).to.be.reverted;
-        });
-
-        // TODO: resolve this test
-        it.skip(`longBytes -> ${randomValues[2]}`, async () => {
-          await expect(
-            context.keyManagerInternalTester.verifyAllowedCall(
-              controller.longBytes.address,
-              randomAddress,
-            ),
-          ).to.be.reverted;
+        allowedCallsValues.forEach((testCase, index) => {
+          it(`multiple of 34 bytes -> ${testCase}`, async () => {
+            await expect(
+              context.keyManagerInternalTester.verifyAllowedCall(
+                // `index + 1` because `accounts[0]` has all permissions
+                context.accounts[index + 1].address,
+                payload,
+              ),
+            )
+              .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
+              .withArgs(
+                context.accounts[index + 1].address,
+                ethers.utils.getAddress(randomAddress),
+                randomData,
+              );
+          });
         });
       });
     });
@@ -864,10 +764,9 @@ export const testAllowedCallsInternals = (
         ALL_PERMISSIONS,
         combinePermissions(PERMISSIONS.CALL, PERMISSIONS.TRANSFERVALUE),
         combineAllowedCalls(
-          // we do not consider the first 4 bytes (32 bits) of the allowed call
-          // as they are for the call types
-          // the test below should revert regardless of the call type
-          // TODO: is this the correct behaviour?
+          // We do not consider the first 4 bytes (32 bits) of the allowed calls as they are for the call types
+          // The expected behaviour for this test below is to always revert regardless of the call type
+          // if we have 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff as an Allowed Call
           ['0x00000000'],
           ['0xffffffffffffffffffffffffffffffffffffffff'],
           ['0xffffffff'],

--- a/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
@@ -364,9 +364,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           txParams.to,
         );
 
-        // TODO: the Helper contract TokenReceiverWithLSP1 does not emit the standard `UniversalReceiver` event.
-        // modify this behaviour to emit the UniversalReceiver event
-        await expect(tx).to.emit(receiver, 'UniversalReceiverCalled');
+        await expect(tx).to.emit(receiver, 'UniversalReceiver');
       }
     };
 

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -775,8 +775,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   );
 
                   await expect(tx)
-                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                    .withArgs(typeId, packedData);
+                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                    .withArgs(context.lsp7.address, 0, typeId, packedData, '0x');
                 });
               });
 
@@ -848,8 +848,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   );
 
                   await expect(tx)
-                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                    .withArgs(typeId, packedData);
+                    .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                    .withArgs(context.lsp7.address, 0, typeId, packedData, '0x');
                 });
               });
 
@@ -1274,8 +1274,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                       );
 
                       await expect(tx)
-                        .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                        .withArgs(typeId, packedData);
+                        .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                        .withArgs(context.lsp7.address, 0, typeId, packedData, '0x');
                     }),
                   );
                 });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -639,8 +639,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 );
 
                 await expect(tx)
-                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                  .withArgs(typeId, packedData);
+                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                  .withArgs(context.lsp8.address, 0, typeId, packedData, '0x');
               });
             });
 
@@ -738,8 +738,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 );
 
                 await expect(tx)
-                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                  .withArgs(typeId, packedData);
+                  .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                  .withArgs(context.lsp8.address, 0, typeId, packedData, '0x');
               });
             });
 
@@ -1087,8 +1087,8 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     );
 
                     await expect(tx)
-                      .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiverCalled')
-                      .withArgs(typeId, packedData);
+                      .to.emit(helperContracts.tokenReceiverWithLSP1, 'UniversalReceiver')
+                      .withArgs(context.lsp8.address, 0, typeId, packedData, '0x');
                   }),
                 );
               });

--- a/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
@@ -23,7 +23,7 @@ export const shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios = (
     testERC725XExecuteToLSP6ExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 
-  // This tests will be enabled when we allow `ERC725X.execute(uint256[],address[],uint256[],bytes[])` in the LSP6.execute(bytes)
+  // TODO: enable these tests once we allow `ERC725X.execute(uint256[],address[],uint256[],bytes[])` in the LSP6.execute(bytes)
   describe.skip('first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`', () => {
     testERC725XBatchExecuteToERC725XExecute(buildContext, buildReentrancyContext);
   });


### PR DESCRIPTION
# What does this PR introduce?

## 🧪 Tests

- Resolve all the tests related to Allowed Calls in the Key Manager that are marked as `.skip` (no more skipped tests in the whole test suite).
- Resolve the TODOs included in the Key Manager tests + in LSP7 for the `UniversalReceiver` event.
- Replace the emitted event `UniversalReceiverCalled` by the native `UniversalReceiver` event from LSP1 for mock contracts that inherit from LSP1.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc) (N/A)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
