### PR TITLE
chore: fix ESLint warnings in LSP17 and LSP23 tests

### DIFF
--- a/tests/LSP17ContractExtension/LSP17ExtendableTokens.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17ExtendableTokens.behaviour.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 
@@ -18,12 +17,6 @@ import {
   TransferExtension,
   ReenterAccountExtension__factory,
   ReenterAccountExtension,
-  OnERC721ReceivedExtension,
-  OnERC721ReceivedExtension__factory,
-  RequireCallbackToken,
-  RequireCallbackToken__factory,
-  RevertFallbackExtension,
-  RevertFallbackExtension__factory,
   BuyExtension,
   BuyExtension__factory,
 } from '../../types';
@@ -43,7 +36,6 @@ export type LSP17TestContext = {
 export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestContext>) => {
   let context: LSP17TestContext;
   let notExistingFunctionSignature,
-    onERC721ReceivedFunctionSelector,
     checkMsgVariableFunctionSelector,
     nameFunctionSelector,
     ageFunctionSelector,
@@ -63,7 +55,6 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
     revertStringFunctionExtensionHandlerKey,
     revertCustomFunctionExtensionHandlerKey,
     emitEventFunctionExtensionHandlerKey,
-    onERC721ReceivedFunctionExtensionHandlerKey,
     buyFunctionExtensionHandlerKey,
     supportsInterfaceFunctionExtensionHandlerKey;
 
@@ -96,9 +87,6 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
     // reenterAccount(bytes)
     reenterAccountFunctionSelector = '0x864e5589';
-
-    // onERC721Received(address,address,uint256,bytes)
-    onERC721ReceivedFunctionSelector = '0x150b7a02';
 
     // buy()
     buyFunctionSelector = '0xa6f2ae3a';
@@ -144,11 +132,6 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
     emitEventFunctionExtensionHandlerKey =
       ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
       emitEventFunctionSelector.substring(2) +
-      '00000000000000000000000000000000'; // zero padded
-
-    onERC721ReceivedFunctionExtensionHandlerKey =
-      ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-      onERC721ReceivedFunctionSelector.substring(2) +
       '00000000000000000000000000000000'; // zero padded
 
     buyFunctionExtensionHandlerKey =
@@ -652,8 +635,6 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
     describe('when calling with calldata that is not checked for extension', () => {
       describe('when calling with a payload of length less than 4bytes', () => {
-        let revertFallbackExtension: RevertFallbackExtension;
-
         it('should revert', async () => {
           await expect(
             context.accounts[0].sendTransaction({

--- a/tests/LSP23LinkedContractsDeployment/LSP23LinkedContractsDeployment.test.ts
+++ b/tests/LSP23LinkedContractsDeployment/LSP23LinkedContractsDeployment.test.ts
@@ -779,12 +779,8 @@ describe('UniversalProfileDeployer', function () {
       expect(secondaryAddress).to.not.equal(ethers.constants.AddressZero);
     });
     it('should deploy proxies with correct initialization calldata (with secondary contract contains extraParams)', async function () {
-      const {
-        LSP23LinkedContractsFactory,
-        upInitPostDeploymentModule,
-        universalProfileInit,
-        keyManagerInit,
-      } = await deployImplementationContracts();
+      const { LSP23LinkedContractsFactory, upInitPostDeploymentModule, universalProfileInit } =
+        await deployImplementationContracts();
 
       const KeyManagerWithExtraParamsFactory = await ethers.getContractFactory(
         'KeyManagerInitWithExtraParams',


### PR DESCRIPTION
# What does this PR introduce?

## 🧹 Chore

There were some ESLint warnings introduced in #697 that got missed + one ES Lint warning in the LSP23 tests.

<img width="1728" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/217a65b6-3486-4b21-913a-d0a0c948d711">

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
