### PR TITLE
docs: add updated Markdown generated docs from Natspec

### DIFF
--- a/docs/_interface_ids_table.mdx
+++ b/docs/_interface_ids_table.mdx
@@ -1,0 +1,19 @@
+| Contract                         | Interface ID | Description                                                                                                                                              |
+| :------------------------------- | :----------: | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ERC165**                       | `0x01ffc9a7` | Standard Interface Detection.                                                                                                                            |
+| **ERC1271**                      | `0x1626ba7e` | Standard Signature Validation Method for Contracts.                                                                                                      |
+| **ERC725X**                      | `0x7545acac` | General executor.                                                                                                                                        |
+| **ERC725Y**                      | `0x629aa694` | General Data key-value store.                                                                                                                            |
+| **LSP0ERC725Account**            | `0x24871b3d` | Interface of the [LSP-0-ERC725Account] standard, an account based smart contract that represents an identity on-chain.                                   |
+| **LSP1UniversalReceiver**        | `0x6bb56a14` | Interface of the LSP1 - Universal Receiver standard, an entry function for a contract to receive arbitrary information.                                  |
+| **LSP6KeyManager**               | `0x627ca5d3` | Interface of the LSP6 - Key Manager standard, a contract acting as a controller of an ERC725 Account using predfined permissions.                        |
+| **LSP7DigitalAsset**             | `0xda1f85e4` | Interface of the LSP7 - Digital Asset standard, a fungible digital asset.                                                                                |
+| **LSP8IdentifiableDigitalAsset** | `0x622e7a01` | Interface of the LSP8 - Identifiable Digital Asset standard, a non-fungible digital asset.                                                               |
+| **LSP9Vault**                    | `0x28af17e6` | Interface of LSP9 - Vault standard, a blockchain vault that can hold assets and interact with other smart contracts.                                     |
+| **LSP11BasicSocialRecovery**     | `0x049a28f1` | Interface of the LSP11 - Basic Social Recovery standard, a contract to recover access control into an account.                                           |
+| **LSP14Ownable2Step**            | `0x94be5999` | Interface of the LSP14 - Ownable 2-step standard, an extension of the [EIP173] (Ownable) standard with 2-step process to transfer or renounce ownership. |
+| **LSP17Extendable**              | `0xa918fa6b` | Module to add more functionalities to a contract using extensions.                                                                                       |
+| **LSP17Extension**               | `0xcee78b40` | Module to create a contract that can act as an extension.                                                                                                |
+| **LSP20CallVerification**        | `0x1a0eb6a5` | Implementation of a contract calling the verification functions according to LSP20 - Call Verification standard.                                         |
+| **LSP20CallVerifier**            | `0x480c0ec2` | Interface for the LSP20 Call Verification standard, a set of functions intended to perform verifications on behalf of another contract.                  |
+| **LSP25ExecuteRelayCall**        | `0x5ac79908` |                                                                                                                                                          |

