### PR TITLE
fix: add `receive()` function in LSP7 & LSP8 to silent compiler warning

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -17,6 +17,7 @@ import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
 import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
+import {LSP7TokenContractCannotHoldValue} from "./LSP7Errors.sol";
 
 import {
     _LSP17_EXTENSION_PREFIX
@@ -89,6 +90,19 @@ abstract contract LSP7DigitalAsset is
             revert InvalidFunctionSelector(callData);
         }
         return _fallbackLSP17Extendable(callData);
+    }
+
+    /**
+     * @dev Reverts whenever someone tries to send native tokens to a LSP7 contract.
+     * @notice LSP7 contract cannot receive native tokens.
+     */
+    receive() external payable virtual {
+        // revert on empty calls with no value
+        if (msg.value == 0) {
+            revert InvalidFunctionSelector(hex"00000000");
+        }
+
+        revert LSP7TokenContractCannotHoldValue();
     }
 
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -555,13 +555,16 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
                 _INTERFACEID_LSP1
             )
         ) {
-            operator.call(
-                abi.encodeWithSelector(
-                    ILSP1UniversalReceiver.universalReceiver.selector,
+            try
+                ILSP1UniversalReceiver(operator).universalReceiver(
                     _TYPEID_LSP7_TOKENOPERATOR,
                     lsp1Data
                 )
-            );
+            {
+                return;
+            } catch {
+                return;
+            }
         }
     }
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -18,6 +18,7 @@ import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
 import {_INTERFACEID_LSP7} from "./LSP7Constants.sol";
+import {LSP7TokenContractCannotHoldValue} from "./LSP7Errors.sol";
 
 import {
     _LSP17_EXTENSION_PREFIX
@@ -84,6 +85,19 @@ abstract contract LSP7DigitalAssetInitAbstract is
             revert InvalidFunctionSelector(callData);
         }
         return _fallbackLSP17Extendable(callData);
+    }
+
+    /**
+     * @dev Reverts whenever someone tries to send native tokens to a LSP7 contract.
+     * @notice LSP7 contract cannot receive native tokens.
+     */
+    receive() external payable virtual {
+        // revert on empty calls with no value
+        if (msg.value == 0) {
+            revert InvalidFunctionSelector(hex"00000000");
+        }
+
+        revert LSP7TokenContractCannotHoldValue();
     }
 
     /**

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -68,3 +68,12 @@ error LSP7TokenOwnerCannotBeOperator();
  * @dev Reverts when trying to decrease an operator's allowance to more than its current allowance.
  */
 error LSP7DecreasedAllowanceBelowZero();
+
+/**
+ * @dev Error occurs when sending native tokens to the LSP7 contract without sending any data.
+ *
+ * E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
+ *
+ * @notice LSP7 contract cannot receive native tokens.
+ */
+error LSP7TokenContractCannotHoldValue();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -4,57 +4,57 @@ pragma solidity ^0.8.4;
 // --- Errors
 
 /**
- * @dev reverts when `tokenId` has not been minted.
+ * @dev Reverts when `tokenId` has not been minted.
  */
 error LSP8NonExistentTokenId(bytes32 tokenId);
 
 /**
- * @dev reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+ * @dev Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
  */
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `caller` is not an allowed operator for `tokenId`.
+ * @dev Reverts when `caller` is not an allowed operator for `tokenId`.
  */
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 
 /**
- * @dev reverts when `operator` is already authorized for the `tokenId`.
+ * @dev Reverts when `operator` is already authorized for the `tokenId`.
  */
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 
 /**
- * @dev reverts when trying to set the zero address as an operator.
+ * @dev Reverts when trying to set the zero address as an operator.
  */
 error LSP8CannotUseAddressZeroAsOperator();
 
 /**
- * @dev reverts when trying to send token to the zero address.
+ * @dev Reverts when trying to send token to the zero address.
  */
 error LSP8CannotSendToAddressZero();
 
 /**
- * @dev reverts when specifying the same address for `from` and `to` in a token transfer.
+ * @dev Reverts when specifying the same address for `from` and `to` in a token transfer.
  */
 error LSP8CannotSendToSelf();
 
 /**
- * @dev reverts when `operator` is not an operator for the `tokenId`.
+ * @dev Reverts when `operator` is not an operator for the `tokenId`.
  */
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 
 /**
- * @dev reverts when `tokenId` has already been minted.
+ * @dev Reverts when `tokenId` has already been minted.
  */
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 
 /**
- * @dev reverts when the parameters used for `transferBatch` have different lengths.
+ * @dev Reverts when the parameters used for `transferBatch` have different lengths.
  */
 error LSP8InvalidTransferBatch();
 
 /**
- * @dev reverts if the `tokenReceiver` does not implement LSP1
+ * @dev Reverts if the `tokenReceiver` does not implement LSP1
  * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
@@ -62,12 +62,21 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 
 /**
- * @dev reverts if the `tokenReceiver` is an EOA
+ * @dev Reverts if the `tokenReceiver` is an EOA
  * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 
 /**
- * @dev reverts when trying to authorize or revoke the token's owner as an operator.
+ * @dev Reverts when trying to authorize or revoke the token's owner as an operator.
  */
 error LSP8TokenOwnerCannotBeOperator();
