### PR TITLE
chore: :coffin: remove unused function `getTransferDetails` from `LSP1Utils.sol`

### DIFF
--- a/contracts/LSP1UniversalReceiver/LSP1Utils.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Utils.sol
@@ -17,13 +17,6 @@ import {
     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY,
     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX
 } from "../LSP1UniversalReceiver/LSP1Constants.sol";
-import "../LSP0ERC725Account/LSP0Constants.sol";
-import "../LSP5ReceivedAssets/LSP5Constants.sol";
-import "../LSP7DigitalAsset/LSP7Constants.sol";
-import "../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
-import "../LSP9Vault/LSP9Constants.sol";
-import "../LSP14Ownable2Step/LSP14Constants.sol";
-import "../LSP10ReceivedVaults/LSP10Constants.sol";
 
 /**
  * @title LSP1 Utility library.
@@ -133,57 +126,5 @@ library LSP1Utils {
             bytes20(typeId)
         );
         return erc725YStorage[lsp1TypeIdDataKey];
-    }
-
-    /**
-     * @dev Gets all the transfer details based on the provided `bytes32 typeId`.
-     *
-     * @param typeId A `bytes32` unique identifier for a specific action or information.
-     *
-     * @return invalid `true` if the `typeId` was not recognised, `false otherwise.
-     * @return mapPrefix The standard 10 bytes defined in a LSP standard associated with the specific `typeId`.
-     * @return interfaceId The bytes4 ERC165 interface ID defined in a LSP standard associated with a specific `typeId`.
-     * @return isReceiving When the typeId relate to LSP7/8 tokens or LSP9 Vaults, describe if the `typeId` relates
-     * to receiving assets/vaults (`true`), or sending them (`false`).
-     */
-    function getTransferDetails(
-        bytes32 typeId
-    )
-        internal
-        pure
-        returns (
-            bool invalid,
-            bytes10 mapPrefix,
-            bytes4 interfaceId,
-            bool isReceiving
-        )
-    {
-        if (
-            typeId == _TYPEID_LSP7_TOKENSSENDER ||
-            typeId == _TYPEID_LSP7_TOKENSRECIPIENT
-        ) {
-            mapPrefix = _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX;
-            interfaceId = _INTERFACEID_LSP7;
-            isReceiving = typeId == _TYPEID_LSP7_TOKENSRECIPIENT ? true : false;
-        } else if (
-            typeId == _TYPEID_LSP8_TOKENSSENDER ||
-            typeId == _TYPEID_LSP8_TOKENSRECIPIENT
-        ) {
-            mapPrefix = _LSP5_RECEIVED_ASSETS_MAP_KEY_PREFIX;
-            interfaceId = _INTERFACEID_LSP8;
-            isReceiving = typeId == _TYPEID_LSP8_TOKENSRECIPIENT ? true : false;
-        } else if (
-            typeId == _TYPEID_LSP9_OwnershipTransferred_SenderNotification ||
-            typeId == _TYPEID_LSP9_OwnershipTransferred_RecipientNotification
-        ) {
-            mapPrefix = _LSP10_VAULTS_MAP_KEY_PREFIX;
-            interfaceId = _INTERFACEID_LSP9;
-            isReceiving = (typeId ==
-                _TYPEID_LSP9_OwnershipTransferred_RecipientNotification)
-                ? true
-                : false;
-        } else {
-            invalid = true;
-        }
     }
 }

--- a/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
+++ b/contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol
@@ -476,7 +476,7 @@ library LSP2Utils {
      *
      * @custom:info The function assumes that the Data Value stored under the mapping Data Key is of length 20 where the last 16 bytes are the index of the element in the array.
      *
-     * @param ERC725YContract The ERC725Y contract.
+     * @param erc725YContract The ERC725Y contract.
      * @param arrayKey The Data Key of Key Type Array.
      * @param newArrayLength The new Array Length for the `arrayKey`.
      * @param removedElementIndexKey The Data Key of Key Type Array Index for the removed element.
@@ -484,7 +484,7 @@ library LSP2Utils {
      * @param removedElementMapKey The Data Key of a mapping to be removed.
      */
     function removeElementFromArrayAndMap(
-        IERC725Y ERC725YContract,
+        IERC725Y erc725YContract,
         bytes32 arrayKey,
         uint128 newArrayLength,
         bytes32 removedElementIndexKey,
@@ -514,7 +514,7 @@ library LSP2Utils {
 
         // Get the data value from the key of the last element in the array
         bytes20 lastElementIndexValue = bytes20(
-            ERC725YContract.getData(lastElementIndexKey)
+            erc725YContract.getData(lastElementIndexKey)
         );
 
         // Set data value of the last element instead of the element from the array that will be removed
@@ -533,7 +533,7 @@ library LSP2Utils {
 
         // Generate the mapping value for the swapped array element
         bytes memory lastElementMapValue = abi.encodePacked(
-            bytes4(ERC725YContract.getData(lastElementMapKey)),
+            bytes4(erc725YContract.getData(lastElementMapKey)),
             removedElementIndex
         );
 

--- a/docs/libraries/LSP1UniversalReceiver/LSP1Utils.md
+++ b/docs/libraries/LSP1UniversalReceiver/LSP1Utils.md
@@ -135,38 +135,3 @@ the value set under the `LSP1UniversalReceiverDelegate:<bytes32>` data key for a
 | `0`  | `bytes` | The bytes value stored under the `LSP1UniversalReceiverDelegate:<bytes32>` data key. |
 
 <br/>
-
-### getTransferDetails
-
-```solidity
-function getTransferDetails(
-  bytes32 typeId
-)
-  internal
-  pure
-  returns (
-    bool invalid,
-    bytes10 mapPrefix,
-    bytes4 interfaceId,
-    bool isReceiving
-  );
-```
-
-Gets all the transfer details based on the provided `bytes32 typeId`.
-
-#### Parameters
-
-| Name     |   Type    | Description                                                         |
-| -------- | :-------: | ------------------------------------------------------------------- |
-| `typeId` | `bytes32` | A `bytes32` unique identifier for a specific action or information. |
-
-#### Returns
-
-| Name          |   Type    | Description                                                                                   |
-| ------------- | :-------: | --------------------------------------------------------------------------------------------- |
-| `invalid`     |  `bool`   | `true` if the `typeId` was not recognised, `false otherwise.                                  |
-| `mapPrefix`   | `bytes10` | The standard 10 bytes defined in a LSP standard associated with the specific `typeId`.        |
-| `interfaceId` | `bytes4`  | The bytes4 ERC165 interface ID defined in a LSP standard associated with a specific `typeId`. |
-| `isReceiving` |  `bool`   | When the typeId relate to LSP7/8 tokens or LSP9 Vaults, describe if the `typeId` relates      |
-
-<br/>


### PR DESCRIPTION
# What does this PR introduce?


## Chore

Remove function `getTransferDetails` from `LSP1Utils.sol`, as this function is not used anymore in the LSP1 Delegate implementation for UP and Vault.

Also removed the function from the auto-generated docs.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
