### PR TITLE
chore: fix comment typo in LSP0

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -449,13 +449,13 @@ abstract contract LSP0ERC725AccountCore is
             }
         }
 
-        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
+        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 typeId>}
         bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
             _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
             bytes20(typeId)
         );
 
-        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}
+        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 typeId>}
         bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
         bytes memory resultTypeIdDelegate;
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

## 📄 Documentation
The comments in LSP0 > universalReceiver was mentioning `
{_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY + <bytes32 typeId>}` instead of `
{_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 typeId>}`