+
+/**
+ * @dev Error occurs when sending native tokens to the LSP8 contract without sending any data.
+ *
+ * E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
+ *
+ * @notice LSP8 contract cannot receive native tokens.
+ */
+error LSP8TokenContractCannotHoldValue();

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -20,6 +20,7 @@ import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
 import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
+import {LSP8TokenContractCannotHoldValue} from "./LSP8Errors.sol";
 
 import {
     _LSP17_EXTENSION_PREFIX
@@ -90,6 +91,19 @@ abstract contract LSP8IdentifiableDigitalAsset is
             revert InvalidFunctionSelector(callData);
         }
         return _fallbackLSP17Extendable(callData);
+    }
+
+    /**
+     * @dev Reverts whenever someone tries to send native tokens to a LSP8 contract.
+     * @notice LSP8 contract cannot receive native tokens.
+     */
+    receive() external payable virtual {
+        // revert on empty calls with no value
+        if (msg.value == 0) {
+            revert InvalidFunctionSelector(hex"00000000");
+        }
+
+        revert LSP8TokenContractCannotHoldValue();
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -534,13 +534,16 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
                 _INTERFACEID_LSP1
             )
         ) {
-            operator.call(
-                abi.encodeWithSelector(
-                    ILSP1UniversalReceiver.universalReceiver.selector,
+            try
+                ILSP1UniversalReceiver(operator).universalReceiver(
                     _TYPEID_LSP8_TOKENOPERATOR,
                     lsp1Data
                 )
-            );
+            {
+                return;
+            } catch {
+                return;
+            }
         }
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -20,6 +20,7 @@ import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";
 
 // constants
 import {_INTERFACEID_LSP8} from "./LSP8Constants.sol";
+import {LSP8TokenContractCannotHoldValue} from "./LSP8Errors.sol";
 
 import {
     _LSP17_EXTENSION_PREFIX
@@ -90,6 +91,19 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
             revert InvalidFunctionSelector(callData);
         }
         return _fallbackLSP17Extendable(callData);
+    }
+
+    /**
+     * @dev Reverts whenever someone tries to send native tokens to a LSP8 contract.
+     * @notice LSP8 contract cannot receive native tokens.
+     */
+    receive() external payable virtual {
+        // revert on empty calls with no value
+        if (msg.value == 0) {
+            revert InvalidFunctionSelector(hex"00000000");
+        }
+
+        revert LSP8TokenContractCannotHoldValue();
     }
 
     /**

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -58,6 +58,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP7 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1557,6 +1576,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP7 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1582,6 +1601,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP7 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1608,6 +1627,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7CompatibleERC20.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP7 contract.
+
+<br/>
+
 ### allowance
 
 :::note References
@@ -1727,6 +1746,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7CompatibleERC20.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -61,6 +61,21 @@ fallback() external payable;
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7CompatibleERC20Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+<br/>
+
 ### allowance
 
 :::note References
@@ -1765,6 +1780,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7CompatibleERC20Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -87,6 +87,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#receive)
+- Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP7 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1619,6 +1638,27 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
+- Error signature: `LSP7TokenContractCannotHoldValue()`
+- Error hash: `0x388f5adc`
+
+:::
+
+```solidity
+error LSP7TokenContractCannotHoldValue();
+```
+
+_LSP7 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP7 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -58,6 +58,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8IdentifiableDigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1323,7 +1342,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1342,7 +1361,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1361,7 +1380,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1380,7 +1399,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1399,7 +1418,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1424,7 +1443,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1450,7 +1469,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1476,7 +1495,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1505,7 +1524,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1530,7 +1549,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1555,7 +1574,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1563,6 +1582,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8IdentifiableDigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1581,7 +1621,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1349,7 +1368,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1368,7 +1387,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1387,7 +1406,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1406,7 +1425,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1425,7 +1444,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1450,7 +1469,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1476,7 +1495,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1502,7 +1521,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1531,7 +1550,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1556,7 +1575,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1581,7 +1600,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1589,6 +1608,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1607,7 +1647,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1333,7 +1352,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1352,7 +1371,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1371,7 +1390,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1432,7 +1451,7 @@ Reverts when setting `0` for the [`tokenSupplyCap`](#tokensupplycap). The max to
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1451,7 +1470,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1476,7 +1495,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1502,7 +1521,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1528,7 +1547,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1557,7 +1576,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1582,7 +1601,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1607,7 +1626,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1615,6 +1634,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1633,7 +1673,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8CompatibleERC721.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### approve
 
 :::note References
@@ -1728,7 +1747,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1747,7 +1766,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1766,7 +1785,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1785,7 +1804,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1804,7 +1823,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1829,7 +1848,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1855,7 +1874,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1881,7 +1900,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1910,7 +1929,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1935,7 +1954,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1960,7 +1979,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1968,6 +1987,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8CompatibleERC721.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1986,7 +2026,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -56,6 +56,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8Enumerable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1350,7 +1369,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1369,7 +1388,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1388,7 +1407,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1407,7 +1426,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1426,7 +1445,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1451,7 +1470,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1477,7 +1496,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1503,7 +1522,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1532,7 +1551,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1557,7 +1576,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1582,7 +1601,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1590,6 +1609,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8Enumerable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1608,7 +1648,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -61,6 +61,21 @@ fallback() external payable;
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8CompatibleERC721Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+<br/>
+
 ### approve
 
 :::note References
@@ -1768,7 +1783,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1787,7 +1802,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1806,7 +1821,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1825,7 +1840,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1844,7 +1859,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1869,7 +1884,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1895,7 +1910,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1921,7 +1936,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1950,7 +1965,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1975,7 +1990,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -2000,7 +2015,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -2008,6 +2023,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8CompatibleERC721Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -2026,7 +2062,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has already been minted.
+Reverts when `tokenId` has already been minted.
 
 #### Parameters
 
@@ -2051,7 +2087,7 @@ reverts when `tokenId` has already been minted.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -81,6 +81,25 @@ This function is executed when:
 
 <br/>
 
+### receive
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#receive)
+- Solidity implementation: [`LSP8Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol)
+
+:::
+
+```solidity
+receive() external payable;
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Reverts whenever someone tries to send native tokens to a LSP8 contract.
+
+<br/>
+
 ### authorizeOperator
 
 :::note References
@@ -1381,7 +1400,7 @@ Reverts when trying to edit the data key `LSP4TokenSymbol` after the digital ass
 error LSP8CannotSendToAddressZero();
 ```
 
-reverts when trying to send token to the zero address.
+Reverts when trying to send token to the zero address.
 
 <br/>
 
@@ -1400,7 +1419,7 @@ reverts when trying to send token to the zero address.
 error LSP8CannotSendToSelf();
 ```
 
-reverts when specifying the same address for `from` and `to` in a token transfer.
+Reverts when specifying the same address for `from` and `to` in a token transfer.
 
 <br/>
 
@@ -1419,7 +1438,7 @@ reverts when specifying the same address for `from` and `to` in a token transfer
 error LSP8CannotUseAddressZeroAsOperator();
 ```
 
-reverts when trying to set the zero address as an operator.
+Reverts when trying to set the zero address as an operator.
 
 <br/>
 
@@ -1438,7 +1457,7 @@ reverts when trying to set the zero address as an operator.
 error LSP8InvalidTransferBatch();
 ```
 
-reverts when the parameters used for `transferBatch` have different lengths.
+Reverts when the parameters used for `transferBatch` have different lengths.
 
 <br/>
 
@@ -1457,7 +1476,7 @@ reverts when the parameters used for `transferBatch` have different lengths.
 error LSP8NonExistentTokenId(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has not been minted.
+Reverts when `tokenId` has not been minted.
 
 #### Parameters
 
@@ -1482,7 +1501,7 @@ reverts when `tokenId` has not been minted.
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is not an operator for the `tokenId`.
+Reverts when `operator` is not an operator for the `tokenId`.
 
 #### Parameters
 
@@ -1508,7 +1527,7 @@ reverts when `operator` is not an operator for the `tokenId`.
 error LSP8NotTokenOperator(bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not an allowed operator for `tokenId`.
+Reverts when `caller` is not an allowed operator for `tokenId`.
 
 #### Parameters
 
@@ -1534,7 +1553,7 @@ reverts when `caller` is not an allowed operator for `tokenId`.
 error LSP8NotTokenOwner(address tokenOwner, bytes32 tokenId, address caller);
 ```
 
-reverts when `caller` is not the `tokenOwner` of the `tokenId`.
+Reverts when `caller` is not the `tokenOwner` of the `tokenId`.
 
 #### Parameters
 
@@ -1563,7 +1582,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1588,7 +1607,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
+Reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1613,7 +1632,7 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 error LSP8OperatorAlreadyAuthorized(address operator, bytes32 tokenId);
 ```
 
-reverts when `operator` is already authorized for the `tokenId`.
+Reverts when `operator` is already authorized for the `tokenId`.
 
 #### Parameters
 
@@ -1621,6 +1640,27 @@ reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8TokenContractCannotHoldValue
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8tokencontractcannotholdvalue)
+- Solidity implementation: [`LSP8Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol)
+- Error signature: `LSP8TokenContractCannotHoldValue()`
+- Error hash: `0x61f49442`
+
+:::
+
+```solidity
+error LSP8TokenContractCannotHoldValue();
+```
+
+_LSP8 contract cannot receive native tokens._
+
+Error occurs when sending native tokens to the LSP8 contract without sending any data. E.g. Sending value without passing a bytes4 function selector to call a LSP17 Extension.
 
 <br/>
 
@@ -1639,7 +1679,7 @@ reverts when `operator` is already authorized for the `tokenId`.
 error LSP8TokenIdAlreadyMinted(bytes32 tokenId);
 ```
 
-reverts when `tokenId` has already been minted.
+Reverts when `tokenId` has already been minted.
 
 #### Parameters
 
@@ -1664,7 +1704,7 @@ reverts when `tokenId` has already been minted.
 error LSP8TokenOwnerCannotBeOperator();
 ```
 
-reverts when trying to authorize or revoke the token's owner as an operator.
+Reverts when trying to authorize or revoke the token's owner as an operator.
 
 <br/>
 

--- a/tests/LSP17ContractExtension/LSP17ExtendableTokens.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17ExtendableTokens.behaviour.ts
@@ -145,30 +145,6 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
       '00000000000000000000000000000000'; // zero padded
   });
 
-  describe('when calling the contract with empty calldata', () => {
-    describe('when making a call without any value', () => {
-      it('should revert', async () => {
-        await expect(
-          context.accounts[0].sendTransaction({
-            to: context.contract.address,
-          }),
-        ).to.be.revertedWithCustomError(context.contract, 'InvalidFunctionSelector');
-      });
-    });
-
-    describe('when making a call with sending value', () => {
-      it('should revert', async () => {
-        const amountSent = 200;
-        await expect(
-          context.accounts[0].sendTransaction({
-            to: context.contract.address,
-            value: amountSent,
-          }),
-        ).to.be.revertedWithCustomError(context.contract, 'InvalidFunctionSelector');
-      });
-    });
-  });
-
   describe('when calling the contract with calldata', () => {
     describe("when calling method that doesn't exist", () => {
       describe('when there is no extension for the function called', () => {

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -2144,6 +2144,32 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
       });
     });
   });
+
+  describe('when calling the contract with empty calldata', () => {
+    describe('when making a call without any value', () => {
+      it('should revert', async () => {
+        await expect(
+          context.accounts.anyone.sendTransaction({
+            to: context.lsp7.address,
+          }),
+        )
+          .to.be.revertedWithCustomError(context.lsp7, 'InvalidFunctionSelector')
+          .withArgs('0x00000000');
+      });
+    });
+
+    describe('when making a call with sending value', () => {
+      it('should revert', async () => {
+        const amountSent = 200;
+        await expect(
+          context.accounts.anyone.sendTransaction({
+            to: context.lsp7.address,
+            value: amountSent,
+          }),
+        ).to.be.revertedWithCustomError(context.lsp7, 'LSP7TokenContractCannotHoldValue');
+      });
+    });
+  });
 };
 
 export type LSP7InitializeTestContext = {

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -1765,6 +1765,32 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
       });
     });
   });
+
+  describe('when calling the contract with empty calldata', () => {
+    describe('when making a call without any value', () => {
+      it('should revert', async () => {
+        await expect(
+          context.accounts.anyone.sendTransaction({
+            to: context.lsp8.address,
+          }),
+        )
+          .to.be.revertedWithCustomError(context.lsp8, 'InvalidFunctionSelector')
+          .withArgs('0x00000000');
+      });
+    });
+
+    describe('when making a call with sending value', () => {
+      it('should revert', async () => {
+        const amountSent = 200;
+        await expect(
+          context.accounts.anyone.sendTransaction({
+            to: context.lsp8.address,
+            value: amountSent,
+          }),
+        ).to.be.revertedWithCustomError(context.lsp8, 'LSP8TokenContractCannotHoldValue');
+      });
+    });
+  });
 };
 
 export type LSP8InitializeTestContext = {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## ♻️ Refactor

This PR introduces the following changes:

- New error in both LSP7 & LSP8 for not allowing sending native tokens to LSP7 & LSP8 contracts.
- Add `receive()` that reverts in LSP7 & LSP8

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
