### PR TITLE
refactor: Change `abi.encodePacked` => `abi.encode` in LSP7 & LSP8

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -350,7 +350,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             data
         );
 
-        bytes memory lsp1Data = abi.encodePacked(address(0), to, amount, data);
+        bytes memory lsp1Data = abi.encode(address(0), to, amount, data);
         _notifyTokenReceiver(to, allowNonLSP1Recipient, lsp1Data);
     }
 
@@ -416,12 +416,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         emit Transfer(operator, from, address(0), amount, false, data);
 
-        bytes memory lsp1Data = abi.encodePacked(
-            from,
-            address(0),
-            amount,
-            data
-        );
+        bytes memory lsp1Data = abi.encode(from, address(0), amount, data);
         _notifyTokenSender(from, lsp1Data);
     }
 
@@ -473,7 +468,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         emit Transfer(operator, from, to, amount, allowNonLSP1Recipient, data);
 
-        bytes memory lsp1Data = abi.encodePacked(from, to, amount, data);
+        bytes memory lsp1Data = abi.encode(from, to, amount, data);
 
         _notifyTokenSender(from, lsp1Data);
         _notifyTokenReceiver(to, allowNonLSP1Recipient, lsp1Data);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -349,7 +349,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             data
         );
 
-        bytes memory lsp1Data = abi.encodePacked(address(0), to, tokenId, data);
+        bytes memory lsp1Data = abi.encode(address(0), to, tokenId, data);
         _notifyTokenReceiver(to, allowNonLSP1Recipient, lsp1Data);
     }
 
@@ -389,7 +389,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(operator, tokenOwner, address(0), tokenId, false, data);
 
