### PR TITLE
ci: add new solc versions in CI

### DIFF
--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -27,9 +27,13 @@ jobs:
             "0.8.12",
             "0.8.13",
             "0.8.14",
-            # 0.8.15 skipped as default in hardhat.config.ts
+            "0.8.15",
             "0.8.16",
-            "0.8.17",
+            # 0.8.17 skipped as default in hardhat.config.ts
+            "0.8.18",
+            "0.8.19",
+            "0.8.20",
+            "0.8.21",
           ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# What does this PR introduce?

## 🤖 CI

Add the in the matrix of the `solc_version.yaml` new versions of Solidity compiler `0.8.18` to `0.8.21` to ensure the `@lukso/lsp-smart-contracts` compile with the latest Solidity versions.


