### PR TITLE
fix: add check for permission value length in `_getPermissionToSetControllerPermissions` and in `LSP6Utils` function `getPermissionsFor`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -431,12 +431,16 @@ abstract contract LSP6SetDataModule {
         address controlledContract,
         bytes32 inputPermissionDataKey
     ) internal view virtual returns (bytes32) {
+        // extract the address of the controller from the data key `AddressPermissions:Permissions:<controller>`
+        address controller = address(bytes20(inputPermissionDataKey << 96));
+
+        bytes32 controllerPermissions = ERC725Y(controlledContract)
+            .getPermissionsFor(controller);
+
         return
             // if there is nothing stored under the data key, we are trying to ADD a new controller.
             // if there are already some permissions set under the data key, we are trying to CHANGE the permissions of a controller.
-            bytes32(
-                ERC725Y(controlledContract).getData(inputPermissionDataKey)
-            ) == bytes32(0)
+            controllerPermissions == bytes32(0)
                 ? _PERMISSION_ADDCONTROLLER
                 : _PERMISSION_EDITPERMISSIONS;
     }

--- a/contracts/LSP6KeyManager/LSP6Utils.sol
+++ b/contracts/LSP6KeyManager/LSP6Utils.sol
@@ -50,6 +50,9 @@ library LSP6Utils {
      * @param caller The controller address to read the permissions from.
      *
      * @return A `bytes32` BitArray containing the permissions of a controller address.
+     *
+     * @custom:info If the raw value fetched from the ERC725Y storage of `target` is not 32 bytes long, this is considered
+     * like _"no permissions are set"_ and will return 32 x `0x00` bytes as `bytes32(0)`.
      */
     function getPermissionsFor(
         IERC725Y target,
@@ -61,6 +64,10 @@ library LSP6Utils {
                 bytes20(caller)
             )
         );
+
+        if (permissions.length != 32) {
+            return bytes32(0);
+        }
 
         return bytes32(permissions);
     }

--- a/docs/libraries/LSP6KeyManager/LSP6Utils.md
+++ b/docs/libraries/LSP6KeyManager/LSP6Utils.md
@@ -26,6 +26,13 @@ Internal functions cannot be called externally, whether from other smart contrac
 
 ### getPermissionsFor
 
+:::info
+
+If the raw value fetched from the ERC725Y storage of `target` is not 32 bytes long, this is considered
+like _&quot;no permissions are set&quot;_ and will return 32 x `0x00` bytes as `bytes32(0)`.
+
+:::
+
 ```solidity
 function getPermissionsFor(contract IERC725Y target, address caller) internal view returns (bytes32);
 ```

--- a/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
@@ -48,13 +48,97 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
   let permissionArrayKeys: string[] = [];
   let permissionArrayValues: string[] = [];
 
+  // addresses with not 32 bytes long permissions value set
+  // used to check that the caller editing the permissions value for these controllers requires the permission ADDCONTROLLER,
+  const callerHasAllPermissionsTestCase = {
+    addressWith16BytesHexPermissionsLength: '',
+    addressWith40BytesHexPermsissionsLength: '',
+  };
+
+  const callerHasAddControllerTestCase = {
+    addressWith16BytesHexPermissionsLength: '',
+    addressWith40BytesHexPermsissionsLength: '',
+  };
+
+  const callerHasEditPermissionsTestCase = {
+    addressWith16BytesHexPermissionsLength: '',
+    addressWith40BytesHexPermsissionsLength: '',
+  };
+
+  const callerHasSetDataTestCase = {
+    addressWith16BytesHexPermissionsLength: '',
+    addressWith40BytesHexPermsissionsLength: '',
+  };
+
   before('setup', async () => {
     context = await buildContext();
 
+    callerHasAllPermissionsTestCase.addressWith16BytesHexPermissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasAllPermissionsTestCase.addressWith40BytesHexPermsissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasAddControllerTestCase.addressWith16BytesHexPermissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasAddControllerTestCase.addressWith40BytesHexPermsissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasEditPermissionsTestCase.addressWith16BytesHexPermissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasEditPermissionsTestCase.addressWith40BytesHexPermsissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasSetDataTestCase.addressWith16BytesHexPermissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    callerHasSetDataTestCase.addressWith40BytesHexPermsissionsLength =
+      new ethers.Wallet.createRandom().address.toLowerCase();
+
+    const firstSetupPermissionsKeys = [
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasAllPermissionsTestCase.addressWith16BytesHexPermissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasAllPermissionsTestCase.addressWith40BytesHexPermsissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasAddControllerTestCase.addressWith16BytesHexPermissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasAddControllerTestCase.addressWith40BytesHexPermsissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasEditPermissionsTestCase.addressWith16BytesHexPermissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasEditPermissionsTestCase.addressWith40BytesHexPermsissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasSetDataTestCase.addressWith16BytesHexPermissionsLength.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        callerHasSetDataTestCase.addressWith40BytesHexPermsissionsLength.substring(2),
+    ];
+
+    // We need to setup these first from the start, as the setup and teardown in the tests reset the permissions via the Key Manager,
+    // as the Key Manager will revert with custom error `InvalidDataValuesForDataKeys(AddressPermissions:Permissions:<controller>, invalidPermissionValue)`
+    const firstSetupPermissionsValues = [
+      // 16 bytes long hex string = not 32 bytes long = equivalent to No Permissions Set
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      // 40 bytes long hex string = not 32 bytes long = equivalent to No Permissions Set
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      // same for other controllers (just repeated)
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ];
+
     await setupKeyManager(
       context,
-      [ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2)],
-      [ALL_PERMISSIONS],
+      [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ...firstSetupPermissionsKeys,
+      ],
+      [ALL_PERMISSIONS, ...firstSetupPermissionsValues],
     );
   });
 