-        bytes memory lsp1Data = abi.encodePacked(
+        bytes memory lsp1Data = abi.encode(
             tokenOwner,
             address(0),
             tokenId,
@@ -453,7 +453,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(operator, from, to, tokenId, allowNonLSP1Recipient, data);
 
-        bytes memory lsp1Data = abi.encodePacked(from, to, tokenId, data);
+        bytes memory lsp1Data = abi.encode(from, to, tokenId, data);
 
         _notifyTokenSender(from, lsp1Data);
         _notifyTokenReceiver(to, allowNonLSP1Recipient, lsp1Data);

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
@@ -45,12 +45,12 @@ contract UniversalReceiverDelegateTokenReentrant is ERC165Storage {
             typeId == _TYPEID_LSP8_TOKENSRECIPIENT
         ) {
             // if the optional data field when minting/transferring is existing, re-execute the data on token contract
-            if (data.length > 72) {
-                bytes memory tokenPayload = BytesLib.slice(
+            if (data.length > 160) {
+                (, , , bytes memory tokenPayload) = abi.decode(
                     data,
-                    72,
-                    data.length - 72
+                    (address, address, uint256, bytes)
                 );
+
                 bytes memory executePayload = abi.encodeWithSelector(
                     IERC725X.execute.selector,
                     0, // OPERATION CALL

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -958,7 +958,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
         // the call to the universalReceiver(...) in LSP7 sends the transfer details as `data` argument
         // all the params are packed/concatenated together.
-        const expectedReceivedData = ethers.utils.solidityPack(
+        const expectedReceivedData = abiCoder.encode(
           ['address', 'address', 'uint256', 'bytes'],
           [txParams.from, txParams.to, txParams.amount, txParams.data],
         );
@@ -1140,7 +1140,7 @@ export const shouldBehaveLikeLSP1Delegate = (
             token.address,
             0,
             LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
-            ethers.utils.solidityPack(
+            abiCoder.encode(
               ['address', 'address', 'uint256', 'bytes'],
               [ethers.constants.AddressZero, context.universalProfile1.address, 10_000, '0x'],
             ),
@@ -1275,11 +1275,15 @@ export const shouldBehaveLikeLSP1Delegate = (
       it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.universalProfile1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.universalProfile1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],
@@ -1354,11 +1358,15 @@ export const shouldBehaveLikeLSP1Delegate = (
       it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.universalProfile1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.universalProfile1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],
@@ -1437,11 +1445,15 @@ export const shouldBehaveLikeLSP1Delegate = (
       it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.universalProfile1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.universalProfile1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -919,18 +919,22 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
           .execute(OPERATION_TYPES.CALL, context.lsp9Vault1.address, 0, vaultTokenTransferCalldata);
       });
 
-      it('it should pass', async () => {
+      it('should pass', async () => {
         expect(tokenTransferTx).to.not.be.reverted;
       });
 
-      it('it should emit UniversalReceiver event', async () => {
+      it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.lsp9Vault1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.lsp9Vault1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],
@@ -1012,11 +1016,15 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.lsp9Vault1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.lsp9Vault1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],
@@ -1098,11 +1106,15 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
       it('should emit UniversalReceiver event', async () => {
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
-        const tokenTransferData = (
-          context.lsp9Vault1.address +
-          context.accounts.owner1.address.substring(2) +
-          tokensSentBytes32Value.substring(2)
-        ).toLowerCase();
+        const tokenTransferData = abiCoder.encode(
+          ['address', 'address', 'uint256', 'bytes'],
+          [
+            context.lsp9Vault1.address,
+            context.accounts.owner1.address,
+            tokensSentBytes32Value,
+            '0x',
+          ],
+        );
 
         const lsp1ReturnedData = ethers.utils.defaultAbiCoder.encode(
           ['string', 'bytes'],

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -17,6 +17,8 @@ import {
 // constants
 import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from '../../constants';
 
+import { abiCoder } from '../utils/helpers';
+
 export type LSP7TestAccounts = {
   owner: SignerWithAddress;
 
@@ -812,7 +814,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   const tx = await transferSuccessScenario(txParams, operator);
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
-                  const packedData = ethers.utils.solidityPack(
+                  const packedData = abiCoder.encode(
                     ['address', 'address', 'uint256', 'bytes'],
                     [txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
@@ -885,7 +887,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                   const tx = await transferSuccessScenario(txParams, operator);
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
-                  const packedData = ethers.utils.solidityPack(
+                  const packedData = abiCoder.encode(
                     ['address', 'address', 'uint256', 'bytes'],
                     [txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
@@ -1306,7 +1308,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
                     txParams.amount.map((_, index) => async () => {
                       const typeId =
                         '0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895';
-                      const packedData = ethers.utils.solidityPack(
+                      const packedData = abiCoder.encode(
                         ['address', 'address', 'uint256', 'bytes'],
                         [
                           txParams.from[index],

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -16,6 +16,7 @@ import {
 
 // helpers
 import { tokenIdAsBytes32 } from '../utils/tokens';
+import { abiCoder } from '../utils/helpers';
 
 // constants
 import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS, SupportedStandards } from '../../constants';
@@ -633,7 +634,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 const tx = await transferSuccessScenario(txParams, operator);
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
-                const packedData = ethers.utils.solidityPack(
+                const packedData = abiCoder.encode(
                   ['address', 'address', 'bytes32', 'bytes'],
                   [txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
@@ -732,7 +733,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 const tx = await transferSuccessScenario(txParams, operator);
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
-                const packedData = ethers.utils.solidityPack(
+                const packedData = abiCoder.encode(
                   ['address', 'address', 'bytes32', 'bytes'],
                   [txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
@@ -1076,7 +1077,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   txParams.tokenId.map((_, index) => async () => {
                     const typeId =
                       '0x29ddb589b1fb5fc7cf394961c1adf5f8c6454761adf795e67fe149f658abe895';
-                    const packedData = ethers.utils.solidityPack(
+                    const packedData = abiCoder.encode(
                       ['address', 'address', 'bytes32', 'bytes'],
                       [
                         txParams.from[index],


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## ♻️ Refactor

Change `abi.encodePacked` to `abi.encode` when notifying LSP1 from LSP7 or LSP8

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