--- a/docs/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.md
+++ b/docs/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.md
@@ -1,0 +1,965 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# LSP11BasicSocialRecovery
+
+:::info Standard Specifications
+
+[`LSP-11-BasicSocialRecovery`](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md)
+
+:::
+:::info Solidity implementation
+
+[`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+
+:::
+
+> Implementation of LSP11 - Basic Social Recovery standard
+
+Sets permission for a controller address after a recovery process to interact with an ERC725 contract via the LSP6KeyManager
+
+## Public Methods
+
+Public methods are accessible externally from users, allowing interaction with this function from dApps or other smart contracts.
+When marked as 'public', a method can be called both externally and internally, on the other hand, when marked as 'external', a method can only be called externally.
+
+### constructor
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#constructor)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+
+:::
+
+```solidity
+constructor(address _owner, address target_);
+```
+
+_Sets the target and the owner addresses_
+
+#### Parameters
+
+| Name      |   Type    | Description                                  |
+| --------- | :-------: | -------------------------------------------- |
+| `_owner`  | `address` | The owner of the LSP11 contract              |
+| `target_` | `address` | The address of the ER725 contract to recover |
+
+<br/>
+
+### addGuardian
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#addguardian)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `addGuardian(address)`
+- Function selector: `0xa526d83b`
+
+:::
+
+```solidity
+function addGuardian(address newGuardian) external nonpayable;
+```
+
+Adds a guardian of the targetCan be called only by the owner
+
+#### Parameters
+
+| Name          |   Type    | Description                      |
+| ------------- | :-------: | -------------------------------- |
+| `newGuardian` | `address` | The address to add as a guardian |
+
+<br/>
+
+### getGuardianChoice
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#getguardianchoice)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `getGuardianChoice(address)`
+- Function selector: `0xf6a22f02`
+
+:::
+
+```solidity
+function getGuardianChoice(address guardian) external view returns (address);
+```
+
+Returns the address of a controller that a `guardian` selected for in order to recover the target
+
+#### Parameters
+
+| Name       |   Type    | Description                                      |
+| ---------- | :-------: | ------------------------------------------------ |
+| `guardian` | `address` | the address of a guardian to query his selection |
+
+#### Returns
+
+| Name |   Type    | Description                          |
+| ---- | :-------: | ------------------------------------ |
+| `0`  | `address` | the address that `guardian` selected |
+
+<br/>
+
+### getGuardians
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#getguardians)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `getGuardians()`
+- Function selector: `0x0665f04b`
+
+:::
+
+```solidity
+function getGuardians() external view returns (address[]);
+```
+
+Returns the addresses of all guardians The guardians will select an address to be added as a controller key for the linked `target` if he reaches the guardian threshold and provide the correct string that produce the secretHash
+
+#### Returns
+
+| Name |    Type     | Description |
+| ---- | :---------: | ----------- |
+| `0`  | `address[]` | -           |
+
+<br/>
+
+### getGuardiansThreshold
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#getguardiansthreshold)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `getGuardiansThreshold()`
+- Function selector: `0x187c5348`
+
+:::
+
+```solidity
+function getGuardiansThreshold() external view returns (uint256);
+```
+
+Returns the guardian threshold The guardian threshold represents the minimum number of selection by guardians required for an address to start a recovery process
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `uint256` | -           |
+
+<br/>
+
+### getRecoveryCounter
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#getrecoverycounter)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `getRecoveryCounter()`
+- Function selector: `0xf79c8b77`
+
+:::
+
+```solidity
+function getRecoveryCounter() external view returns (uint256);
+```
+
+Returns the current recovery counter When a recovery process is successfully finished the recovery counter is incremented
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `uint256` | -           |
+
+<br/>
+
+### getRecoverySecretHash
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#getrecoverysecrethash)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `getRecoverySecretHash()`
+- Function selector: `0x8f9083bb`
+
+:::
+
+```solidity
+function getRecoverySecretHash() external view returns (bytes32);
+```
+
+Returns the recovery secret hash
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `bytes32` | -           |
+
+<br/>
+
+### isGuardian
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#isguardian)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `isGuardian(address)`
+- Function selector: `0x0c68ba21`
+
+:::
+
+```solidity
+function isGuardian(address _address) external view returns (bool);
+```
+
+Returns TRUE if the address provided is a guardian, FALSE otherwise
+
+#### Parameters
+
+| Name       |   Type    | Description          |
+| ---------- | :-------: | -------------------- |
+| `_address` | `address` | The address to query |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+### owner
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#owner)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `owner()`
+- Function selector: `0x8da5cb5b`
+
+:::
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the address of the current owner.
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `address` | -           |
+
+<br/>
+
+### recoverOwnership
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#recoverownership)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `recoverOwnership(address,string,bytes32)`
+- Function selector: `0xae8481b2`
+
+:::
+
+```solidity
+function recoverOwnership(
+  address recoverer,
+  string plainSecret,
+  bytes32 newSecretHash
+) external nonpayable;
+```
+
+Recovers the ownership permissions of an address in the linked target and increment the recover counter Requirements
+
+- the address of the recoverer must have a selection equal or higher than the threshold defined in `getGuardiansThreshold(...)`
+
+- must have provided the right `plainSecret` that produces the secret Hash
+
+#### Parameters
+
+| Name            |   Type    | Description                                  |
+| --------------- | :-------: | -------------------------------------------- |
+| `recoverer`     | `address` | The address of the recoverer                 |
+| `plainSecret`   | `string`  | The secret word that produce the secret Hash |
+| `newSecretHash` | `bytes32` | -                                            |
+
+<br/>
+
+### removeGuardian
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#removeguardian)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `removeGuardian(address)`
+- Function selector: `0x71404156`
+
+:::
+
+```solidity
+function removeGuardian(address existingGuardian) external nonpayable;
+```
+
+Removes a guardian of the targetCan be called only by the owner
+
+#### Parameters
+
+| Name               |   Type    | Description |
+| ------------------ | :-------: | ----------- |
+| `existingGuardian` | `address` | -           |
+
+<br/>
+
+### renounceOwnership
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#renounceownership)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `renounceOwnership()`
+- Function selector: `0x715018a6`
+
+:::
+
+```solidity
+function renounceOwnership() external nonpayable;
+```
+
+Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.
+
+<br/>
+
+### selectNewController
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#selectnewcontroller)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `selectNewController(address)`
+- Function selector: `0xaa7806d6`
+
+:::
+
+```solidity
+function selectNewController(address addressSelected) external nonpayable;
+```
+
+select an address to be a potentiel controller address if he reaches the guardian threshold and provide the correct secret string Requirements:
+
+- only guardians can select an address
+
+#### Parameters
+
+| Name              |   Type    | Description                          |
+| ----------------- | :-------: | ------------------------------------ |
+| `addressSelected` | `address` | The address selected by the guardian |
+
+<br/>
+
+### setGuardiansThreshold
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#setguardiansthreshold)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `setGuardiansThreshold(uint256)`
+- Function selector: `0x6bfed20b`
+
+:::
+
+```solidity
+function setGuardiansThreshold(uint256 newThreshold) external nonpayable;
+```
+
+Sets the minimum number of selection by the guardians required so that an address can recover ownershipCan be called only by the owner
+
+#### Parameters
+
+| Name           |   Type    | Description |
+| -------------- | :-------: | ----------- |
+| `newThreshold` | `uint256` | -           |
+
+<br/>
+
+### setRecoverySecretHash
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#setrecoverysecrethash)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `setRecoverySecretHash(bytes32)`
+- Function selector: `0xf799e38d`
+
+:::
+
+```solidity
+function setRecoverySecretHash(
+  bytes32 newRecoverSecretHash
+) external nonpayable;
+```
+
+Throws if hash provided is bytes32(0)
+
+#### Parameters
+
+| Name                   |   Type    | Description                                                                     |
+| ---------------------- | :-------: | ------------------------------------------------------------------------------- |
+| `newRecoverSecretHash` | `bytes32` | The hash of the secret string Requirements: - `secretHash` cannot be bytes32(0) |
+
+<br/>
+
+### supportsInterface
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#supportsinterface)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 _interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name           |   Type   | Description |
+| -------------- | :------: | ----------- |
+| `_interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+### target
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#target)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `target()`
+- Function selector: `0xd4b83992`
+
+:::
+
+```solidity
+function target() external view returns (address);
+```
+
+The address of an ERC725 contract where we want to recover and set permissions for a controller address
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `address` | -           |
+
+<br/>
+
+### transferOwnership
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#transferownership)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Function signature: `transferOwnership(address)`
+- Function selector: `0xf2fde38b`
+
+:::
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable;
+```
+
+Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.
+
+#### Parameters
+
+| Name       |   Type    | Description |
+| ---------- | :-------: | ----------- |
+| `newOwner` | `address` | -           |
+
+<br/>
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_checkOwner
+
+```solidity
+function _checkOwner() internal view;
+```
+
+Throws if the sender is not the owner.
+
+<br/>
+
+### \_setOwner
+
+```solidity
+function _setOwner(address newOwner) internal nonpayable;
+```
+
+Changes the owner if `newOwner` and oldOwner are different
+This pattern is useful in inheritance.
+
+<br/>
+
+### \_validateRequirements
+
+```solidity
+function _validateRequirements(
+  address recoverer,
+  uint256 currentRecoveryCounter,
+  string plainSecret,
+  bytes32 newHash,
+  address[] guardians
+) internal view;
+```
+
+The number of guardians should be reasonable, as the validation method
+is using a loop to check the selection of each guardian
+Throws if:
+
+- The address trying to recover didn't reach the guardiansThreshold
+
+- The new hash being set is bytes32(0)
+
+- The secret word provided is incorrect
+
+<br/>
+
+### \_cleanStorage
+
+```solidity
+function _cleanStorage(
+  uint256 recoveryCounter,
+  uint256 guardiansLength,
+  address[] guardians
+) internal nonpayable;
+```
+
+Remove the guardians choice after a successfull recovery process
+To avoid keeping unnecessary state
+
+<br/>
+
+## Events
+
+### GuardianAdded
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardianadded)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `GuardianAdded(address)`
+- Event topic hash: `0x038596bb31e2e7d3d9f184d4c98b310103f6d7f5830e5eec32bffe6f1728f969`
+
+:::
+
+```solidity
+event GuardianAdded(address indexed newGuardian);
+```
+
+_Emitted when setting a new guardian for the target_
+
+#### Parameters
+
+| Name                        |   Type    | Description                       |
+| --------------------------- | :-------: | --------------------------------- |
+| `newGuardian` **`indexed`** | `address` | The address of the added guardian |
+
+<br/>
+
+### GuardianRemoved
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardianremoved)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `GuardianRemoved(address)`
+- Event topic hash: `0xb8107d0c6b40be480ce3172ee66ba6d64b71f6b1685a851340036e6e2e3e3c52`
+
+:::
+
+```solidity
+event GuardianRemoved(address indexed removedGuardian);
+```
+
+_Emitted when removing an existing guardian for the target_
+
+#### Parameters
+
+| Name                            |   Type    | Description                         |
+| ------------------------------- | :-------: | ----------------------------------- |
+| `removedGuardian` **`indexed`** | `address` | The address of the guardian removed |
+
+<br/>
+
+### GuardiansThresholdChanged
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardiansthresholdchanged)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `GuardiansThresholdChanged(uint256)`
+- Event topic hash: `0x7146d20a2c7b7c75c203774c9f241b61698fac43a4a81ccd828f0d8162392790`
+
+:::
+
+```solidity
+event GuardiansThresholdChanged(uint256 indexed guardianThreshold);
+```
+
+_Emitted when changing the guardian threshold_
+
+#### Parameters
+
+| Name                              |   Type    | Description                                                                                     |
+| --------------------------------- | :-------: | ----------------------------------------------------------------------------------------------- |
+| `guardianThreshold` **`indexed`** | `uint256` | The minimum number of selection by guardians needed by a controller to start a recovery process |
+
+<br/>
+
+### OwnershipTransferred
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#ownershiptransferred)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `OwnershipTransferred(address,address)`
+- Event topic hash: `0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0`
+
+:::
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+```
+
+#### Parameters
+
+| Name                          |   Type    | Description |
+| ----------------------------- | :-------: | ----------- |
+| `previousOwner` **`indexed`** | `address` | -           |
+| `newOwner` **`indexed`**      | `address` | -           |
+
+<br/>
+
+### RecoveryProcessSuccessful
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#recoveryprocesssuccessful)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `RecoveryProcessSuccessful(uint256,address,bytes32,address[])`
+- Event topic hash: `0xf4ff8803d6b43af46d48c200977209829c2f42f19f27eda1c89dbf26a28009cd`
+
+:::
+
+```solidity
+event RecoveryProcessSuccessful(uint256 indexed recoveryCounter, address indexed newController, bytes32 indexed newSecretHash, address[] guardians);
+```
+
+_Emitted when the recovery process is finished by the controller who reached the guardian threshold and submitted the string that produce the secretHash_
+
+#### Parameters
+
+| Name                            |    Type     | Description                                                                |
+| ------------------------------- | :---------: | -------------------------------------------------------------------------- |
+| `recoveryCounter` **`indexed`** |  `uint256`  | The current recovery process                                               |
+| `newController` **`indexed`**   |  `address`  | The address of the new controller controlling the target by the KeyManager |
+| `newSecretHash` **`indexed`**   |  `bytes32`  | -                                                                          |
+| `guardians`                     | `address[]` | The array of addresses containing the guardians of the target              |
+
+<br/>
+
+### SecretHashChanged
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#secrethashchanged)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `SecretHashChanged(bytes32)`
+- Event topic hash: `0x2e8c5419a62207ade549fe0b66c1c85c16f5e1ed654815dee3a3f3ac41770df3`
+
+:::
+
+```solidity
+event SecretHashChanged(bytes32 indexed secretHash);
+```
+
+_Emitted when changing the secret hash_
+
+#### Parameters
+
+| Name                       |   Type    | Description                                         |
+| -------------------------- | :-------: | --------------------------------------------------- |
+| `secretHash` **`indexed`** | `bytes32` | The secret hash used to finish the recovery process |
+
+<br/>
+
+### SelectedNewController
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#selectednewcontroller)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Event signature: `SelectedNewController(uint256,address,address)`
+- Event topic hash: `0xe43f3c1093c69ab76b2cf6246090acb2f8eab7f19ba9942dfc8b8ec446e3a3de`
+
+:::
+
+```solidity
+event SelectedNewController(uint256 indexed recoveryCounter, address indexed guardian, address indexed addressSelected);
+```
+
+_Emitted when a guardian select a new potentiel controller address for the target_
+
+#### Parameters
+
+| Name                            |   Type    | Description                          |
+| ------------------------------- | :-------: | ------------------------------------ |
+| `recoveryCounter` **`indexed`** | `uint256` | The current recovery process counter |
+| `guardian` **`indexed`**        | `address` | The address of the guardian          |
+| `addressSelected` **`indexed`** | `address` | The address selected by the guardian |
+
+<br/>
+
+## Errors
+
+### AddressZeroNotAllowed
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#addresszeronotallowed)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `AddressZeroNotAllowed()`
+- Error hash: `0x0855380c`
+
+:::
+
+```solidity
+error AddressZeroNotAllowed();
+```
+
+reverts when the address zero calls `recoverOwnership(..)` function
+
+<br/>
+
+### CallerIsNotGuardian
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#callerisnotguardian)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `CallerIsNotGuardian(address)`
+- Error hash: `0x5560e16d`
+
+:::
+
+```solidity
+error CallerIsNotGuardian(address caller);
+```
+
+reverts when the caller is not a guardian
+
+#### Parameters
+
+| Name     |   Type    | Description |
+| -------- | :-------: | ----------- |
+| `caller` | `address` | -           |
+
+<br/>
+
+### GuardianAlreadyExist
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardianalreadyexist)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `GuardianAlreadyExist(address)`
+- Error hash: `0xd52858db`
+
+:::
+
+```solidity
+error GuardianAlreadyExist(address addressToAdd);
+```
+
+reverts when adding an already existing guardian
+
+#### Parameters
+
+| Name           |   Type    | Description |
+| -------------- | :-------: | ----------- |
+| `addressToAdd` | `address` | -           |
+
+<br/>
+
+### GuardianDoNotExist
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardiandonotexist)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `GuardianDoNotExist(address)`
+- Error hash: `0x3d8e524e`
+
+:::
+
+```solidity
+error GuardianDoNotExist(address addressToRemove);
+```
+
+reverts when removing a non-existing guardian
+
+#### Parameters
+
+| Name              |   Type    | Description |
+| ----------------- | :-------: | ----------- |
+| `addressToRemove` | `address` | -           |
+
+<br/>
+
+### GuardiansNumberCannotGoBelowThreshold
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#guardiansnumbercannotgobelowthreshold)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `GuardiansNumberCannotGoBelowThreshold(uint256)`
+- Error hash: `0x27113777`
+
+:::
+
+```solidity
+error GuardiansNumberCannotGoBelowThreshold(uint256 guardianThreshold);
+```
+
+reverts when removing a guardian and the threshold is equal to the number of guardians
+
+#### Parameters
+
+| Name                |   Type    | Description |
+| ------------------- | :-------: | ----------- |
+| `guardianThreshold` | `uint256` | -           |
+
+<br/>
+
+### SecretHashCannotBeZero
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#secrethashcannotbezero)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `SecretHashCannotBeZero()`
+- Error hash: `0x7f617002`
+
+:::
+
+```solidity
+error SecretHashCannotBeZero();
+```
+
+reverts when the secret hash provided is equal to bytes32(0)
+
+<br/>
+
+### ThresholdCannotBeHigherThanGuardiansNumber
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#thresholdcannotbehigherthanguardiansnumber)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `ThresholdCannotBeHigherThanGuardiansNumber(uint256,uint256)`
+- Error hash: `0xe3db80bd`
+
+:::
+
+```solidity
+error ThresholdCannotBeHigherThanGuardiansNumber(
+  uint256 thresholdGiven,
+  uint256 guardianNumber
+);
+```
+
+reverts when setting the guardians threshold to a number higher than the guardians number
+
+#### Parameters
+
+| Name             |   Type    | Description |
+| ---------------- | :-------: | ----------- |
+| `thresholdGiven` | `uint256` | -           |
+| `guardianNumber` | `uint256` | -           |
+
+<br/>
+
+### ThresholdNotReachedForRecoverer
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#thresholdnotreachedforrecoverer)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `ThresholdNotReachedForRecoverer(address,uint256,uint256)`
+- Error hash: `0xf78f0507`
+
+:::
+
+```solidity
+error ThresholdNotReachedForRecoverer(
+  address recoverer,
+  uint256 selections,
+  uint256 guardiansThreshold
+);
+```
+
+reverts when `recoverOwnership(..)` is called with a recoverer that didn't reach the guardians threshold
+
+#### Parameters
+
+| Name                 |   Type    | Description                                      |
+| -------------------- | :-------: | ------------------------------------------------ |
+| `recoverer`          | `address` | The address of the recoverer                     |
+| `selections`         | `uint256` | The number of selections that the recoverer have |
+| `guardiansThreshold` | `uint256` | The minimum number of selection needed           |
+
+<br/>
+
+### WrongPlainSecret
+
+:::note References
+
+- Specification details: [**LSP-11-BasicSocialRecovery**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-11-BasicSocialRecovery.md#wrongplainsecret)
+- Solidity implementation: [`LSP11BasicSocialRecovery.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol)
+- Error signature: `WrongPlainSecret()`
+- Error hash: `0x6fa723c3`
+
+:::
+
+```solidity
+error WrongPlainSecret();
+```
+
+reverts when the plain secret produce a different hash than the secret hash originally set
+
+<br/>

--- a/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
+++ b/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
@@ -1,0 +1,113 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# LSP17Extendable
+
+:::info Standard Specifications
+
+[`LSP-17-ContractExtension`](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-17-ContractExtension.md)
+
+:::
+:::info Solidity implementation
+
+[`LSP17Extendable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP17ContractExtension/LSP17Extendable.sol)
+
+:::
+
+> Module to add more functionalities to a contract using extensions.
+
+Implementation of the `fallback(...)` logic according to LSP17
+
+- Contract Extension standard. This module can be inherited to extend the functionality of the parent contract when calling a function that doesn't exist on the parent contract via forwarding the call to an extension mapped to the function selector being called, set originally by the parent contract
+
+## Public Methods
+
+Public methods are accessible externally from users, allowing interaction with this function from dApps or other smart contracts.
+When marked as 'public', a method can be called both externally and internally, on the other hand, when marked as 'external', a method can only be called externally.
+
+### supportsInterface
+
+:::note References
+
+- Specification details: [**LSP-17-ContractExtension**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-17-ContractExtension.md#supportsinterface)
+- Solidity implementation: [`LSP17Extendable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP17ContractExtension/LSP17Extendable.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name          |   Type   | Description |
+| ------------- | :------: | ----------- |
+| `interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_supportsInterfaceInERC165Extension
+
+```solidity
+function _supportsInterfaceInERC165Extension(
+  bytes4 interfaceId
+) internal view returns (bool);
+```
+
+Returns whether the interfaceId being checked is supported in the extension of the
+[`supportsInterface`](#supportsinterface) selector.
+To be used by extendable contracts wishing to extend the ERC165 interfaceIds originally
+supported by reading whether the interfaceId queried is supported in the `supportsInterface`
+extension if the extension is set, if not it returns false.
+
+<br/>
+
+### \_getExtension
+
+```solidity
+function _getExtension(bytes4 functionSelector) internal view returns (address);
+```
+
+Returns the extension mapped to a specific function selector
+If no extension was found, return the address(0)
+To be overrided.
+Up to the implementor contract to return an extension based on a function selector
+
+<br/>
+
+### \_fallbackLSP17Extendable
+
+```solidity
+function _fallbackLSP17Extendable(
+  bytes callData
+) internal nonpayable returns (bytes);
+```
+
+Forwards the call to an extension mapped to a function selector.
+Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+called on the account. If there is no extension, the address(0) will be returned.
+Reverts if there is no extension for the function being called.
+If there is an extension for the function selector being called, it calls the extension with the
+CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and
+32 bytes of the [`msg.value`](#msg.value)
+Because the function uses assembly [`return()/revert()`](#return) to terminate the call, it cannot be
+called before other codes in fallback().
+Otherwise, the codes after \_fallbackLSP17Extendable() may never be reached.
+
+<br/>

--- a/docs/contracts/LSP17ContractExtension/LSP17Extension.md
+++ b/docs/contracts/LSP17ContractExtension/LSP17Extension.md
@@ -1,0 +1,92 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# LSP17Extension
+
+:::info Standard Specifications
+
+[`LSP-17-ContractExtension`](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-17-ContractExtension.md)
+
+:::
+:::info Solidity implementation
+
+[`LSP17Extension.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP17ContractExtension/LSP17Extension.sol)
+
+:::
+
+> Module to create a contract that can act as an extension.
+
+Implementation of the extension logic according to LSP17ContractExtension. This module can be inherited to provide context of the msg variable related to the extendable contract
+
+## Public Methods
+
+Public methods are accessible externally from users, allowing interaction with this function from dApps or other smart contracts.
+When marked as 'public', a method can be called both externally and internally, on the other hand, when marked as 'external', a method can only be called externally.
+
+### supportsInterface
+
+:::note References
+
+- Specification details: [**LSP-17-ContractExtension**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-17-ContractExtension.md#supportsinterface)
+- Solidity implementation: [`LSP17Extension.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP17ContractExtension/LSP17Extension.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name          |   Type   | Description |
+| ------------- | :------: | ----------- |
+| `interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_extendableMsgData
+
+```solidity
+function _extendableMsgData() internal view returns (bytes);
+```
+
+Returns the original msg.data passed to the extendable contract
+without the appended msg.sender and msg.value
+
+<br/>
+
+### \_extendableMsgSender
+
+```solidity
+function _extendableMsgSender() internal view returns (address);
+```
+
+Returns the original msg.sender calling the extendable contract
+
+<br/>
+
+### \_extendableMsgValue
+
+```solidity
+function _extendableMsgValue() internal view returns (uint256);
+```
+
+Returns the original msg.value sent to the extendable contract
+
+<br/>

--- a/docs/contracts/LSP20CallVerification/LSP20CallVerification.md
+++ b/docs/contracts/LSP20CallVerification/LSP20CallVerification.md
@@ -1,0 +1,76 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# LSP20CallVerification
+
+:::info Standard Specifications
+
+[`LSP-20-CallVerification`](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-20-CallVerification.md)
+
+:::
+:::info Solidity implementation
+
+[`LSP20CallVerification.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP20CallVerification/LSP20CallVerification.sol)
+
+:::
+
+> Implementation of a contract calling the verification functions according to LSP20 - Call Verification standard.
+
+Module to be inherited used to verify the execution of functions according to a verifier address. Verification can happen before or after execution based on a magicValue.
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_verifyCall
+
+```solidity
+function _verifyCall(
+  address logicVerifier
+) internal nonpayable returns (bool verifyAfter);
+```
+
+Calls [`lsp20VerifyCall`](#lsp20verifycall) function on the logicVerifier.
+Reverts in case the value returned does not match the magic value (lsp20VerifyCall selector)
+Returns whether a verification after the execution should happen based on the last byte of the magicValue
+
+<br/>
+
+### \_verifyCallResult
+
+```solidity
+function _verifyCallResult(
+  address logicVerifier,
+  bytes callResult
+) internal nonpayable;
+```
+
+Calls [`lsp20VerifyCallResult`](#lsp20verifycallresult) function on the logicVerifier.
+Reverts in case the value returned does not match the magic value (lsp20VerifyCallResult selector)
+
+<br/>
+
+### \_validateCall
+
+```solidity
+function _validateCall(
+  bool postCall,
+  bool success,
+  bytes returnedData
+) internal pure;
+```
+
+<br/>
+
+### \_revertWithLSP20DefaultError
+
+```solidity
+function _revertWithLSP20DefaultError(
+  bool postCall,
+  bytes returnedData
+) internal pure;
+```
+
+<br/>

--- a/docs/contracts/LSP23LinkedContractsDeployment/IPostDeploymentModule.md
+++ b/docs/contracts/LSP23LinkedContractsDeployment/IPostDeploymentModule.md
@@ -46,8 +46,8 @@ Executes post-deployment logic for the primary and secondary contracts.
 
 | Name                             |   Type    | Description                                              |
 | -------------------------------- | :-------: | -------------------------------------------------------- |
-| `primaryContract`                | `address` | Address of the deployed primary contract.                |
-| `secondaryContract`              | `address` | Address of the deployed secondary contract.              |
+| `primaryContract`                | `address` | The address of the deployed primary contract.            |
+| `secondaryContract`              | `address` | The address of the deployed secondary contract.          |
 | `calldataToPostDeploymentModule` |  `bytes`  | Calldata to be passed for the post-deployment execution. |
 
 <br/>

--- a/docs/contracts/LSP23LinkedContractsDeployment/LSP23LinkedContractsFactory.md
+++ b/docs/contracts/LSP23LinkedContractsDeployment/LSP23LinkedContractsFactory.md
@@ -254,16 +254,18 @@ function _generatePrimaryContractProxySalt(struct ILSP23LinkedContractsFactory.P
 event DeployedContracts(address indexed primaryContract, address indexed secondaryContract, ILSP23LinkedContractsFactory.PrimaryContractDeployment primaryContractDeployment, ILSP23LinkedContractsFactory.SecondaryContractDeployment secondaryContractDeployment, address postDeploymentModule, bytes postDeploymentModuleCalldata);
 ```
 
+Emitted when a primary and secondary contract are deployed.
+
 #### Parameters
 
-| Name                              |                            Type                            | Description |
-| --------------------------------- | :--------------------------------------------------------: | ----------- |
-| `primaryContract` **`indexed`**   |                         `address`                          | -           |
-| `secondaryContract` **`indexed`** |                         `address`                          | -           |
-| `primaryContractDeployment`       |  `ILSP23LinkedContractsFactory.PrimaryContractDeployment`  | -           |
-| `secondaryContractDeployment`     | `ILSP23LinkedContractsFactory.SecondaryContractDeployment` | -           |
-| `postDeploymentModule`            |                         `address`                          | -           |
-| `postDeploymentModuleCalldata`    |                          `bytes`                           | -           |
+| Name                              |                            Type                            | Description                                            |
+| --------------------------------- | :--------------------------------------------------------: | ------------------------------------------------------ |
+| `primaryContract` **`indexed`**   |                         `address`                          | Address of the deployed primary contract.              |
+| `secondaryContract` **`indexed`** |                         `address`                          | Address of the deployed secondary contract.            |
+| `primaryContractDeployment`       |  `ILSP23LinkedContractsFactory.PrimaryContractDeployment`  | Parameters used for the primary contract deployment.   |
+| `secondaryContractDeployment`     | `ILSP23LinkedContractsFactory.SecondaryContractDeployment` | Parameters used for the secondary contract deployment. |
+| `postDeploymentModule`            |                         `address`                          | Address of the post-deployment module.                 |
+| `postDeploymentModuleCalldata`    |                          `bytes`                           | Calldata passed to the post-deployment module.         |
 
 <br/>
 
@@ -282,16 +284,18 @@ event DeployedContracts(address indexed primaryContract, address indexed seconda
 event DeployedERC1167Proxies(address indexed primaryContract, address indexed secondaryContract, ILSP23LinkedContractsFactory.PrimaryContractDeploymentInit primaryContractDeploymentInit, ILSP23LinkedContractsFactory.SecondaryContractDeploymentInit secondaryContractDeploymentInit, address postDeploymentModule, bytes postDeploymentModuleCalldata);
 ```
 
+Emitted when proxies of a primary and secondary contract are deployed.
+
 #### Parameters
 
-| Name                              |                              Type                              | Description |
-| --------------------------------- | :------------------------------------------------------------: | ----------- |
-| `primaryContract` **`indexed`**   |                           `address`                            | -           |
-| `secondaryContract` **`indexed`** |                           `address`                            | -           |
-| `primaryContractDeploymentInit`   |  `ILSP23LinkedContractsFactory.PrimaryContractDeploymentInit`  | -           |
-| `secondaryContractDeploymentInit` | `ILSP23LinkedContractsFactory.SecondaryContractDeploymentInit` | -           |
-| `postDeploymentModule`            |                           `address`                            | -           |
-| `postDeploymentModuleCalldata`    |                            `bytes`                             | -           |
+| Name                              |                              Type                              | Description                                                  |
+| --------------------------------- | :------------------------------------------------------------: | ------------------------------------------------------------ |
+| `primaryContract` **`indexed`**   |                           `address`                            | Address of the deployed primary contract proxy.              |
+| `secondaryContract` **`indexed`** |                           `address`                            | Address of the deployed secondary contract proxy.            |
+| `primaryContractDeploymentInit`   |  `ILSP23LinkedContractsFactory.PrimaryContractDeploymentInit`  | Parameters used for the primary contract proxy deployment.   |
+| `secondaryContractDeploymentInit` | `ILSP23LinkedContractsFactory.SecondaryContractDeploymentInit` | Parameters used for the secondary contract proxy deployment. |
+| `postDeploymentModule`            |                           `address`                            | Address of the post-deployment module.                       |
+| `postDeploymentModuleCalldata`    |                            `bytes`                             | Calldata passed to the post-deployment module.               |
 
 <br/>
 

--- a/docs/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.md
+++ b/docs/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.md
@@ -108,9 +108,7 @@ The address of the signer will be recovered using the LSP25 signature format.
 function _verifyValidityTimestamps(uint256 validityTimestamps) internal view;
 ```
 
-_Verifying if the current timestamp is within the date and time range provided by `validityTimestamps`._
-
-Verify that the validity timestamp provided is within a valid range compared to the current timestamp.
+Verify that the current timestamp is within the date and time range provided by `validityTimestamps`.
 
 #### Parameters
 

--- a/docs/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.md
+++ b/docs/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.md
@@ -1,0 +1,446 @@
+<!-- This file is auto-generated. Do not edit! -->
+<!-- Check `@lukso-network/lsp-smart-contracts/CONTRIBUTING.md#solidity-code-comments` for more information. -->
+
+# LSP4Compatibility
+
+:::info Standard Specifications
+
+[`LSP-4-DigitalAssetMetadata`](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md)
+
+:::
+:::info Solidity implementation
+
+[`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+
+:::
+
+> LSP4Compatibility
+
+LSP4 extension, for compatibility with clients & tools that expect ERC20/721.
+
+## Public Methods
+
+Public methods are accessible externally from users, allowing interaction with this function from dApps or other smart contracts.
+When marked as 'public', a method can be called both externally and internally, on the other hand, when marked as 'external', a method can only be called externally.
+
+### getData
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#getdata)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `getData(bytes32)`
+- Function selector: `0x54f6127f`
+
+:::
+
+```solidity
+function getData(bytes32 dataKey) external view returns (bytes dataValue);
+```
+
+_Gets singular data at a given `dataKey`_
+
+#### Parameters
+
+| Name      |   Type    | Description                     |
+| --------- | :-------: | ------------------------------- |
+| `dataKey` | `bytes32` | The key which value to retrieve |
+
+#### Returns
+
+| Name        |  Type   | Description                |
+| ----------- | :-----: | -------------------------- |
+| `dataValue` | `bytes` | The data stored at the key |
+
+<br/>
+
+### getDataBatch
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#getdatabatch)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `getDataBatch(bytes32[])`
+- Function selector: `0xdedff9c6`
+
+:::
+
+```solidity
+function getDataBatch(
+  bytes32[] dataKeys
+) external view returns (bytes[] dataValues);
+```
+
+_Gets array of data for multiple given keys_
+
+#### Parameters
+
+| Name       |    Type     | Description                                |
+| ---------- | :---------: | ------------------------------------------ |
+| `dataKeys` | `bytes32[]` | The array of keys which values to retrieve |
+
+#### Returns
+
+| Name         |   Type    | Description                               |
+| ------------ | :-------: | ----------------------------------------- |
+| `dataValues` | `bytes[]` | The array of data stored at multiple keys |
+
+<br/>
+
+### name
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#name)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `name()`
+- Function selector: `0x06fdde03`
+
+:::
+
+```solidity
+function name() external view returns (string);
+```
+
+Returns the name of the token.
+
+#### Returns
+
+| Name |   Type   | Description           |
+| ---- | :------: | --------------------- |
+| `0`  | `string` | The name of the token |
+
+<br/>
+
+### owner
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#owner)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `owner()`
+- Function selector: `0x8da5cb5b`
+
+:::
+
+```solidity
+function owner() external view returns (address);
+```
+
+Returns the address of the current owner.
+
+#### Returns
+
+| Name |   Type    | Description |
+| ---- | :-------: | ----------- |
+| `0`  | `address` | -           |
+
+<br/>
+
+### renounceOwnership
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#renounceownership)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `renounceOwnership()`
+- Function selector: `0x715018a6`
+
+:::
+
+```solidity
+function renounceOwnership() external nonpayable;
+```
+
+Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.
+
+<br/>
+
+### setData
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#setdata)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `setData(bytes32,bytes)`
+- Function selector: `0x7f23690c`
+
+:::
+
+```solidity
+function setData(bytes32 dataKey, bytes dataValue) external payable;
+```
+
+_Sets singular data for a given `dataKey`_
+
+#### Parameters
+
+| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
+| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
+| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+
+<br/>
+
+### setDataBatch
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#setdatabatch)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `setDataBatch(bytes32[],bytes[])`
+- Function selector: `0x97902421`
+
+:::
+
+```solidity
+function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
+```
+
+Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+
+0. Emits a [`DataChanged`](#datachanged) event.
+
+#### Parameters
+
+| Name         |    Type     | Description                              |
+| ------------ | :---------: | ---------------------------------------- |
+| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
+| `dataValues` |  `bytes[]`  | The array of values to set               |
+
+<br/>
+
+### supportsInterface
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#supportsinterface)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `supportsInterface(bytes4)`
+- Function selector: `0x01ffc9a7`
+
+:::
+
+```solidity
+function supportsInterface(bytes4 interfaceId) external view returns (bool);
+```
+
+See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
+
+#### Parameters
+
+| Name          |   Type   | Description |
+| ------------- | :------: | ----------- |
+| `interfaceId` | `bytes4` | -           |
+
+#### Returns
+
+| Name |  Type  | Description |
+| ---- | :----: | ----------- |
+| `0`  | `bool` | -           |
+
+<br/>
+
+### symbol
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#symbol)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `symbol()`
+- Function selector: `0x95d89b41`
+
+:::
+
+```solidity
+function symbol() external view returns (string);
+```
+
+Returns the symbol of the token, usually a shorter version of the name.
+
+#### Returns
+
+| Name |   Type   | Description             |
+| ---- | :------: | ----------------------- |
+| `0`  | `string` | The symbol of the token |
+
+<br/>
+
+### transferOwnership
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#transferownership)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Function signature: `transferOwnership(address)`
+- Function selector: `0xf2fde38b`
+
+:::
+
+```solidity
+function transferOwnership(address newOwner) external nonpayable;
+```
+
+Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.
+
+#### Parameters
+
+| Name       |   Type    | Description |
+| ---------- | :-------: | ----------- |
+| `newOwner` | `address` | -           |
+
+<br/>
+
+## Internal Methods
+
+Any method labeled as `internal` serves as utility function within the contract. They can be used when writing solidity contracts that inherit from this contract. These methods can be extended or modified by overriding their internal behavior to suit specific needs.
+
+Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
+
+### \_checkOwner
+
+```solidity
+function _checkOwner() internal view;
+```
+
+Throws if the sender is not the owner.
+
+<br/>
+
+### \_setOwner
+
+```solidity
+function _setOwner(address newOwner) internal nonpayable;
+```
+
+Changes the owner if `newOwner` and oldOwner are different
+This pattern is useful in inheritance.
+
+<br/>
+
+### \_getData
+
+```solidity
+function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
+```
+
+<br/>
+
+### \_setData
+
+```solidity
+function _setData(bytes32 dataKey, bytes dataValue) internal nonpayable;
+```
+
+<br/>
+
+## Events
+
+### DataChanged
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#datachanged)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Event signature: `DataChanged(bytes32,bytes)`
+- Event topic hash: `0xece574603820d07bc9b91f2a932baadf4628aabcb8afba49776529c14a6104b2`
+
+:::
+
+```solidity
+event DataChanged(bytes32 indexed dataKey, bytes dataValue);
+```
+
+_Emitted when data at a key is changed_
+
+#### Parameters
+
+| Name                    |   Type    | Description                          |
+| ----------------------- | :-------: | ------------------------------------ |
+| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
+| `dataValue`             |  `bytes`  | The data value to set                |
+
+<br/>
+
+### OwnershipTransferred
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#ownershiptransferred)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Event signature: `OwnershipTransferred(address,address)`
+- Event topic hash: `0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0`
+
+:::
+
+```solidity
+event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+```
+
+#### Parameters
+
+| Name                          |   Type    | Description |
+| ----------------------------- | :-------: | ----------- |
+| `previousOwner` **`indexed`** | `address` | -           |
+| `newOwner` **`indexed`**      | `address` | -           |
+
+<br/>
+
+## Errors
+
+### ERC725Y_DataKeysValuesEmptyArray
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#erc725y_datakeysvaluesemptyarray)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Error signature: `ERC725Y_DataKeysValuesEmptyArray()`
+- Error hash: `0x97da5f95`
+
+:::
+
+```solidity
+error ERC725Y_DataKeysValuesEmptyArray();
+```
+
+reverts when one of the array parameter provided to `setDataBatch` is an empty array
+
+<br/>
+
+### ERC725Y_DataKeysValuesLengthMismatch
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#erc725y_datakeysvalueslengthmismatch)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Error signature: `ERC725Y_DataKeysValuesLengthMismatch()`
+- Error hash: `0x3bcc8979`
+
+:::
+
+```solidity
+error ERC725Y_DataKeysValuesLengthMismatch();
+```
+
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+
+<br/>
+
+### ERC725Y_MsgValueDisallowed
+
+:::note References
+
+- Specification details: [**LSP-4-DigitalAssetMetadata**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-4-DigitalAssetMetadata.md#erc725y_msgvaluedisallowed)
+- Solidity implementation: [`LSP4Compatibility.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol)
+- Error signature: `ERC725Y_MsgValueDisallowed()`
+- Error hash: `0xf36ba737`
+
+:::
+
+```solidity
+error ERC725Y_MsgValueDisallowed();
+```
+
+reverts when sending value to the `setData(..)` functions
+
+<br/>

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -1027,9 +1027,7 @@ The address of the signer will be recovered using the LSP25 signature format.
 function _verifyValidityTimestamps(uint256 validityTimestamps) internal view;
 ```
 
-_Verifying if the current timestamp is within the date and time range provided by `validityTimestamps`._
-
-Verify that the validity timestamp provided is within a valid range compared to the current timestamp.
+Verify that the current timestamp is within the date and time range provided by `validityTimestamps`.
 
 #### Parameters
 
@@ -1350,7 +1348,7 @@ Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,addre
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
 
 <br/>
 
@@ -1887,6 +1885,8 @@ Reverts when the relay call is cannot yet bet executed. This mean that the start
 ```solidity
 error RelayCallExpired();
 ```
+
+_Relay call expired (deadline passed)._
 
 Reverts when the period to execute the relay call has expired.
 

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -850,14 +850,14 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -927,14 +927,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -953,18 +953,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -875,14 +875,14 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -952,14 +952,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -978,18 +978,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -859,14 +859,14 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -936,14 +936,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -962,18 +962,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -967,15 +967,15 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event Approval(address indexed owner, address indexed spender, uint256 value);
 ```
 
-Emitted when `owner` enables `approved` for `tokenId`.
+ERC721 `Approval` event emitted when `owner` enables `operator` for `tokenId`. To provide compatibility with indexing ERC721 events.
 
 #### Parameters
 
-| Name                    |   Type    | Description                               |
-| ----------------------- | :-------: | ----------------------------------------- |
-| `owner` **`indexed`**   | `address` | The address of the owner of the `tokenId` |
-| `spender` **`indexed`** | `address` | -                                         |
-| `value`                 | `uint256` | -                                         |
+| Name                    |   Type    | Description                                |
+| ----------------------- | :-------: | ------------------------------------------ |
+| `owner` **`indexed`**   | `address` | The address of the owner of the `tokenId`. |
+| `spender` **`indexed`** | `address` | -                                          |
+| `value`                 | `uint256` | -                                          |
 
 <br/>
 
@@ -994,14 +994,14 @@ Emitted when `owner` enables `approved` for `tokenId`.
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -1071,14 +1071,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -1097,18 +1097,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1025,15 +1025,15 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event Approval(address indexed owner, address indexed spender, uint256 value);
 ```
 
-Emitted when `owner` enables `approved` for `tokenId`.
+ERC721 `Approval` event emitted when `owner` enables `operator` for `tokenId`. To provide compatibility with indexing ERC721 events.
 
 #### Parameters
 
-| Name                    |   Type    | Description                               |
-| ----------------------- | :-------: | ----------------------------------------- |
-| `owner` **`indexed`**   | `address` | The address of the owner of the `tokenId` |
-| `spender` **`indexed`** | `address` | -                                         |
-| `value`                 | `uint256` | -                                         |
+| Name                    |   Type    | Description                                |
+| ----------------------- | :-------: | ------------------------------------------ |
+| `owner` **`indexed`**   | `address` | The address of the owner of the `tokenId`. |
+| `spender` **`indexed`** | `address` | -                                          |
+| `value`                 | `uint256` | -                                          |
 
 <br/>
 
@@ -1052,14 +1052,14 @@ Emitted when `owner` enables `approved` for `tokenId`.
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -1129,14 +1129,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -1155,18 +1155,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -912,14 +912,14 @@ If `to` is is an EOA or a contract that does not support the LSP1 interface, the
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, uint256 indexed amount);
 ```
 
-Emitted when `tokenOwner` enables `operator` for `tokenId`.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address authorized as an operator                                   |
-| `tokenOwner` **`indexed`** | `address` | The token owner                                                         |
+| `operator` **`indexed`**   | `address` | The address authorized as an operator.                                  |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                             |
 | `amount` **`indexed`**     | `uint256` | The amount of tokens `operator` address has access to from `tokenOwner` |
 
 <br/>
@@ -989,14 +989,14 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event RevokedOperator(address indexed operator, address indexed tokenOwner);
 ```
 
-Emitted when `tokenOwner` disables `operator` for `tokenId`.
+Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on its behalf.
 
 #### Parameters
 
-| Name                       |   Type    | Description                        |
-| -------------------------- | :-------: | ---------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked from operating |
-| `tokenOwner` **`indexed`** | `address` | The token owner                    |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
 
 <br/>
 
@@ -1015,18 +1015,18 @@ Emitted when `tokenOwner` disables `operator` for `tokenId`.
 event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
 ```
 
-Emitted when `tokenId` token is transferred from `from` to `to`.
+Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 
 #### Parameters
 
-| Name                     |   Type    | Description                                                                                                                  |
-| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------- |
-| `operator` **`indexed`** | `address` | The address of operator sending tokens                                                                                       |
-| `from` **`indexed`**     | `address` | The address which tokens are sent                                                                                            |
-| `to` **`indexed`**       | `address` | The receiving address                                                                                                        |
-| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | When set to TRUE, `to` may be any address but when set to FALSE `to` must be a contract that supports LSP1 UniversalReceiver |
-| `data`                   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses           |
+| Name                     |   Type    | Description                                                                                                                        |
+| ------------------------ | :-------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `operator` **`indexed`** | `address` | The address of operator that sent the `tokenId`                                                                                    |
+| `from` **`indexed`**     | `address` | The previous owner of the `tokenId`                                                                                                |
+| `to` **`indexed`**       | `address` | The new owner of `tokenId`                                                                                                         |
+| `amount`                 | `uint256` | The amount of tokens transferred.                                                                                                  |
+| `allowNonLSP1Recipient`  |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `data`                   |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -16,7 +16,7 @@
 
 > Implementation of a LSP8 Identifiable Digital Asset, a contract that represents a non-fungible token.
 
-Standard implementation contract of the LSP8 standard. Minting and transferring are done using by giving a unique `tokenId`. This implementation is agnostic to the way tokens are created. A supply mechanism has to be added in a derived contract using [`_mint`](#_mint) For a generic mechanism, see [`LSP7Mintable`](#lsp7mintable).
+Standard implementation contract of the LSP8 standard. Minting and transferring are done by providing a unique `tokenId`. This implementation is agnostic to the way tokens are created. A supply mechanism has to be added in a derived contract using [`_mint`](#_mint) For a generic mechanism, see [`LSP7Mintable`](#lsp7mintable).
 
 ## Public Methods
 
@@ -849,7 +849,7 @@ The receiver may revert when the token being sent is not wanted.
 event AuthorizedOperator(address indexed operator, address indexed tokenOwner, bytes32 indexed tokenId);
 ```
 
-Emitted when `tokenOwner` enables `operator` to transfer or burn `tokenId` on its behalf.
+Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 
 #### Parameters
 
@@ -930,11 +930,11 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 
 #### Parameters
 
-| Name                       |   Type    | Description                                          |
-| -------------------------- | :-------: | ---------------------------------------------------- |
-| `operator` **`indexed`**   | `address` | The address revoked as an operator.                  |
-| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                          |
-| `tokenId` **`indexed`**    | `bytes32` | The tokenId `operator` is revoked from operating on. |
+| Name                       |   Type    | Description                                                     |
+| -------------------------- | :-------: | --------------------------------------------------------------- |
+| `operator` **`indexed`**   | `address` | The address revoked from the operator array ({getOperatorsOf}). |
+| `tokenOwner` **`indexed`** | `address` | The owner of the `tokenId`.                                     |
+| `tokenId` **`indexed`**    | `bytes32` | The tokenId `operator` is revoked from operating on.            |
 
 <br/>
 

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -283,15 +283,21 @@ function execute(
 ) external payable returns (bytes);
 ```
 
-_Calling address `target` using `operationType`, transferring `value` wei and data: `data`. _
-
 Generic executor function to:
 
 - send native tokens to any address.
 
 - interact with any contract by passing an abi-encoded function call in the `data` parameter.
 
-- deploy a contract by providing its creation bytecode in the `data` parameter.
+- deploy a contract by providing its creation bytecode in the `data` parameter. Requirements:
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `value` SHOULD be 0.
+
+- `target` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
 
 <blockquote>
 
@@ -321,7 +327,7 @@ Generic executor function to:
 | `operationType` | `uint256` | The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4          |
 | `target`        | `address` | The address of the EOA or smart contract. (unused if a contract is created via operation type 1 or 2) |
 | `value`         | `uint256` | The amount of native tokens to transfer (in Wei)                                                      |
-| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.   |
+| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy                                     |
 
 #### Returns
 
@@ -357,9 +363,23 @@ function executeBatch(
 ) external payable returns (bytes[]);
 ```
 
-_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`. _
+Generic batch executor function to:
 
-Batch executor function that behaves the same as [`execute`](#execute) but allowing multiple operations in the same transaction.
+- send native tokens to any address.
+
+- interact with any contract by passing an abi-encoded function call in the `datas` parameter.
+
+- deploy a contract by providing its creation bytecode in the `datas` parameter. Requirements:
+
+- The length of the parameters provided MUST be equal
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `values` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `values` SHOULD be 0.
+
+- `targets` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
 
 <blockquote>
 
@@ -385,12 +405,12 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 
 #### Parameters
 
-| Name             |    Type     | Description                                                                                                     |
-| ---------------- | :---------: | --------------------------------------------------------------------------------------------------------------- |
-| `operationsType` | `uint256[]` | The list of operations type used: `CALL = 0`; `CREATE = 1`; `CREATE2 = 2`; `STATICCALL = 3`; `DELEGATECALL = 4` |
-| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2).     |
-| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei).                                                          |
-| `datas`          |  `bytes[]`  | The list of calldata, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.      |
+| Name             |    Type     | Description                                                                                                 |
+| ---------------- | :---------: | ----------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The list of operations type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4       |
+| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2). |
+| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei)                                                       |
+| `datas`          |  `bytes[]`  | The list of call data, or the creation bytecode of the contract to deploy                                   |
 
 #### Returns
 
@@ -415,21 +435,19 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
-
-Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
+_Gets singular data at a given `dataKey`_
 
 #### Parameters
 
-| Name      |   Type    | Description                                   |
-| --------- | :-------: | --------------------------------------------- |
-| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
+| Name      |   Type    | Description                     |
+| --------- | :-------: | ------------------------------- |
+| `dataKey` | `bytes32` | The key which value to retrieve |
 
 #### Returns
 
-| Name        |  Type   | Description                                          |
-| ----------- | :-----: | ---------------------------------------------------- |
-| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
+| Name        |  Type   | Description                |
+| ----------- | :-----: | -------------------------- |
+| `dataValue` | `bytes` | The data stored at the key |
 
 <br/>
 
@@ -450,9 +468,7 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
-
-Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
+_Gets array of data for multiple given keys_
 
 #### Parameters
 
@@ -578,9 +594,7 @@ Renounce ownership of the contract in a 2-step process.
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`. _
-
-Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+_Sets singular data for a given `dataKey`_
 
 <blockquote>
 
@@ -601,10 +615,10 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 
 #### Parameters
 
-| Name        |   Type    | Description                                |
-| ----------- | :-------: | ------------------------------------------ |
-| `dataKey`   | `bytes32` | The data key for which to set a new value. |
-| `dataValue` |  `bytes`  | The new bytes value to set.                |
+| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
+| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
+| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
 
 <br/>
 
@@ -623,9 +637,9 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`. _
+Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
 
-Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+0. Emits a [`DataChanged`](#datachanged) event.
 
 <blockquote>
 
@@ -646,10 +660,10 @@ Batch data setting function that behaves the same as [`setData`](#setdata) but a
 
 #### Parameters
 
-| Name         |    Type     | Description                                          |
-| ------------ | :---------: | ---------------------------------------------------- |
-| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
-| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
+| Name         |    Type     | Description                              |
+| ------------ | :---------: | ---------------------------------------- |
+| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
+| `dataValues` |  `bytes[]`  | The array of values to set               |
 
 <br/>
 
@@ -849,7 +863,8 @@ function _executeBatch(
 ) internal nonpayable returns (bytes[]);
 ```
 
-check each `operationType` provided in the batch and perform the associated low-level opcode after checking for requirements (see [`executeBatch`](#executebatch)).
+same as `_execute` but for batch execution
+see `IERC725X,execute(uint256[],address[],uint256[],bytes[])`
 
 <br/>
 
@@ -863,7 +878,7 @@ function _executeCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level call (operation type = 0)
+perform low-level call (operation type = 0)
 
 #### Parameters
 
@@ -890,7 +905,7 @@ function _executeStaticCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level staticcall (operation type = 3)
+perform low-level staticcall (operation type = 3)
 
 #### Parameters
 
@@ -916,7 +931,7 @@ function _executeDelegateCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level delegatecall (operation type = 4)
+perform low-level delegatecall (operation type = 4)
 
 #### Parameters
 
@@ -942,7 +957,7 @@ function _deployCreate(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-Deploy a contract using the `CREATE` opcode (operation type = 1)
+deploy a contract using the CREATE opcode (operation type = 1)
 
 #### Parameters
 
@@ -968,7 +983,7 @@ function _deployCreate2(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-Deploy a contract using the `CREATE2` opcode (operation type = 2)
+deploy a contract using the CREATE2 opcode (operation type = 2)
 
 #### Parameters
 
@@ -990,25 +1005,6 @@ Deploy a contract using the `CREATE2` opcode (operation type = 2)
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
-
-Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
-represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
-
-```solidity
-mapping(bytes32 => bytes) _store
-```
-
-#### Parameters
-
-| Name      |   Type    | Description                                                             |
-| --------- | :-------: | ----------------------------------------------------------------------- |
-| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
-
-#### Returns
-
-| Name        |  Type   | Description                                                                   |
-| ----------- | :-----: | ----------------------------------------------------------------------------- |
-| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -1153,18 +1149,18 @@ Modifier restricting the call to the owner of the contract and the UniversalRece
 event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
 ```
 
-_Deployed new contract at address `contractAddress` and funded with `value` wei (deployed using opcode: `operationType`)._
+_Emitted when deploying a contract_
 
-Emitted when a new contract was created and deployed.
+Emitted whenever a contract is created
 
 #### Parameters
 
-| Name                            |   Type    | Description                                                                                                                               |
-| ------------------------------- | :-------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (`CREATE` or `CREATE2`).                                                                           |
-| `contractAddress` **`indexed`** | `address` | The created contract address.                                                                                                             |
-| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract on deployment.                                                     |
-| `salt`                          | `bytes32` | The salt used to deterministically deploy the contract (`CREATE2` only). If `CREATE` opcode is used, the salt value will be `bytes32(0)`. |
+| Name                            |   Type    | Description                                                                    |
+| ------------------------------- | :-------: | ------------------------------------------------------------------------------ |
+| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (CREATE or CREATE2)                     |
+| `contractAddress` **`indexed`** | `address` | The created contract address                                                   |
+| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract address |
+| `salt`                          | `bytes32` | -                                                                              |
 
 <br/>
 
@@ -1183,16 +1179,14 @@ Emitted when a new contract was created and deployed.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
-
-Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
+_Emitted when data at a key is changed_
 
 #### Parameters
 
-| Name                    |   Type    | Description                                  |
-| ----------------------- | :-------: | -------------------------------------------- |
-| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
-| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
+| Name                    |   Type    | Description                          |
+| ----------------------- | :-------: | ------------------------------------ |
+| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
+| `dataValue`             |  `bytes`  | The data value to set                |
 
 <br/>
 
@@ -1211,18 +1205,16 @@ Emitted when data at a specific `dataKey` was changed to a new value `dataValue`
 event Executed(uint256 indexed operationType, address indexed target, uint256 indexed value, bytes4 selector);
 ```
 
-_Called address `target` using `operationType` with `value` wei and `data`._
-
-Emitted when calling an address `target` (EOA or contract) with `value`.
+_Emitted when calling an address (EOA or contract)_
 
 #### Parameters
 
-| Name                          |   Type    | Description                                                                                          |
-| ----------------------------- | :-------: | ---------------------------------------------------------------------------------------------------- |
-| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `target` address (`CALL`, `STATICALL` or `DELEGATECALL`). |
-| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2).     |
-| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred along the call (in Wei).                                     |
-| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call.                              |
+| Name                          |   Type    | Description                                                                                      |
+| ----------------------------- | :-------: | ------------------------------------------------------------------------------------------------ |
+| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `to` address (CALL, STATICALL or DELEGATECALL)        |
+| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2). |
+| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred with the call (in Wei)                                   |
+| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call                           |
 
 <br/>
 
@@ -1419,7 +1411,7 @@ Reverts when trying to transfer ownership to the `address(this)`.
 error ERC725X_ContractDeploymentFailed();
 ```
 
-Reverts when contract deployment failed via [`execute`](#execute) or [`executeBatch`](#executebatch) functions, This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when contract deployment via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` failed. whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1438,7 +1430,7 @@ Reverts when contract deployment failed via [`execute`](#execute) or [`executeBa
 error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
 ```
 
-Reverts when passing a `to` address that is not `address(0)` (= address zero) while deploying a contract via [`execute`](#execute) or [`executeBatch`](#executebatch) functions. This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1457,7 +1449,7 @@ Reverts when passing a `to` address that is not `address(0)` (= address zero) wh
 error ERC725X_ExecuteParametersEmptyArray();
 ```
 
-Reverts when one of the array parameter provided to the [`executeBatch`](#executebatch) function is an empty array.
+reverts when one of the array parameter provided to `executeBatch(uint256[],address[],uint256[],bytes[]) is an empty array
 
 <br/>
 
@@ -1476,7 +1468,7 @@ Reverts when one of the array parameter provided to the [`executeBatch`](#execut
 error ERC725X_ExecuteParametersLengthMismatch();
 ```
 
-Reverts when there is not the same number of elements in the `operationTypes`, `targets` addresses, `values`, and `datas` array parameters provided when calling the [`executeBatch`](#executebatch) function.
+reverts when there is not the same number of operation, to addresses, value, and data.
 
 <br/>
 
@@ -1495,14 +1487,14 @@ Reverts when there is not the same number of elements in the `operationTypes`, `
 error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
 ```
 
-Reverts when trying to send more native tokens `value` than available in current `balance`.
+reverts when trying to send more native tokens `value` than available in current `balance`.
 
 #### Parameters
 
-| Name      |   Type    | Description                                                                                                                            |
-| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `balance` | `uint256` | The balance of native tokens of the ERC725X smart contract.                                                                            |
-| `value`   | `uint256` | The amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` that is greater than the contract's `balance`. |
+| Name      |   Type    | Description                                                                              |
+| --------- | :-------: | ---------------------------------------------------------------------------------------- |
+| `balance` | `uint256` | the balance of the ERC725X contract.                                                     |
+| `value`   | `uint256` | the amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
 
 <br/>
 
@@ -1521,7 +1513,7 @@ Reverts when trying to send more native tokens `value` than available in current
 error ERC725X_MsgValueDisallowedInStaticCall();
 ```
 
-Reverts when trying to send native tokens (`value` / `values[]` parameter of [`execute`](#execute) or [`executeBatch`](#executebatch) functions) while making a `staticcall` (`operationType == 3`). Sending native tokens via `staticcall` is not allowed because it is a state changing operation.
+the `value` parameter (= sending native tokens) is not allowed when making a staticcall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because sending native tokens is a state changing operation.
 
 <br/>
 
@@ -1540,7 +1532,7 @@ Reverts when trying to send native tokens (`value` / `values[]` parameter of [`e
 error ERC725X_NoContractBytecodeProvided();
 ```
 
-Reverts when no contract bytecode was provided as parameter when trying to deploy a contract via [`execute`](#execute) or [`executeBatch`](#executebatch). This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when no contract bytecode was provided as parameter when trying to deploy a contract via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1559,13 +1551,13 @@ Reverts when no contract bytecode was provided as parameter when trying to deplo
 error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
 ```
 
-Reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
+reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                            |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------ |
-| `operationTypeProvided` | `uint256` | The unrecognised operation type number provided to `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
+| Name                    |   Type    | Description |
+| ----------------------- | :-------: | ----------- |
+| `operationTypeProvided` | `uint256` | -           |
 
 <br/>
 
@@ -1584,7 +1576,7 @@ Reverts when the `operationTypeProvided` is none of the default operation types 
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
 
 <br/>
 
@@ -1603,7 +1595,7 @@ Reverts when there is not the same number of elements in the `datakeys` and `dat
 error ERC725Y_MsgValueDisallowed();
 ```
 
-Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
+reverts when sending value to the `setData(..)` functions
 
 <br/>
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -234,15 +234,21 @@ function execute(
 ) external payable returns (bytes);
 ```
 
-_Calling address `target` using `operationType`, transferring `value` wei and data: `data`. _
-
 Generic executor function to:
 
 - send native tokens to any address.
 
 - interact with any contract by passing an abi-encoded function call in the `data` parameter.
 
-- deploy a contract by providing its creation bytecode in the `data` parameter.
+- deploy a contract by providing its creation bytecode in the `data` parameter. Requirements:
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `value` SHOULD be 0.
+
+- `target` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
 
 <blockquote>
 
@@ -272,7 +278,7 @@ Generic executor function to:
 | `operationType` | `uint256` | The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4          |
 | `target`        | `address` | The address of the EOA or smart contract. (unused if a contract is created via operation type 1 or 2) |
 | `value`         | `uint256` | The amount of native tokens to transfer (in Wei)                                                      |
-| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.   |
+| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy                                     |
 
 #### Returns
 
@@ -302,9 +308,23 @@ function executeBatch(
 ) external payable returns (bytes[]);
 ```
 
-_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`. _
+Generic batch executor function to:
 
-Batch executor function that behaves the same as [`execute`](#execute) but allowing multiple operations in the same transaction.
+- send native tokens to any address.
+
+- interact with any contract by passing an abi-encoded function call in the `datas` parameter.
+
+- deploy a contract by providing its creation bytecode in the `datas` parameter. Requirements:
+
+- The length of the parameters provided MUST be equal
+
+- SHOULD only be callable by the owner of the contract set via ERC173.
+
+- if a `values` is provided, the contract MUST have at least this amount in its balance to execute successfully.
+
+- if the operation type is STATICCALL or DELEGATECALL, `values` SHOULD be 0.
+
+- `targets` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
 
 <blockquote>
 
@@ -330,12 +350,12 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 
 #### Parameters
 
-| Name             |    Type     | Description                                                                                                     |
-| ---------------- | :---------: | --------------------------------------------------------------------------------------------------------------- |
-| `operationsType` | `uint256[]` | The list of operations type used: `CALL = 0`; `CREATE = 1`; `CREATE2 = 2`; `STATICCALL = 3`; `DELEGATECALL = 4` |
-| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2).     |
-| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei).                                                          |
-| `datas`          |  `bytes[]`  | The list of calldata, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.      |
+| Name             |    Type     | Description                                                                                                 |
+| ---------------- | :---------: | ----------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The list of operations type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4       |
+| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2). |
+| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei)                                                       |
+| `datas`          |  `bytes[]`  | The list of call data, or the creation bytecode of the contract to deploy                                   |
 
 #### Returns
 
@@ -360,21 +380,19 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
-
-Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
+_Gets singular data at a given `dataKey`_
 
 #### Parameters
 
-| Name      |   Type    | Description                                   |
-| --------- | :-------: | --------------------------------------------- |
-| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
+| Name      |   Type    | Description                     |
+| --------- | :-------: | ------------------------------- |
+| `dataKey` | `bytes32` | The key which value to retrieve |
 
 #### Returns
 
-| Name        |  Type   | Description                                          |
-| ----------- | :-----: | ---------------------------------------------------- |
-| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
+| Name        |  Type   | Description                |
+| ----------- | :-----: | -------------------------- |
+| `dataValue` | `bytes` | The data stored at the key |
 
 <br/>
 
@@ -395,9 +413,7 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
-
-Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
+_Gets array of data for multiple given keys_
 
 #### Parameters
 
@@ -572,9 +588,7 @@ Renounce ownership of the contract in a 2-step process.
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`. _
-
-Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+_Sets singular data for a given `dataKey`_
 
 <blockquote>
 
@@ -595,10 +609,10 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 
 #### Parameters
 
-| Name        |   Type    | Description                                |
-| ----------- | :-------: | ------------------------------------------ |
-| `dataKey`   | `bytes32` | The data key for which to set a new value. |
-| `dataValue` |  `bytes`  | The new bytes value to set.                |
+| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
+| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
+| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
 
 <br/>
 
@@ -617,9 +631,9 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`. _
+Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
 
-Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+0. Emits a [`DataChanged`](#datachanged) event.
 
 <blockquote>
 
@@ -640,10 +654,10 @@ Batch data setting function that behaves the same as [`setData`](#setdata) but a
 
 #### Parameters
 
-| Name         |    Type     | Description                                          |
-| ------------ | :---------: | ---------------------------------------------------- |
-| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
-| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
+| Name         |    Type     | Description                              |
+| ------------ | :---------: | ---------------------------------------- |
+| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
+| `dataValues` |  `bytes[]`  | The array of values to set               |
 
 <br/>
 
@@ -813,7 +827,8 @@ function _execute(
 ) internal nonpayable returns (bytes);
 ```
 
-check the `operationType` provided and perform the associated low-level opcode after checking for requirements (see [`execute`](#execute)).
+check the `operationType` provided and perform the associated low-level opcode.
+see `IERC725X.execute(uint256,address,uint256,bytes)`.
 
 <br/>
 
@@ -828,7 +843,8 @@ function _executeBatch(
 ) internal nonpayable returns (bytes[]);
 ```
 
-check each `operationType` provided in the batch and perform the associated low-level opcode after checking for requirements (see [`executeBatch`](#executebatch)).
+same as `_execute` but for batch execution
+see `IERC725X,execute(uint256[],address[],uint256[],bytes[])`
 
 <br/>
 
@@ -842,7 +858,7 @@ function _executeCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level call (operation type = 0)
+perform low-level call (operation type = 0)
 
 #### Parameters
 
@@ -869,7 +885,7 @@ function _executeStaticCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level staticcall (operation type = 3)
+perform low-level staticcall (operation type = 3)
 
 #### Parameters
 
@@ -895,7 +911,7 @@ function _executeDelegateCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-Perform low-level delegatecall (operation type = 4)
+perform low-level delegatecall (operation type = 4)
 
 #### Parameters
 
@@ -921,7 +937,7 @@ function _deployCreate(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-Deploy a contract using the `CREATE` opcode (operation type = 1)
+deploy a contract using the CREATE opcode (operation type = 1)
 
 #### Parameters
 
@@ -947,7 +963,7 @@ function _deployCreate2(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-Deploy a contract using the `CREATE2` opcode (operation type = 2)
+deploy a contract using the CREATE2 opcode (operation type = 2)
 
 #### Parameters
 
@@ -969,25 +985,6 @@ Deploy a contract using the `CREATE2` opcode (operation type = 2)
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
-
-Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
-represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
-
-```solidity
-mapping(bytes32 => bytes) _store
-```
-
-#### Parameters
-
-| Name      |   Type    | Description                                                             |
-| --------- | :-------: | ----------------------------------------------------------------------- |
-| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
-
-#### Returns
-
-| Name        |  Type   | Description                                                                   |
-| ----------- | :-----: | ----------------------------------------------------------------------------- |
-| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -1173,18 +1170,18 @@ function _revertWithLSP20DefaultError(
 event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
 ```
 
-_Deployed new contract at address `contractAddress` and funded with `value` wei (deployed using opcode: `operationType`)._
+_Emitted when deploying a contract_
 
-Emitted when a new contract was created and deployed.
+Emitted whenever a contract is created
 
 #### Parameters
 
-| Name                            |   Type    | Description                                                                                                                               |
-| ------------------------------- | :-------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (`CREATE` or `CREATE2`).                                                                           |
-| `contractAddress` **`indexed`** | `address` | The created contract address.                                                                                                             |
-| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract on deployment.                                                     |
-| `salt`                          | `bytes32` | The salt used to deterministically deploy the contract (`CREATE2` only). If `CREATE` opcode is used, the salt value will be `bytes32(0)`. |
+| Name                            |   Type    | Description                                                                    |
+| ------------------------------- | :-------: | ------------------------------------------------------------------------------ |
+| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (CREATE or CREATE2)                     |
+| `contractAddress` **`indexed`** | `address` | The created contract address                                                   |
+| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract address |
+| `salt`                          | `bytes32` | -                                                                              |
 
 <br/>
 
@@ -1203,16 +1200,14 @@ Emitted when a new contract was created and deployed.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
-
-Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
+_Emitted when data at a key is changed_
 
 #### Parameters
 
-| Name                    |   Type    | Description                                  |
-| ----------------------- | :-------: | -------------------------------------------- |
-| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
-| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
+| Name                    |   Type    | Description                          |
+| ----------------------- | :-------: | ------------------------------------ |
+| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
+| `dataValue`             |  `bytes`  | The data value to set                |
 
 <br/>
 
@@ -1231,18 +1226,16 @@ Emitted when data at a specific `dataKey` was changed to a new value `dataValue`
 event Executed(uint256 indexed operationType, address indexed target, uint256 indexed value, bytes4 selector);
 ```
 
-_Called address `target` using `operationType` with `value` wei and `data`._
-
-Emitted when calling an address `target` (EOA or contract) with `value`.
+_Emitted when calling an address (EOA or contract)_
 
 #### Parameters
 
-| Name                          |   Type    | Description                                                                                          |
-| ----------------------------- | :-------: | ---------------------------------------------------------------------------------------------------- |
-| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `target` address (`CALL`, `STATICALL` or `DELEGATECALL`). |
-| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2).     |
-| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred along the call (in Wei).                                     |
-| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call.                              |
+| Name                          |   Type    | Description                                                                                      |
+| ----------------------------- | :-------: | ------------------------------------------------------------------------------------------------ |
+| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `to` address (CALL, STATICALL or DELEGATECALL)        |
+| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2). |
+| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred with the call (in Wei)                                   |
+| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call                           |
 
 <br/>
 
@@ -1439,7 +1432,7 @@ Reverts when trying to transfer ownership to the `address(this)`.
 error ERC725X_ContractDeploymentFailed();
 ```
 
-Reverts when contract deployment failed via [`execute`](#execute) or [`executeBatch`](#executebatch) functions, This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when contract deployment via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` failed. whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1458,7 +1451,7 @@ Reverts when contract deployment failed via [`execute`](#execute) or [`executeBa
 error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
 ```
 
-Reverts when passing a `to` address that is not `address(0)` (= address zero) while deploying a contract via [`execute`](#execute) or [`executeBatch`](#executebatch) functions. This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1477,7 +1470,7 @@ Reverts when passing a `to` address that is not `address(0)` (= address zero) wh
 error ERC725X_ExecuteParametersEmptyArray();
 ```
 
-Reverts when one of the array parameter provided to the [`executeBatch`](#executebatch) function is an empty array.
+reverts when one of the array parameter provided to `executeBatch(uint256[],address[],uint256[],bytes[]) is an empty array
 
 <br/>
 
@@ -1496,7 +1489,7 @@ Reverts when one of the array parameter provided to the [`executeBatch`](#execut
 error ERC725X_ExecuteParametersLengthMismatch();
 ```
 
-Reverts when there is not the same number of elements in the `operationTypes`, `targets` addresses, `values`, and `datas` array parameters provided when calling the [`executeBatch`](#executebatch) function.
+reverts when there is not the same number of operation, to addresses, value, and data.
 
 <br/>
 
@@ -1515,14 +1508,14 @@ Reverts when there is not the same number of elements in the `operationTypes`, `
 error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
 ```
 
-Reverts when trying to send more native tokens `value` than available in current `balance`.
+reverts when trying to send more native tokens `value` than available in current `balance`.
 
 #### Parameters
 
-| Name      |   Type    | Description                                                                                                                            |
-| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `balance` | `uint256` | The balance of native tokens of the ERC725X smart contract.                                                                            |
-| `value`   | `uint256` | The amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` that is greater than the contract's `balance`. |
+| Name      |   Type    | Description                                                                              |
+| --------- | :-------: | ---------------------------------------------------------------------------------------- |
+| `balance` | `uint256` | the balance of the ERC725X contract.                                                     |
+| `value`   | `uint256` | the amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
 
 <br/>
 
@@ -1541,7 +1534,7 @@ Reverts when trying to send more native tokens `value` than available in current
 error ERC725X_MsgValueDisallowedInDelegateCall();
 ```
 
-Reverts when trying to send native tokens (`value` / `values[]` parameter of [`execute`](#execute) or [`executeBatch`](#executebatch) functions) while making a `delegatecall` (`operationType == 4`). Sending native tokens via `staticcall` is not allowed because `msg.value` is persisting.
+the `value` parameter (= sending native tokens) is not allowed when making a delegatecall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because msg.value is persisting.
 
 <br/>
 
@@ -1560,7 +1553,7 @@ Reverts when trying to send native tokens (`value` / `values[]` parameter of [`e
 error ERC725X_MsgValueDisallowedInStaticCall();
 ```
 
-Reverts when trying to send native tokens (`value` / `values[]` parameter of [`execute`](#execute) or [`executeBatch`](#executebatch) functions) while making a `staticcall` (`operationType == 3`). Sending native tokens via `staticcall` is not allowed because it is a state changing operation.
+the `value` parameter (= sending native tokens) is not allowed when making a staticcall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because sending native tokens is a state changing operation.
 
 <br/>
 
@@ -1579,7 +1572,7 @@ Reverts when trying to send native tokens (`value` / `values[]` parameter of [`e
 error ERC725X_NoContractBytecodeProvided();
 ```
 
-Reverts when no contract bytecode was provided as parameter when trying to deploy a contract via [`execute`](#execute) or [`executeBatch`](#executebatch). This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
+reverts when no contract bytecode was provided as parameter when trying to deploy a contract via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
 
 <br/>
 
@@ -1598,13 +1591,13 @@ Reverts when no contract bytecode was provided as parameter when trying to deplo
 error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
 ```
 
-Reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
+reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                            |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------ |
-| `operationTypeProvided` | `uint256` | The unrecognised operation type number provided to `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
+| Name                    |   Type    | Description |
+| ----------------------- | :-------: | ----------- |
+| `operationTypeProvided` | `uint256` | -           |
 
 <br/>
 
@@ -1623,7 +1616,7 @@ Reverts when the `operationTypeProvided` is none of the default operation types 
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
+reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
 
 <br/>
 

--- a/dodoc/config.ts
+++ b/dodoc/config.ts
@@ -17,6 +17,7 @@ export const dodocConfig = {
     'contracts/LSP17ContractExtension/LSP17Extension.sol',
     'contracts/LSP20CallVerification/LSP20CallVerification.sol',
     'contracts/LSP23LinkedContractsDeployment/LSP23LinkedContractsFactory.sol',
+    'contracts/LSP23LinkedContractsDeployment/IPostDeploymentModule.sol',
     'contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.sol',
 
     // tokens


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

- Add updated Markdown docs from Natspec comments.
- Add table of generated ERC165 interface IDs in Markdown