@@ -100,7 +184,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
         PERMISSIONS.SETDATA,
         // placeholder permission
         PERMISSIONS.TRANSFERVALUE,
-        // 0x0000... = similar to empty, or 'no permissions set'
+        // `bytes32(0)` = similar to empty, or 'no permissions set'
         '0x0000000000000000000000000000000000000000000000000000000000000000',
       ];
 
@@ -183,6 +267,36 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           // prettier-ignore
           const result = await context.universalProfile.getData(key);
           expect(result).to.equal(value);
+        });
+
+        it('should be allowed to ADD a new controller if this address has a 16 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasAllPermissionsTestCase.addressWith16BytesHexPermissionsLength.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await context.keyManager.connect(context.owner).execute(payload);
+          expect(await context.universalProfile.getData(key)).to.equal(value);
+        });
+
+        it('should be allowed to ADD a new controller if this address has a 40 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasAllPermissionsTestCase.addressWith40BytesHexPermsissionsLength.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await context.keyManager.connect(context.owner).execute(payload);
+          expect(await context.universalProfile.getData(key)).to.equal(value);
         });
 
         describe('when editing `AddressPermissions[]` array length', () => {
@@ -429,6 +543,36 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
         });
 
+        it('should be allowed to ADD a new controller if this address has a 16 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasAddControllerTestCase.addressWith16BytesHexPermissionsLength.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await context.keyManager.connect(canOnlyAddController).execute(payload);
+          expect(await context.universalProfile.getData(key)).to.equal(value);
+        });
+
+        it('should be allowed to ADD a new controller if this address has a 40 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasAddControllerTestCase.addressWith40BytesHexPermsissionsLength.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await context.keyManager.connect(canOnlyAddController).execute(payload);
+          expect(await context.universalProfile.getData(key)).to.equal(value);
+        });
+
         describe('when editing `AddressPermissions[]` array length', () => {
           it('should be allowed to increment the length', async () => {
             const key = ERC725YDataKeys.LSP6['AddressPermissions[]'].length;
@@ -599,7 +743,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           ]);
         });
 
-        it('should not be allowed to ADD a permission', async () => {
+        it('should not be allowed to ADD a new controller', async () => {
           const newController = ethers.Wallet.createRandom();
 
           const key =
@@ -618,7 +762,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it('should not be allowed to set (= ADD) a permission for an address that has 32 x 0 bytes (0x0000...0000) as permission value', async () => {
+        it('should not be allowed to ADD a new controller if this address had 32 x 0 bytes (0x0000...0000) already as permission value', async () => {
           const key =
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
@@ -634,7 +778,40 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
         });
 
-        it('should be allowed to CHANGE a permission', async () => {
+        it('should not be allowed to ADD a new controller if this address has a 16 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasEditPermissionsTestCase.addressWith16BytesHexPermissionsLength.substring(2);
+
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
+        });
+
+        it('should not be allowed to ADD a new controller if this address has a 40 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasEditPermissionsTestCase.addressWith40BytesHexPermsissionsLength.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
+        });
+
+        it('should be allowed to EDIT the existing permissions of a controller', async () => {
           const key =
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressToEditPermissions.address.substring(2);
@@ -848,6 +1025,39 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
           const key =
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             addressWithZeroHexPermissions.address.substring(2);
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlySetData).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
+        });
+
+        it('should not be allowed to ADD a new controller if this address has a 16 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasSetDataTestCase.addressWith16BytesHexPermissionsLength.substring(2);
+
+          const value = PERMISSIONS.SETDATA;
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlySetData).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlySetData.address, 'ADDCONTROLLER');
+        });
+
+        it('should not be allowed to ADD a new controller if this address has a 40 bytes long bytes value already set under its permission', async () => {
+          const key =
+            ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+            callerHasSetDataTestCase.addressWith40BytesHexPermsissionsLength.substring(2);
           const value = PERMISSIONS.SETDATA;
 
           const payload = context.universalProfile.interface.encodeFunctionData('setData', [


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug

- **Important Bug Fix**: fix the check against permissions `ADD_CONTROLLER` vs `EDIT_PERMISSIONS`. If the permission value stored under the controller we are setting the permissions for is not exactly 32 bytes long, consider it as _"no permissions set"_, and **require the permission `ADD_CONTROLLER`**.

- Add check in function `getPermissionsFor` to ensure that the raw `bytes` value of a permission fetched from the ERC725Y storage are **exactly 32 bytes long**. If they raw bytes value is not 32 bytes long, consider this as no permissions check.

This is to make it consistent with the input validation below in `LSP6SetDataModule`.

![image](https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/2baee1f2-426b-4c2e-a013-59b6f19fc65e)

## 📄 Documentation

- Add info Natspec tag above this function and update auto generated docs.

## 🧪 Tests

- Add extra tests for the new bug fix mentioned above, depending on the caller's permissions.