### PR TITLE
fix: lsp1 urd prefix docs and comparison

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -397,7 +397,7 @@ abstract contract LSP0ERC725AccountCore is
      *      - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
      *
      *
-     * 2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes32(typeId)`.
+     * 2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes20(typeId)`.
      *   (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
      *
      *      - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.
@@ -449,13 +449,13 @@ abstract contract LSP0ERC725AccountCore is
             }
         }
 
-        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 typeId>}
+        // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + bytes2(0) + bytes20(typeId)}
         bytes32 lsp1typeIdDelegateKey = LSP2Utils.generateMappingKey(
             _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
             bytes20(typeId)
         );
 
-        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 typeId>}
+        // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + bytes2(0) + bytes20(typeId)}
         bytes memory lsp1TypeIdDelegateValue = _getData(lsp1typeIdDelegateKey);
         bytes memory resultTypeIdDelegate;
 

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -292,7 +292,7 @@ abstract contract LSP6SetDataModule {
             // LSP1UniversalReceiverDelegate or LSP1UniversalReceiverDelegate:<typeId>
         } else if (
             inputDataKey == _LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY ||
-            bytes12(inputDataKey) == _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX
+            bytes10(inputDataKey) == _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX
         ) {
             // CHECK that `dataValue` contains exactly 20 bytes, which corresponds to an address for a LSP1 Delegate contract
             if (inputDataValue.length != 20 && inputDataValue.length != 0) {

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -305,7 +305,7 @@ contract LSP9VaultCore is
      *      - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
      *
      *
-     * 2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes32(typeId)`.
+     * 2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes20(typeId)`.
      *   (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
      *
      *      - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -242,9 +242,9 @@ contract LSP9VaultCore is
         bool isURD = _validateAndIdentifyCaller();
         if (isURD) {
             if (
-                bytes12(dataKey) == _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX ||
+                bytes10(dataKey) == _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX ||
                 bytes6(dataKey) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
-                bytes12(dataKey) == _LSP17_EXTENSION_PREFIX
+                bytes10(dataKey) == _LSP17_EXTENSION_PREFIX
             ) {
                 revert LSP1DelegateNotAllowedToSetDataKey(dataKey);
             }
@@ -275,10 +275,10 @@ contract LSP9VaultCore is
         for (uint256 i = 0; i < dataKeys.length; ) {
             if (isURD) {
                 if (
-                    bytes12(dataKeys[i]) ==
+                    bytes10(dataKeys[i]) ==
                     _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX ||
                     bytes6(dataKeys[i]) == _LSP6KEY_ADDRESSPERMISSIONS_PREFIX ||
-                    bytes12(dataKeys[i]) == _LSP17_EXTENSION_PREFIX
+                    bytes10(dataKeys[i]) == _LSP17_EXTENSION_PREFIX
                 ) {
                     revert LSP1DelegateNotAllowedToSetDataKey(dataKeys[i]);
                 }

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -802,7 +802,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
 
-2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes32(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
+2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes20(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
 
 - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.
 

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -751,7 +751,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
 
-2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes32(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
+2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes20(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
 
 - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.
 

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -751,7 +751,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
 
-2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes32(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
+2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes32(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
 
 - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -745,7 +745,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 - If yes, call this address with the typeId and data (params), along with additional calldata consisting of 20 bytes of `msg.sender` and 32 bytes of `msg.value`. If not, continue the execution of the function.
 
-2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes32(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
+2. Query the [ERC-725Y] storage with the data key [_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX] + `bytes2(0)` + `bytes20(typeId)`. (Check [LSP-2-ERC725YJSONSchema] for encoding the data key)
 
 - If there is an address stored under the data key, check if this address supports the LSP1 interfaceId.
 

--- a/tests/foundry/LSP6KeyManager/LSP6SetDataTest.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6SetDataTest.t.sol
@@ -43,8 +43,8 @@ contract LSP6SetDataTest is Test {
         // dataKey cannot be LSP1, LSP6, or LSP17 data key
         vm.assume(bytes16(dataKey) != _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX);
         vm.assume(bytes6(dataKey) != _LSP6KEY_ADDRESSPERMISSIONS_PREFIX);
-        vm.assume(bytes12(dataKey) != _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX);
-        vm.assume(bytes12(dataKey) != _LSP17_EXTENSION_PREFIX);
+        vm.assume(bytes10(dataKey) != _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX);
+        vm.assume(bytes10(dataKey) != _LSP17_EXTENSION_PREFIX);
 
         // Give owner ability to transfer ownership
         bytes32 ownerDataKey = LSP2Utils.generateMappingWithGroupingKey(
@@ -126,8 +126,8 @@ contract LSP6SetDataTest is Test {
         // dataKey cannot be LSP1, LSP6, or LSP17 data key
         vm.assume(bytes16(dataKey) != _LSP6KEY_ADDRESSPERMISSIONS_ARRAY_PREFIX);
         vm.assume(bytes6(dataKey) != _LSP6KEY_ADDRESSPERMISSIONS_PREFIX);
-        vm.assume(bytes12(dataKey) != _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX);
-        vm.assume(bytes12(dataKey) != _LSP17_EXTENSION_PREFIX);
+        vm.assume(bytes10(dataKey) != _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX);
+        vm.assume(bytes10(dataKey) != _LSP17_EXTENSION_PREFIX);
 
         // Give owner ability to transfer ownership
         bytes32 ownerDataKey = LSP2Utils.generateMappingWithGroupingKey(


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

Fixes for the docs and comments in code related to LSP1 URD prefix.
Also, fixes in conditions where `_LSP17_EXTENSION_PREFIX` and `_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX` are being compared against `bytes12` instead of `bytes10`.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
