### PR TITLE
refactor: add input validations when setting data in `LSP6SetDataModule`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -92,18 +92,6 @@ error InvalidERC725Function(bytes4 invalidFunction);
 error InvalidEncodedAllowedCalls(bytes allowedCallsValue);
 
 /**
- * @notice Could not store `invalidValue` inside the `AddressPermissions[]` Array at index: `dataKey`.
- * @dev Reverts when trying to set a value that is not 20 bytes long (not an `address`) under the `AddressPermissions[index]` data key.
- *
- * @param dataKey The `AddressPermissions[index]` data key, that specify the index in the `AddressPermissions[]` array.
- * @param invalidValue The invalid value that was attempted to be set under `AddressPermissions[index]`.
- */
-error AddressPermissionArrayIndexValueNotAnAddress(
-    bytes32 dataKey,
-    bytes invalidValue
-);
-
-/**
  * @notice The address `from` is not authorised to set data, because it has no ERC725Y Data Key allowed.
  *
  * @dev Reverts when the `from` address has no AllowedERC725YDataKeys set and cannot set
@@ -227,6 +215,32 @@ error CannotSendValueToSetData();
 error CallingKeyManagerNotAllowed();
 
 /**
- * @dev reverts when the address of the Key Manager is being set as extensions for lsp20 functions
+ * @notice Relay call not valid yet.
+ *
+ * @dev Reverts when the start timestamp provided to {executeRelayCall} function is bigger than the current timestamp.
+ */
+error RelayCallBeforeStartTime();
+
+/**
+ * @notice The date of the relay call expired.
+ *
+ * @dev Reverts when the period to execute the relay call has expired.
+ */
+error RelayCallExpired();
+
+/**
+ * @notice Key Manager cannot be used as an LSP17 extension for LSP20 functions.
+ *
+ * @dev Reverts when the address of the Key Manager is being set as extensions for lsp20 functions
  */
 error KeyManagerCannotBeSetAsExtensionForLSP20Functions();
+
+/**
+ * @notice Data value: `dataValue` length is different from the required length for the data key which is set.
+ *
+ * @dev Reverts when the data value length is not one of the required lengths for the specific data key.
+ *
+ * @param dataKey The data key that has a required length for the data value.
+ * @param dataValue The data value that has an invalid length.
+ */
+error InvalidDataValuesForDataKeys(bytes32 dataKey, bytes dataValue);

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -1230,37 +1230,6 @@ Emitted when the LSP6KeyManager contract verified the permissions of the `signer
 
 ## Errors
 
-### AddressPermissionArrayIndexValueNotAnAddress
-
-:::note References
-
-- Specification details: [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#addresspermissionarrayindexvaluenotanaddress)
-- Solidity implementation: [`LSP6KeyManager.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP6KeyManager/LSP6KeyManager.sol)
-- Error signature: `AddressPermissionArrayIndexValueNotAnAddress(bytes32,bytes)`
-- Error hash: `0x8f4afa38`
-
-:::
-
-```solidity
-error AddressPermissionArrayIndexValueNotAnAddress(
-  bytes32 dataKey,
-  bytes invalidValue
-);
-```
-
-_Could not store `invalidValue` inside the `AddressPermissions[]` Array at index: `dataKey`._
-
-Reverts when trying to set a value that is not 20 bytes long (not an `address`) under the `AddressPermissions[index]` data key.
-
-#### Parameters
-
-| Name           |   Type    | Description                                                                                           |
-| -------------- | :-------: | ----------------------------------------------------------------------------------------------------- |
-| `dataKey`      | `bytes32` | The `AddressPermissions[index]` data key, that specify the index in the `AddressPermissions[]` array. |
-| `invalidValue` |  `bytes`  | The invalid value that was attempted to be set under `AddressPermissions[index]`.                     |
-
-<br/>
-
 ### BatchExecuteParamsLengthMismatch
 
 :::note References
