### PR TITLE
build: add TS types for JSON Metadata of LSP3 and LSP4

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,20 @@ See the [issue related to Hardhat Typescript + ES Modules](https://hardhat.org/h
 
 ### Typescript types
 
-The following additional typescript types are also available.
+The following additional typescript types are also available, including types for the JSON format of the LSP3 Profile and LSP4 Digital Asset metadata.
 
 ```ts
 import {
   LSP2ArrayKey,
   LSPSupportedStandard,
   LSP6PermissionName,
-  LSPErrorInfo,
+  LSP3ProfileMetadataJSON,
+  LSP3ProfileMetadata,
+  LSP4DigitalAssetMetadataJSON,
+  LSP4DigitalAssetMetadata,
+  ImageMetadata,
+  LinkMetadata,
+  AssetMetadata,
 } from "@lukso/lsp-smart-contracts/constants";
 ```
 

--- a/constants.ts
+++ b/constants.ts
@@ -90,6 +90,54 @@ export const OPERATION_TYPES = {
 export type LSP2ArrayKey = { length: string; index: string };
 export type LSPSupportedStandard = { key: string; value: string };
 
+// JSON Metadata
+
+export type LSP3ProfileMetadataJSON = {
+  LSP3Profile: LSP3ProfileMetadata;
+};
+
+export type LSP3ProfileMetadata = {
+  name: string;
+  description: string;
+  profileImage?: ImageMetadata[];
+  backgroundImage?: ImageMetadata[];
+  tags?: string[];
+  links?: LinkMetadata[];
+  avatar?: AssetMetadata[];
+};
+
+export type LSP4DigitalAssetMetadataJSON = {
+  LSP4Metadata: LSP4DigitalAssetMetadata;
+};
+
+export type LSP4DigitalAssetMetadata = {
+  description: string;
+  links: LinkMetadata[];
+  images: ImageMetadata[][];
+  assets: AssetMetadata[];
+  icon: ImageMetadata[];
+};
+
+export type ImageMetadata = {
+  width: number;
+  height: number;
+  hashFunction: string;
+  hash: string;
+  url: string;
+};
+
+export type LinkMetadata = {
+  title: string;
+  url: string;
+};
+
+export type AssetMetadata = {
+  hashFunction: string;
+  hash: string;
+  url: string;
+  fileType: string;
+};
+
 /**
  * @dev list of ERC725Y keys from the LSP standards.
  * Can be used to detect if a contract implements a specific LSP Metadata standard


### PR DESCRIPTION
# What does this PR introduce?

## 📦 Build

Add Typescript types of the JSON structure for the metadata of LSP3Profile and LSP4DigitalAsset.

These types are currently defined in the lsp-factory, but have a better place in the lsp-smart-contracts repository, to be imported from the constants.

https://github.com/lukso-network/tools-lsp-factory/blob/develop/src/lib/interfaces/lsp3-profile.ts

https://github.com/lukso-network/tools-lsp-factory/blob/develop/src/lib/interfaces/lsp4-digital-asset.ts

https://github.com/lukso-network/tools-lsp-factory/blob/develop/src/lib/interfaces/metadata.ts



### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
