### PR TITLE
build: upgrade `@erc725/smart-contracts` to 5.2.0 + generate new ABI docs

### DIFF
--- a/docs/contracts/ERC725/ERC725.md
+++ b/docs/contracts/ERC725/ERC725.md
@@ -16,7 +16,7 @@
 
 > ERC725 bundle.
 
-Bundle ERC725X and ERC725Y together into one smart contract. This implementation does not have by default a `receive() external payable {}` or `fallback() external payable {}` function.
+Bundle ERC725X and ERC725Y together into one smart contract.
 
 ## Public Methods
 
@@ -76,7 +76,7 @@ function execute(
 ) external payable returns (bytes);
 ```
 
-_Calling address `target` using `operationType`, transferring `value` wei and data: `data`. _
+_Calling address `target` using `operationType`, transferring `value` wei and data: `data`._
 
 Generic executor function to:
 
@@ -143,7 +143,7 @@ function executeBatch(
 ) external payable returns (bytes[]);
 ```
 
-_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`. _
+_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`._
 
 Batch executor function that behaves the same as [`execute`](#execute) but allowing multiple operations in the same transaction.
 
@@ -316,7 +316,7 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`. _
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
 
 Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
 
@@ -366,7 +366,7 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`. _
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
 Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
 
@@ -716,7 +716,7 @@ event ContractCreated(uint256 indexed operationType, address indexed contractAdd
 
 _Deployed new contract at address `contractAddress` and funded with `value` wei (deployed using opcode: `operationType`)._
 
-Emitted whenever a contract is created
+Emitted when a new contract was created and deployed.
 
 #### Parameters
 

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -291,7 +291,7 @@ function execute(
 ) external payable returns (bytes);
 ```
 
-_Calling address `target` using `operationType`, transferring `value` wei and data: `data`. _
+_Calling address `target` using `operationType`, transferring `value` wei and data: `data`._
 
 Generic executor function to:
 
@@ -359,7 +359,7 @@ function executeBatch(
 ) external payable returns (bytes[]);
 ```
 
-_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`. _
+_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`._
 
 Batch executor function that behaves the same as [`execute`](#execute) but allowing multiple operations in the same transaction.
 
@@ -629,7 +629,7 @@ Renounce ownership of the contract in a 2-step process.
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`. _
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
 
 Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
 
@@ -674,7 +674,7 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`. _
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
 Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
 

--- a/docs/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.md
+++ b/docs/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.md
@@ -38,19 +38,21 @@ When marked as 'public', a method can be called both externally and internally, 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -71,7 +73,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -167,18 +171,42 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -193,20 +221,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -324,6 +374,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -331,6 +400,28 @@ function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```solidity
 function _setData(bytes32 dataKey, bytes dataValue) internal nonpayable;
 ```
+
+Write a `dataValue` to the underlying ERC725Y storage, represented as a mapping of
+`bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event emitted after a successful `setData` call.
+
+</blockquote>
+
+#### Parameters
+
+| Name        |   Type    | Description                                                                     |
+| ----------- | :-------: | ------------------------------------------------------------------------------- |
+| `dataKey`   | `bytes32` | A bytes32 data key to write the associated `bytes` value to the store.          |
+| `dataValue` |  `bytes`  | The `bytes` value to associate with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -351,14 +442,16 @@ function _setData(bytes32 dataKey, bytes dataValue) internal nonpayable;
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -403,7 +496,7 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -422,7 +515,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -441,6 +534,6 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>

--- a/docs/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.md
+++ b/docs/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.md
@@ -38,19 +38,21 @@ When marked as 'public', a method can be called both externally and internally, 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -71,7 +73,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -142,18 +146,42 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -168,20 +196,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -274,6 +324,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -303,14 +372,16 @@ Save gas by emitting the [`DataChanged`](#datachanged) event with only the first
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -355,7 +426,7 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -374,7 +445,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -393,7 +464,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -151,7 +151,7 @@ Same as [`execute`](#execute) but execute a batch of payloads (abi-encoded funct
 
 :::tip Hint
 
-If you are looking to learn how to sign and execute relay transactions via the Key Manager, see our Javascript step by step guide [_&quot;Execute Relay Transactions&quot;_](../../guides/key-manager/execute-relay-transactions.md). See the LSP6 Standard page for more details on how to [generate a valid signature for Execute Relay Call](../universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
+If you are looking to learn how to sign and execute relay transactions via the Key Manager, see our Javascript step by step guide [_&quot;Execute Relay Transactions&quot;_](../../../guides/key-manager/execute-relay-transactions.md). See the LSP6 Standard page for more details on how to [generate a valid signature for Execute Relay Call](../../../standards/universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
 
 :::
 
@@ -1348,7 +1348,7 @@ Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,addre
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -219,19 +219,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -252,7 +254,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -402,18 +406,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -428,20 +456,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -628,6 +678,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -877,14 +946,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -985,7 +1056,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1004,7 +1075,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1023,7 +1094,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -244,19 +244,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -277,7 +279,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -427,18 +431,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -453,20 +481,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -653,6 +703,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -902,14 +971,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1010,7 +1081,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1029,7 +1100,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1048,7 +1119,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -217,19 +217,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -250,7 +252,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -400,18 +404,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -426,20 +454,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -653,6 +703,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -886,14 +955,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -994,7 +1065,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1013,7 +1084,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1032,7 +1103,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -283,19 +283,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -316,7 +318,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -491,18 +495,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -517,20 +545,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -823,6 +873,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -1021,14 +1090,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1129,7 +1200,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1148,7 +1219,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1167,7 +1238,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -308,19 +308,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -341,7 +343,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -549,18 +553,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -575,20 +603,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -881,6 +931,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -1079,14 +1148,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1187,7 +1258,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1206,7 +1277,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1225,7 +1296,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -248,19 +248,21 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -281,7 +283,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -464,18 +468,42 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -490,20 +518,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -690,6 +740,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -939,14 +1008,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1047,7 +1118,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1066,7 +1137,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1085,7 +1156,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -98,19 +98,21 @@ Get the number of token IDs owned by `tokenOwner`.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -131,7 +133,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -294,18 +298,42 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -320,20 +348,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -582,6 +632,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -876,14 +945,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -985,7 +1056,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1004,7 +1075,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1023,7 +1094,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -124,19 +124,21 @@ See internal [`_burn`](#_burn) function for details.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -157,7 +159,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -320,18 +324,42 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -346,20 +374,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -608,6 +658,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -902,14 +971,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1011,7 +1082,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1030,7 +1101,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1049,7 +1120,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -96,19 +96,21 @@ Get the number of token IDs owned by `tokenOwner`.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -129,7 +131,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -292,18 +296,42 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -318,20 +346,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -607,6 +657,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -886,14 +955,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -995,7 +1066,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1014,7 +1085,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1033,7 +1104,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -166,19 +166,21 @@ Compatible with ERC721 getApproved.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -199,7 +201,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -559,18 +563,42 @@ See [`_setApprovalForAll`](#_setapprovalforall)
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -585,20 +613,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -941,6 +991,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -1252,14 +1321,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1363,7 +1434,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1382,7 +1453,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1401,7 +1472,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -96,19 +96,21 @@ Get the number of token IDs owned by `tokenOwner`.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -129,7 +131,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -292,18 +296,42 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -318,20 +346,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -613,6 +663,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -903,14 +972,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1012,7 +1083,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1031,7 +1102,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1050,7 +1121,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -191,19 +191,21 @@ Compatible with ERC721 getApproved.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -224,7 +226,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -619,18 +623,42 @@ See [`_setApprovalForAll`](#_setapprovalforall)
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -645,20 +673,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -1001,6 +1051,25 @@ This pattern is useful in inheritance.
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
 
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
+
 <br/>
 
 ### \_setData
@@ -1312,14 +1381,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1423,7 +1494,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1442,7 +1513,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1461,7 +1532,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -121,19 +121,21 @@ Get the number of token IDs owned by `tokenOwner`.
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -154,7 +156,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -352,18 +356,42 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner).
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event.
+
+</blockquote>
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -378,20 +406,42 @@ _Sets singular data for a given `dataKey`_
 
 :::
 
+:::caution Warning
+
+**Note for developers:** despite the fact that this function is set as `payable`, if the function is not intended to receive value (= native tokens), **an additional check should be implemented to ensure that `msg.value` sent was equal to 0**.
+
+:::
+
 ```solidity
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
+
+<blockquote>
+
+**Requirements:**
+
+- SHOULD only be callable by the [`owner`](#owner) of the contract.
+
+</blockquote>
+
+<blockquote>
+
+**Emitted events:**
+
+- [`DataChanged`](#datachanged) event **for each data key/value pair set**.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -640,6 +690,25 @@ This pattern is useful in inheritance.
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -934,14 +1003,16 @@ Emitted when `tokenOwner` enables `operator` to transfer or burn the `tokenId`.
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1043,7 +1114,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 error ERC725Y_DataKeysValuesEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `setDataBatch` is an empty array
+Reverts when one of the array parameter provided to [`setDataBatch`](#setdatabatch) function is an empty array.
 
 <br/>
 
@@ -1062,7 +1133,7 @@ reverts when one of the array parameter provided to `setDataBatch` is an empty a
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 
@@ -1081,7 +1152,7 @@ reverts when there is not the same number of elements in the lists of data keys 
 error ERC725Y_MsgValueDisallowed();
 ```
 
-reverts when sending value to the `setData(..)` functions
+Reverts when sending value to the [`setData`](#setdata) or [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -234,21 +234,15 @@ function execute(
 ) external payable returns (bytes);
 ```
 
+_Calling address `target` using `operationType`, transferring `value` wei and data: `data`._
+
 Generic executor function to:
 
 - send native tokens to any address.
 
 - interact with any contract by passing an abi-encoded function call in the `data` parameter.
 
-- deploy a contract by providing its creation bytecode in the `data` parameter. Requirements:
-
-- SHOULD only be callable by the owner of the contract set via ERC173.
-
-- if a `value` is provided, the contract MUST have at least this amount in its balance to execute successfully.
-
-- if the operation type is STATICCALL or DELEGATECALL, `value` SHOULD be 0.
-
-- `target` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
+- deploy a contract by providing its creation bytecode in the `data` parameter.
 
 <blockquote>
 
@@ -278,7 +272,7 @@ Generic executor function to:
 | `operationType` | `uint256` | The operation type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4          |
 | `target`        | `address` | The address of the EOA or smart contract. (unused if a contract is created via operation type 1 or 2) |
 | `value`         | `uint256` | The amount of native tokens to transfer (in Wei)                                                      |
-| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy                                     |
+| `data`          |  `bytes`  | The call data, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.   |
 
 #### Returns
 
@@ -308,23 +302,9 @@ function executeBatch(
 ) external payable returns (bytes[]);
 ```
 
-Generic batch executor function to:
+_Calling multiple addresses `targets` using `operationsType`, transferring `values` wei and data: `datas`._
 
-- send native tokens to any address.
-
-- interact with any contract by passing an abi-encoded function call in the `datas` parameter.
-
-- deploy a contract by providing its creation bytecode in the `datas` parameter. Requirements:
-
-- The length of the parameters provided MUST be equal
-
-- SHOULD only be callable by the owner of the contract set via ERC173.
-
-- if a `values` is provided, the contract MUST have at least this amount in its balance to execute successfully.
-
-- if the operation type is STATICCALL or DELEGATECALL, `values` SHOULD be 0.
-
-- `targets` SHOULD be address(0) when deploying a contract. Emits an [`Executed`](#executed) event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL) Emits a [`ContractCreated`](#contractcreated) event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
+Batch executor function that behaves the same as [`execute`](#execute) but allowing multiple operations in the same transaction.
 
 <blockquote>
 
@@ -350,12 +330,12 @@ Generic batch executor function to:
 
 #### Parameters
 
-| Name             |    Type     | Description                                                                                                 |
-| ---------------- | :---------: | ----------------------------------------------------------------------------------------------------------- |
-| `operationsType` | `uint256[]` | The list of operations type used: CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4       |
-| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2). |
-| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei)                                                       |
-| `datas`          |  `bytes[]`  | The list of call data, or the creation bytecode of the contract to deploy                                   |
+| Name             |    Type     | Description                                                                                                     |
+| ---------------- | :---------: | --------------------------------------------------------------------------------------------------------------- |
+| `operationsType` | `uint256[]` | The list of operations type used: `CALL = 0`; `CREATE = 1`; `CREATE2 = 2`; `STATICCALL = 3`; `DELEGATECALL = 4` |
+| `targets`        | `address[]` | The list of addresses to call. `targets` will be unused if a contract is created (operation types 1 and 2).     |
+| `values`         | `uint256[]` | The list of native token amounts to transfer (in Wei).                                                          |
+| `datas`          |  `bytes[]`  | The list of calldata, or the creation bytecode of the contract to deploy if `operationType` is `1` or `2`.      |
 
 #### Returns
 
@@ -380,19 +360,21 @@ Generic batch executor function to:
 function getData(bytes32 dataKey) external view returns (bytes dataValue);
 ```
 
-_Gets singular data at a given `dataKey`_
+_Reading the ERC725Y storage for data key `dataKey` returned the following value: `dataValue`._
+
+Get in the ERC725Y storage the bytes data stored at a specific data key `dataKey`.
 
 #### Parameters
 
-| Name      |   Type    | Description                     |
-| --------- | :-------: | ------------------------------- |
-| `dataKey` | `bytes32` | The key which value to retrieve |
+| Name      |   Type    | Description                                   |
+| --------- | :-------: | --------------------------------------------- |
+| `dataKey` | `bytes32` | The data key for which to retrieve the value. |
 
 #### Returns
 
-| Name        |  Type   | Description                |
-| ----------- | :-----: | -------------------------- |
-| `dataValue` | `bytes` | The data stored at the key |
+| Name        |  Type   | Description                                          |
+| ----------- | :-----: | ---------------------------------------------------- |
+| `dataValue` | `bytes` | The bytes value stored under the specified data key. |
 
 <br/>
 
@@ -413,7 +395,9 @@ function getDataBatch(
 ) external view returns (bytes[] dataValues);
 ```
 
-_Gets array of data for multiple given keys_
+_Reading the ERC725Y storage for data keys `dataKeys` returned the following values: `dataValues`._
+
+Get in the ERC725Y storage the bytes data stored at multiple data keys `dataKeys`.
 
 #### Parameters
 
@@ -588,7 +572,9 @@ Renounce ownership of the contract in a 2-step process.
 function setData(bytes32 dataKey, bytes dataValue) external payable;
 ```
 
-_Sets singular data for a given `dataKey`_
+_Setting the following data key value pair in the ERC725Y storage. Data key: `dataKey`, data value: `dataValue`._
+
+Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data key `dataKey`. The function is marked as payable to enable flexibility on child contracts. For instance to implement a fee mechanism for setting specific data.
 
 <blockquote>
 
@@ -609,10 +595,10 @@ _Sets singular data for a given `dataKey`_
 
 #### Parameters
 
-| Name        |   Type    | Description                                                                                                                                                                                                                                                                                                           |
-| ----------- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `dataKey`   | `bytes32` | The key to retrieve stored value                                                                                                                                                                                                                                                                                      |
-| `dataValue` |  `bytes`  | The value to set SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal 0. Emits a {DataChanged} event. |
+| Name        |   Type    | Description                                |
+| ----------- | :-------: | ------------------------------------------ |
+| `dataKey`   | `bytes32` | The data key for which to set a new value. |
+| `dataValue` |  `bytes`  | The new bytes value to set.                |
 
 <br/>
 
@@ -631,9 +617,9 @@ _Sets singular data for a given `dataKey`_
 function setDataBatch(bytes32[] dataKeys, bytes[] dataValues) external payable;
 ```
 
-Sets array of data for multiple given `dataKeys` SHOULD only be callable by the owner of the contract set via ERC173 The function is marked as payable to enable flexibility on child contracts If the function is not intended to receive value, an additional check should be implemented to check that value equal
+_Setting the following data key value pairs in the ERC725Y storage. Data keys: `dataKeys`, data values: `dataValues`._
 
-0. Emits a [`DataChanged`](#datachanged) event.
+Batch data setting function that behaves the same as [`setData`](#setdata) but allowing to set multiple data key/value pairs in the ERC725Y storage in the same transaction.
 
 <blockquote>
 
@@ -654,10 +640,10 @@ Sets array of data for multiple given `dataKeys` SHOULD only be callable by the 
 
 #### Parameters
 
-| Name         |    Type     | Description                              |
-| ------------ | :---------: | ---------------------------------------- |
-| `dataKeys`   | `bytes32[]` | The array of data keys for values to set |
-| `dataValues` |  `bytes[]`  | The array of values to set               |
+| Name         |    Type     | Description                                          |
+| ------------ | :---------: | ---------------------------------------------------- |
+| `dataKeys`   | `bytes32[]` | An array of data keys to set bytes values for.       |
+| `dataValues` |  `bytes[]`  | An array of bytes values to set for each `dataKeys`. |
 
 <br/>
 
@@ -827,8 +813,7 @@ function _execute(
 ) internal nonpayable returns (bytes);
 ```
 
-check the `operationType` provided and perform the associated low-level opcode.
-see `IERC725X.execute(uint256,address,uint256,bytes)`.
+check the `operationType` provided and perform the associated low-level opcode after checking for requirements (see [`execute`](#execute)).
 
 <br/>
 
@@ -843,8 +828,7 @@ function _executeBatch(
 ) internal nonpayable returns (bytes[]);
 ```
 
-same as `_execute` but for batch execution
-see `IERC725X,execute(uint256[],address[],uint256[],bytes[])`
+check each `operationType` provided in the batch and perform the associated low-level opcode after checking for requirements (see [`executeBatch`](#executebatch)).
 
 <br/>
 
@@ -858,7 +842,7 @@ function _executeCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-perform low-level call (operation type = 0)
+Perform low-level call (operation type = 0)
 
 #### Parameters
 
@@ -885,7 +869,7 @@ function _executeStaticCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-perform low-level staticcall (operation type = 3)
+Perform low-level staticcall (operation type = 3)
 
 #### Parameters
 
@@ -911,7 +895,7 @@ function _executeDelegateCall(
 ) internal nonpayable returns (bytes result);
 ```
 
-perform low-level delegatecall (operation type = 4)
+Perform low-level delegatecall (operation type = 4)
 
 #### Parameters
 
@@ -937,7 +921,7 @@ function _deployCreate(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-deploy a contract using the CREATE opcode (operation type = 1)
+Deploy a contract using the `CREATE` opcode (operation type = 1)
 
 #### Parameters
 
@@ -963,7 +947,7 @@ function _deployCreate2(
 ) internal nonpayable returns (bytes newContract);
 ```
 
-deploy a contract using the CREATE2 opcode (operation type = 2)
+Deploy a contract using the `CREATE2` opcode (operation type = 2)
 
 #### Parameters
 
@@ -985,6 +969,25 @@ deploy a contract using the CREATE2 opcode (operation type = 2)
 ```solidity
 function _getData(bytes32 dataKey) internal view returns (bytes dataValue);
 ```
+
+Read the value stored under a specific `dataKey` inside the underlying ERC725Y storage,
+represented as a mapping of `bytes32` data keys mapped to their `bytes` data values.
+
+```solidity
+mapping(bytes32 => bytes) _store
+```
+
+#### Parameters
+
+| Name      |   Type    | Description                                                             |
+| --------- | :-------: | ----------------------------------------------------------------------- |
+| `dataKey` | `bytes32` | A bytes32 data key to read the associated `bytes` value from the store. |
+
+#### Returns
+
+| Name        |  Type   | Description                                                                   |
+| ----------- | :-----: | ----------------------------------------------------------------------------- |
+| `dataValue` | `bytes` | The `bytes` value associated with the given `dataKey` in the ERC725Y storage. |
 
 <br/>
 
@@ -1170,18 +1173,18 @@ function _revertWithLSP20DefaultError(
 event ContractCreated(uint256 indexed operationType, address indexed contractAddress, uint256 indexed value, bytes32 salt);
 ```
 
-_Emitted when deploying a contract_
+_Deployed new contract at address `contractAddress` and funded with `value` wei (deployed using opcode: `operationType`)._
 
-Emitted whenever a contract is created
+Emitted when a new contract was created and deployed.
 
 #### Parameters
 
-| Name                            |   Type    | Description                                                                    |
-| ------------------------------- | :-------: | ------------------------------------------------------------------------------ |
-| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (CREATE or CREATE2)                     |
-| `contractAddress` **`indexed`** | `address` | The created contract address                                                   |
-| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract address |
-| `salt`                          | `bytes32` | -                                                                              |
+| Name                            |   Type    | Description                                                                                                                               |
+| ------------------------------- | :-------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `operationType` **`indexed`**   | `uint256` | The opcode used to deploy the contract (`CREATE` or `CREATE2`).                                                                           |
+| `contractAddress` **`indexed`** | `address` | The created contract address.                                                                                                             |
+| `value` **`indexed`**           | `uint256` | The amount of native tokens (in Wei) sent to fund the created contract on deployment.                                                     |
+| `salt`                          | `bytes32` | The salt used to deterministically deploy the contract (`CREATE2` only). If `CREATE` opcode is used, the salt value will be `bytes32(0)`. |
 
 <br/>
 
@@ -1200,14 +1203,16 @@ Emitted whenever a contract is created
 event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 ```
 
-_Emitted when data at a key is changed_
+_The following data key/value pair has been changed in the ERC725Y storage: Data key: `dataKey`, data value: `dataValue`._
+
+Emitted when data at a specific `dataKey` was changed to a new value `dataValue`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                          |
-| ----------------------- | :-------: | ------------------------------------ |
-| `dataKey` **`indexed`** | `bytes32` | The data key which data value is set |
-| `dataValue`             |  `bytes`  | The data value to set                |
+| Name                    |   Type    | Description                                  |
+| ----------------------- | :-------: | -------------------------------------------- |
+| `dataKey` **`indexed`** | `bytes32` | The data key for which a bytes value is set. |
+| `dataValue`             |  `bytes`  | The value to set for the given data key.     |
 
 <br/>
 
@@ -1226,16 +1231,18 @@ _Emitted when data at a key is changed_
 event Executed(uint256 indexed operationType, address indexed target, uint256 indexed value, bytes4 selector);
 ```
 
-_Emitted when calling an address (EOA or contract)_
+_Called address `target` using `operationType` with `value` wei and `data`._
+
+Emitted when calling an address `target` (EOA or contract) with `value`.
 
 #### Parameters
 
-| Name                          |   Type    | Description                                                                                      |
-| ----------------------------- | :-------: | ------------------------------------------------------------------------------------------------ |
-| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `to` address (CALL, STATICALL or DELEGATECALL)        |
-| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2). |
-| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred with the call (in Wei)                                   |
-| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call                           |
+| Name                          |   Type    | Description                                                                                          |
+| ----------------------------- | :-------: | ---------------------------------------------------------------------------------------------------- |
+| `operationType` **`indexed`** | `uint256` | The low-level call opcode used to call the `target` address (`CALL`, `STATICALL` or `DELEGATECALL`). |
+| `target` **`indexed`**        | `address` | The address to call. `target` will be unused if a contract is created (operation types 1 and 2).     |
+| `value` **`indexed`**         | `uint256` | The amount of native tokens transferred along the call (in Wei).                                     |
+| `selector`                    | `bytes4`  | The first 4 bytes (= function selector) of the data sent with the call.                              |
 
 <br/>
 
@@ -1432,7 +1439,7 @@ Reverts when trying to transfer ownership to the `address(this)`.
 error ERC725X_ContractDeploymentFailed();
 ```
 
-reverts when contract deployment via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` failed. whether using operation type 1 (CREATE) or 2 (CREATE2).
+Reverts when contract deployment failed via [`execute`](#execute) or [`executeBatch`](#executebatch) functions, This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
 
 <br/>
 
@@ -1451,7 +1458,7 @@ reverts when contract deployment via `ERC725X.execute(...)`/`ERC725X.executeBatc
 error ERC725X_CreateOperationsRequireEmptyRecipientAddress();
 ```
 
-reverts when passing a `to` address while deploying a contract va `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` whether using operation type 1 (CREATE) or 2 (CREATE2).
+Reverts when passing a `to` address that is not `address(0)` (= address zero) while deploying a contract via [`execute`](#execute) or [`executeBatch`](#executebatch) functions. This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
 
 <br/>
 
@@ -1470,7 +1477,7 @@ reverts when passing a `to` address while deploying a contract va `ERC725X.execu
 error ERC725X_ExecuteParametersEmptyArray();
 ```
 
-reverts when one of the array parameter provided to `executeBatch(uint256[],address[],uint256[],bytes[]) is an empty array
+Reverts when one of the array parameter provided to the [`executeBatch`](#executebatch) function is an empty array.
 
 <br/>
 
@@ -1489,7 +1496,7 @@ reverts when one of the array parameter provided to `executeBatch(uint256[],addr
 error ERC725X_ExecuteParametersLengthMismatch();
 ```
 
-reverts when there is not the same number of operation, to addresses, value, and data.
+Reverts when there is not the same number of elements in the `operationTypes`, `targets` addresses, `values`, and `datas` array parameters provided when calling the [`executeBatch`](#executebatch) function.
 
 <br/>
 
@@ -1508,14 +1515,14 @@ reverts when there is not the same number of operation, to addresses, value, and
 error ERC725X_InsufficientBalance(uint256 balance, uint256 value);
 ```
 
-reverts when trying to send more native tokens `value` than available in current `balance`.
+Reverts when trying to send more native tokens `value` than available in current `balance`.
 
 #### Parameters
 
-| Name      |   Type    | Description                                                                              |
-| --------- | :-------: | ---------------------------------------------------------------------------------------- |
-| `balance` | `uint256` | the balance of the ERC725X contract.                                                     |
-| `value`   | `uint256` | the amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
+| Name      |   Type    | Description                                                                                                                            |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `balance` | `uint256` | The balance of native tokens of the ERC725X smart contract.                                                                            |
+| `value`   | `uint256` | The amount of native tokens sent via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` that is greater than the contract's `balance`. |
 
 <br/>
 
@@ -1534,7 +1541,7 @@ reverts when trying to send more native tokens `value` than available in current
 error ERC725X_MsgValueDisallowedInDelegateCall();
 ```
 
-the `value` parameter (= sending native tokens) is not allowed when making a delegatecall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because msg.value is persisting.
+Reverts when trying to send native tokens (`value` / `values[]` parameter of [`execute`](#execute) or [`executeBatch`](#executebatch) functions) while making a `delegatecall` (`operationType == 4`). Sending native tokens via `staticcall` is not allowed because `msg.value` is persisting.
 
 <br/>
 
@@ -1553,7 +1560,7 @@ the `value` parameter (= sending native tokens) is not allowed when making a del
 error ERC725X_MsgValueDisallowedInStaticCall();
 ```
 
-the `value` parameter (= sending native tokens) is not allowed when making a staticcall via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)` because sending native tokens is a state changing operation.
+Reverts when trying to send native tokens (`value` / `values[]` parameter of [`execute`](#execute) or [`executeBatch`](#executebatch) functions) while making a `staticcall` (`operationType == 3`). Sending native tokens via `staticcall` is not allowed because it is a state changing operation.
 
 <br/>
 
@@ -1572,7 +1579,7 @@ the `value` parameter (= sending native tokens) is not allowed when making a sta
 error ERC725X_NoContractBytecodeProvided();
 ```
 
-reverts when no contract bytecode was provided as parameter when trying to deploy a contract via `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`, whether using operation type 1 (CREATE) or 2 (CREATE2).
+Reverts when no contract bytecode was provided as parameter when trying to deploy a contract via [`execute`](#execute) or [`executeBatch`](#executebatch). This error can occur using either operation type 1 (`CREATE`) or 2 (`CREATE2`).
 
 <br/>
 
@@ -1591,13 +1598,13 @@ reverts when no contract bytecode was provided as parameter when trying to deplo
 error ERC725X_UnknownOperationType(uint256 operationTypeProvided);
 ```
 
-reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
+Reverts when the `operationTypeProvided` is none of the default operation types available. (CALL = 0; CREATE = 1; CREATE2 = 2; STATICCALL = 3; DELEGATECALL = 4)
 
 #### Parameters
 
-| Name                    |   Type    | Description |
-| ----------------------- | :-------: | ----------- |
-| `operationTypeProvided` | `uint256` | -           |
+| Name                    |   Type    | Description                                                                                            |
+| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------ |
+| `operationTypeProvided` | `uint256` | The unrecognised operation type number provided to `ERC725X.execute(...)`/`ERC725X.executeBatch(...)`. |
 
 <br/>
 
@@ -1616,7 +1623,7 @@ reverts when the `operationTypeProvided` is none of the default operation types 
 error ERC725Y_DataKeysValuesLengthMismatch();
 ```
 
-reverts when there is not the same number of elements in the lists of data keys and data values when calling setDataBatch.
+Reverts when there is not the same number of elements in the `datakeys` and `dataValues` array parameters provided when calling the [`setDataBatch`](#setdatabatch) function.
 
 <br/>
 

--- a/docs/libraries/LSP2ERC725YJSONSchema/LSP2Utils.md
+++ b/docs/libraries/LSP2ERC725YJSONSchema/LSP2Utils.md
@@ -486,7 +486,7 @@ The function assumes that the Data Value stored under the mapping Data Key is of
 :::
 
 ```solidity
-function removeElementFromArrayAndMap(contract IERC725Y ERC725YContract, bytes32 arrayKey, uint128 newArrayLength, bytes32 removedElementIndexKey, uint128 removedElementIndex, bytes32 removedElementMapKey) internal view returns (bytes32[] dataKeys, bytes[] dataValues);
+function removeElementFromArrayAndMap(contract IERC725Y erc725YContract, bytes32 arrayKey, uint128 newArrayLength, bytes32 removedElementIndexKey, uint128 removedElementIndex, bytes32 removedElementMapKey) internal view returns (bytes32[] dataKeys, bytes[] dataValues);
 ```
 
 Generates Data Key/Value pairs for removing an element from an LSP2 Array and a mapping Data Key.
@@ -495,7 +495,7 @@ Generates Data Key/Value pairs for removing an element from an LSP2 Array and a 
 
 | Name                     |        Type         | Description                                                   |
 | ------------------------ | :-----------------: | ------------------------------------------------------------- |
-| `ERC725YContract`        | `contract IERC725Y` | The ERC725Y contract.                                         |
+| `erc725YContract`        | `contract IERC725Y` | The ERC725Y contract.                                         |
 | `arrayKey`               |      `bytes32`      | The Data Key of Key Type Array.                               |
 | `newArrayLength`         |      `uint128`      | The new Array Length for the `arrayKey`.                      |
 | `removedElementIndexKey` |      `bytes32`      | The Data Key of Key Type Array Index for the removed element. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.11.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^5.1.0",
+        "@erc725/smart-contracts": "^5.2.0",
         "@openzeppelin/contracts": "^4.9.2",
         "@openzeppelin/contracts-upgradeable": "^4.9.2",
         "solidity-bytes-utils": "0.8.0"
@@ -618,12 +618,12 @@
       }
     },
     "node_modules/@erc725/smart-contracts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-5.1.0.tgz",
-      "integrity": "sha512-emOphI3RHzgpJiFyOlaM2SALR+ZbnImBau8Y5EuFuWar9BGzt5qGVIOHOvayO8roW8i88cycuSyQpcxogaGvMA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-5.2.0.tgz",
+      "integrity": "sha512-ML7eXO2l6GO847CKGTbSO7MxpfVpmZvVPA/4KutYwVkaZmPxB05WC2flPxUilUz7ws0S7xgyt50sPHLA1ffojA==",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.9.2",
-        "@openzeppelin/contracts-upgradeable": "^4.9.2",
+        "@openzeppelin/contracts": "^4.9.3",
+        "@openzeppelin/contracts-upgradeable": "^4.9.3",
         "solidity-bytes-utils": "0.8.0"
       }
     },
@@ -2550,14 +2550,14 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.2.tgz",
-      "integrity": "sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.3.tgz",
+      "integrity": "sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.2.tgz",
-      "integrity": "sha512-siviV3PZV/fHfPaoIC51rf1Jb6iElkYWnNYZ0leO23/ukXuvOyoC/ahy8jqiV7g+++9Nuo3n/rk5ajSN/+d/Sg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz",
+      "integrity": "sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A=="
     },
     "node_modules/@remix-project/remixd": {
       "version": "0.6.13",
@@ -23362,12 +23362,12 @@
       }
     },
     "@erc725/smart-contracts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-5.1.0.tgz",
-      "integrity": "sha512-emOphI3RHzgpJiFyOlaM2SALR+ZbnImBau8Y5EuFuWar9BGzt5qGVIOHOvayO8roW8i88cycuSyQpcxogaGvMA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@erc725/smart-contracts/-/smart-contracts-5.2.0.tgz",
+      "integrity": "sha512-ML7eXO2l6GO847CKGTbSO7MxpfVpmZvVPA/4KutYwVkaZmPxB05WC2flPxUilUz7ws0S7xgyt50sPHLA1ffojA==",
       "requires": {
-        "@openzeppelin/contracts": "^4.9.2",
-        "@openzeppelin/contracts-upgradeable": "^4.9.2",
+        "@openzeppelin/contracts": "^4.9.3",
+        "@openzeppelin/contracts-upgradeable": "^4.9.3",
         "solidity-bytes-utils": "0.8.0"
       }
     },
@@ -24552,14 +24552,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.2.tgz",
-      "integrity": "sha512-mO+y6JaqXjWeMh9glYVzVu8HYPGknAAnWyxTRhGeckOruyXQMNnlcW6w/Dx9ftLeIQk6N+ZJFuVmTwF7lEIFrg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.3.tgz",
+      "integrity": "sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.2.tgz",
-      "integrity": "sha512-siviV3PZV/fHfPaoIC51rf1Jb6iElkYWnNYZ0leO23/ukXuvOyoC/ahy8jqiV7g+++9Nuo3n/rk5ajSN/+d/Sg=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz",
+      "integrity": "sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A=="
     },
     "@remix-project/remixd": {
       "version": "0.6.13",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "homepage": "https://github.com/lukso-network/lsp-smart-contracts#readme",
   "dependencies": {
-    "@erc725/smart-contracts": "^5.1.0",
+    "@erc725/smart-contracts": "^5.2.0",
     "@openzeppelin/contracts": "^4.9.2",
     "@openzeppelin/contracts-upgradeable": "^4.9.2",
     "solidity-bytes-utils": "0.8.0"


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

Upgrade `@erc725/smart-contracts` package from `5.1.0` to `5.2.0` to get the latest up to date Natspec comments.

## 📄 Documentation

Update all the auto generated docs for the contracts that inherit the methods from ERC725X and ERC725Y, so that it gets the new Natspec comments.