@@ -1381,7 +1350,35 @@ Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,addre
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
+
+<br/>
+
+### InvalidDataValuesForDataKeys
+
+:::note References
+
+- Specification details: [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#invaliddatavaluesfordatakeys)
+- Solidity implementation: [`LSP6KeyManager.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `InvalidDataValuesForDataKeys(bytes32,bytes)`
+- Error hash: `0x1fa41397`
+
+:::
+
+```solidity
+error InvalidDataValuesForDataKeys(bytes32 dataKey, bytes dataValue);
+```
+
+_Data value: `dataValue` length is different from the required length for the data key which is set._
+
+Reverts when the data value length is not one of the required lengths for the specific data key.
+
+#### Parameters
+
+| Name        |   Type    | Description                                                 |
+| ----------- | :-------: | ----------------------------------------------------------- |
+| `dataKey`   | `bytes32` | The data key that has a required length for the data value. |
+| `dataValue` |  `bytes`  | The data value that has an invalid length.                  |
 
 <br/>
 
@@ -1596,7 +1593,9 @@ Reverts when a `from` address has _"any whitelisted call"_ as allowed call set. 
 error KeyManagerCannotBeSetAsExtensionForLSP20Functions();
 ```
 
-reverts when the address of the Key Manager is being set as extensions for lsp20 functions
+_Key Manager cannot be used as an LSP17 extension for LSP20 functions._
+
+Reverts when the address of the Key Manager is being set as extensions for lsp20 functions
 
 <br/>
 

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
@@ -552,7 +552,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             ],
             dataValues: [
               extensionB,
-              ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 32),
+              ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 16),
               '0xaabb',
             ],
           };

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
@@ -220,10 +220,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -236,10 +233,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -270,10 +264,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -286,10 +277,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             // set some random bytes under AddressPermissions[7]
 
             await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -434,10 +422,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(
               context.universalProfile.connect(canOnlyAddController).setData(key, randomValue),
             )
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -450,10 +435,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(
               context.universalProfile.connect(canOnlyAddController).setData(key, randomValue),
             )
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -590,7 +572,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
-            const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 32);
+            const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
             await context.universalProfile.connect(canOnlyEditPermissions).setData(key, value);
 
@@ -643,10 +625,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(
               context.universalProfile.connect(canOnlyEditPermissions).setData(key, randomValue),
             )
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -661,10 +640,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             await expect(
               context.universalProfile.connect(canOnlyEditPermissions).setData(key, randomValue),
             )
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -684,7 +684,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             ],
             dataValues: [
               extensionB,
-              ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 32),
+              ethers.utils.hexZeroPad(ethers.utils.hexlify(8), 16),
               '0xaabb',
             ],
           };

--- a/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
+++ b/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
@@ -431,7 +431,7 @@ describe('When deploying LSP7 with LSP6 as owner', () => {
         const key =
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2);
-        const value = ARRAY_LENGTH.ZERO;
+        const value = '0x';
         const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await expect(context.keyManager.connect(addressCanAddController).execute(payload))
@@ -443,7 +443,7 @@ describe('When deploying LSP7 with LSP6 as owner', () => {
         const key =
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2);
-        const value = ARRAY_LENGTH.ZERO;
+        const value = '0x';
         const payload = context.token.interface.encodeFunctionData('setData', [key, value]);
 
         await context.keyManager.connect(context.owner).execute(payload);

--- a/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
@@ -256,10 +256,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -274,10 +271,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -313,10 +307,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -331,10 +322,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(context.owner).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -511,10 +499,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -529,10 +514,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(canOnlyAddController).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });
@@ -698,7 +680,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const newLength = ethers.BigNumber.from(currentLength).sub(1).toNumber();
 
-            const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 32);
+            const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
             const payload = context.universalProfile.interface.encodeFunctionData('setData', [
               key,
@@ -760,10 +742,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
 
@@ -778,10 +757,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ]);
 
             await expect(context.keyManager.connect(canOnlyEditPermissions).execute(setupPayload))
-              .to.be.revertedWithCustomError(
-                context.keyManager,
-                'AddressPermissionArrayIndexValueNotAnAddress',
-              )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
         });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

## ♻️ Refactor

Add input validations for the data values of specific data keys.

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
