### PR TITLE
docs: add Natspec comments to document read-only permissions verifications in `LSP6KeyManager` via `lsp20VerifyCall`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.5;
 
-import "hardhat/console.sol";
-
 // interfaces
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {
@@ -552,8 +550,6 @@ abstract contract LSP6KeyManagerCore is
                 uint256 value,
                 bytes memory data
             ) = abi.decode(payload[4:], (uint256, address, uint256, bytes));
-
-            console.log("breakpoint");
 
             LSP6ExecuteModule._verifyCanExecute(
                 _target,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.5;
 
+import "hardhat/console.sol";
+
 // interfaces
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import {
@@ -550,6 +552,8 @@ abstract contract LSP6KeyManagerCore is
                 uint256 value,
                 bytes memory data
             ) = abi.decode(payload[4:], (uint256, address, uint256, bytes));
+
+            console.log("breakpoint");
 
             LSP6ExecuteModule._verifyCanExecute(
                 _target,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -305,6 +305,16 @@ abstract contract LSP6KeyManagerCore is
 
     /**
      * @inheritdoc ILSP20
+     *
+     * @custom:hint This function can call by any other address than the {`target`}.
+     * This allows to verify permissions in a _"read-only"_ manner.
+     *
+     * Anyone can call this function to verify if the `caller` has the right permissions to perform the abi-encoded function call `data`
+     * on the {`target`} contract (while sending `msgValue` alongside the call).
+     *
+     * If the permissions have been verified successfully and `caller` is authorized, one of the following two LSP20 magic value will be returned:
+     *  - `0x9bf04b00`: LSP20 magic value **without** post verification (last byte is `0x00`).
+     *  - `0x9bf04b01`: LSP20 magic value **with** post-verification (last byte is `0x01`).
      */
     function lsp20VerifyCall(
         address caller,
@@ -332,8 +342,8 @@ abstract contract LSP6KeyManagerCore is
                     ? _LSP20_VERIFY_CALL_MAGIC_VALUE_WITHOUT_POST_VERIFICATION
                     : _LSP20_VERIFY_CALL_MAGIC_VALUE_WITH_POST_VERIFICATION;
         }
-        // If a different address is invoking the verification, do not change the state
-        // and do read-only verification
+        /// @dev If a different address is invoking the verification,
+        /// do not change the state or emit the event to allow read-only verification
         else {
             bool isReentrantCall = _reentrancyStatus;
 

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -117,7 +117,15 @@ contract KeyManagerInternalTester is LSP6KeyManager {
         address from,
         uint256 msgValue,
         bytes calldata payload
-    ) public view {
+    ) public {
         super._verifyPermissions(from, msgValue, payload);
+
+        // This event is emitted just for a sake of not marking this function as `view`,
+        // as Hardhat has a bug that does not catch error that occured from failed `abi.decode`
+        // inside view functions.
+        // See these issues in the Github repository of Hardhat:
+        //  - https://github.com/NomicFoundation/hardhat/issues/3084
+        //  - https://github.com/NomicFoundation/hardhat/issues/3475
+        emit PermissionsVerified(from, msgValue, bytes4(payload));
     }
 }

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -337,6 +337,15 @@ Checks if a signature was signed by a controller that has the permission `SIGN`.
 
 :::
 
+:::tip Hint
+
+This function can call by any other address than the {`target`}. This allows to verify permissions in a _&quot;read-only&quot;_ manner. Anyone can call this function to verify if the `caller` has the right permissions to perform the abi-encoded function call `data` on the {`target`} contract (while sending `msgValue` alongside the call). If the permissions have been verified successfully and `caller` is authorized, one of the following two LSP20 magic value will be returned:
+
+- `0x9bf04b00`: LSP20 magic value **without** post verification (last byte is `0x00`).
+- `0x9bf04b01`: LSP20 magic value **with** post-verification (last byte is `0x01`).
+
+:::
+
 ```solidity
 function lsp20VerifyCall(
   address caller,

--- a/tests/LSP6KeyManager/internals/Execute.internal.ts
+++ b/tests/LSP6KeyManager/internals/Execute.internal.ts
@@ -43,7 +43,7 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
       ).to.not.be.reverted;
     });
 
-    it('should revert with `InvalidPayload` error if the address param is not left padded with 12 x `00` bytes', async () => {
+    it('should revert if the address param is not left padded with 12 x `00` bytes', async () => {
       const executeParameters = {
         operationType: OPERATION_TYPES.CALL,
         to: context.accounts[3].address,
@@ -68,11 +68,15 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
         invalidPart + addressPart,
       );
 
-      await context.keyManagerInternalTester.verifyPermissions(
-        context.owner.address,
-        0,
-        invalidCalldata,
-      );
+      // `abi.decode` will fail to decode an `address` type not padded with `00` on the left,
+      // resulting in a revert without any error data
+      await expect(
+        context.keyManagerInternalTester.verifyPermissions(
+          context.owner.address,
+          0,
+          invalidCalldata,
+        ),
+      ).to.be.reverted;
     });
   });
 };


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

In QA 15 from Code4Rena, it is suggested that the event emission was missing in the function `lsp20VerifyCall` when the caller was not the `target`

![image](https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/0b021fef-63c5-492d-a3f5-c03310b8bbaf)

![image](https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/61c1e64e-b575-4749-ac68-8d493ac8263b)

This is intended behaviour to allow permissions verification in a read-only manner, without toggling the reentrancy flag or emitting the event (such as in the case of EIP4337). Add Natspec comments to document this intended behaviour.

### PR Checklist

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
