### PR TITLE
perf: replace calldata slices by `abi.decode` to extract `ERC725X.execute` params

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Errors.sol
+++ b/contracts/LSP6KeyManager/LSP6Errors.sol
@@ -114,10 +114,9 @@ error AddressPermissionArrayIndexValueNotAnAddress(
 error NoERC725YDataKeysAllowed(address from);
 
 /**
- * @notice The address `from` is not authorised to use the linked account contract to make external calls, because it has Allowed Calls set.
+ * @notice The address `from` is not authorised to use the linked account contract to make external calls, because it has no Allowed Calls set.
  *
- * @dev Reverts when the `from` address has no `AllowedCalls` set and cannot interact with any address
- * using the linked {target}.
+ * @dev Reverts when the `from` address has no `AllowedCalls` set and cannot interact with any address using the linked {target}.
  *
  * @param from The address that has no AllowedCalls.
  */

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -528,19 +528,6 @@ abstract contract LSP6KeyManagerCore is
 
             // ERC725X.execute(uint256,address,uint256,bytes)
         } else if (erc725Function == IERC725X.execute.selector) {
-            // CHECK the offset of `data` is not pointing to the previous parameters
-            //
-            // offsets in calldata for ERC725X.execute(...) parameters (excluding function selector)
-            //
-            // - `operationType`: index 0 in calldata
-            // - `to`: index 32
-            // - `value`: index 64
-            // - `data`'s offset location: index 96
-            // - `data` starts at: index 128 (= 0x0000...0080)
-            if (bytes32(payload[100:132]) != bytes32(uint256(128))) {
-                revert InvalidPayload(payload);
-            }
-
             (
                 uint256 operationType,
                 address to,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -153,7 +153,7 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc ILSP6KeyManager
      *
-     * @custom:events VerifiedCall event when the permissions related to `payload` have been verified successfully.
+     * @custom:events {PermissionsVerified} event when the permissions related to `payload` have been verified successfully.
      */
     function execute(
         bytes calldata payload
@@ -164,7 +164,7 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc ILSP6KeyManager
      *
-     * @custom:events VerifiedCall event for each permissions related to each `payload` that have been verified successfully.
+     * @custom:events {PermissionsVerified} event for each permissions related to each `payload` that have been verified successfully.
      */
     function executeBatch(
         uint256[] calldata values,
@@ -199,7 +199,7 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc ILSP6KeyManager
      *
-     * @custom:events {VerifiedCall} event when the permissions related to `payload` have been verified successfully.
+     * @custom:events {PermissionsVerified} event when the permissions related to `payload` have been verified successfully.
      *
      * @custom:hint You can use `validityTimestamps == 0` to define an `executeRelayCall` transaction that is indefinitely valid,
      * meaning that does not require to start from a specific date/time, or that has an expiration date/time/

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -206,15 +206,6 @@ abstract contract LSP6ExecuteModule {
             );
         }
 
-        // Skip if both SUPER permissions are present
-        if (hasSuperCall && hasSuperTransferValue) return;
-
-        // Skip if caller has SUPER permission for value transfers
-        if (isEmptyCall && isValueTransfer && hasSuperTransferValue) return;
-
-        // Skip if caller has SUPER permissions for external calls, with or without calldata (empty calls)
-        if (!isValueTransfer && hasSuperCall) return;
-
         // CHECK if we are doing an empty call, as the receive() or fallback() function
         // of the controlledContract could run some code.
         if (isEmptyCall && !isValueTransfer && !hasSuperCall) {
@@ -224,6 +215,15 @@ abstract contract LSP6ExecuteModule {
         if (!isEmptyCall && !hasSuperCall) {
             _requirePermissions(controller, permissions, _PERMISSION_CALL);
         }
+
+        // Skip if caller has SUPER permissions for external calls, with or without calldata (empty calls)
+        if (!isValueTransfer && hasSuperCall) return;
+
+        // Skip if caller has SUPER permission for value transfers
+        if (isEmptyCall && isValueTransfer && hasSuperTransferValue) return;
+
+        // Skip if both SUPER permissions are present
+        if (hasSuperCall && hasSuperTransferValue) return;
 
         _verifyAllowedCall(
             controlledContract,

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -55,7 +55,6 @@ abstract contract LSP6ExecuteModule {
      * @param controller the address who want to run the execute function on the ERC725Account.
      * @param permissions the permissions of the controller address.
      */
-    //  * @param payload the ABI encoded payload `controlledContract.execute(...)`.
     function _verifyCanExecute(
         address controlledContract,
         address controller,

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -113,9 +113,11 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         return _addressPermission.hasPermission(_permissions);
     }
 
-    // function extractExecuteParameters(
-    //     bytes calldata executeCalldata
-    // ) public pure returns (uint256, address, uint256, bytes4, bool) {
-    //     return super._extractExecuteParameters(executeCalldata);
-    // }
+    function verifyPermissions(
+        address from,
+        uint256 msgValue,
+        bytes calldata payload
+    ) public view {
+        super._verifyPermissions(from, msgValue, payload);
+    }
 }

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -34,9 +34,19 @@ contract KeyManagerInternalTester is LSP6KeyManager {
 
     function verifyAllowedCall(
         address _sender,
-        bytes calldata _payload
+        uint256 operationType,
+        address to,
+        uint256 value,
+        bytes memory data
     ) public view {
-        super._verifyAllowedCall(_target, _sender, _payload);
+        super._verifyAllowedCall(
+            _target,
+            _sender,
+            operationType,
+            to,
+            value,
+            data
+        );
     }
 
     function isCompactBytesArrayOfAllowedCalls(
@@ -103,9 +113,9 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         return _addressPermission.hasPermission(_permissions);
     }
 
-    function extractExecuteParameters(
-        bytes calldata executeCalldata
-    ) public pure returns (uint256, address, uint256, bytes4, bool) {
-        return super._extractExecuteParameters(executeCalldata);
-    }
+    // function extractExecuteParameters(
+    //     bytes calldata executeCalldata
+    // ) public pure returns (uint256, address, uint256, bytes4, bool) {
+    //     return super._extractExecuteParameters(executeCalldata);
+    // }
 }

--- a/contracts/Mocks/TargetContract.sol
+++ b/contracts/Mocks/TargetContract.sol
@@ -27,6 +27,10 @@ contract TargetContract {
     }
 
     function setNamePayable(string memory name) public payable {
+        _name = name;
+    }
+
+    function setNamePayableMinimumValue(string memory name) public payable {
         require(msg.value >= 50, "Not enough value provided");
         _name = name;
     }

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -33,7 +33,7 @@ import { ERC725YDataKeys, INTERFACE_IDS, OPERATION_TYPES, LSP1_TYPE_IDS } from '
 // fixtures
 import { callPayload, getLSP5MapAndArrayKeysValue, setupKeyManager } from '../utils/fixtures';
 import { LSP6TestContext } from '../utils/context';
-import { BigNumber, BytesLike, ContractTransaction, Transaction } from 'ethers';
+import { BigNumber, BytesLike, Transaction } from 'ethers';
 
 export type LSP1TestAccounts = {
   owner1: SignerWithAddress;

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import {
@@ -25,9 +26,17 @@ import { LSP6TestContext } from '../../../utils/context';
 import { setupKeyManager } from '../../../utils/fixtures';
 
 // helpers
-import { abiCoder, combineAllowedCalls } from '../../../utils/helpers';
+import {
+  abiCoder,
+  combineAllowedCalls,
+  combineCallTypes,
+  combinePermissions,
+  provider,
+} from '../../../utils/helpers';
 
-export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6TestContext>) => {
+export const shouldBehaveLikePermissionCall = (
+  buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
+) => {
   let context: LSP6TestContext;
 
   describe('when making an empty call via `ERC25X.execute(...)` -> (`data` = `0x`, `value` = 0)', () => {
@@ -348,32 +357,6 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
       await setupKeyManager(context, permissionKeys, permissionsValues);
     });
 
-    describe("when the 'offset' of the `data` payload is not `0x00...80`", () => {
-      it('should revert', async () => {
-        let payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.CALL,
-          targetContract.address,
-          0,
-          '0xcafecafe',
-        ]);
-
-        // edit the `data` offset
-        payload = payload.replace(
-          '0000000000000000000000000000000000000000000000000000000000000080',
-          '0000000000000000000000000000000000000000000000000000000000000040',
-        );
-
-        await expect(
-          addressCanMakeCallWithAllowedCalls.sendTransaction({
-            to: context.universalProfile.address,
-            data: payload,
-          }),
-        )
-          .to.be.revertedWithCustomError(context.keyManager, 'InvalidPayload')
-          .withArgs(payload);
-      });
-    });
-
     describe('when interacting via `execute(...)`', () => {
       describe('when caller has ALL PERMISSIONS', () => {
         it('should pass and change state at the target contract', async () => {
@@ -493,6 +476,412 @@ export const shouldBehaveLikePermissionCall = (buildContext: () => Promise<LSP6T
           )
             .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(addressCannotMakeCall.address, 'CALL');
+        });
+      });
+    });
+  });
+
+  describe('`execute(...)` edge cases', async () => {
+    let targetContract: TargetContract;
+    let addressWithNoPermissions: SignerWithAddress;
+
+    before(async () => {
+      context = await buildContext();
+
+      addressWithNoPermissions = context.accounts[1];
+
+      targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
+
+      const permissionKeys = [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ];
+
+      const permissionValues = [ALL_PERMISSIONS];
+
+      await setupKeyManager(context, permissionKeys, permissionValues);
+    });
+
+    it('Should revert when caller calls the KeyManager through execute', async () => {
+      const lsp20VerifyCallPayload = context.keyManager.interface.encodeFunctionData(
+        'lsp20VerifyCall',
+        [context.accounts[2].address, 0, '0xaabbccdd'], // random arguments
+      );
+
+      await expect(
+        context.universalProfile.execute(
+          OPERATION_TYPES.CALL,
+          context.keyManager.address,
+          0,
+          lsp20VerifyCallPayload,
+        ),
+      ).to.be.revertedWithCustomError(context.keyManager, 'CallingKeyManagerNotAllowed');
+    });
+
+    describe('when the offset of the `data` payload is not `0x00...80`', () => {
+      describe('if the offset points backwards to the `value` parameter', () => {
+        // We add the target in the allowed calls for each of these controller
+        let controllerCanTransferValue;
+        let controllerCanTransferValueAndCall;
+        let controllerCanCall;
+
+        let controllerCanOnlySign;
+
+        let controllerCanSuperCall;
+        let controllerCanSuperTransferValue;
+
+        let targetContract: FallbackInitializer;
+
+        let executePayload;
+
+        before(async () => {
+          context = await buildContext(ethers.utils.parseEther('50'));
+
+          const accounts = await ethers.getSigners();
+
+          controllerCanTransferValue = accounts[1];
+          controllerCanTransferValueAndCall = accounts[2];
+          controllerCanCall = accounts[3];
+
+          controllerCanOnlySign = accounts[4];
+
+          controllerCanSuperCall = accounts[5];
+          controllerCanSuperTransferValue = accounts[6];
+
+          targetContract = await new FallbackInitializer__factory(context.accounts[0]).deploy();
+
+          const permissionKeys = [
+            // permissions
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanTransferValue.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanTransferValueAndCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanOnlySign.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanSuperCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanSuperTransferValue.address.substring(2),
+            // allowed calls
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+              controllerCanTransferValue.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+              controllerCanTransferValueAndCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+              controllerCanCall.address.substring(2),
+          ];
+
+          const allowedCall = combineAllowedCalls(
+            [combineCallTypes(CALLTYPE.CALL, CALLTYPE.VALUE)],
+            [targetContract.address],
+            ['0xffffffff'],
+            ['0xffffffff'],
+          );
+
+          const permissionValues = [
+            // permissions
+            PERMISSIONS.TRANSFERVALUE,
+            combinePermissions(PERMISSIONS.TRANSFERVALUE, PERMISSIONS.CALL),
+            PERMISSIONS.CALL,
+            PERMISSIONS.SIGN,
+            PERMISSIONS.SUPER_CALL,
+            PERMISSIONS.SUPER_TRANSFERVALUE,
+            // allowed calls,
+            allowedCall,
+            allowedCall,
+            allowedCall,
+          ];
+
+          await setupKeyManager(context, permissionKeys, permissionValues);
+        });
+
+        afterEach('clearing target contract storage', async () => {
+          await context.accounts[0].sendTransaction({
+            to: targetContract.address,
+            data: '0xcafecafe',
+          });
+        });
+
+        describe('when the `value` parameter has some number, that points to some `data == 0x0000...04deadbe`', () => {
+          before(async () => {
+            executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              36,
+              '0xdeadbeef',
+            ]);
+
+            // edit the `data` offset to points to the `value` parameter
+            executePayload = executePayload.replace(
+              '0000000000000000000000000000000000000000000000000000000000000080',
+              '0000000000000000000000000000000000000000000000000000000000000040',
+            );
+          });
+
+          describe('when caller has permission TRANSFERVALUE only', () => {
+            it("should revert with 'NotAuthorised' error to 'CALL'", async () => {
+              await expect(
+                // We need to do low level send transactions as the data offset is not standard
+                controllerCanTransferValue.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanTransferValue.address, 'CALL');
+            });
+          });
+
+          describe('when caller has permission CALL only', () => {
+            it("should revert with 'NotAuthorised' error to 'TRANSFERVALUE'", async () => {
+              await expect(
+                controllerCanCall.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanCall.address, 'TRANSFERVALUE');
+            });
+          });
+
+          describe('when caller does not have neither CALL nor TRANSFERVALUE permissions', () => {
+            it("should revert with 'NotAuthorised' error to 'TRANSFERVALUE' (as value transfer is the first thing being checked", async () => {
+              await expect(
+                controllerCanOnlySign.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanOnlySign.address, 'TRANSFERVALUE');
+            });
+          });
+
+          describe('when caller has both permissions CALL + TRANSFERVALUE', () => {
+            it('should pass and allow to call the contract', async () => {
+              expect(await provider.getBalance(targetContract.address)).to.equal(0);
+
+              await controllerCanTransferValueAndCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+              expect(await provider.getBalance(targetContract.address)).to.equal(36);
+            });
+          });
+        });
+
+        describe('when the `value` parameter is 0, meaning calldata is empty (= empty call)', () => {
+          before(async () => {
+            executePayload = context.universalProfile.interface.encodeFunctionData('execute', [
+              OPERATION_TYPES.CALL,
+              targetContract.address,
+              0,
+              '0x',
+            ]);
+
+            // edit the `data` offset to points to the `value` parameter
+            executePayload = executePayload.replace(
+              '0000000000000000000000000000000000000000000000000000000000000080',
+              '0000000000000000000000000000000000000000000000000000000000000040',
+            );
+          });
+
+          describe('when controller has permission CALL only', () => {
+            it('should pass', async () => {
+              await controllerCanCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe('when controller has SUPER_CALL', () => {
+            it('should pass', async () => {
+              await controllerCanSuperCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe('when controller does not have permission CALL', () => {
+            it('should revert with `NotAuthorised` error to `CALL`', async () => {
+              await expect(
+                controllerCanOnlySign.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanOnlySign.address, 'CALL');
+            });
+          });
+        });
+      });
+
+      describe("if the offset points forwards (there are 32 random bytes between the data's offset and the data's length", () => {
+        // We add the target in the allowed calls for each of these controller
+        let controllerCanCall;
+        let controllerCanSuperCall;
+        let controllerCanOnlySign;
+
+        let targetContract: FallbackInitializer;
+
+        let executePayload;
+
+        before(async () => {
+          context = await buildContext(ethers.utils.parseEther('50'));
+
+          const accounts = await ethers.getSigners();
+
+          controllerCanCall = accounts[1];
+          controllerCanSuperCall = accounts[2];
+          controllerCanOnlySign = accounts[3];
+
+          targetContract = await new FallbackInitializer__factory(context.accounts[0]).deploy();
+
+          const permissionKeys = [
+            // permissions
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanSuperCall.address.substring(2),
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+              controllerCanOnlySign.address.substring(2),
+            // allowed calls
+            ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
+              controllerCanCall.address.substring(2),
+          ];
+
+          const allowedCall = combineAllowedCalls(
+            [combineCallTypes(CALLTYPE.CALL)],
+            [targetContract.address],
+            ['0xffffffff'],
+            ['0xffffffff'],
+          );
+
+          const permissionValues = [
+            // permissions
+            PERMISSIONS.CALL,
+            PERMISSIONS.SUPER_CALL,
+            PERMISSIONS.SIGN,
+            // allowed calls,
+            allowedCall,
+          ];
+
+          await setupKeyManager(context, permissionKeys, permissionValues);
+        });
+
+        afterEach('clearing target contract storage', async () => {
+          await context.accounts[0].sendTransaction({
+            to: targetContract.address,
+            data: '0xcafecafe',
+          });
+        });
+
+        describe('the length byte points to some number', () => {
+          before('constructing manually the payload', async () => {
+            // 0x44c028fe                                                         --> ERC725X.execute(uint256,address,uint256,bytes) selector
+            //   0000000000000000000000000000000000000000000000000000000000000000 --> operationType = CALL (0)
+            //   0000000000000000000000004ed7c70f96b99c776995fb64377f0d4ab3b0e1c1 --> target = targetContract.address
+            //   0000000000000000000000000000000000000000000000000000000000000000 --> value = 0
+            //   00000000000000000000000000000000000000000000000000000000000000a0 --> offset = 160
+            //   cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe --> 32 random bytes in between
+            //   0000000000000000000000000000000000000000000000000000000000000004 --> `data.length` = 4
+            //   deadbeef00000000000000000000000000000000000000000000000000000000 --> `data` = 0xdeadbeef
+            executePayload =
+              '0x44c028fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' +
+              targetContract.address.substring(2).toLowerCase() +
+              '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe0000000000000000000000000000000000000000000000000000000000000004deadbeef00000000000000000000000000000000000000000000000000000000';
+          });
+
+          describe('when caller has permission CALL', () => {
+            it('should pass', async () => {
+              await controllerCanCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe('when caller has permission SUPER_CALL', () => {
+            it('should pass', async () => {
+              await controllerCanSuperCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe("when caller does not have permission 'CALL' nor 'SUPER_CALL'", () => {
+            it("should revert with 'NotAuthorised' error to 'CALL'", async () => {
+              await expect(
+                controllerCanOnlySign.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanOnlySign.address, 'CALL');
+            });
+          });
+        });
+
+        describe('the length byte points to `0x0000...0000` (= no data, this is an empty call)', () => {
+          before('constructing manually the payload', async () => {
+            // 0x44c028fe                                                         --> ERC725X.execute(uint256,address,uint256,bytes) selector
+            //   0000000000000000000000000000000000000000000000000000000000000000 --> operationType = CALL (0)
+            //   0000000000000000000000004ed7c70f96b99c776995fb64377f0d4ab3b0e1c1 --> target = targetContract.address
+            //   0000000000000000000000000000000000000000000000000000000000000000 --> value = 0
+            //   00000000000000000000000000000000000000000000000000000000000000a0 --> offset = 160
+            //   cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe --> 32 random bytes in between
+            //   0000000000000000000000000000000000000000000000000000000000000000 --> `data.length` = 0
+            executePayload =
+              '0x44c028fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' +
+              targetContract.address.substring(2).toLowerCase() +
+              '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a0cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe0000000000000000000000000000000000000000000000000000000000000000';
+          });
+
+          describe('when caller has permission CALL', () => {
+            it('should pass', async () => {
+              await controllerCanCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe('when caller has permission SUPER_CALL', () => {
+            it('should pass', async () => {
+              await controllerCanSuperCall.sendTransaction({
+                to: context.universalProfile.address,
+                data: executePayload,
+              });
+              expect(await targetContract.caller()).to.equal(context.universalProfile.address);
+            });
+          });
+
+          describe("when caller does not have permission 'CALL' nor 'SUPER_CALL'", () => {
+            it("should revert with 'NotAuthorised' error to 'CALL'", async () => {
+              await expect(
+                controllerCanOnlySign.sendTransaction({
+                  to: context.universalProfile.address,
+                  data: executePayload,
+                }),
+              )
+                .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+                .withArgs(controllerCanOnlySign.address, 'CALL');
+            });
+          });
         });
       });
     });

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -39,7 +39,7 @@ describe('LSP6KeyManager with constructor', () => {
     shouldBehaveLikeLSP6(buildTestContext);
   });
 
-  describe('testing internal functions', () => {
+  describe.only('testing internal functions', () => {
     testLSP6InternalFunctions(async () => {
       const accounts = await ethers.getSigners();
       const owner = accounts[0];

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -39,7 +39,7 @@ describe('LSP6KeyManager with constructor', () => {
     shouldBehaveLikeLSP6(buildTestContext);
   });
 
-  describe.only('testing internal functions', () => {
+  describe('testing internal functions', () => {
     testLSP6InternalFunctions(async () => {
       const accounts = await ethers.getSigners();
       const owner = accounts[0];

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -336,11 +336,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
             it('should revert', async () => {
               const nameToSet = 'Alice';
               const targetContractPayload = targetContract.interface.encodeFunctionData(
-                'setNamePayable',
+                'setNamePayableMinimumValue',
                 [nameToSet],
               );
 
-              const requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+              const requiredValueForExecution = 51; // specified in `setNamePayableMinimumValue(..)`
 
               const latestNonce = await context.keyManager.callStatic.getNonce(signer.address, 0);
 
@@ -413,11 +413,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
             it('should pass if signer has the target contract address in its list of allowed calls', async () => {
               const nameToSet = 'Alice';
               const targetContractPayload = targetContract.interface.encodeFunctionData(
-                'setNamePayable',
+                'setNamePayableMinimumValue',
                 [nameToSet],
               );
 
-              const requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+              const requiredValueForExecution = 51; // specified in `setNamePayableMinimumValue(..)`
 
               const latestNonce = await context.keyManager.callStatic.getNonce(signer.address, 0);
 
@@ -481,11 +481,11 @@ export const shouldBehaveLikeExecuteRelayCall = (
             it("should revert with 'NotAllowedCall' error if signer does not have any listed under its allowed calls", async () => {
               const nameToSet = 'Alice';
               const targetContractPayload = targetContract.interface.encodeFunctionData(
-                'setNamePayable',
+                'setNamePayableMinimumValue',
                 [nameToSet],
               );
 
-              const requiredValueForExecution = 51; // specified in `setNamePayable(..)`
+              const requiredValueForExecution = 51; // specified in `setNamePayableMinimumValue(..)`
 
               const latestNonce = await context.keyManager.callStatic.getNonce(
                 signerNoAllowedCalls.address,

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -199,17 +199,20 @@ export const testAllowedCallsInternals = (
     describe('`verifyAllowedCall(...)`', () => {
       describe('when the ERC725X payload (transfer 1 LYX) is for an address listed in the allowed calls', () => {
         it('should pass', async () => {
-          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-            OPERATION_TYPES.CALL,
-            allowedEOA.address,
-            ethers.utils.parseEther('1'),
-            '0x',
-          ]);
+          const executeParams = {
+            operationType: OPERATION_TYPES.CALL,
+            to: allowedEOA.address,
+            value: ethers.utils.parseEther('1'),
+            data: '0x',
+          };
 
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallOnlyTwoAddresses.address,
-              payload,
+              executeParams.operationType,
+              executeParams.to,
+              executeParams.value,
+              executeParams.data,
             ),
           ).to.not.be.reverted;
         });
@@ -221,17 +224,20 @@ export const testAllowedCallsInternals = (
             '0xdeadbeefdeadbeefdeaddeadbeefdeadbeefdead',
           );
 
-          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-            OPERATION_TYPES.CALL,
-            disallowedAddress,
-            ethers.utils.parseEther('1'),
-            '0x',
-          ]);
+          const executeParams = {
+            operationType: OPERATION_TYPES.CALL,
+            to: disallowedAddress,
+            value: ethers.utils.parseEther('1'),
+            data: '0x',
+          };
 
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallOnlyTwoAddresses.address,
-              payload,
+              executeParams.operationType,
+              executeParams.to,
+              executeParams.value,
+              executeParams.data,
             ),
           )
             .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
@@ -243,17 +249,20 @@ export const testAllowedCallsInternals = (
         it('should revert', async () => {
           const randomAddress = ethers.Wallet.createRandom().address;
 
-          const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-            OPERATION_TYPES.CALL,
-            randomAddress,
-            ethers.utils.parseEther('1'),
-            '0x',
-          ]);
+          const executeParams = {
+            operationType: OPERATION_TYPES.CALL,
+            to: randomAddress,
+            value: ethers.utils.parseEther('1'),
+            data: '0x',
+          };
 
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               canCallNoAllowedCalls.address,
-              payload,
+              executeParams.operationType,
+              executeParams.to,
+              executeParams.value,
+              executeParams.data,
             ),
           )
             .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NoCallsAllowed')
@@ -332,58 +341,82 @@ export const testAllowedCallsInternals = (
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.CALL,
-          targetContractValue.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.CALL,
+          to: targetContractValue.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
       it('should pass when the allowed address has `c` permission only (`c` = CALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.CALL,
-          targetContractCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.CALL,
+          to: targetContractCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         ).to.not.be.reverted;
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.CALL,
-          targetContractStaticCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.CALL,
+          to: targetContractStaticCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractStaticCall.address, randomPayload);
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.CALL,
-          targetContractDelegateCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.CALL,
+          to: targetContractDelegateCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractDelegateCall.address, randomPayload);

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-import { TargetContract, TargetContract__factory, UniversalProfile__factory } from '../../../types';
+import { TargetContract, TargetContract__factory } from '../../../types';
 
 // constants
 import {
@@ -714,8 +714,6 @@ export const testAllowedCallsInternals = (
 
       describe('should revert with `NoCallsAllowed` error', () => {
         it(`when AllowedCalls contain noBytes -> 0x`, async () => {
-          const params = Object.values(executeParams);
-
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controllers[0].account.address,

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -452,58 +452,82 @@ export const testAllowedCallsInternals = (
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.STATICCALL,
-          targetContractValue.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.STATICCALL,
+          to: targetContractValue.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.STATICCALL,
-          targetContractCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.STATICCALL,
+          to: targetContractCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractCall.address, randomPayload);
       });
 
       it('should pass when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.STATICCALL,
-          targetContractStaticCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.STATICCALL,
+          to: targetContractStaticCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         ).to.not.be.reverted;
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.STATICCALL,
-          targetContractDelegateCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.STATICCALL,
+          to: targetContractDelegateCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractDelegateCall.address, randomPayload);
@@ -539,60 +563,84 @@ export const testAllowedCallsInternals = (
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `v` permission only (`v` = VALUE)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.DELEGATECALL,
-          targetContractValue.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.DELEGATECALL,
+          to: targetContractValue.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractValue.address, randomPayload);
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `c` permission only (`c` = CALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.DELEGATECALL,
-          targetContractCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.DELEGATECALL,
+          to: targetContractCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractCall.address, randomPayload);
       });
 
       it('should fail with `NotAllowedCall` error when the allowed address has `s` permission only (`s` = STATICCALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.DELEGATECALL,
-          targetContractStaticCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.DELEGATECALL,
+          to: targetContractStaticCall.address,
+          value: 0,
+          data: randomPayload,
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         )
           .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
           .withArgs(controller.address, targetContractStaticCall.address, randomPayload);
       });
 
       it('should pass when the allowed address has `d` permission only (`d` = DELEGATECALL)', async () => {
-        const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-          OPERATION_TYPES.DELEGATECALL,
-          targetContractDelegateCall.address,
-          0,
-          randomPayload, // random payload
-        ]);
+        const executeParams = {
+          operationType: OPERATION_TYPES.DELEGATECALL,
+          to: targetContractDelegateCall.address,
+          value: 0,
+          data: randomPayload, // random payload
+        };
 
         await expect(
-          context.keyManagerInternalTester.verifyAllowedCall(controller.address, payload),
+          context.keyManagerInternalTester.verifyAllowedCall(
+            controller.address,
+            executeParams.operationType,
+            executeParams.to,
+            executeParams.value,
+            executeParams.data,
+          ),
         ).to.not.be.reverted;
       });
     });
@@ -650,8 +698,6 @@ export const testAllowedCallsInternals = (
 
       permissionValues = permissionValues.concat(zeroBytesValues);
 
-      console.log(permissionValues);
-
       await setupKeyManagerHelper(context, permissionKeys, permissionValues);
     });
 
@@ -659,21 +705,24 @@ export const testAllowedCallsInternals = (
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
       const randomData = '0xaabbccdd';
 
-      const universalProfileInterface = UniversalProfile__factory.createInterface();
-
-      const payload: string = universalProfileInterface.encodeFunctionData('execute', [
-        OPERATION_TYPES.CALL,
-        randomAddress,
-        ethers.utils.parseEther('1'),
-        randomData,
-      ]);
+      const executeParams = {
+        operationType: OPERATION_TYPES.CALL,
+        to: randomAddress,
+        value: ethers.utils.parseEther('1'),
+        data: randomData,
+      };
 
       describe('should revert with `NoCallsAllowed` error', () => {
         it(`when AllowedCalls contain noBytes -> 0x`, async () => {
+          const params = Object.values(executeParams);
+
           await expect(
             context.keyManagerInternalTester.verifyAllowedCall(
               controllers[0].account.address,
-              payload,
+              executeParams.operationType,
+              executeParams.to,
+              executeParams.value,
+              executeParams.data,
             ),
           ).to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NoCallsAllowed');
         });
@@ -688,7 +737,10 @@ export const testAllowedCallsInternals = (
             await expect(
               context.keyManagerInternalTester.verifyAllowedCall(
                 controllers[index + 1].account.address,
-                payload,
+                executeParams.operationType,
+                executeParams.to,
+                executeParams.value,
+                executeParams.data,
               ),
             )
               .to.be.revertedWithCustomError(
@@ -714,17 +766,15 @@ export const testAllowedCallsInternals = (
     const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
     const randomData = '0xaabbccdd';
 
-    let payload: string;
+    const executeParams = {
+      operationType: OPERATION_TYPES.CALL,
+      to: randomAddress,
+      value: ethers.utils.parseEther('1'),
+      data: randomData,
+    };
 
     before(async () => {
       context = await buildContext();
-
-      payload = context.universalProfile.interface.encodeFunctionData('execute', [
-        OPERATION_TYPES.CALL,
-        randomAddress,
-        ethers.utils.parseEther('1'),
-        randomData,
-      ]);
 
       const permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
@@ -762,7 +812,10 @@ export const testAllowedCallsInternals = (
               context.keyManagerInternalTester.verifyAllowedCall(
                 // `index + 1` because `accounts[0]` has all permissions
                 context.accounts[index + 1].address,
-                payload,
+                executeParams.operationType,
+                executeParams.to,
+                executeParams.value,
+                executeParams.data,
               ),
             )
               .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'NotAllowedCall')
@@ -814,15 +867,21 @@ export const testAllowedCallsInternals = (
       const randomData = '0xaabbccdd';
       const randomAddress = ethers.Wallet.createRandom().address.toLowerCase();
 
-      const payload = context.universalProfile.interface.encodeFunctionData('execute', [
-        OPERATION_TYPES.CALL,
-        randomAddress,
-        ethers.utils.parseEther('1'),
-        randomData,
-      ]);
+      const executeParams = {
+        operationType: OPERATION_TYPES.CALL,
+        to: randomAddress,
+        value: ethers.utils.parseEther('1'),
+        data: randomData,
+      };
 
       await expect(
-        context.keyManagerInternalTester.verifyAllowedCall(anyAllowedCalls.address, payload),
+        context.keyManagerInternalTester.verifyAllowedCall(
+          anyAllowedCalls.address,
+          executeParams.operationType,
+          executeParams.to,
+          executeParams.value,
+          executeParams.data,
+        ),
       )
         .to.be.revertedWithCustomError(context.keyManagerInternalTester, 'InvalidWhitelistedCall')
         .withArgs(anyAllowedCalls.address);


### PR DESCRIPTION
# What does this PR introduce?

## 🚀 Perfs

Replace calldata slices by `abi.decode` in the Key Manager for extracting the ERC725X execute parameters.

This reduce the deployment cost + runtime cost as follow (except for the main controller).

### Deployment cost

![image](https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/f9e5fde4-be4a-4830-af2c-7bfd9fbbd140)

### Runtime cost

<img width="1188" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/541ef576-a3c4-439e-a85a-cff156bd0ed2">


### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
