### PR TITLE
feat!: add first implementation of LSP25 Execute Relay Call + update LSP6 interface ID

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -26,7 +26,7 @@ export const INTERFACE_IDS = {
   ERC725Y: '0x629aa694',
   LSP0ERC725Account: '0x3e89ad98',
   LSP1UniversalReceiver: '0x6bb56a14',
-  LSP6KeyManager: '0x38bb3cdb',
+  LSP6KeyManager: '0x627ca5d3',
   LSP7DigitalAsset: '0xda1f85e4',
   LSP8IdentifiableDigitalAsset: '0x622e7a01',
   LSP9Vault: '0x28af17e6',
@@ -36,6 +36,7 @@ export const INTERFACE_IDS = {
   LSP17Extension: '0xcee78b40',
   LSP20CallVerification: '0x1a0eb6a5',
   LSP20CallVerifier: '0x480c0ec2',
+  LSP25ExecuteRelayCall: '0x5ac79908',
 };
 
 // ERC1271
@@ -210,12 +211,6 @@ export const ERC725YDataKeys = {
 // ----------
 
 /**
- * @dev LSP6 version number for signing `executeRelayCall(...)` transaction using EIP191
- * @see for details see: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-6-KeyManager.md#executerelaycall
- */
-export const LSP6_VERSION = 6;
-
-/**
  * @dev The types of calls for an AllowedCall
  */
 export const CALLTYPE = {
@@ -319,3 +314,12 @@ export const LSP1_TYPE_IDS = {
   LSP14OwnershipTransferred_RecipientNotification:
     '0xe32c7debcb817925ba4883fdbfc52797187f28f73f860641dab1a68d9b32902c',
 };
+
+// LSP25
+// ----------
+
+/**
+ * @dev LSP25 version number for signing `executeRelayCall(...)` transaction using EIP191
+ * @see for details see: https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-25-ExecuteRelayCall.md#executerelaycall
+ */
+export const LSP25_VERSION = 25;

--- a/contracts/LSP25ExecuteRelayCall/ILSP25ExecuteRelayCall.sol
+++ b/contracts/LSP25ExecuteRelayCall/ILSP25ExecuteRelayCall.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity ^0.8.0;
+
+interface ILSP25ExecuteRelayCall {
+    /**
+     * @notice Get latest nonce for `from` in channel ID: `channelId`.
+     *
+     * @dev Get the nonce for a specific controller `from` address that can be used for signing relay transaction.
+     *
+     * @param from the address of the signer of the transaction.
+     * @param channelId the channel id that the signer wants to use for executing the transaction.
+     *
+     * @return the current nonce on a specific `channelId`
+     */
+    function getNonce(
+        address from,
+        uint128 channelId
+    ) external view returns (uint256);
+
+    /**
+     * @dev Allows any address (executor) to execute a payload (= abi-encoded function call) in the linked {target} given they have a signed message from
+     * a controller with some permissions.
+     *
+     * @param signature a 65 bytes long signature for a meta transaction according to LSP6.
+     * @param nonce the nonce of the address that signed the calldata (in a specific `_channel`), obtained via {getNonce}. Used to prevent replay attack.
+     * @param validityTimestamps * Two `uint128` timestamps concatenated together that describes
+     * when the relay transaction is valid "from" (left `uint128`) and "until" as a deadline (right `uint128`).
+     * @param payload the abi-encoded function call to execute on the linked {target}.
+     *
+     * @return the data being returned by the function called on the linked {target}.
+     */
+    function executeRelayCall(
+        bytes calldata signature,
+        uint256 nonce,
+        uint256 validityTimestamps,
+        bytes calldata payload
+    ) external payable returns (bytes memory);
+
+    /**
+     * @dev Same as {executeRelayCall} but execute a batch of signed calldata payloads (abi-encoded function calls) in a single transaction.
+     * The signed transactions can be from multiple controllers, not necessarely the same controller signer, as long as each of these controllers
+     * that signed have the right permissions related to the calldata `payload` they signed.
+     *
+     * @param signatures An array of 65 bytes long signatures for meta transactions according to LSP6.
+     * @param nonces An array of nonces of the addresses that signed the calldata payloads (in specific channels). Obtained via {getNonce}. Used to prevent replay attack.
+     * @param validityTimestamps An array of two `uint128` concatenated timestamps that describe when the relay transaction is valid "from" (left `uint128`) and "until" (right `uint128`).
+     * @param values An array of amount of native tokens to be transferred for each calldata `payload`.
+     * @param payloads An array of abi-encoded function calls to execute successively on the linked {target}.
+     *
+     * @return An array of abi-decoded return data returned by the functions called on the linked {target}.
+     */
+    function executeRelayCallBatch(
+        bytes[] calldata signatures,
+        uint256[] calldata nonces,
+        uint256[] calldata validityTimestamps,
+        uint256[] calldata values,
+        bytes[] calldata payloads
+    ) external payable returns (bytes[] memory);
+}

--- a/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.4;
+
+// version number used to validate signed relayed call
+uint256 constant LSP25_VERSION = 25;

--- a/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.4;
 
+// --- ERC165 interface ids
+bytes4 constant _INTERFACEID_LSP25 = 0x5ac79908;
+
 // version number used to validate signed relayed call
 uint256 constant LSP25_VERSION = 25;

--- a/contracts/LSP25ExecuteRelayCall/LSP25Errors.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25Errors.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+/**
+ * @dev Reverts when the `signer` address retrieved from the `signature` has an invalid nonce: `invalidNonce`.
+ *
+ * @param signer The address of the signer
+ * @param invalidNonce The nonce retrieved for the `signer` address
+ * @param signature The signature used to retrieve the `signer` address
+ */
+error InvalidRelayNonce(address signer, uint256 invalidNonce, bytes signature);
+
+/**
+ * @dev Reverts when the start timestamp provided to {executeRelayCall} function is bigger than the current timestamp.
+ */
+error RelayCallBeforeStartTime();
+
+/**
+ * @dev Reverts when the period to execute the relay call has expired.
+ */
+error RelayCallExpired();

--- a/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {LSP25_VERSION} from "./LSP25Constants.sol";
+
+// libraries
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+// errors
+import {
+    InvalidRelayNonce,
+    RelayCallBeforeStartTime,
+    RelayCallExpired
+} from "./LSP25Errors.sol";
+
+abstract contract LSP25MultiChannelNonce {
+    using ECDSA for *;
+
+    // Mapping of signer -> channelId -> nonce in channel
+    mapping(address => mapping(uint256 => uint256)) internal _nonceStore;
+
+    function getNonce(
+        address from,
+        uint128 channelId
+    ) public view virtual returns (uint256) {
+        uint256 nonceInChannel = _nonceStore[from][channelId];
+        return (uint256(channelId) << 128) | nonceInChannel;
+    }
+
+    function _validateExecuteRelayCall(
+        bytes memory signature,
+        uint256 nonce,
+        uint256 validityTimestamps,
+        uint256 msgValue,
+        bytes calldata callData
+    ) internal returns (address signerAddress) {
+        bytes memory encodedMessage = abi.encodePacked(
+            LSP25_VERSION,
+            block.chainid,
+            nonce,
+            validityTimestamps,
+            msgValue,
+            callData
+        );
+
+        signerAddress = address(this)
+            .toDataWithIntendedValidatorHash(encodedMessage)
+            .recover(signature);
+
+        if (!_isValidNonce(signerAddress, nonce)) {
+            revert InvalidRelayNonce(signerAddress, nonce, signature);
+        }
+
+        // increase nonce after successful verification
+        _nonceStore[signerAddress][nonce >> 128]++;
+
+        if (validityTimestamps != 0) {
+            uint128 startingTimestamp = uint128(validityTimestamps >> 128);
+            uint128 endingTimestamp = uint128(validityTimestamps);
+
+            // solhint-disable not-rely-on-time
+            if (block.timestamp < startingTimestamp) {
+                revert RelayCallBeforeStartTime();
+            }
+            if (block.timestamp > endingTimestamp) {
+                revert RelayCallExpired();
+            }
+        }
+
+        return signerAddress;
+    }
+
+    /**
+     * @notice verify the nonce `_idx` for `_from` (obtained via `getNonce(...)`)
+     * @dev "idx" is a 256bits (unsigned) integer, where:
+     *          - the 128 leftmost bits = channelId
+     *      and - the 128 rightmost bits = nonce within the channel
+     * @param from caller address
+     * @param idx (channel id + nonce within the channel)
+     */
+    function _isValidNonce(
+        address from,
+        uint256 idx
+    ) internal view virtual returns (bool) {
+        uint256 mask = ~uint128(0);
+        // Alternatively:
+        // uint256 mask = (1<<128)-1;
+        // uint256 mask = 0xffffffffffffffffffffffffffffffff;
+        return (idx & mask) == (_nonceStore[from][idx >> 128]);
+    }
+}

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -30,21 +30,6 @@ interface ILSP6KeyManager is
     function target() external view returns (address);
 
     /**
-     * @notice Get latest nonce for `from` in channel ID: `channelId`.
-     *
-     * @dev Get the nonce for a specific controller `from` address that can be used for signing relay transaction.
-     *
-     * @param from the address of the signer of the transaction.
-     * @param channelId the channel id that the signer wants to use for executing the transaction.
-     *
-     * @return the current nonce on a specific `channelId`
-     */
-    function getNonce(
-        address from,
-        uint128 channelId
-    ) external view returns (uint256);
-
-    /**
      * @notice execute the following payload on the linked contract: `payload`
      *
      * @dev execute a `payload` on the linked {target} after having verified the permissions associated with the function being run.
@@ -67,46 +52,6 @@ interface ILSP6KeyManager is
      * @return An array of abi-decoded of return data returned by the functions called on the linked {target}.
      */
     function executeBatch(
-        uint256[] calldata values,
-        bytes[] calldata payloads
-    ) external payable returns (bytes[] memory);
-
-    /**
-     * @dev Allows any address (executor) to execute a payload (= abi-encoded function call) in the linked {target} given they have a signed message from
-     * a controller with some permissions.
-     *
-     * @param signature a 65 bytes long signature for a meta transaction according to LSP6.
-     * @param nonce the nonce of the address that signed the calldata (in a specific `_channel`), obtained via {getNonce}. Used to prevent replay attack.
-     * @param validityTimestamps * Two `uint128` timestamps concatenated together that describes
-     * when the relay transaction is valid "from" (left `uint128`) and "until" as a deadline (right `uint128`).
-     * @param payload the abi-encoded function call to execute on the linked {target}.
-     *
-     * @return the data being returned by the function called on the linked {target}.
-     */
-    function executeRelayCall(
-        bytes calldata signature,
-        uint256 nonce,
-        uint256 validityTimestamps,
-        bytes calldata payload
-    ) external payable returns (bytes memory);
-
-    /**
-     * @dev Same as {executeRelayCall} but execute a batch of signed calldata payloads (abi-encoded function calls) in a single transaction.
-     * The signed transactions can be from multiple controllers, not necessarely the same controller signer, as long as each of these controllers
-     * that signed have the right permissions related to the calldata `payload` they signed.
-     *
-     * @param signatures An array of 65 bytes long signatures for meta transactions according to LSP6.
-     * @param nonces An array of nonces of the addresses that signed the calldata payloads (in specific channels). Obtained via {getNonce}. Used to prevent replay attack.
-     * @param validityTimestamps An array of two `uint128` concatenated timestamps that describe when the relay transaction is valid "from" (left `uint128`) and "until" (right `uint128`).
-     * @param values An array of amount of native tokens to be transferred for each calldata `payload`.
-     * @param payloads An array of abi-encoded function calls to execute successively on the linked {target}.
-     *
-     * @return An array of abi-decoded return data returned by the functions called on the linked {target}.
-     */
-    function executeRelayCallBatch(
-        bytes[] calldata signatures,
-        uint256[] calldata nonces,
-        uint256[] calldata validityTimestamps,
         uint256[] calldata values,
         bytes[] calldata payloads
     ) external payable returns (bytes[] memory);

--- a/contracts/LSP6KeyManager/ILSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/ILSP6KeyManager.sol
@@ -12,10 +12,10 @@ interface ILSP6KeyManager is
     /* is ERC165 */
 {
     /**
-     * @dev Emitted when a calldata payload that includes `selector` and `value` as msg.value was verified for `signer`
-     * @param signer the address of the controller that executed the calldata payload.
+     * @dev Emitted when the LSP6KeyManager contract verified the permissions of the `signer` successfully.
+     * @param signer the address of the controller that executed the calldata payload (either directly via {execute} or via meta transaction using {executeRelayCall}).
      * @param value the amount of native token to be transferred in the calldata payload.
-     * @param selector the bytes4 function of the function to run in the calldata payload.
+     * @param selector the bytes4 function of the function that was executed on the linked {target}
      */
     event VerifiedCall(
         address indexed signer,
@@ -24,21 +24,20 @@ interface ILSP6KeyManager is
     );
 
     /**
-     * @notice returns the address of the account linked to this KeyManager
-     * @dev this can be a contract that implements
-     *  - ERC725X only
-     *  - ERC725Y only
-     *  - any ERC725 based contract (so implementing both ERC725X and ERC725Y)
-     *
+     * @dev Get the address of the contract linked to this Key Manager.
      * @return the address of the linked account
      */
     function target() external view returns (address);
 
     /**
-     * @notice get latest nonce for `from` in channel ID: `channelId`
-     * @dev use channel ID = 0 for sequential nonces, any other number for out-of-order execution (= execution in parallel)
-     * @param from the caller or signer address
-     * @param channelId the channel id to retrieve the nonce from
+     * @notice Get latest nonce for `from` in channel ID: `channelId`.
+     *
+     * @dev Get the nonce for a specific controller `from` address that can be used for signing relay transaction.
+     *
+     * @param from the address of the signer of the transaction.
+     * @param channelId the channel id that the signer wants to use for executing the transaction.
+     *
+     * @return the current nonce on a specific `channelId`
      */
     function getNonce(
         address from,
@@ -46,17 +45,26 @@ interface ILSP6KeyManager is
     ) external view returns (uint256);
 
     /**
-     * @notice execute the following payload on the ERC725Account: `payload`
-     * @dev the ERC725Account will return some data on successful call, or revert on failure
-     * @param payload the payload to execute. Obtained in web3 via encodeABI()
-     * @return the data being returned by the ERC725 Account
+     * @notice execute the following payload on the linked contract: `payload`
+     *
+     * @dev execute a `payload` on the linked {target} after having verified the permissions associated with the function being run.
+     * The `payload` MUST be a valid abi-encoded function call of one of the functions present in the linked {target}, otherwise the call will fail.
+     * The linked {target} will return some data on successful execution, or revert on failure.
+     *
+     * @param payload the abi-encoded function call to execute on the linked {target}.
+     * @return the abi-decoded data returned by the function called on the linked {target}.
      */
     function execute(
         bytes calldata payload
     ) external payable returns (bytes memory);
 
     /**
-     * @dev batch `execute(bytes)`
+     * @dev Same as {execute} but execute a batch of payloads (abi-encoded function calls) in a single transaction.
+     *
+     * @param values An array of amount of native tokens to be transferred for each `payload`.
+     * @param payloads An array of abi-encoded function calls to execute successively on the linked {target}.
+     *
+     * @return An array of abi-decoded of return data returned by the functions called on the linked {target}.
      */
     function executeBatch(
         uint256[] calldata values,
@@ -64,12 +72,16 @@ interface ILSP6KeyManager is
     ) external payable returns (bytes[] memory);
 
     /**
-     * @dev allows anybody to execute given they have a signed message from an executor
-     * @param signature bytes32 ethereum signature
-     * @param nonce the address' nonce (in a specific `_channel`), obtained via `getNonce(...)`. Used to prevent replay attack
-     * @param validityTimestamps two `uint128` timestamps concatenated, the first timestamp determines from when the payload can be executed, the second timestamp delimits the end of the validity of the payload. If `validityTimestamps` is 0, the checks regardin the timestamps are skipped
-     * @param payload obtained via encodeABI() in web3
-     * @return the data being returned by the ERC725 Account
+     * @dev Allows any address (executor) to execute a payload (= abi-encoded function call) in the linked {target} given they have a signed message from
+     * a controller with some permissions.
+     *
+     * @param signature a 65 bytes long signature for a meta transaction according to LSP6.
+     * @param nonce the nonce of the address that signed the calldata (in a specific `_channel`), obtained via {getNonce}. Used to prevent replay attack.
+     * @param validityTimestamps * Two `uint128` timestamps concatenated together that describes
+     * when the relay transaction is valid "from" (left `uint128`) and "until" as a deadline (right `uint128`).
+     * @param payload the abi-encoded function call to execute on the linked {target}.
+     *
+     * @return the data being returned by the function called on the linked {target}.
      */
     function executeRelayCall(
         bytes calldata signature,
@@ -79,7 +91,17 @@ interface ILSP6KeyManager is
     ) external payable returns (bytes memory);
 
     /**
-     * @dev batch `executeRelayCall(...)`
+     * @dev Same as {executeRelayCall} but execute a batch of signed calldata payloads (abi-encoded function calls) in a single transaction.
+     * The signed transactions can be from multiple controllers, not necessarely the same controller signer, as long as each of these controllers
+     * that signed have the right permissions related to the calldata `payload` they signed.
+     *
+     * @param signatures An array of 65 bytes long signatures for meta transactions according to LSP6.
+     * @param nonces An array of nonces of the addresses that signed the calldata payloads (in specific channels). Obtained via {getNonce}. Used to prevent replay attack.
+     * @param validityTimestamps An array of two `uint128` concatenated timestamps that describe when the relay transaction is valid "from" (left `uint128`) and "until" (right `uint128`).
+     * @param values An array of amount of native tokens to be transferred for each calldata `payload`.
+     * @param payloads An array of abi-encoded function calls to execute successively on the linked {target}.
+     *
+     * @return An array of abi-decoded return data returned by the functions called on the linked {target}.
      */
     function executeRelayCallBatch(
         bytes[] calldata signatures,

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP6 = 0x38bb3cdb;
+bytes4 constant _INTERFACEID_LSP6 = 0x627ca5d3;
 
 // --- ERC725Y Data Keys
 

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.4;
 
-uint256 constant LSP6_VERSION = 6;
-
 // --- ERC165 interface ids
 bytes4 constant _INTERFACEID_LSP6 = 0x38bb3cdb;
 

--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -2,74 +2,87 @@
 pragma solidity ^0.8.4;
 
 /**
- * @dev reverts when address `from` does not have any permissions set
- * on the account linked to this Key Manager
+ * @dev Reverts when address `from` does not have any permissions set on the account linked to this Key Manager
+ *
  * @param from the address that does not have permissions
  */
 error NoPermissionsSet(address from);
 
 /**
- * @dev reverts when address `from` is not authorised to perform `permission` on the linked account
- * @param permission permission required
- * @param from address not-authorised
+ * @dev Reverts when address `from` is not authorised and does not have `permission` on the linked {target}
+ *
+ * @param from address The address that was not authorised.
+ * @param permission permission The permission required (_e.g: `SETDATA`, `CALL`, `TRANSFERVALUE`)
  */
 error NotAuthorised(address from, string permission);
 
 /**
- * @dev reverts when `from` is not authorised to make the call because of a not allowed standard, address or function.
- * @param from address making the request
- * @param to the address of an EOA or contract that `from` is trying to interact with
- * @param selector if `to` is a contract, the bytes4 selector of the function that `from` is trying to call.
+ * @dev Reverts when `from` is not authorised to call the `execute(uint256,address,uint256,bytes)` function because of
+ * a not allowed callType, address, standard or function.
+ *
+ * @param from address The controller that tried to call the `execute(uint256,address,uint256,bytes)` function.
+ * @param to The address of an EOA or contract that `from` tried to call using the linked {target}
+ * @param selector If `to` is a contract, the bytes4 selector of the function that `from` is trying to call.
  * If no function is called (e.g: a native token transfer), selector = 0x00000000
  */
 error NotAllowedCall(address from, address to, bytes4 selector);
 
 /**
- * @dev reverts when address `from` is not authorised to set the key `disallowedKey` on the linked account
- * @param from address making the request
- * @param disallowedKey a bytes32 key that `from` is not authorised to set on the ERC725Y storage
+ * @dev Reverts when address `from` is not authorised to set the key `disallowedKey` on the linked {target}.
+ *
+ * @param from address The controller that tried to `setData` on the linked {target}.
+ * @param disallowedKey A bytes32 data key that `from` is not authorised to set on the ERC725Y storage of the linked {target}.
  */
 error NotAllowedERC725YDataKey(address from, bytes32 disallowedKey);
 
 /**
- * @dev reverts when `dataKey` is a bytes32 that does not adhere to any of the
- *      permission data keys specified by the LSP6 standard
+ * @dev Reverts when `dataKey` is a bytes32 value that does not adhere to any of the
+ * permission data keys defined by the LSP6 standard
  *
- * @param dataKey the dataKey that does not match with any of the standard LSP6 permission data keys
+ * @param dataKey The dataKey that does not match any of the standard LSP6 permission data keys.
  */
 error NotRecognisedPermissionKey(bytes32 dataKey);
 
 /**
- * @dev reverts when the address provided as a target (= account) linked to this KeyManager is invalid
- *      e.g. address(0)
+ * @dev Reverts when the address provided to set as the {target} linked to this KeyManager is invalid (_e.g. `address(0)`_).
  */
 error InvalidLSP6Target();
 
 /**
- * @dev reverts when the `signer` address retrieved from the `signature` has an invalid nonce: `invalidNonce`.
- * @param signer the address of the signer
- * @param invalidNonce the nonce retrieved for the `signer` address
- * @param signature the signature used to retrieve the `signer` address
+ * @dev Reverts when the `signer` address retrieved from the `signature` has an invalid nonce: `invalidNonce`.
+ *
+ * @param signer The address of the signer
+ * @param invalidNonce The nonce retrieved for the `signer` address
+ * @param signature The signature used to retrieve the `signer` address
  */
 error InvalidRelayNonce(address signer, uint256 invalidNonce, bytes signature);
 
 /**
- * @dev reverts when trying to run an invalid function on the linked target account via the Key Manager.
- * @param invalidFunction the bytes4 selector of the invalid function
+ * @dev Reverts when trying to call a function on the linked {target}, that is not any of the following:
+ * - `setData(bytes32,bytes)` (ERC725Y)
+ * - `setDataBatch(bytes32[],bytes[])` (ERC725Y)
+ * - `execute(uint256,address,uint256,bytes)` (ERC725X)
+ * - `transferOwnership(address)`
+ * - `acceptOwnership()` (LSP14)
+ *
+ * @param invalidFunction The `bytes4` selector of the function selector that was attempted
+ * to be called on the linked {target} but not recognised.
  */
 error InvalidERC725Function(bytes4 invalidFunction);
 
 /**
- * @dev reverts when `allowedCallsValue` is not properly encoded as a bytes28[CompactBytesArray]
- * (CompactBytesArray of bytes28 entries). See LSP2 value type `CompactBytesArray` for details.
- * @param allowedCallsValue the list of allowedCalls
+ * @dev Reverts when `allowedCallsValue` is not properly encoded as a `(bytes4,address,bytes4,bytes4)[CompactBytesArray]`
+ * (CompactBytesArray made of tuples that are 32 bytes long each). See LSP2 value type `CompactBytesArray` for more infos.
+ *
+ * @param allowedCallsValue The list of allowedCalls that are not encoded correctly as a `(bytes4,address,bytes4,bytes4)[CompactBytesArray]`.
  */
 error InvalidEncodedAllowedCalls(bytes allowedCallsValue);
 
 /**
- * @dev reverts when trying to set a value that is not 20 bytes long under AddressPermissions[index]
- * @param dataKey the AddressPermissions[index] data key
- * @param invalidValue the invalid value that was attempted to be set under AddressPermissions[index]
+ * @dev Reverts when trying to set a value that is not 20 bytes long (not an `address`) under the `AddressPermissions[index]` data key.
+ *
+ * @param dataKey The `AddressPermissions[index]` data key, that specify the index in the `AddressPermissions[]` array.
+ * @param invalidValue The invalid value that was attempted to be set under `AddressPermissions[index]`.
  */
 error AddressPermissionArrayIndexValueNotAnAddress(
     bytes32 dataKey,
@@ -77,56 +90,69 @@ error AddressPermissionArrayIndexValueNotAnAddress(
 );
 
 /**
- * @dev reverts if there are no AllowedERC725YDataKeys set for the caller
- * @param from the address that has no AllowedERC725YDataKeys
+ * @dev Reverts when the `from` address has no AllowedERC725YDataKeys set and cannot set
+ * any ERC725Y data key on the ERC725Y storage of the linked {target}.
+ *
+ * @param from The address that has no `AllowedERC725YDataKeys` set.
  */
 error NoERC725YDataKeysAllowed(address from);
 
 /**
- * @dev reverts if there are no allowed calls set for `from`
- * @param from the address that has no AllowedCalls
+ * @dev Reverts when the `from` address has no `AllowedCalls` set and cannot interact with any address
+ * using the linked {target}.
+ *
+ * @param from The address that has no AllowedCalls.
  */
 error NoCallsAllowed(address from);
 
 /**
- * @dev reverts when `value` is not encoded properly using the CompactBytesArray
- * @param value the value to check for an CompactBytesArray
- * @param context a brief description of where the error occured
+ * @dev Reverts when `value` is not encoded properly as a `bytes32[CompactBytesArray]`. The `context` string provides context
+ * on when this error occured (_e.g: when fetching the `AllowedERC725YDataKeys` to verify the permissions of a controller,
+ * or when validating the `AllowedERC725YDataKeys` when setting them for a controller).
+ *
+ * @param value The value that is not a valid `bytes32[CompactBytesArray]`
+ * @param context A brief description of where the error occured.
  */
 error InvalidEncodedAllowedERC725YDataKeys(bytes value, string context);
 
 /**
- * @dev a `from` address is not allowed to have 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff
- * in its list of AddressPermissions:AllowedCalls:<address>, as this allows any STANDARD:ADDRESS:FUNCTION.
+ * @dev Reverts when verifying the permissions of a `from` address for its allowed calls, and has a "any whitelisted call" allowed call set.
+ * A `from` address is not allowed to have 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+ * in its list of `AddressPermissions:AllowedCalls:<address>`, as this allows any STANDARD:ADDRESS:FUNCTION.
  * This is equivalent to granting the SUPER permission and should never be valid.
  *
- * @param from the address that has any allowed calls whitelisted.
+ * @param from The controller address that has any allowed calls whitelisted set.
  */
 error InvalidWhitelistedCall(address from);
 
 /**
- * @dev reverts when providing array parameters of different sizes to `executeRelayCall(bytes[],uint256[],bytes[])`
+ * @dev Reverts when providing array parameters of different sizes to `executeRelayCall(bytes[],uint256[],bytes[])`
  */
 error BatchExecuteRelayCallParamsLengthMismatch();
 
 /**
- * @dev there should be the same number of elements for each array parameters
- * in the following batch functions:
- *  - execute(uint256[],bytes[])
- *  - executeRelayCall(bytes[],uint256[],uint256[],bytes[])
+ * @dev Reverts when the array parameters `uint256[] value` and `bytes[] payload` have different sizes.
+ * There should be the same number of elements for each array parameters.
  */
 error BatchExecuteParamsLengthMismatch();
 
 /**
- * @dev the `msg.value` sent is not enough to cover the sum of all the values being
- * forwarded on each payloads (`values[]` parameter) in the following batch functions:
- *  - execute(uint256[],bytes[])
- *  - executeRelayCall(bytes[],uint256[],uint256[],bytes[])
+ * @dev This error occurs when there was not enough funds sent to the batch functions `execute(uint256[],bytes[])` or
+ * `executeRelayCall(bytes[],uint256[],uint256[],bytes[])` to cover the sum of all the values forwarded on
+ * each payloads (`values[]` parameter from the batch functions above).
+ *
+ * This mean that `msg.value` is less than the sum of all the values being forwarded on each payloads (`values[]` parameters).
+ *
+ * @param totalValues The sum of all the values forwarded on each payloads (`values[]` parameter from the batch functions above).
+ * @param msgValue The amount of native tokens sent to the batch functions `execute(uint256[],bytes[])` or `executeRelayCall(bytes[],uint256[],uint256[],bytes[])`.
  */
 error LSP6BatchInsufficientValueSent(uint256 totalValues, uint256 msgValue);
 
 /**
- * @dev reverts to avoid the KeyManager to holds some remaining funds sent
+ * @dev This error occurs when there was too much funds sent to the batch functions `execute(uint256[],bytes[])` or
+ * `executeRelayCall(bytes[],uint256[],uint256[],bytes[])` to cover the sum of all the values forwarded on
+ *
+ * Reverts to avoid the KeyManager to holds some remaining funds sent
  * to the following batch functions:
  *  - execute(uint256[],bytes[])
  *  - executeRelayCall(bytes[],uint256[],uint256[],bytes[])
@@ -137,32 +163,35 @@ error LSP6BatchInsufficientValueSent(uint256 totalValues, uint256 msgValue);
 error LSP6BatchExcessiveValueSent(uint256 totalValues, uint256 msgValue);
 
 /**
- * @dev ERC725X operation type 4 (DELEGATECALL) is disallowed by default
+ * @dev Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,address,uint256,bytes) (operation type 4)
+ * function of the linked {target}.
+ * `DELEGATECALL` is disallowed by default on the LSP6KeyManager.
  */
 error DelegateCallDisallowedViaKeyManager();
 
 /**
- * @dev reverts when the payload is invalid.
+ * @dev Reverst when the payload is invalid.
  */
 error InvalidPayload(bytes payload);
 
 /**
- * @dev reverts when sending value to the `setData(..)` functions
+ * @dev Reverts when trying to call to the `setData(byte32,bytes)` or `setData(bytes32[],bytes[]) functions
+ * on the linked {target} while sending value.
  */
 error CannotSendValueToSetData();
 
 /**
- * @dev reverts when calling the KeyManager through execute(..)
+ * @dev Reverts when calling the KeyManager through `execute(uint256,address,uint256,bytes)`.
  */
 error CallingKeyManagerNotAllowed();
 
 /**
- * @dev reverts when relay call start timestamp is bigger than the current timestamp
+ * @dev Reverts when the start timestamp provided to {executeRelayCall} function is bigger than the current timestamp.
  */
 error RelayCallBeforeStartTime();
 
 /**
- * @dev reverts when the period to execute the relay call has expired
+ * @dev Reverts when the period to execute the relay call has expired.
  */
 error RelayCallExpired();
 

--- a/contracts/LSP6KeyManager/LSP6KeyManager.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManager.sol
@@ -6,14 +6,17 @@ import {LSP6KeyManagerCore} from "./LSP6KeyManagerCore.sol";
 import {InvalidLSP6Target} from "./LSP6Errors.sol";
 
 /**
- * @title Implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage
+ * @title Implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage.
  * @author Fabian Vogelsteller <frozeman>, Jean Cavallera (CJ42), Yamen Merhi (YamenMerhi)
- * @dev all the permissions can be set on the ERC725 Account using `setData(...)` with the keys constants below
+ * @dev All the permissions can be set on the ERC725 Account using `setData(bytes32,bytes)` or `setData(bytes32[],bytes[])`.
  */
 contract LSP6KeyManager is LSP6KeyManagerCore {
     /**
-     * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
-     * @param target_ The address of the ER725Account to control
+     * @notice Deploying a LSP6KeyManager linked to contract at address `target_`.
+     * @dev Deploy a Key Manager and set the `target_` address in the contract storage,
+     * making this Key Manager linked to this `target_` contract.
+     *
+     * @param target_ The address of the contract to control and forward calldata payloads to.
      */
     constructor(address target_) {
         if (target_ == address(0)) revert InvalidLSP6Target();

--- a/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerInit.sol
@@ -18,8 +18,11 @@ contract LSP6KeyManagerInit is LSP6KeyManagerInitAbstract {
     }
 
     /**
-     * @notice Initiate the account with the address of the ERC725Account contract and sets LSP6KeyManager InterfaceId
-     * @param target_ The address of the ER725Account to control
+     * @notice Deploying a LSP6KeyManager linked to contract at address `target_`.
+     * @dev Deploy a Key Manager and set the `target_` address in the contract storage,
+     * making this Key Manager linked to this `target_` contract.
+     *
+     * @param target_ The address of the contract to control and forward calldata payloads to.
      */
     function initialize(address target_) external virtual initializer {
         LSP6KeyManagerInitAbstract._initialize(target_);

--- a/contracts/Mocks/ERC165Interfaces.sol
+++ b/contracts/Mocks/ERC165Interfaces.sol
@@ -47,6 +47,9 @@ import {
 import {
     ILSP20CallVerifier as ILSP20
 } from "../LSP20CallVerification/ILSP20CallVerifier.sol";
+import {
+    ILSP25ExecuteRelayCall as ILSP25
+} from "../LSP25ExecuteRelayCall/ILSP25ExecuteRelayCall.sol";
 
 // constants
 import {_INTERFACEID_LSP0} from "../LSP0ERC725Account/LSP0Constants.sol";
@@ -69,9 +72,9 @@ import {
     _INTERFACEID_LSP20_CALL_VERIFICATION,
     _INTERFACEID_LSP20_CALL_VERIFIER
 } from "../LSP20CallVerification/LSP20Constants.sol";
+import {_INTERFACEID_LSP25} from "../LSP25ExecuteRelayCall/LSP25Constants.sol";
 
 // libraries
-
 import {
     ERC165Checker
 } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
@@ -231,6 +234,20 @@ contract CalculateLSPInterfaces {
         require(
             interfaceId == _INTERFACEID_LSP20_CALL_VERIFIER,
             "hardcoded _INTERFACEID_LSP20_CALL_VERIFIER does not match XOR of the functions"
+        );
+
+        return interfaceId;
+    }
+
+    function calculateInterfaceLSP25ExecuteRelayCall()
+        public
+        pure
+        returns (bytes4)
+    {
+        bytes4 interfaceId = type(ILSP25).interfaceId;
+        require(
+            interfaceId == _INTERFACEID_LSP25,
+            "hardcoded _INTERFACEID_LSP25 does not match type(ILSP25).interfaceId"
         );
 
         return interfaceId;

--- a/contracts/Mocks/Reentrancy/BatchReentrancyRelayer.sol
+++ b/contracts/Mocks/Reentrancy/BatchReentrancyRelayer.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.4;
 
 // interfaces
-import {ILSP6KeyManager} from "../../LSP6KeyManager/ILSP6KeyManager.sol";
+import {
+    ILSP25ExecuteRelayCall
+} from "../../LSP25ExecuteRelayCall/ILSP25ExecuteRelayCall.sol";
 
 contract BatchReentrancyRelayer {
     bytes[] private _signatures;
@@ -31,7 +33,7 @@ contract BatchReentrancyRelayer {
         address keyManagerAddress
     ) external returns (bytes[] memory) {
         return
-            ILSP6KeyManager(keyManagerAddress).executeRelayCallBatch(
+            ILSP25ExecuteRelayCall(keyManagerAddress).executeRelayCallBatch(
                 _signatures,
                 _nonces,
                 _validityTimestamps,

--- a/contracts/Mocks/Reentrancy/SingleReentrancyRelayer.sol
+++ b/contracts/Mocks/Reentrancy/SingleReentrancyRelayer.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.4;
 
 // interfaces
-import {ILSP6KeyManager} from "../../LSP6KeyManager/ILSP6KeyManager.sol";
+import {
+    ILSP25ExecuteRelayCall
+} from "../../LSP25ExecuteRelayCall/ILSP25ExecuteRelayCall.sol";
 
 contract SingleReentrancyRelayer {
     bytes private _signature;
@@ -28,7 +30,7 @@ contract SingleReentrancyRelayer {
         address keyManagerAddress
     ) external returns (bytes memory) {
         return
-            ILSP6KeyManager(keyManagerAddress).executeRelayCall(
+            ILSP25ExecuteRelayCall(keyManagerAddress).executeRelayCall(
                 _signature,
                 _nonce,
                 _validityTimestamps,

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -1,0 +1,986 @@
+# LSP6KeyManager
+
+:::info Solidity contract
+
+[`LSP6KeyManager.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+
+:::
+
+> Implementation of a contract acting as a controller of an ERC725 Account, using permissions stored in the ERC725Y storage.
+
+All the permissions can be set on the ERC725 Account using `setData(bytes32,bytes)` or `setData(bytes32[],bytes[])`.
+
+## Methods
+
+### constructor
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#constructor)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+
+:::
+
+```solidity
+constructor(address target_);
+```
+
+_Deploying a LSP6KeyManager linked to contract at address `target_`._
+
+Deploy a Key Manager and set the `target_` address in the contract storage, making this Key Manager linked to this `target_` contract.
+
+#### Parameters
+
+| Name      |   Type    | Description                                                              |
+| --------- | :-------: | ------------------------------------------------------------------------ |
+| `target_` | `address` | The address of the contract to control and forward calldata payloads to. |
+
+### execute
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#execute)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `execute(bytes)`
+- Function selector: `0x09c5eabe`
+
+:::
+
+```solidity
+function execute(bytes payload) external payable returns (bytes);
+```
+
+_execute the following payload on the linked contract: `payload`_
+
+execute a `payload` on the linked [`target`](#target) after having verified the permissions associated with the function being run. The `payload` MUST be a valid abi-encoded function call of one of the functions present in the linked [`target`](#target), otherwise the call will fail. The linked [`target`](#target) will return some data on successful execution, or revert on failure.
+
+<blockquote>
+
+**Emitted events:**
+
+- VerifiedCall event when the permissions related to `payload` have been verified successfully.
+
+</blockquote>
+
+#### Parameters
+
+| Name      |  Type   | Description                                                      |
+| --------- | :-----: | ---------------------------------------------------------------- |
+| `payload` | `bytes` | the abi-encoded function call to execute on the linked {target}. |
+
+#### Returns
+
+| Name |  Type   | Description                                                                  |
+| ---- | :-----: | ---------------------------------------------------------------------------- |
+| `0`  | `bytes` | the abi-decoded data returned by the function called on the linked {target}. |
+
+### executeBatch
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#executebatch)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `executeBatch(uint256[],bytes[])`
+- Function selector: `0xbf0176ff`
+
+:::
+
+```solidity
+function executeBatch(
+  uint256[] values,
+  bytes[] payloads
+) external payable returns (bytes[]);
+```
+
+Same as [`execute`](#execute) but execute a batch of payloads (abi-encoded function calls) in a single transaction.
+
+<blockquote>
+
+**Emitted events:**
+
+- VerifiedCall event for each permissions related to each `payload` that have been verified successfully.
+
+</blockquote>
+
+#### Parameters
+
+| Name       |    Type     | Description                                                                            |
+| ---------- | :---------: | -------------------------------------------------------------------------------------- |
+| `values`   | `uint256[]` | An array of amount of native tokens to be transferred for each `payload`.              |
+| `payloads` |  `bytes[]`  | An array of abi-encoded function calls to execute successively on the linked {target}. |
+
+#### Returns
+
+| Name |   Type    | Description                                                                                     |
+| ---- | :-------: | ----------------------------------------------------------------------------------------------- |
+| `0`  | `bytes[]` | An array of abi-decoded of return data returned by the functions called on the linked {target}. |
+
+### executeRelayCall
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#executerelaycall)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `executeRelayCall(bytes,uint256,uint256,bytes)`
+- Function selector: `0x4c8a4e74`
+
+:::
+
+:::tip Hint
+
+If you are looking to learn how to sign and execute relay transactions via the Key Manager, see our Javascript step by step guide [_&quot;Execute Relay Transactions&quot;_](../../guides/key-manager/execute-relay-transactions.md). See the LSP6 Standard page for more details on how to [generate a valid signature for Execute Relay Call](../universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
+
+:::
+
+```solidity
+function executeRelayCall(
+  bytes signature,
+  uint256 nonce,
+  uint256 validityTimestamps,
+  bytes payload
+) external payable returns (bytes);
+```
+
+Allows any address (executor) to execute a payload (= abi-encoded function call) in the linked [`target`](#target) given they have a signed message from a controller with some permissions.
+
+<blockquote>
+
+**Emitted events:**
+
+- [`VerifiedCall`](#verifiedcall) event when the permissions related to `payload` have been verified successfully.
+
+</blockquote>
+
+#### Parameters
+
+| Name                 |   Type    | Description                                                                                                                                                                                   |
+| -------------------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signature`          |  `bytes`  | a 65 bytes long signature for a meta transaction according to LSP6.                                                                                                                           |
+| `nonce`              | `uint256` | the nonce of the address that signed the calldata (in a specific `_channel`), obtained via {getNonce}. Used to prevent replay attack.                                                         |
+| `validityTimestamps` | `uint256` | \* Two `uint128` timestamps concatenated together that describes when the relay transaction is valid &quot;from&quot; (left `uint128`) and &quot;until&quot; as a deadline (right `uint128`). |
+| `payload`            |  `bytes`  | the abi-encoded function call to execute on the linked {target}.                                                                                                                              |
+
+#### Returns
+
+| Name |  Type   | Description                                                            |
+| ---- | :-----: | ---------------------------------------------------------------------- |
+| `0`  | `bytes` | the data being returned by the function called on the linked {target}. |
+
+### executeRelayCallBatch
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#executerelaycallbatch)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `executeRelayCallBatch(bytes[],uint256[],uint256[],uint256[],bytes[])`
+- Function selector: `0xa20856a5`
+
+:::
+
+```solidity
+function executeRelayCallBatch(
+  bytes[] signatures,
+  uint256[] nonces,
+  uint256[] validityTimestamps,
+  uint256[] values,
+  bytes[] payloads
+) external payable returns (bytes[]);
+```
+
+Same as [`executeRelayCall`](#executerelaycall) but execute a batch of signed calldata payloads (abi-encoded function calls) in a single transaction. The signed transactions can be from multiple controllers, not necessarely the same controller signer, as long as each of these controllers that signed have the right permissions related to the calldata `payload` they signed.
+
+<blockquote>
+
+**Requirements:**
+
+- the length of `signatures`, `nonces`, `validityTimestamps`, `values` and `payloads` MUST be the same.
+- the value sent to this function (`msg.value`) MUST be equal to the sum of all `values` in the batch. There should not be any excess value sent to this function.
+
+</blockquote>
+
+#### Parameters
+
+| Name                 |    Type     | Description                                                                                                                                                                    |
+| -------------------- | :---------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `signatures`         |  `bytes[]`  | An array of 65 bytes long signatures for meta transactions according to LSP6.                                                                                                  |
+| `nonces`             | `uint256[]` | An array of nonces of the addresses that signed the calldata payloads (in specific channels). Obtained via {getNonce}. Used to prevent replay attack.                          |
+| `validityTimestamps` | `uint256[]` | An array of two `uint128` concatenated timestamps that describe when the relay transaction is valid &quot;from&quot; (left `uint128`) and &quot;until&quot; (right `uint128`). |
+| `values`             | `uint256[]` | An array of amount of native tokens to be transferred for each calldata `payload`.                                                                                             |
+| `payloads`           |  `bytes[]`  | An array of abi-encoded function calls to execute successively on the linked {target}.                                                                                         |
+
+#### Returns
+
+| Name |   Type    | Description                                                                                  |
+| ---- | :-------: | -------------------------------------------------------------------------------------------- |
+| `0`  | `bytes[]` | An array of abi-decoded return data returned by the functions called on the linked {target}. |
+
+### getNonce
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#getnonce)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `getNonce(address,uint128)`
+- Function selector: `0xb44581d9`
+
+:::
+
+:::info
+
+A signer can choose its channel number arbitrarily. Channel ID = 0 can be used for sequential nonces (transactions that are order dependant), any other channel ID for out-of-order execution (= execution in parallel).
+
+:::
+
+```solidity
+function getNonce(
+  address from,
+  uint128 channelId
+) external view returns (uint256);
+```
+
+_Get latest nonce for `from` in channel ID: `channelId`._
+
+Get the nonce for a specific controller `from` address that can be used for signing relay transaction.
+
+#### Parameters
+
+| Name        |   Type    | Description                                                                |
+| ----------- | :-------: | -------------------------------------------------------------------------- |
+| `from`      | `address` | the address of the signer of the transaction.                              |
+| `channelId` | `uint128` | the channel id that the signer wants to use for executing the transaction. |
+
+#### Returns
+
+| Name |   Type    | Description                                 |
+| ---- | :-------: | ------------------------------------------- |
+| `0`  | `uint256` | the current nonce on a specific `channelId` |
+
+### isValidSignature
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#isvalidsignature)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `isValidSignature(bytes32,bytes)`
+- Function selector: `0x1626ba7e`
+
+:::
+
+```solidity
+function isValidSignature(
+  bytes32 dataHash,
+  bytes signature
+) external view returns (bytes4 magicValue);
+```
+
+Checks if a signature was signed by a controller that has the permission `SIGN`. If the signer is a controller with the permission `SIGN`, it will return the ERC1271 magic value.
+
+#### Parameters
+
+| Name        |   Type    | Description                                 |
+| ----------- | :-------: | ------------------------------------------- |
+| `dataHash`  | `bytes32` | -                                           |
+| `signature` |  `bytes`  | Signature byte array associated with \_data |
+
+#### Returns
+
+| Name         |   Type   | Description                                          |
+| ------------ | :------: | ---------------------------------------------------- |
+| `magicValue` | `bytes4` | `0x1626ba7e` on success, or `0xffffffff` on failure. |
+
+### lsp20VerifyCall
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#lsp20verifycall)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `lsp20VerifyCall(address,uint256,bytes)`
+- Function selector: `0x9bf04b11`
+
+:::
+
+```solidity
+function lsp20VerifyCall(
+  address caller,
+  uint256 msgValue,
+  bytes data
+) external nonpayable returns (bytes4);
+```
+
+#### Parameters
+
+| Name       |   Type    | Description                                           |
+| ---------- | :-------: | ----------------------------------------------------- |
+| `caller`   | `address` | The address who called the function on the msg.sender |
+| `msgValue` | `uint256` | -                                                     |
+| `data`     |  `bytes`  | -                                                     |
+
+#### Returns
+
+| Name |   Type   | Description                                                                                                                                                                                                                                                                                                                                     |
+| ---- | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | `bytes4` | MUST return the first 3 bytes of `lsp20VerifyCall(address,uint256,bytes)` function selector if the call to the function is allowed, concatened with a byte that determines if the lsp20VerifyCallResult function should be called after the original function call. The byte that invoke the lsp20VerifyCallResult function is strictly `0x01`. |
+
+### lsp20VerifyCallResult
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#,))
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `,)`
+- Function selector: `0x9f47dbd3`
+
+:::
+
+```solidity
+function lsp20VerifyCallResult(
+  bytes32,
+  bytes
+) external nonpayable returns (bytes4);
+```
+
+#### Parameters
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `_0` | `bytes32` | -           |
+| `_1` |  `bytes`  | -           |
+
+#### Returns
+
+| Name |   Type   | Description                                                                                    |
+| ---- | :------: | ---------------------------------------------------------------------------------------------- |
+| `0`  | `bytes4` | MUST return the lsp20VerifyCallResult function selector if the call to the function is allowed |
+
+### supportsInterface
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#supportsinterface)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name          |   Type   | Description |
+| ------------- | :------: | ----------- |
+| `interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+### target
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#target)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Function signature: `target()`
+- Function selector: `0xd4b83992`
+
+:::
+
+```solidity
+function target() external view returns (address);
+```
+
+Get the address of the contract linked to this Key Manager.
+
+#### Returns
+
+| Name |   Type    | Description                       |
+| ---- | :-------: | --------------------------------- |
+| `0`  | `address` | the address of the linked account |
+
+---
+
+## Events
+
+### VerifiedCall
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#verifiedcall)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Event signature: `VerifiedCall(address,uint256,bytes4)`
+- Event hash: `0xa54458b75709e42f79700ffb6cfc57c7e224d8a77a52c457ee7ecb8e22636280`
+
+:::
+
+```solidity
+event VerifiedCall(address indexed signer, uint256 indexed value, bytes4 indexed selector);
+```
+
+Emitted when the LSP6KeyManager contract verified the permissions of the `signer` successfully.
+
+#### Parameters
+
+| Name                     |   Type    | Description                                                                                                                                        |
+| ------------------------ | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signer` **`indexed`**   | `address` | the address of the controller that executed the calldata payload (either directly via {execute} or via meta transaction using {executeRelayCall}). |
+| `value` **`indexed`**    | `uint256` | the amount of native token to be transferred in the calldata payload.                                                                              |
+| `selector` **`indexed`** | `bytes4`  | the bytes4 function of the function that was executed on the linked {target}                                                                       |
+
+---
+
+## Errors
+
+### AddressPermissionArrayIndexValueNotAnAddress
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#addresspermissionarrayindexvaluenotanaddress)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `AddressPermissionArrayIndexValueNotAnAddress(bytes32,bytes)`
+- Error hash: `0x8f4afa38`
+
+:::
+
+```solidity
+error AddressPermissionArrayIndexValueNotAnAddress(
+  bytes32 dataKey,
+  bytes invalidValue
+);
+```
+
+Reverts when trying to set a value that is not 20 bytes long (not an `address`) under the `AddressPermissions[index]` data key.
+
+#### Parameters
+
+| Name           |   Type    | Description                                                                                           |
+| -------------- | :-------: | ----------------------------------------------------------------------------------------------------- |
+| `dataKey`      | `bytes32` | The `AddressPermissions[index]` data key, that specify the index in the `AddressPermissions[]` array. |
+| `invalidValue` |  `bytes`  | The invalid value that was attempted to be set under `AddressPermissions[index]`.                     |
+
+### BatchExecuteParamsLengthMismatch
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#batchexecuteparamslengthmismatch)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `BatchExecuteParamsLengthMismatch()`
+- Error hash: `0x55a187db`
+
+:::
+
+```solidity
+error BatchExecuteParamsLengthMismatch();
+```
+
+Reverts when the array parameters `uint256[] value` and `bytes[] payload` have different sizes. There should be the same number of elements for each array parameters.
+
+### BatchExecuteRelayCallParamsLengthMismatch
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#batchexecuterelaycallparamslengthmismatch)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `BatchExecuteRelayCallParamsLengthMismatch()`
+- Error hash: `0xb4d50d21`
+
+:::
+
+```solidity
+error BatchExecuteRelayCallParamsLengthMismatch();
+```
+
+Reverts when providing array parameters of different sizes to `executeRelayCall(bytes[],uint256[],bytes[])`
+
+### CallingKeyManagerNotAllowed
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#callingkeymanagernotallowed)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `CallingKeyManagerNotAllowed()`
+- Error hash: `0xa431b236`
+
+:::
+
+```solidity
+error CallingKeyManagerNotAllowed();
+```
+
+Reverts when calling the KeyManager through `execute(uint256,address,uint256,bytes)`.
+
+### CannotSendValueToSetData
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#cannotsendvaluetosetdata)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `CannotSendValueToSetData()`
+- Error hash: `0x59a529fc`
+
+:::
+
+```solidity
+error CannotSendValueToSetData();
+```
+
+Reverts when trying to call to the `setData(byte32,bytes)` or `setData(bytes32[],bytes[]) functions on the linked [`target`](#target) while sending value.
+
+### DelegateCallDisallowedViaKeyManager
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#delegatecalldisallowedviakeymanager)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `DelegateCallDisallowedViaKeyManager()`
+- Error hash: `0x80d6ebae`
+
+:::
+
+```solidity
+error DelegateCallDisallowedViaKeyManager();
+```
+
+Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,address,uint256,bytes) (operation type 4) function of the linked [`target`](#target). `DELEGATECALL` is disallowed by default on the LSP6KeyManager.
+
+### ERC725Y_DataKeysValuesLengthMismatch
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#erc725y_datakeysvalueslengthmismatch)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `ERC725Y_DataKeysValuesLengthMismatch()`
+- Error hash: `0x3bcc8979`
+
+:::
+
+```solidity
+error ERC725Y_DataKeysValuesLengthMismatch();
+```
+
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+
+### InvalidERC725Function
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invaliderc725function)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidERC725Function(bytes4)`
+- Error hash: `0x2ba8851c`
+
+:::
+
+```solidity
+error InvalidERC725Function(bytes4 invalidFunction);
+```
+
+Reverts when trying to call a function on the linked [`target`](#target), that is not any of the following:
+
+- `setData(bytes32,bytes)` (ERC725Y)
+
+- `setDataBatch(bytes32[],bytes[])` (ERC725Y)
+
+- `execute(uint256,address,uint256,bytes)` (ERC725X)
+
+- `transferOwnership(address)`
+
+- `acceptOwnership()` (LSP14)
+
+#### Parameters
+
+| Name              |   Type   | Description                                                                                                               |
+| ----------------- | :------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `invalidFunction` | `bytes4` | The `bytes4` selector of the function selector that was attempted to be called on the linked {target} but not recognised. |
+
+### InvalidEncodedAllowedCalls
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidencodedallowedcalls)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidEncodedAllowedCalls(bytes)`
+- Error hash: `0x187e77ab`
+
+:::
+
+```solidity
+error InvalidEncodedAllowedCalls(bytes allowedCallsValue);
+```
+
+Reverts when `allowedCallsValue` is not properly encoded as a `(bytes4,address,bytes4,bytes4)[CompactBytesArray]` (CompactBytesArray made of tuples that are 32 bytes long each). See LSP2 value type `CompactBytesArray` for more infos.
+
+#### Parameters
+
+| Name                |  Type   | Description                                                                                                       |
+| ------------------- | :-----: | ----------------------------------------------------------------------------------------------------------------- |
+| `allowedCallsValue` | `bytes` | The list of allowedCalls that are not encoded correctly as a `(bytes4,address,bytes4,bytes4)[CompactBytesArray]`. |
+
+### InvalidEncodedAllowedERC725YDataKeys
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidencodedallowederc725ydatakeys)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidEncodedAllowedERC725YDataKeys(bytes,string)`
+- Error hash: `0xae6cbd37`
+
+:::
+
+```solidity
+error InvalidEncodedAllowedERC725YDataKeys(bytes value, string context);
+```
+
+Reverts when `value` is not encoded properly as a `bytes32[CompactBytesArray]`. The `context` string provides context on when this error occured (\_e.g: when fetching the `AllowedERC725YDataKeys` to verify the permissions of a controller, or when validating the `AllowedERC725YDataKeys` when setting them for a controller).
+
+#### Parameters
+
+| Name      |   Type   | Description                                                |
+| --------- | :------: | ---------------------------------------------------------- |
+| `value`   | `bytes`  | The value that is not a valid `bytes32[CompactBytesArray]` |
+| `context` | `string` | A brief description of where the error occured.            |
+
+### InvalidLSP6Target
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidlsp6target)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidLSP6Target()`
+- Error hash: `0xfc854579`
+
+:::
+
+```solidity
+error InvalidLSP6Target();
+```
+
+Reverts when the address provided to set as the [`target`](#target) linked to this KeyManager is invalid (_e.g. `address(0)`_).
+
+### InvalidPayload
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidpayload)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidPayload(bytes)`
+- Error hash: `0x3621bbcc`
+
+:::
+
+```solidity
+error InvalidPayload(bytes payload);
+```
+
+Reverst when the payload is invalid.
+
+#### Parameters
+
+| Name      |  Type   | Description |
+| --------- | :-----: | ----------- |
+| `payload` | `bytes` | -           |
+
+### InvalidRelayNonce
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidrelaynonce)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidRelayNonce(address,uint256,bytes)`
+- Error hash: `0xc9bd9eb9`
+
+:::
+
+```solidity
+error InvalidRelayNonce(address signer, uint256 invalidNonce, bytes signature);
+```
+
+Reverts when the `signer` address retrieved from the `signature` has an invalid nonce: `invalidNonce`.
+
+#### Parameters
+
+| Name           |   Type    | Description                                         |
+| -------------- | :-------: | --------------------------------------------------- |
+| `signer`       | `address` | The address of the signer                           |
+| `invalidNonce` | `uint256` | The nonce retrieved for the `signer` address        |
+| `signature`    |  `bytes`  | The signature used to retrieve the `signer` address |
+
+### InvalidWhitelistedCall
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invalidwhitelistedcall)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidWhitelistedCall(address)`
+- Error hash: `0x6fd203c5`
+
+:::
+
+```solidity
+error InvalidWhitelistedCall(address from);
+```
+
+Reverts when verifying the permissions of a `from` address for its allowed calls, and has a "any whitelisted call" allowed call set. A `from` address is not allowed to have 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff in its list of `AddressPermissions:AllowedCalls:<address>`, as this allows any STANDARD:ADDRESS:FUNCTION. This is equivalent to granting the SUPER permission and should never be valid.
+
+#### Parameters
+
+| Name   |   Type    | Description                                                        |
+| ------ | :-------: | ------------------------------------------------------------------ |
+| `from` | `address` | The controller address that has any allowed calls whitelisted set. |
+
+### LSP6BatchExcessiveValueSent
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#lsp6batchexcessivevaluesent)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `LSP6BatchExcessiveValueSent(uint256,uint256)`
+- Error hash: `0xa51868b6`
+
+:::
+
+```solidity
+error LSP6BatchExcessiveValueSent(uint256 totalValues, uint256 msgValue);
+```
+
+This error occurs when there was too much funds sent to the batch functions `execute(uint256[],bytes[])` or `executeRelayCall(bytes[],uint256[],uint256[],bytes[])` to cover the sum of all the values forwarded on Reverts to avoid the KeyManager to holds some remaining funds sent to the following batch functions:
+
+- execute(uint256[],bytes[])
+
+- executeRelayCall(bytes[],uint256[],uint256[],bytes[]) This error occurs when `msg.value` is more than the sum of all the values being forwarded on each payloads (`values[]` parameter from the batch functions above).
+
+#### Parameters
+
+| Name          |   Type    | Description |
+| ------------- | :-------: | ----------- |
+| `totalValues` | `uint256` | -           |
+| `msgValue`    | `uint256` | -           |
+
+### LSP6BatchInsufficientValueSent
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#lsp6batchinsufficientvaluesent)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `LSP6BatchInsufficientValueSent(uint256,uint256)`
+- Error hash: `0x30a324ac`
+
+:::
+
+```solidity
+error LSP6BatchInsufficientValueSent(uint256 totalValues, uint256 msgValue);
+```
+
+This error occurs when there was not enough funds sent to the batch functions `execute(uint256[],bytes[])` or `executeRelayCall(bytes[],uint256[],uint256[],bytes[])` to cover the sum of all the values forwarded on each payloads (`values[]` parameter from the batch functions above). This mean that `msg.value` is less than the sum of all the values being forwarded on each payloads (`values[]` parameters).
+
+#### Parameters
+
+| Name          |   Type    | Description                                                                                                                                      |
+| ------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `totalValues` | `uint256` | The sum of all the values forwarded on each payloads (`values[]` parameter from the batch functions above).                                      |
+| `msgValue`    | `uint256` | The amount of native tokens sent to the batch functions `execute(uint256[],bytes[])` or `executeRelayCall(bytes[],uint256[],uint256[],bytes[])`. |
+
+### NoCallsAllowed
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#nocallsallowed)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NoCallsAllowed(address)`
+- Error hash: `0x6cb60587`
+
+:::
+
+```solidity
+error NoCallsAllowed(address from);
+```
+
+Reverts when the `from` address has no `AllowedCalls` set and cannot interact with any address using the linked [`target`](#target).
+
+#### Parameters
+
+| Name   |   Type    | Description                           |
+| ------ | :-------: | ------------------------------------- |
+| `from` | `address` | The address that has no AllowedCalls. |
+
+### NoERC725YDataKeysAllowed
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#noerc725ydatakeysallowed)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NoERC725YDataKeysAllowed(address)`
+- Error hash: `0xed7fa509`
+
+:::
+
+```solidity
+error NoERC725YDataKeysAllowed(address from);
+```
+
+Reverts when the `from` address has no AllowedERC725YDataKeys set and cannot set any ERC725Y data key on the ERC725Y storage of the linked [`target`](#target).
+
+#### Parameters
+
+| Name   |   Type    | Description                                           |
+| ------ | :-------: | ----------------------------------------------------- |
+| `from` | `address` | The address that has no `AllowedERC725YDataKeys` set. |
+
+### NoPermissionsSet
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#nopermissionsset)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NoPermissionsSet(address)`
+- Error hash: `0xf292052a`
+
+:::
+
+```solidity
+error NoPermissionsSet(address from);
+```
+
+Reverts when address `from` does not have any permissions set on the account linked to this Key Manager
+
+#### Parameters
+
+| Name   |   Type    | Description                                |
+| ------ | :-------: | ------------------------------------------ |
+| `from` | `address` | the address that does not have permissions |
+
+### NotAllowedCall
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#notallowedcall)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NotAllowedCall(address,address,bytes4)`
+- Error hash: `0x45147bce`
+
+:::
+
+```solidity
+error NotAllowedCall(address from, address to, bytes4 selector);
+```
+
+Reverts when `from` is not authorised to call the `execute(uint256,address,uint256,bytes)` function because of a not allowed callType, address, standard or function.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                                                                                              |
+| ---------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `from`     | `address` | address The controller that tried to call the `execute(uint256,address,uint256,bytes)` function.                                                                         |
+| `to`       | `address` | The address of an EOA or contract that `from` tried to call using the linked {target}                                                                                    |
+| `selector` | `bytes4`  | If `to` is a contract, the bytes4 selector of the function that `from` is trying to call. If no function is called (e.g: a native token transfer), selector = 0x00000000 |
+
+### NotAllowedERC725YDataKey
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#notallowederc725ydatakey)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NotAllowedERC725YDataKey(address,bytes32)`
+- Error hash: `0x557ae079`
+
+:::
+
+```solidity
+error NotAllowedERC725YDataKey(address from, bytes32 disallowedKey);
+```
+
+Reverts when address `from` is not authorised to set the key `disallowedKey` on the linked [`target`](#target).
+
+#### Parameters
+
+| Name            |   Type    | Description                                                                                            |
+| --------------- | :-------: | ------------------------------------------------------------------------------------------------------ |
+| `from`          | `address` | address The controller that tried to `setData` on the linked {target}.                                 |
+| `disallowedKey` | `bytes32` | A bytes32 data key that `from` is not authorised to set on the ERC725Y storage of the linked {target}. |
+
+### NotAuthorised
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#notauthorised)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NotAuthorised(address,string)`
+- Error hash: `0x3bdad6e6`
+
+:::
+
+```solidity
+error NotAuthorised(address from, string permission);
+```
+
+Reverts when address `from` is not authorised and does not have `permission` on the linked [`target`](#target)
+
+#### Parameters
+
+| Name         |   Type    | Description                                                                    |
+| ------------ | :-------: | ------------------------------------------------------------------------------ |
+| `from`       | `address` | address The address that was not authorised.                                   |
+| `permission` | `string`  | permission The permission required (\_e.g: `SETDATA`, `CALL`, `TRANSFERVALUE`) |
+
+### NotRecognisedPermissionKey
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#notrecognisedpermissionkey)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `NotRecognisedPermissionKey(bytes32)`
+- Error hash: `0x0f7d735b`
+
+:::
+
+```solidity
+error NotRecognisedPermissionKey(bytes32 dataKey);
+```
+
+Reverts when `dataKey` is a bytes32 value that does not adhere to any of the permission data keys defined by the LSP6 standard
+
+#### Parameters
+
+| Name      |   Type    | Description                                                                    |
+| --------- | :-------: | ------------------------------------------------------------------------------ |
+| `dataKey` | `bytes32` | The dataKey that does not match any of the standard LSP6 permission data keys. |
+
+### RelayCallBeforeStartTime
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#relaycallbeforestarttime)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `RelayCallBeforeStartTime()`
+- Error hash: `0x00de4b8a`
+
+:::
+
+```solidity
+error RelayCallBeforeStartTime();
+```
+
+Reverts when the start timestamp provided to [`executeRelayCall`](#executerelaycall) function is bigger than the current timestamp.
+
+### RelayCallExpired
+
+:::note Links
+
+- Specification details in [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#relaycallexpired)
+- Solidity implementation in [**LSP6KeyManager**](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `RelayCallExpired()`
+- Error hash: `0x5c53a98c`
+
+:::
+
+```solidity
+error RelayCallExpired();
+```
+
+Reverts when the period to execute the relay call has expired.

--- a/dodoc/config.ts
+++ b/dodoc/config.ts
@@ -17,7 +17,7 @@ export const dodocConfig = {
     'contracts/LSP17ContractExtension/LSP17Extension.sol',
     'contracts/LSP20CallVerification/LSP20CallVerification.sol',
 
-    // tokens --------------------
+    // tokens
     'contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol',
     'contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol',
     'contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol',
@@ -34,7 +34,7 @@ export const dodocConfig = {
     'contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol',
     'contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol',
 
-    // libraries
+    // libraries --------------------
     'contracts/LSP0ERC725Account/LSP0Utils.sol',
     'contracts/LSP1UniversalReceiver/LSP1Utils.sol',
     'contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol',

--- a/tests/LSP6KeyManager/Admin/PermissionChangeOwner.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeOwner.test.ts
@@ -4,7 +4,7 @@ import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 // constants
-import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES, LSP6_VERSION } from '../../../constants';
+import { ERC725YDataKeys, PERMISSIONS, OPERATION_TYPES, LSP25_VERSION } from '../../../constants';
 
 import { LSP6KeyManager, LSP6KeyManager__factory } from '../../../types';
 
@@ -355,7 +355,7 @@ export const shouldBehaveLikePermissionChangeOwner = (
 
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-          [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
+          [LSP25_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
         );
 
         const eip191Signer = new EIP191Signer();

--- a/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
@@ -16,7 +16,7 @@ import {
 import {
   ERC725YDataKeys,
   OPERATION_TYPES,
-  LSP6_VERSION,
+  LSP25_VERSION,
   PERMISSIONS,
   INTERFACE_IDS,
   CALLTYPE,
@@ -219,7 +219,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           const encodedMessage = ethers.utils.solidityPack(
             ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
-              LSP6_VERSION,
+              LSP25_VERSION,
               HARDHAT_CHAINID,
               nonce,
               validityTimestamps,
@@ -272,7 +272,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
           const encodedMessage = ethers.utils.solidityPack(
             ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
-              LSP6_VERSION,
+              LSP25_VERSION,
               HARDHAT_CHAINID,
               nonce,
               validityTimestamps,

--- a/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
@@ -17,7 +17,7 @@ import {
   ERC725YDataKeys,
   ALL_PERMISSIONS,
   PERMISSIONS,
-  LSP6_VERSION,
+  LSP25_VERSION,
   OPERATION_TYPES,
   CALLTYPE,
 } from '../../../constants';
@@ -603,7 +603,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                LSP6_VERSION,
+                LSP25_VERSION,
                 HARDHAT_CHAINID,
                 nonce,
                 validityTimestamps,
@@ -660,7 +660,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                LSP6_VERSION,
+                LSP25_VERSION,
                 HARDHAT_CHAINID,
                 nonce,
                 validityTimestamps,
@@ -722,7 +722,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               const encodedMessage = ethers.utils.solidityPack(
                 ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
-                  LSP6_VERSION,
+                  LSP25_VERSION,
                   HARDHAT_CHAINID,
                   nonce,
                   validityTimestamps,
@@ -777,7 +777,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
               const encodedMessage = ethers.utils.solidityPack(
                 ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
-                  LSP6_VERSION,
+                  LSP25_VERSION,
                   HARDHAT_CHAINID,
                   nonce,
                   validityTimestamps,
@@ -834,7 +834,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                LSP6_VERSION,
+                LSP25_VERSION,
                 HARDHAT_CHAINID,
                 nonce,
                 validityTimestamps,
@@ -895,7 +895,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                LSP6_VERSION,
+                LSP25_VERSION,
                 HARDHAT_CHAINID,
                 nonce,
                 validityTimestamps,
@@ -955,7 +955,7 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                LSP6_VERSION,
+                LSP25_VERSION,
                 HARDHAT_CHAINID,
                 nonce,
                 validityTimestamps,

--- a/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
@@ -10,7 +10,7 @@ import { TargetContract__factory, UniversalProfile__factory } from '../../../typ
 import {
   ERC725YDataKeys,
   ALL_PERMISSIONS,
-  LSP6_VERSION,
+  LSP25_VERSION,
   PERMISSIONS,
   OPERATION_TYPES,
 } from '../../../constants';
@@ -606,7 +606,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-              [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
+              [LSP25_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
             const ethereumSignature = await addressCannotDeploy.signMessage(encodedMessage);
@@ -656,7 +656,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-              [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
+              [LSP25_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
             const eip191Signer = new EIP191Signer();
@@ -705,7 +705,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-              [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
+              [LSP25_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
             const ethereumSignature = await addressCannotDeploy.signMessage(encodedMessage);
@@ -755,7 +755,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-              [LSP6_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
+              [LSP25_VERSION, HARDHAT_CHAINID, nonce, validityTimestamps, valueToSend, payload],
             );
 
             const lsp6Signer = new EIP191Signer();

--- a/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
@@ -23,7 +23,7 @@ import {
 import {
   ERC725YDataKeys,
   ALL_PERMISSIONS,
-  LSP6_VERSION,
+  LSP25_VERSION,
   PERMISSIONS,
   OPERATION_TYPES,
   CALLTYPE,
@@ -370,7 +370,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           const encodedMessage = ethers.utils.solidityPack(
             ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
-              LSP6_VERSION,
+              LSP25_VERSION,
               HARDHAT_CHAINID,
               0,
               validityTimestamps,
@@ -413,7 +413,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           const encodedMessage = ethers.utils.solidityPack(
             ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
-              LSP6_VERSION,
+              LSP25_VERSION,
               HARDHAT_CHAINID,
               0,
               validityTimestamps,

--- a/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.behaviour.ts
@@ -147,6 +147,13 @@ export const shouldInitializeLikeLSP6 = (buildContext: () => Promise<LSP6TestCon
       expect(result).to.be.true;
     });
 
+    it('should support LSP25 interface', async () => {
+      const result = await context.keyManager.supportsInterface(
+        INTERFACE_IDS.LSP25ExecuteRelayCall,
+      );
+      expect(result).to.be.true;
+    });
+
     it('should be linked to the right ERC725 account contract', async () => {
       const account = await context.keyManager.target();
       expect(account).to.equal(context.universalProfile.address);

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -17,7 +17,7 @@ import {
   ALL_PERMISSIONS,
   ERC725YDataKeys,
   OPERATION_TYPES,
-  LSP6_VERSION,
+  LSP25_VERSION,
   PERMISSIONS,
   CALLTYPE,
   INTERFACE_IDS,
@@ -102,7 +102,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const valueToSign = 5;
 
             const signedMessageParams = {
-              lsp6Version: LSP6_VERSION,
+              lsp25Version: LSP25_VERSION,
               chainId: 31337, // HARDHAT_CHAINID
               nonce: latestNonce,
               validityTimestamps,
@@ -115,7 +115,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                signedMessageParams.lsp6Version,
+                signedMessageParams.lsp25Version,
                 signedMessageParams.chainId,
                 signedMessageParams.nonce,
                 signedMessageParams.validityTimestamps,
@@ -160,7 +160,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const valueToSign = 5;
 
             const signedMessageParams = {
-              lsp6Version: LSP6_VERSION,
+              lsp25Version: LSP25_VERSION,
               chainId: 31337, // HARDHAT_CHAINID
               nonce: latestNonce,
               validityTimestamps,
@@ -173,7 +173,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                signedMessageParams.lsp6Version,
+                signedMessageParams.lsp25Version,
                 signedMessageParams.chainId,
                 signedMessageParams.nonce,
                 signedMessageParams.validityTimestamps,
@@ -218,7 +218,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const valueToSendFromRelayer = 10;
 
             const signedMessageParams = {
-              lsp6Version: LSP6_VERSION,
+              lsp25Version: LSP25_VERSION,
               chainId: 31337, // HARDHAT_CHAINID
               nonce: latestNonce,
               validityTimestamps,
@@ -229,7 +229,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                signedMessageParams.lsp6Version,
+                signedMessageParams.lsp25Version,
                 signedMessageParams.chainId,
                 signedMessageParams.nonce,
                 signedMessageParams.validityTimestamps,
@@ -287,7 +287,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const valueToSendFromRelayer = 10;
 
             const signedMessageParams = {
-              lsp6Version: LSP6_VERSION,
+              lsp25Version: LSP25_VERSION,
               chainId: 31337, // HARDHAT_CHAINID
               nonce: latestNonce,
               validityTimestamps,
@@ -298,7 +298,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             const encodedMessage = ethers.utils.solidityPack(
               ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
               [
-                signedMessageParams.lsp6Version,
+                signedMessageParams.lsp25Version,
                 signedMessageParams.chainId,
                 signedMessageParams.nonce,
                 signedMessageParams.validityTimestamps,
@@ -359,7 +359,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const valueToSendFromRelayer = 0;
 
               const signedMessageParams = {
-                lsp6Version: LSP6_VERSION,
+                lsp25Version: LSP25_VERSION,
                 chainId: 31337, // HARDHAT_CHAINID
                 nonce: latestNonce,
                 validityTimestamps,
@@ -370,7 +370,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const encodedMessage = ethers.utils.solidityPack(
                 ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
-                  signedMessageParams.lsp6Version,
+                  signedMessageParams.lsp25Version,
                   signedMessageParams.chainId,
                   signedMessageParams.nonce,
                   signedMessageParams.validityTimestamps,
@@ -436,7 +436,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const valueToSendFromRelayer = 51;
 
               const signedMessageParams = {
-                lsp6Version: LSP6_VERSION,
+                lsp25Version: LSP25_VERSION,
                 chainId: 31337, // HARDHAT_CHAINID
                 nonce: latestNonce,
                 validityTimestamps,
@@ -447,7 +447,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const encodedMessage = ethers.utils.solidityPack(
                 ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
-                  signedMessageParams.lsp6Version,
+                  signedMessageParams.lsp25Version,
                   signedMessageParams.chainId,
                   signedMessageParams.nonce,
                   signedMessageParams.validityTimestamps,
@@ -507,7 +507,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const valueToSendFromRelayer = 51;
 
               const signedMessageParams = {
-                lsp6Version: LSP6_VERSION,
+                lsp25Version: LSP25_VERSION,
                 chainId: 31337, // HARDHAT_CHAINID
                 nonce: latestNonce,
                 validityTimestamps,
@@ -518,7 +518,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
               const encodedMessage = ethers.utils.solidityPack(
                 ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
                 [
-                  signedMessageParams.lsp6Version,
+                  signedMessageParams.lsp25Version,
                   signedMessageParams.chainId,
                   signedMessageParams.nonce,
                   signedMessageParams.validityTimestamps,
@@ -1100,7 +1100,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
       // the Key Manager recovers the address based on:
       // - the signature provided
       // - the encoded message generated internally using:
-      //        `abi.encodePacked(LSP6_VERSION, block.chainid,nonce, msg.value, payload);`
+      //        `abi.encodePacked(LSP25_VERSION, block.chainid,nonce, msg.value, payload);`
       //
       // the address is recovered as follow:
       //    `address signer = address(this).toDataWithIntendedValidator(encodedMessage).recover(signature);`
@@ -1116,7 +1116,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
       const encodedMessage = ethers.utils.solidityPack(
         ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
-        [6, 31337, ownerNonce.add(1), validityTimestamps, 0, transferLyxPayload],
+        [LSP25_VERSION, 31337, ownerNonce.add(1), validityTimestamps, 0, transferLyxPayload],
       );
 
       const hashedDataWithIntendedValidator = eip191.hashDataWithIntendedValidator(

--- a/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
@@ -10,7 +10,7 @@ import {
   ALL_PERMISSIONS,
   ERC725YDataKeys,
   OPERATION_TYPES,
-  LSP6_VERSION,
+  LSP25_VERSION,
   PERMISSIONS,
   CALLTYPE,
 } from '../../../constants';
@@ -108,7 +108,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ["uint256", "uint256", "uint256", "uint256", "uint256", "bytes"],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             latestNonce,
             validityTimestamps,
@@ -173,7 +173,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -224,7 +224,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -280,7 +280,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -331,7 +331,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -387,7 +387,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -438,7 +438,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,
@@ -493,7 +493,7 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
         const encodedMessage = ethers.utils.solidityPack(
           ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
           [
-            LSP6_VERSION,
+            LSP25_VERSION,
             HARDHAT_CHAINID,
             nonceBefore,
             validityTimestamps,

--- a/tests/Mocks/ERC165Interfaces.test.ts
+++ b/tests/Mocks/ERC165Interfaces.test.ts
@@ -88,6 +88,11 @@ describe('Calculate LSP interfaces', () => {
     const result = await contract.calculateInterfaceLSP20CallVerifier();
     expect(result).to.equal(INTERFACE_IDS.LSP20CallVerifier);
   });
+
+  it('LSP25ExecuteRelayCall', async () => {
+    const result = await contract.calculateInterfaceLSP25ExecuteRelayCall();
+    expect(result).to.equal(INTERFACE_IDS.LSP25ExecuteRelayCall);
+  });
 });
 
 describe('Calculate ERC interfaces', () => {

--- a/tests/Reentrancy/LSP6/LSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP6/LSP6Reentrancy.test.ts
@@ -20,7 +20,7 @@ import {
   CALLTYPE,
   ERC725YDataKeys,
   LSP1_TYPE_IDS,
-  LSP6_VERSION,
+  LSP25_VERSION,
   OPERATION_TYPES,
   PERMISSIONS,
 } from '../../../constants';
@@ -152,7 +152,7 @@ export const shouldBehaveLikeLSP6ReentrancyScenarios = (
           const encodedMessage = ethers.utils.solidityPack(
             ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
             [
-              LSP6_VERSION,
+              LSP25_VERSION,
               HARDHAT_CHAINID,
               nonce,
               validityTimestamps,

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat';
 import { LSP6KeyManager } from '../../types';
 
 // constants
-import { LSP6_VERSION } from '../../constants';
+import { LSP25_VERSION } from '../../constants';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
 
 export const abiCoder = ethers.utils.defaultAbiCoder;
@@ -153,7 +153,7 @@ export async function signLSP6ExecuteRelayCall(
   _payload: string,
 ) {
   const signedMessageParams = {
-    lsp6Version: LSP6_VERSION,
+    lsp25Version: LSP25_VERSION,
     chainId: 31337, // HARDHAT_CHAINID
     nonce: _signerNonce,
     validityTimestamps: _signerValidityTimestamps,
@@ -164,7 +164,7 @@ export async function signLSP6ExecuteRelayCall(
   const encodedMessage = ethers.utils.solidityPack(
     ['uint256', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
     [
-      signedMessageParams.lsp6Version,
+      signedMessageParams.lsp25Version,
       signedMessageParams.chainId,
       signedMessageParams.nonce,
       signedMessageParams.validityTimestamps,


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

### Change in LSP6 interface

The 3 x functions `getNonce(address,uint128)`, `executeRelayCall(...)` and `executeRelayCallBatch(...)` are part of their own standard LSP25 Execute Relay Call.

**This change the interface ID of LSP6 from `0x38bb3cdb` --> to `0x627ca5d3 ` **

`LSP6KeyManagerCore` now also supports the interface ID of LSP25: `0x5ac79908`

### Change in the version to sign for `executeRelayCall`

Since Relay Calls / Meta Transactions are now in their own standard LSP25, the version used to sign execute relay call has changed:

- before: number `6`
- **now: number `25` ✅ **

## 🚀 Feature

- Add `abstract` contract `LSP25MultiChannelNonce` that contains all the logic and handle the signature validation 

## ♻️ Refactor

- Add LSP25 in inheritance of `LSP6KeyManagerCore`
- add LSP25 interface ID in `supportsInterface(bytes4)` function of `LSP6KeyManagerCore`.

## 🧪 Tests

- [ ] More tests to be defined for the LSP25 standard, so that this implementation is not on its own without any unit tests.
- [ ] Add them in the CI and in `package.json` as `npm run test:lsp25`

## ⚡️ Performance

- [ ] Gas diff to be checked compared to before.

## 📄 Documentation

- [ ] Natspec comments to be reviewed for LSP25 vs LSP6 since the functions have been migrated out of LSP6. Also check if any LSP6 function or references are still old or outdated.
- Change in the README in the `import` section for the constants from `LSP6_VERSION` to `LSP25_VERSION`.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
