### PR TITLE
refactor!: change back parameter name from `allowNonLSP1Recipient` to `force`

### DIFF
--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -20,7 +20,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param from The address which tokens were sent from (balance decreased by `-amount`).
      * @param to The address that received the tokens (balance increased by `+amount`).
      * @param amount The amount of tokens transferred.
-     * @param allowNonLSP1Recipient if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.
+     * @param force if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.
      * @param data Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses.
      */
     event Transfer(
@@ -28,7 +28,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
         address indexed from,
         address indexed to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes data
     );
 
@@ -173,7 +173,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param from The sender address.
      * @param to The recipient address.
      * @param amount The amount of tokens to transfer.
-     * @param allowNonLSP1Recipient When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard.
+     * @param force When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard.
      * @param data Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.
      *
      * @custom:requirements
@@ -188,19 +188,19 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * - if the transfer is triggered by an operator, either the {AuthorizedOperator} event will be emitted with the updated allowance or the {RevokedOperator}
      * event will be emitted if the operator has no more allowance left.
      *
-     * @custom:hint The `allowNonLSP1Recipient` parameter **MUST be set to `true`** to transfer tokens to Externally Owned Accounts (EOAs)
+     * @custom:hint The `force` parameter **MUST be set to `true`** to transfer tokens to Externally Owned Accounts (EOAs)
      * or contracts that do not implement the LSP1 Universal Receiver Standard. Otherwise the function will revert making the transfer fail.
      *
-     * @custom:info if the `to` address is a contract that implements LSP1, it will always be notified via its `universalReceiver(...)` function, regardless if `allowNonLSP1Recipient` is set to `true` or `false`.
+     * @custom:info if the `to` address is a contract that implements LSP1, it will always be notified via its `universalReceiver(...)` function, regardless if `force` is set to `true` or `false`.
      *
      * @custom:warning Be aware that when either the sender or the recipient can have logic that revert in their `universalReceiver(...)` function when being notified.
-     * This even if the `allowNonLSP1Recipient` was set to `true`.
+     * This even if the `force` was set to `true`.
      */
     function transfer(
         address from,
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) external;
 
@@ -212,7 +212,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @param from An array of sending addresses.
      * @param to An array of receiving addresses.
      * @param amount An array of amount of tokens to transfer for each `from -> to` transfer.
-     * @param allowNonLSP1Recipient For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard.
+     * @param force For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard.
      * @param data An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.
      *
      * @custom:requirements
@@ -228,7 +228,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
         address[] memory from,
         address[] memory to,
         uint256[] memory amount,
-        bool[] memory allowNonLSP1Recipient,
+        bool[] memory force,
         bytes[] memory data
     ) external;
 }

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -48,14 +48,14 @@ error LSP7InvalidTransferBatch();
 
 /**
  * @dev reverts if the `tokenReceiver` does not implement LSP1
- * when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
     address tokenReceiver
 );
 
 /**
- * @dev reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+ * @dev reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -71,13 +71,13 @@ abstract contract LSP7CappedSupply is LSP7DigitalAsset {
     function _mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (totalSupply() + amount > tokenSupplyCap()) {
             revert LSP7CappedSupplyCannotMintOverCap();
         }
 
-        super._mint(to, amount, allowNonLSP1Recipient, data);
+        super._mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -74,13 +74,13 @@ abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInitAbstract {
     function _mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (totalSupply() + amount > tokenSupplyCap()) {
             revert LSP7CappedSupplyCannotMintOverCap();
         }
 
-        super._mint(to, amount, allowNonLSP1Recipient, data);
+        super._mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -76,7 +76,7 @@ abstract contract LSP7CompatibleERC20 is
     /**
      * @inheritdoc ILSP7CompatibleERC20
      *
-     * @custom:info This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+     * @custom:info This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
      */
     function transferFrom(
         address from,
@@ -92,7 +92,7 @@ abstract contract LSP7CompatibleERC20 is
     /**
      * @inheritdoc ILSP7CompatibleERC20
      *
-     * @custom:info This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+     * @custom:info This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
      */
     function transfer(
         address to,
@@ -126,11 +126,11 @@ abstract contract LSP7CompatibleERC20 is
         address from,
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(from, to, amount);
-        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
+        super._transfer(from, to, amount, force, data);
     }
 
     /**
@@ -141,11 +141,11 @@ abstract contract LSP7CompatibleERC20 is
     function _mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(address(0), to, amount);
-        super._mint(to, amount, allowNonLSP1Recipient, data);
+        super._mint(to, amount, force, data);
     }
 
     /**

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -83,7 +83,7 @@ abstract contract LSP7CompatibleERC20InitAbstract is
     /**
      * @inheritdoc ILSP7CompatibleERC20
      *
-     * @custom:info This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+     * @custom:info This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
      */
     function transferFrom(
         address from,
@@ -99,7 +99,7 @@ abstract contract LSP7CompatibleERC20InitAbstract is
     /**
      * @inheritdoc ILSP7CompatibleERC20
      *
-     * @custom:info This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+     * @custom:info This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
      */
     function transfer(
         address to,
@@ -133,11 +133,11 @@ abstract contract LSP7CompatibleERC20InitAbstract is
         address from,
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(from, to, amount);
-        super._transfer(from, to, amount, allowNonLSP1Recipient, data);
+        super._transfer(from, to, amount, force, data);
     }
 
     /**
@@ -148,11 +148,11 @@ abstract contract LSP7CompatibleERC20InitAbstract is
     function _mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(address(0), to, amount);
-        super._mint(to, amount, allowNonLSP1Recipient, data);
+        super._mint(to, amount, force, data);
     }
 
     /**

--- a/contracts/LSP7DigitalAsset/presets/ILSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/ILSP7Mintable.sol
@@ -12,7 +12,7 @@ interface ILSP7Mintable is ILSP7DigitalAsset {
     /**
      * @param to The address to mint tokens
      * @param amount The amount to mint
-     * @param allowNonLSP1Recipient When set to TRUE, to may be any address but
+     * @param force When set to TRUE, to may be any address but
      * when set to FALSE to must be a contract that supports LSP1 UniversalReceiver
      * @param data Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.
      * @dev Mints `amount` tokens and transfers it to `to`.
@@ -26,7 +26,7 @@ interface ILSP7Mintable is ILSP7DigitalAsset {
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) external;
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
@@ -27,9 +27,9 @@ contract LSP7CompatibleERC20Mintable is LSP7CompatibleERC20 {
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInitAbstract.sol
@@ -29,9 +29,9 @@ abstract contract LSP7CompatibleERC20MintableInitAbstract is
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
@@ -34,9 +34,9 @@ contract LSP7Mintable is LSP7DigitalAsset, ILSP7Mintable {
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -45,9 +45,9 @@ abstract contract LSP7MintableInitAbstract is
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -20,7 +20,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      * @param from The previous owner of the `tokenId`
      * @param to The new owner of `tokenId`
      * @param tokenId The tokenId that was transferred
-     * @param allowNonLSP1Recipient If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.
+     * @param force If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.
      * @param data Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses.
      */
     event Transfer(
@@ -28,7 +28,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
         address indexed from,
         address indexed to,
         bytes32 indexed tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes data
     );
 
@@ -182,13 +182,13 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      *
      * If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred.
      *
-     * The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs)
+     * The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs)
      * or contracts that do not implement the LSP1 standard.
      *
      * @param from The address that owns the given `tokenId`.
      * @param to The address that will receive the `tokenId`.
      * @param tokenId The token ID to transfer.
-     * @param allowNonLSP1Recipient When set to `true`, the `to` address CAN be any addres.
+     * @param force When set to `true`, the `to` address CAN be any addres.
      * When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard.
      * @param data Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.
      *
@@ -202,19 +202,19 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      * @custom:events
      * - {Transfer} event when the `tokenId` is successfully transferred.
      *
-     * @custom:hint The `allowNonLSP1Recipient` parameter **MUST be set to `true`** to transfer tokens to Externally Owned Accounts (EOAs)
+     * @custom:hint The `force` parameter **MUST be set to `true`** to transfer tokens to Externally Owned Accounts (EOAs)
      * or contracts that do not implement the LSP1 Universal Receiver Standard. Otherwise the function will revert making the transfer fail.
      *
-     * @custom:info if the `to` address is a contract that implements LSP1, it will always be notified via its `universalReceiver(...)` function, regardless if `allowNonLSP1Recipient` is set to `true` or `false`.
+     * @custom:info if the `to` address is a contract that implements LSP1, it will always be notified via its `universalReceiver(...)` function, regardless if `force` is set to `true` or `false`.
      *
      * @custom:warning Be aware that when either the sender or the recipient can have logic that revert in their `universalReceiver(...)` function when being notified.
-     * This even if the `allowNonLSP1Recipient` was set to `true`.
+     * This even if the `force` was set to `true`.
      */
     function transfer(
         address from,
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) external;
 
@@ -225,7 +225,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
      * @param from An array of sending addresses.
      * @param to An array of recipient addresses.
      * @param tokenId An array of token IDs to transfer.
-     * @param allowNonLSP1Recipient When set to `true`, `to` may be any address.
+     * @param force When set to `true`, `to` may be any address.
      * When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert.
      * @param data Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.
      *
@@ -245,7 +245,7 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
         address[] memory from,
         address[] memory to,
         bytes32[] memory tokenId,
-        bool[] memory allowNonLSP1Recipient,
+        bool[] memory force,
         bytes[] memory data
     ) external;
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -55,7 +55,7 @@ error LSP8InvalidTransferBatch();
 
 /**
  * @dev reverts if the `tokenReceiver` does not implement LSP1
- * when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
     address tokenReceiver
@@ -63,7 +63,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 
 /**
  * @dev reverts if the `tokenReceiver` is an EOA
- * when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+ * when minting or transferring tokens with `bool force` set as `false`.
  */
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -74,13 +74,13 @@ abstract contract LSP8CappedSupply is LSP8IdentifiableDigitalAsset {
     function _mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (totalSupply() + 1 > tokenSupplyCap()) {
             revert LSP8CappedSupplyCannotMintOverCap();
         }
 
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
+        super._mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -77,13 +77,13 @@ abstract contract LSP8CappedSupplyInitAbstract is
     function _mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (totalSupply() + 1 > tokenSupplyCap()) {
             revert LSP8CappedSupplyCannotMintOverCap();
         }
 
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
+        super._mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -173,7 +173,7 @@ abstract contract LSP8CompatibleERC721 is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function transferFrom(
         address from,
@@ -186,7 +186,7 @@ abstract contract LSP8CompatibleERC721 is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function safeTransferFrom(
         address from,
@@ -199,7 +199,7 @@ abstract contract LSP8CompatibleERC721 is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function safeTransferFrom(
         address from,
@@ -278,7 +278,7 @@ abstract contract LSP8CompatibleERC721 is
         address from,
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (
@@ -289,7 +289,7 @@ abstract contract LSP8CompatibleERC721 is
         }
 
         emit Transfer(from, to, uint256(tokenId));
-        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
+        super._transfer(from, to, tokenId, force, data);
     }
 
     /**
@@ -320,11 +320,11 @@ abstract contract LSP8CompatibleERC721 is
     function _mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(address(0), to, uint256(tokenId));
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
+        super._mint(to, tokenId, force, data);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -181,7 +181,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function transferFrom(
         address from,
@@ -194,7 +194,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function safeTransferFrom(
         address from,
@@ -207,7 +207,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     /**
      * @inheritdoc ILSP8CompatibleERC721
      *
-     * @custom:info This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+     * @custom:info This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
      */
     function safeTransferFrom(
         address from,
@@ -286,7 +286,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
         address from,
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         address operator = msg.sender;
@@ -299,7 +299,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
         }
 
         emit Transfer(from, to, uint256(tokenId));
-        super._transfer(from, to, tokenId, allowNonLSP1Recipient, data);
+        super._transfer(from, to, tokenId, force, data);
     }
 
     /**
@@ -330,11 +330,11 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     function _mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) internal virtual override {
         emit Transfer(address(0), to, uint256(tokenId));
-        super._mint(to, tokenId, allowNonLSP1Recipient, data);
+        super._mint(to, tokenId, force, data);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/ILSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/ILSP8Mintable.sol
@@ -14,7 +14,7 @@ interface ILSP8Mintable is ILSP8IdentifiableDigitalAsset {
     /**
      * @param to The address to mint tokens
      * @param tokenId The tokenId to mint
-     * @param allowNonLSP1Recipient When set to TRUE, to may be any address but
+     * @param force When set to TRUE, to may be any address but
      * when set to FALSE to must be a contract that supports LSP1 UniversalReceiver
      * @param data Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.
      * @dev Mints `amount` tokens and transfers it to `to`.
@@ -28,7 +28,7 @@ interface ILSP8Mintable is ILSP8IdentifiableDigitalAsset {
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) external;
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
@@ -22,21 +22,21 @@ contract LSP8CompatibleERC721Mintable is LSP8CompatibleERC721 {
     ) LSP8CompatibleERC721(name_, symbol_, newOwner_) {}
 
     /**
-     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`).
+     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`).
      *
      * @dev Public {_mint} function only callable by the {owner}.
      *
      * @param to The address that will receive the minted `tokenId`.
      * @param tokenId The tokenId to mint.
-     * @param allowNonLSP1Recipient Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
+     * @param force Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
      * @param data Any addition data to be sent alongside the minting.
      */
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInitAbstract.sol
@@ -24,21 +24,21 @@ contract LSP8CompatibleERC721MintableInitAbstract is
     }
 
     /**
-     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`).
+     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`).
      *
      * @dev Public {_mint} function only callable by the {owner}.
      *
      * @param to The address that will receive the minted `tokenId`.
      * @param tokenId The tokenId to mint.
-     * @param allowNonLSP1Recipient Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
+     * @param force Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
      * @param data Any addition data to be sent alongside the minting.
      */
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
@@ -29,21 +29,21 @@ contract LSP8Mintable is LSP8IdentifiableDigitalAsset, ILSP8Mintable {
     ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_) {}
 
     /**
-     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`).
+     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`).
      *
      * @dev Public {_mint} function only callable by the {owner}.
      *
      * @param to The address that will receive the minted `tokenId`.
      * @param tokenId The tokenId to mint.
-     * @param allowNonLSP1Recipient Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
+     * @param force Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
      * @param data Any addition data to be sent alongside the minting.
      */
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -37,21 +37,21 @@ abstract contract LSP8MintableInitAbstract is
     }
 
     /**
-     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`).
+     * @notice Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`).
      *
      * @dev Public {_mint} function only callable by the {owner}.
      *
      * @param to The address that will receive the minted `tokenId`.
      * @param tokenId The tokenId to mint.
-     * @param allowNonLSP1Recipient Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
+     * @param force Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting.
      * @param data Any addition data to be sent alongside the minting.
      */
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public virtual onlyOwner {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/Mocks/Tokens/LSP7CappedSupplyInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CappedSupplyInitTester.sol
@@ -22,7 +22,7 @@ contract LSP7CappedSupplyInitTester is LSP7CappedSupplyInitAbstract {
     }
 
     function mint(address to, uint256 amount) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, amount, true, "token printer go brrr");
     }
 

--- a/contracts/Mocks/Tokens/LSP7CappedSupplyTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CappedSupplyTester.sol
@@ -20,7 +20,7 @@ contract LSP7CappedSupplyTester is LSP7CappedSupply {
     {}
 
     function mint(address to, uint256 amount) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, amount, true, "token printer go brrr");
     }
 

--- a/contracts/Mocks/Tokens/LSP7CompatibleERC20InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CompatibleERC20InitTester.sol
@@ -24,7 +24,7 @@ contract LSP7CompatibleERC20InitTester is LSP7CompatibleERC20InitAbstract {
     }
 
     function mint(address to, uint256 amount, bytes calldata data) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, amount, true, data);
     }
 

--- a/contracts/Mocks/Tokens/LSP7CompatibleERC20Tester.sol
+++ b/contracts/Mocks/Tokens/LSP7CompatibleERC20Tester.sol
@@ -15,7 +15,7 @@ contract LSP7CompatibleERC20Tester is LSP7CompatibleERC20 {
     ) LSP7CompatibleERC20(name_, symbol_, newOwner_) {}
 
     function mint(address to, uint256 amount, bytes calldata data) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, amount, true, data);
     }
 

--- a/contracts/Mocks/Tokens/LSP7InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7InitTester.sol
@@ -31,9 +31,9 @@ contract LSP7InitTester is
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/Mocks/Tokens/LSP7Tester.sol
+++ b/contracts/Mocks/Tokens/LSP7Tester.sol
@@ -15,9 +15,9 @@ contract LSP7Tester is LSP7DigitalAsset, LSP7Burnable {
     function mint(
         address to,
         uint256 amount,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public {
-        _mint(to, amount, allowNonLSP1Recipient, data);
+        _mint(to, amount, force, data);
     }
 }

--- a/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
+++ b/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
@@ -23,7 +23,7 @@ contract LSP8CompatibleERC721Tester is LSP8CompatibleERC721 {
     }
 
     function mint(address to, uint256 tokenId, bytes calldata data) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, bytes32(tokenId), true, data);
     }
 

--- a/contracts/Mocks/Tokens/LSP8CompatibleERC721TesterInit.sol
+++ b/contracts/Mocks/Tokens/LSP8CompatibleERC721TesterInit.sol
@@ -32,7 +32,7 @@ contract LSP8CompatibleERC721InitTester is LSP8CompatibleERC721InitAbstract {
     }
 
     function mint(address to, uint256 tokenId, bytes calldata data) public {
-        // using allowNonLSP1Recipient=true so we can send to EOA in test
+        // using force=true so we can send to EOA in test
         _mint(to, bytes32(tokenId), true, data);
     }
 

--- a/contracts/Mocks/Tokens/LSP8InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8InitTester.sol
@@ -29,9 +29,9 @@ contract LSP8InitTester is
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/Mocks/Tokens/LSP8Tester.sol
+++ b/contracts/Mocks/Tokens/LSP8Tester.sol
@@ -20,9 +20,9 @@ contract LSP8Tester is LSP8IdentifiableDigitalAsset, LSP8Burnable {
     function mint(
         address to,
         bytes32 tokenId,
-        bool allowNonLSP1Recipient,
+        bool force,
         bytes memory data
     ) public {
-        _mint(to, tokenId, allowNonLSP1Recipient, data);
+        _mint(to, tokenId, force, data);
     }
 }

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -643,7 +643,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -652,13 +652,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -678,7 +678,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -687,13 +687,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -809,7 +809,7 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -826,12 +826,12 @@ Mints `amount` of tokens and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | the address to mint tokens for.                                                                                           |
-| `amount`                | `uint256` | the amount of tokens to mint.                                                                                             |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `to`     | `address` | The address to mint tokens for.                                                                                           |
+| `amount` | `uint256` | The amount of tokens to mint.                                                                                             |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
 
 <br/>
 
@@ -865,8 +865,8 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 | Name     |   Type    | Description                                                                                                               |
 | -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | `address` | the address to burn tokens from its balance.                                                                              |
-| `amount` | `uint256` | the amount of tokens to burn.                                                                                             |
+| `from`   | `address` | The address to burn tokens from its balance.                                                                              |
+| `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
@@ -878,7 +878,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -900,13 +900,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | the address to decrease the balance.                                                                                      |
-| `to`                    | `address` | the address to increase the balance.                                                                                      |
-| `amount`                | `uint256` | the amount of tokens to transfer from `from` to `to`.                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The address to decrease the balance.                                                                                      |
+| `to`     | `address` | The address to increase the balance.                                                                                      |
+| `amount` | `uint256` | The amount of tokens to transfer from `from` to `to`.                                                                     |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
 
@@ -979,26 +979,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1174,7 +1174,7 @@ Emitted when `tokenOwner` disables `operator` for `amount` tokens and set its [`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1187,7 +1187,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1521,7 +1521,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1546,7 +1546,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -668,7 +668,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -677,13 +677,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -703,7 +703,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -712,13 +712,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -834,7 +834,7 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -851,12 +851,12 @@ Mints `amount` of tokens and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | the address to mint tokens for.                                                                                           |
-| `amount`                | `uint256` | the amount of tokens to mint.                                                                                             |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `to`     | `address` | The address to mint tokens for.                                                                                           |
+| `amount` | `uint256` | The amount of tokens to mint.                                                                                             |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
 
 <br/>
 
@@ -890,8 +890,8 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 | Name     |   Type    | Description                                                                                                               |
 | -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | `address` | the address to burn tokens from its balance.                                                                              |
-| `amount` | `uint256` | the amount of tokens to burn.                                                                                             |
+| `from`   | `address` | The address to burn tokens from its balance.                                                                              |
+| `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
@@ -903,7 +903,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -925,13 +925,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | the address to decrease the balance.                                                                                      |
-| `to`                    | `address` | the address to increase the balance.                                                                                      |
-| `amount`                | `uint256` | the amount of tokens to transfer from `from` to `to`.                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The address to decrease the balance.                                                                                      |
+| `to`     | `address` | The address to increase the balance.                                                                                      |
+| `amount` | `uint256` | The amount of tokens to transfer from `from` to `to`.                                                                     |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
 
@@ -1004,26 +1004,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1199,7 +1199,7 @@ Emitted when `tokenOwner` disables `operator` for `amount` tokens and set its [`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1212,7 +1212,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1546,7 +1546,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1571,7 +1571,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -668,7 +668,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -677,13 +677,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -703,7 +703,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -712,13 +712,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -834,7 +834,7 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -874,8 +874,8 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 | Name     |   Type    | Description                                                                                                               |
 | -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | `address` | the address to burn tokens from its balance.                                                                              |
-| `amount` | `uint256` | the amount of tokens to burn.                                                                                             |
+| `from`   | `address` | The address to burn tokens from its balance.                                                                              |
+| `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
@@ -887,7 +887,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -909,13 +909,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | the address to decrease the balance.                                                                                      |
-| `to`                    | `address` | the address to increase the balance.                                                                                      |
-| `amount`                | `uint256` | the amount of tokens to transfer from `from` to `to`.                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The address to decrease the balance.                                                                                      |
+| `to`     | `address` | The address to increase the balance.                                                                                      |
+| `amount` | `uint256` | The amount of tokens to transfer from `from` to `to`.                                                                     |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
 
@@ -988,26 +988,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1183,7 +1183,7 @@ Emitted when `tokenOwner` disables `operator` for `amount` tokens and set its [`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1196,7 +1196,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1572,7 +1572,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1597,7 +1597,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -757,7 +757,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -766,13 +766,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -789,7 +789,7 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 :::info
 
-This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
 
 :::
 
@@ -831,7 +831,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -840,13 +840,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -863,7 +863,7 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 :::info
 
-This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
 
 :::
 
@@ -997,7 +997,7 @@ function _updateOperator(
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1019,7 +1019,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1095,26 +1095,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1344,7 +1344,7 @@ Emitted when `value` tokens are moved from one account (`from`) to another (`to`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1357,7 +1357,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1691,7 +1691,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1716,7 +1716,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -482,7 +482,7 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 function mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -491,12 +491,12 @@ Public [`_mint`](#_mint) function only callable by the [`owner`](#owner).
 
 #### Parameters
 
-| Name                    |   Type    | Description |
-| ----------------------- | :-------: | ----------- |
-| `to`                    | `address` | -           |
-| `amount`                | `uint256` | -           |
-| `allowNonLSP1Recipient` |  `bool`   | -           |
-| `data`                  |  `bytes`  | -           |
+| Name     |   Type    | Description |
+| -------- | :-------: | ----------- |
+| `to`     | `address` | -           |
+| `amount` | `uint256` | -           |
+| `force`  |  `bool`   | -           |
+| `data`   |  `bytes`  | -           |
 
 <br/>
 
@@ -795,7 +795,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -804,13 +804,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -827,7 +827,7 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 :::info
 
-This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
 
 :::
 
@@ -869,7 +869,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -878,13 +878,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -901,7 +901,7 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 :::info
 
-This function uses the `allowNonLSP1Recipient` parameter as `true` so that EOA and any contract can receive tokens.
+This function uses the `force` parameter as `true` so that EOA and any contract can receive tokens.
 
 :::
 
@@ -1035,7 +1035,7 @@ function _updateOperator(
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1057,7 +1057,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1133,26 +1133,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1382,7 +1382,7 @@ Emitted when `value` tokens are moved from one account (`from`) to another (`to`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1395,7 +1395,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1729,7 +1729,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1754,7 +1754,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -442,7 +442,7 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 function mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -451,12 +451,12 @@ Public [`_mint`](#_mint) function only callable by the [`owner`](#owner).
 
 #### Parameters
 
-| Name                    |   Type    | Description |
-| ----------------------- | :-------: | ----------- |
-| `to`                    | `address` | -           |
-| `amount`                | `uint256` | -           |
-| `allowNonLSP1Recipient` |  `bool`   | -           |
-| `data`                  |  `bytes`  | -           |
+| Name     |   Type    | Description |
+| -------- | :-------: | ----------- |
+| `to`     | `address` | -           |
+| `amount` | `uint256` | -           |
+| `force`  |  `bool`   | -           |
+| `data`   |  `bytes`  | -           |
 
 <br/>
 
@@ -705,7 +705,7 @@ function transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
@@ -714,13 +714,13 @@ Transfers an `amount` of tokens from the `from` address to the `to` address and 
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                          |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                                                                  |
-| `to`                    | `address` | The recipient address.                                                                                                                                               |
-| `amount`                | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
+| Name     |   Type    | Description                                                                                                                                                          |
+| -------- | :-------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The sender address.                                                                                                                                                  |
+| `to`     | `address` | The recipient address.                                                                                                                                               |
+| `amount` | `uint256` | The amount of tokens to transfer.                                                                                                                                    |
+| `force`  |  `bool`   | When set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                          |
 
 <br/>
 
@@ -740,7 +740,7 @@ function transferBatch(
   address[] from,
   address[] to,
   uint256[] amount,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -749,13 +749,13 @@ Same as [`transfer(...)`](#`transfer) but transfer multiple tokens based on the 
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                                                                             |
-| ----------------------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                                                                          |
-| `to`                    | `address[]` | An array of receiving addresses.                                                                                                                                                        |
-| `amount`                | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
-| `allowNonLSP1Recipient` |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
+| Name     |    Type     | Description                                                                                                                                                                             |
+| -------- | :---------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address[]` | An array of sending addresses.                                                                                                                                                          |
+| `to`     | `address[]` | An array of receiving addresses.                                                                                                                                                        |
+| `amount` | `uint256[]` | An array of amount of tokens to transfer for each `from -> to` transfer.                                                                                                                |
+| `force`  |  `bool[]`   | For each transfer, when set to `true`, the `to` address CAN be any address. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`   |  `bytes[]`  | An array of additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.                                                         |
 
 <br/>
 
@@ -871,7 +871,7 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 function _mint(
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -888,12 +888,12 @@ Mints `amount` of tokens and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | the address to mint tokens for.                                                                                           |
-| `amount`                | `uint256` | the amount of tokens to mint.                                                                                             |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `to`     | `address` | The address to mint tokens for.                                                                                           |
+| `amount` | `uint256` | The amount of tokens to mint.                                                                                             |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted {Transfer} event, and sent in the LSP1 hook to the `to` address. |
 
 <br/>
 
@@ -927,8 +927,8 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 | Name     |   Type    | Description                                                                                                               |
 | -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`   | `address` | the address to burn tokens from its balance.                                                                              |
-| `amount` | `uint256` | the amount of tokens to burn.                                                                                             |
+| `from`   | `address` | The address to burn tokens from its balance.                                                                              |
+| `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
@@ -940,7 +940,7 @@ function _transfer(
   address from,
   address to,
   uint256 amount,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -962,13 +962,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                               |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | the address to decrease the balance.                                                                                      |
-| `to`                    | `address` | the address to increase the balance.                                                                                      |
-| `amount`                | `uint256` | the amount of tokens to transfer from `from` to `to`.                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+| Name     |   Type    | Description                                                                                                               |
+| -------- | :-------: | ------------------------------------------------------------------------------------------------------------------------- |
+| `from`   | `address` | The address to decrease the balance.                                                                                      |
+| `to`     | `address` | The address to increase the balance.                                                                                      |
+| `amount` | `uint256` | The amount of tokens to transfer from `from` to `to`.                                                                     |
+| `force`  |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.                       |
+| `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
 
 <br/>
 
@@ -1041,26 +1041,26 @@ If `from` is an EOA or a contract that does not support the LSP1 interface, noth
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 Attempt to notify the token receiver `to` about the `amount` tokens being received.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
-If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `allowNonLSP1Recipient` boolean flag.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
 
-- if `allowNonLSP1Recipient` is set to `true`, nothing will happen and no notification will be sent.
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
 
-- if `allowNonLSP1Recipient` is set to `false, the transaction will revert.
+- if `force` is set to `false, the transaction will revert.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                         |
-| ----------------------- | :-------: | --------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | The address to call the {universalReceiver} function on.                                            |
-| `allowNonLSP1Recipient` |  `bool`   | a boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
-| `lsp1Data`              |  `bytes`  | the data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 
@@ -1236,7 +1236,7 @@ Emitted when `tokenOwner` disables `operator` for `amount` tokens and set its [`
 :::
 
 ```solidity
-event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address indexed operator, address indexed from, address indexed to, uint256 amount, bool force, bytes data);
 ```
 
 Emitted when the `from` transferred successfully `amount` of tokens to `to`.
@@ -1249,7 +1249,7 @@ Emitted when the `from` transferred successfully `amount` of tokens to `to`.
 | `from` **`indexed`**     | `address` | The address which tokens were sent from (balance decreased by `-amount`).                                                    |
 | `to` **`indexed`**       | `address` | The address that received the tokens (balance increased by `+amount`).                                                       |
 | `amount`                 | `uint256` | The amount of tokens transferred.                                                                                            |
-| `allowNonLSP1Recipient`  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
+| `force`                  |  `bool`   | if the transferred enforced the `to` recipient address to be a contract that implements the LSP1 standard or not.            |
 | `data`                   |  `bytes`  | Any additional data included by the caller during the transfer, and sent in the LSP1 hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1583,7 +1583,7 @@ error LSP7NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1608,7 +1608,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP7NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -563,22 +563,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -598,7 +598,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -607,13 +607,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -787,7 +787,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -804,12 +804,12 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | @param tokenId The token ID to create (= mint).                                                                            |
-| `tokenId`               | `bytes32` | The token ID to create (= mint).                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `to`      | `address` | @param tokenId The token ID to create (= mint).                                                                            |
+| `tokenId` | `bytes32` | The token ID to create (= mint).                                                                                           |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
 
 <br/>
 
@@ -862,7 +862,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -883,13 +883,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                        |
-| `to`                    | `address` | @param tokenId The token to transfer.                                                                                      |
-| `tokenId`               | `bytes32` | The token to transfer.                                                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The sender address.                                                                                                        |
+| `to`      | `address` | @param tokenId The token to transfer.                                                                                      |
+| `tokenId` | `bytes32` | The token to transfer.                                                                                                     |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
 
 <br/>
 
@@ -955,13 +955,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1139,7 +1139,7 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1152,7 +1152,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1501,7 +1501,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1526,7 +1526,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -589,22 +589,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -624,7 +624,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -633,13 +633,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -813,7 +813,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -830,12 +830,12 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | @param tokenId The token ID to create (= mint).                                                                            |
-| `tokenId`               | `bytes32` | The token ID to create (= mint).                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `to`      | `address` | @param tokenId The token ID to create (= mint).                                                                            |
+| `tokenId` | `bytes32` | The token ID to create (= mint).                                                                                           |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
 
 <br/>
 
@@ -888,7 +888,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -909,13 +909,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                        |
-| `to`                    | `address` | @param tokenId The token to transfer.                                                                                      |
-| `tokenId`               | `bytes32` | The token to transfer.                                                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The sender address.                                                                                                        |
+| `to`      | `address` | @param tokenId The token to transfer.                                                                                      |
+| `tokenId` | `bytes32` | The token to transfer.                                                                                                     |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
 
 <br/>
 
@@ -981,13 +981,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1165,7 +1165,7 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1178,7 +1178,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1527,7 +1527,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1552,7 +1552,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -588,22 +588,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -623,7 +623,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -632,13 +632,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -812,7 +812,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -872,7 +872,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -893,13 +893,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                        |
-| `to`                    | `address` | @param tokenId The token to transfer.                                                                                      |
-| `tokenId`               | `bytes32` | The token to transfer.                                                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The sender address.                                                                                                        |
+| `to`      | `address` | @param tokenId The token to transfer.                                                                                      |
+| `tokenId` | `bytes32` | The token to transfer.                                                                                                     |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
 
 <br/>
 
@@ -965,13 +965,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1149,7 +1149,7 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1162,7 +1162,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1553,7 +1553,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1578,7 +1578,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -501,7 +501,7 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -540,7 +540,7 @@ Safe Transfer function without optional data from the ERC721 standard interface.
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -882,22 +882,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -917,7 +917,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -926,13 +926,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -949,7 +949,7 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -1143,7 +1143,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1165,7 +1165,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1234,13 +1234,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1544,7 +1544,7 @@ Emitted when `value` tokens are moved from one account (`from`) to another (`to`
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1557,7 +1557,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1906,7 +1906,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1931,7 +1931,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -594,22 +594,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -629,7 +629,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -638,13 +638,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -818,7 +818,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -835,12 +835,12 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | @param tokenId The token ID to create (= mint).                                                                            |
-| `tokenId`               | `bytes32` | The token ID to create (= mint).                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `to`      | `address` | @param tokenId The token ID to create (= mint).                                                                            |
+| `tokenId` | `bytes32` | The token ID to create (= mint).                                                                                           |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
 
 <br/>
 
@@ -893,7 +893,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -914,13 +914,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                        |
-| `to`                    | `address` | @param tokenId The token to transfer.                                                                                      |
-| `tokenId`               | `bytes32` | The token to transfer.                                                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The sender address.                                                                                                        |
+| `to`      | `address` | @param tokenId The token to transfer.                                                                                      |
+| `tokenId` | `bytes32` | The token to transfer.                                                                                                     |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
 
 <br/>
 
@@ -982,13 +982,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1166,7 +1166,7 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1179,7 +1179,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1528,7 +1528,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1553,7 +1553,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -375,23 +375,23 @@ Returns whether `operator` address is an operator for a given `tokenId`.
 function mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-_Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`)._
+_Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`)._
 
 Public [`_mint`](#_mint) function only callable by the [`owner`](#owner).
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                    |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------ |
-| `to`                    | `address` | The address that will receive the minted `tokenId`.                                                                            |
-| `tokenId`               | `bytes32` | The tokenId to mint.                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting. |
-| `data`                  |  `bytes`  | Any addition data to be sent alongside the minting.                                                                            |
+| Name      |   Type    | Description                                                                                                                    |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------ |
+| `to`      | `address` | The address that will receive the minted `tokenId`.                                                                            |
+| `tokenId` | `bytes32` | The tokenId to mint.                                                                                                           |
+| `force`   |  `bool`   | Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting. |
+| `data`    |  `bytes`  | Any addition data to be sent alongside the minting.                                                                            |
 
 <br/>
 
@@ -541,7 +541,7 @@ Remove access of `operator` for a given `tokenId`, disallowing it to transfer `t
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -580,7 +580,7 @@ Safe Transfer function without optional data from the ERC721 standard interface.
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -922,22 +922,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -957,7 +957,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -966,13 +966,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -989,7 +989,7 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 :::info
 
-This function sets the `allowNonLSP1Recipient` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
+This function sets the `force` parameter to `true` so that EOAs and any contract can receive the `tokenId`.
 
 :::
 
@@ -1183,7 +1183,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1205,7 +1205,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -1274,13 +1274,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1584,7 +1584,7 @@ Emitted when `value` tokens are moved from one account (`from`) to another (`to`
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1597,7 +1597,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1946,7 +1946,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1971,7 +1971,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -292,23 +292,23 @@ Returns whether `operator` address is an operator for a given `tokenId`.
 function mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-_Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `allowNonLSP1Recipient`)._
+_Minting tokenId `tokenId` for address `to` with the additional data `data` (Note: allow non-LSP1 recipient is set to `force`)._
 
 Public [`_mint`](#_mint) function only callable by the [`owner`](#owner).
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                    |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------ |
-| `to`                    | `address` | The address that will receive the minted `tokenId`.                                                                            |
-| `tokenId`               | `bytes32` | The tokenId to mint.                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting. |
-| `data`                  |  `bytes`  | Any addition data to be sent alongside the minting.                                                                            |
+| Name      |   Type    | Description                                                                                                                    |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------ |
+| `to`      | `address` | The address that will receive the minted `tokenId`.                                                                            |
+| `tokenId` | `bytes32` | The tokenId to mint.                                                                                                           |
+| `force`   |  `bool`   | Set to `false` to ensure that you are minting for a recipient that implements LSP1, `false` otherwise for forcing the minting. |
+| `data`    |  `bytes`  | Any addition data to be sent alongside the minting.                                                                            |
 
 <br/>
 
@@ -621,22 +621,22 @@ function transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) external nonpayable;
 ```
 
-Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `allowNonLSP1Recipient` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
+Transfer a given `tokenId` token from the `from` address to the `to` address. If operators are set for a specific `tokenId`, all the operators are revoked after the tokenId have been transferred. The `force` parameter MUST be set to `true` when transferring tokens to Externally Owned Accounts (EOAs) or contracts that do not implement the LSP1 standard.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                                                         |
-| ----------------------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The address that owns the given `tokenId`.                                                                                                                          |
-| `to`                    | `address` | The address that will receive the `tokenId`.                                                                                                                        |
-| `tokenId`               | `bytes32` | The token ID to transfer.                                                                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
+| Name      |   Type    | Description                                                                                                                                                         |
+| --------- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The address that owns the given `tokenId`.                                                                                                                          |
+| `to`      | `address` | The address that will receive the `tokenId`.                                                                                                                        |
+| `tokenId` | `bytes32` | The token ID to transfer.                                                                                                                                           |
+| `force`   |  `bool`   | When set to `true`, the `to` address CAN be any addres. When set to `false`, the `to` address MUST be a contract that supports the LSP1 UniversalReceiver standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hooks of the `from` and `to` addresses.                                         |
 
 <br/>
 
@@ -656,7 +656,7 @@ function transferBatch(
   address[] from,
   address[] to,
   bytes32[] tokenId,
-  bool[] allowNonLSP1Recipient,
+  bool[] force,
   bytes[] data
 ) external nonpayable;
 ```
@@ -665,13 +665,13 @@ Transfers multiple tokens at once based on the arrays of `from`, `to` and `token
 
 #### Parameters
 
-| Name                    |    Type     | Description                                                                                                                               |
-| ----------------------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address[]` | An array of sending addresses.                                                                                                            |
-| `to`                    | `address[]` | An array of recipient addresses.                                                                                                          |
-| `tokenId`               | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
-| `allowNonLSP1Recipient` |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
-| `data`                  |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
+| Name      |    Type     | Description                                                                                                                               |
+| --------- | :---------: | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address[]` | An array of sending addresses.                                                                                                            |
+| `to`      | `address[]` | An array of recipient addresses.                                                                                                          |
+| `tokenId` | `bytes32[]` | An array of token IDs to transfer.                                                                                                        |
+| `force`   |  `bool[]`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard and not revert. |
+| `data`    |  `bytes[]`  | Any additional data the caller wants included in the emitted event, and sent in the hooks to the `from` and `to` addresses.               |
 
 <br/>
 
@@ -845,7 +845,7 @@ When `tokenId` does not exist then revert with an error.
 function _mint(
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -862,12 +862,12 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `to`                    | `address` | @param tokenId The token ID to create (= mint).                                                                            |
-| `tokenId`               | `bytes32` | The token ID to create (= mint).                                                                                           |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `to`      | `address` | @param tokenId The token ID to create (= mint).                                                                            |
+| `tokenId` | `bytes32` | The token ID to create (= mint).                                                                                           |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.              |
 
 <br/>
 
@@ -920,7 +920,7 @@ function _transfer(
   address from,
   address to,
   bytes32 tokenId,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes data
 ) internal nonpayable;
 ```
@@ -941,13 +941,13 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 
 #### Parameters
 
-| Name                    |   Type    | Description                                                                                                                |
-| ----------------------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
-| `from`                  | `address` | The sender address.                                                                                                        |
-| `to`                    | `address` | @param tokenId The token to transfer.                                                                                      |
-| `tokenId`               | `bytes32` | The token to transfer.                                                                                                     |
-| `allowNonLSP1Recipient` |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
-| `data`                  |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
+| Name      |   Type    | Description                                                                                                                |
+| --------- | :-------: | -------------------------------------------------------------------------------------------------------------------------- |
+| `from`    | `address` | The sender address.                                                                                                        |
+| `to`      | `address` | @param tokenId The token to transfer.                                                                                      |
+| `tokenId` | `bytes32` | The token to transfer.                                                                                                     |
+| `force`   |  `bool`   | When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard. |
+| `data`    |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the hooks to `from` and `to` addresses.        |
 
 <br/>
 
@@ -1013,13 +1013,13 @@ LSP1 interface.
 ```solidity
 function _notifyTokenReceiver(
   address to,
-  bool allowNonLSP1Recipient,
+  bool force,
   bytes lsp1Data
 ) internal nonpayable;
 ```
 
 An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When allowNonLSP1Recipient is FALSE the token receiver MUST support LSP1.
+using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
 The receiver may revert when the token being sent is not wanted.
 
 <br/>
@@ -1197,7 +1197,7 @@ Emitted when `tokenOwner` disables `operator` to transfer or burn `tokenId` on i
 :::
 
 ```solidity
-event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool allowNonLSP1Recipient, bytes data);
+event Transfer(address operator, address indexed from, address indexed to, bytes32 indexed tokenId, bool force, bytes data);
 ```
 
 Emitted when `tokenId` token is transferred from the `from` to the `to` address.
@@ -1210,7 +1210,7 @@ Emitted when `tokenId` token is transferred from the `from` to the `to` address.
 | `from` **`indexed`**    | `address` | The previous owner of the `tokenId`                                                                                                |
 | `to` **`indexed`**      | `address` | The new owner of `tokenId`                                                                                                         |
 | `tokenId` **`indexed`** | `bytes32` | The tokenId that was transferred                                                                                                   |
-| `allowNonLSP1Recipient` |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
+| `force`                 |  `bool`   | If the token transfer enforces the `to` recipient address to be a contract that implements the LSP1 standard or not.               |
 | `data`                  |  `bytes`  | Any additional data the caller included by the caller during the transfer, and sent in the hooks to the `from` and `to` addresses. |
 
 <br/>
@@ -1559,7 +1559,7 @@ error LSP8NotifyTokenReceiverContractMissingLSP1Interface(
 );
 ```
 
-reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` does not implement LSP1 when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 
@@ -1584,7 +1584,7 @@ reverts if the `tokenReceiver` does not implement LSP1 when minting or transferr
 error LSP8NotifyTokenReceiverIsEOA(address tokenReceiver);
 ```
 
-reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool allowNonLSP1Recipient` set as `false`.
+reverts if the `tokenReceiver` is an EOA when minting or transferring tokens with `bool force` set as `false`.
 
 #### Parameters
 

--- a/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
@@ -327,7 +327,7 @@ export const shouldBehaveLikeBatchExecute = (
         [sender, sender, sender], // address[] memory from,
         recipients, // address[] memory to,
         amounts, // uint256[] memory amount,
-        [true, true, true], // bool[] memory allowNonLSP1Recipient,
+        [true, true, true], // bool[] memory force,
         ['0x', '0x', '0x'], // bytes[] memory data
       ]);
 

--- a/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7CompatibleERC20.behaviour.ts
@@ -422,7 +422,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
       from: string;
       to: string;
       amount: BigNumber;
-      allowNonLSP1Recipient?: boolean;
+      force?: boolean;
       data?: string;
     };
 
@@ -450,7 +450,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
           txParams.from,
           txParams.to,
           txParams.amount,
-          txParams.allowNonLSP1Recipient ?? true,
+          txParams.force ?? true,
           expectedData,
         );
 
@@ -810,13 +810,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
         describe('when caller (msg.sender) is the `from` address', () => {
           describe('when `to` is an EOA', () => {
-            it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+            it('should allow transfering the tokens with `force` param = true', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 amount: transferAmount,
-                allowNonLSP1Recipient: true,
+                force: true,
                 data: expectedData,
               };
 
@@ -829,20 +829,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                       txParams.from,
                       txParams.to,
                       txParams.amount,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 expectedData,
               );
             });
 
-            it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+            it('should NOT allow transfering the tokens with `force` param = false', async () => {
               const txParams = {
                 operator: context.accounts.owner,
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 amount: transferAmount,
-                allowNonLSP1Recipient: false,
+                force: false,
                 data: expectedData,
               };
 
@@ -856,7 +856,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     txParams.from,
                     txParams.to,
                     txParams.amount,
-                    txParams.allowNonLSP1Recipient,
+                    txParams.force,
                     txParams.data,
                   ),
               )
@@ -874,13 +874,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
           describe('when `to` is a contract', () => {
             describe('when receiving contract supports LSP1', () => {
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+              it('should allow transfering the tokens with `force` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: true,
+                  force: true,
                   data: expectedData,
                 };
 
@@ -893,20 +893,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
                 );
               });
 
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+              it('should allow transfering the tokens with `force` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: false,
+                  force: false,
                   data: expectedData,
                 };
 
@@ -919,7 +919,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
@@ -928,13 +928,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             });
 
             describe('when receiving contract does not support LSP1', () => {
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+              it('should allow transfering the tokens with `force` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: true,
+                  force: true,
                   data: expectedData,
                 };
 
@@ -947,20 +947,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
                 );
               });
 
-              it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+              it('should NOT allow transfering the tokens with `force` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.owner,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: false,
+                  force: false,
                   data: expectedData,
                 };
 
@@ -974,7 +974,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                       txParams.from,
                       txParams.to,
                       txParams.amount,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 )
@@ -994,13 +994,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
         describe('when caller (msg.sender) is an operator (= Not the `from` address)', () => {
           describe('when `to` is an EOA', () => {
-            it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+            it('should allow transfering the tokens with `force` param = true', async () => {
               const txParams = {
                 operator: context.accounts.operator,
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 amount: transferAmount,
-                allowNonLSP1Recipient: true,
+                force: true,
                 data: expectedData,
               };
 
@@ -1013,20 +1013,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                       txParams.from,
                       txParams.to,
                       txParams.amount,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 expectedData,
               );
             });
 
-            it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+            it('should NOT allow transfering the tokens with `force` param = false', async () => {
               const txParams = {
                 operator: context.accounts.operator,
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 amount: transferAmount,
-                allowNonLSP1Recipient: false,
+                force: false,
                 data: expectedData,
               };
 
@@ -1040,7 +1040,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                     txParams.from,
                     txParams.to,
                     txParams.amount,
-                    txParams.allowNonLSP1Recipient,
+                    txParams.force,
                     txParams.data,
                   ),
               )
@@ -1058,13 +1058,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
 
           describe('when `to` is a contract', () => {
             describe('when receiving contract supports LSP1', () => {
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+              it('should allow transfering the tokens with `force` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: true,
+                  force: true,
                   data: expectedData,
                 };
 
@@ -1077,20 +1077,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
                 );
               });
 
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+              it('should allow transfering the tokens with `force` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: false,
+                  force: false,
                   data: expectedData,
                 };
 
@@ -1103,7 +1103,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
@@ -1112,13 +1112,13 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
             });
 
             describe('when receiving contract does not support LSP1', () => {
-              it('should allow transfering the tokens with `allowNonLSP1Recipient` param = true', async () => {
+              it('should allow transfering the tokens with `force` param = true', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: true,
+                  force: true,
                   data: expectedData,
                 };
 
@@ -1131,20 +1131,20 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                         txParams.from,
                         txParams.to,
                         txParams.amount,
-                        txParams.allowNonLSP1Recipient,
+                        txParams.force,
                         txParams.data,
                       ),
                   expectedData,
                 );
               });
 
-              it('should NOT allow transfering the tokens with `allowNonLSP1Recipient` param = false', async () => {
+              it('should NOT allow transfering the tokens with `force` param = false', async () => {
                 const txParams = {
                   operator: context.accounts.operator,
                   from: context.accounts.owner.address,
                   to: deployedContracts.tokenReceiverWithoutLSP1.address,
                   amount: transferAmount,
-                  allowNonLSP1Recipient: false,
+                  force: false,
                   data: expectedData,
                 };
 
@@ -1158,7 +1158,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                       txParams.from,
                       txParams.to,
                       txParams.amount,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 )
@@ -1189,7 +1189,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               from: context.accounts.owner.address,
               to: deployedContracts.tokenReceiverWithoutLSP1.address,
               amount: ownerBalance.add(1),
-              allowNonLSP1Recipient: true,
+              force: true,
               data: expectedData,
             };
 
@@ -1203,7 +1203,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   txParams.from,
                   txParams.to,
                   txParams.amount,
-                  txParams.allowNonLSP1Recipient,
+                  txParams.force,
                   txParams.data,
                 ),
             )
@@ -1230,7 +1230,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
               from: context.accounts.owner.address,
               to: deployedContracts.tokenReceiverWithoutLSP1.address,
               amount: ownerBalance.add(1),
-              allowNonLSP1Recipient: true,
+              force: true,
               data: expectedData,
             };
 
@@ -1244,7 +1244,7 @@ export const shouldBehaveLikeLSP7CompatibleERC20 = (
                   txParams.from,
                   txParams.to,
                   txParams.amount,
-                  txParams.allowNonLSP1Recipient,
+                  txParams.force,
                   txParams.data,
                 ),
             )

--- a/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
@@ -54,7 +54,7 @@ export const shouldBehaveLikeLSP7Mintable = (
       await context.lsp7Mintable.mint(
         context.accounts.tokenReceiver.address,
         amountToMint,
-        true, // beneficiary is an EOA, so we need to allowNonLSP1Recipient minting
+        true, // beneficiary is an EOA, so we need to force minting
         '0x',
       );
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8CompatibleERC721.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8CompatibleERC721.behaviour.ts
@@ -731,7 +731,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
     const transferSuccessScenario = async (
       { operator, from, to, tokenId, data }: TransferTxParams,
       transferFn: string,
-      allowNonLSP1Recipient: boolean,
+      force: boolean,
       expectedData: string,
     ) => {
       // pre-conditions
@@ -749,14 +749,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
           context.lsp8CompatibleERC721,
           'Transfer(address,address,address,bytes32,bool,bytes)',
         )
-        .withArgs(
-          operator,
-          from,
-          to,
-          tokenIdAsBytes32(tokenId),
-          allowNonLSP1Recipient,
-          expectedData,
-        );
+        .withArgs(operator, from, to, tokenIdAsBytes32(tokenId), force, expectedData);
 
       await expect(tx)
         .to.emit(context.lsp8CompatibleERC721, 'Transfer(address,address,uint256)')
@@ -773,7 +766,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
 
     describe('transferFrom', () => {
       const transferFn = 'transferFrom';
-      const allowNonLSP1Recipient = true;
+      const force = true;
       const expectedData = ethers.utils.hexlify(ethers.utils.toUtf8Bytes(''));
 
       describe('when the from address is the tokenId owner', () => {
@@ -786,12 +779,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
               tokenId: mintedTokenId,
             };
 
-            await transferSuccessScenario(
-              txParams,
-              transferFn,
-              allowNonLSP1Recipient,
-              expectedData,
-            );
+            await transferSuccessScenario(txParams, transferFn, force, expectedData);
           });
         });
 
@@ -805,12 +793,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 tokenId: mintedTokenId,
               };
 
-              await transferSuccessScenario(
-                txParams,
-                transferFn,
-                allowNonLSP1Recipient,
-                expectedData,
-              );
+              await transferSuccessScenario(txParams, transferFn, force, expectedData);
             });
           });
 
@@ -823,12 +806,7 @@ export const shouldBehaveLikeLSP8CompatibleERC721 = (
                 tokenId: mintedTokenId,
               };
 
-              await transferSuccessScenario(
-                txParams,
-                transferFn,
-                allowNonLSP1Recipient,
-                expectedData,
-              );
+              await transferSuccessScenario(txParams, transferFn, force, expectedData);
             });
           });
         });

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -83,17 +83,12 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         const txParams = {
           to: context.accounts.tokenReceiver.address,
           tokenId: mintedTokenId,
-          allowNonLSP1Recipient: true,
+          force: true,
           data: '0x',
         };
 
         await expect(
-          context.lsp8.mint(
-            txParams.to,
-            txParams.tokenId,
-            txParams.allowNonLSP1Recipient,
-            txParams.data,
-          ),
+          context.lsp8.mint(txParams.to, txParams.tokenId, txParams.force, txParams.data),
         )
           .to.be.revertedWithCustomError(context.lsp8, 'LSP8TokenIdAlreadyMinted')
           .withArgs(txParams.tokenId);
@@ -108,17 +103,12 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           const txParams = {
             to: ethers.constants.AddressZero,
             tokenId: toBeMintedTokenId,
-            allowNonLSP1Recipient: true,
+            force: true,
             data: '0x',
           };
 
           await expect(
-            context.lsp8.mint(
-              txParams.to,
-              txParams.tokenId,
-              txParams.allowNonLSP1Recipient,
-              txParams.data,
-            ),
+            context.lsp8.mint(txParams.to, txParams.tokenId, txParams.force, txParams.data),
           ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToAddressZero');
         });
       });
@@ -128,16 +118,11 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           const txParams = {
             to: context.accounts.tokenReceiver.address,
             tokenId: toBeMintedTokenId,
-            allowNonLSP1Recipient: true,
+            force: true,
             data: ethers.utils.toUtf8Bytes('we need more tokens'),
           };
 
-          await context.lsp8.mint(
-            txParams.to,
-            txParams.tokenId,
-            txParams.allowNonLSP1Recipient,
-            txParams.data,
-          );
+          await context.lsp8.mint(txParams.to, txParams.tokenId, txParams.force, txParams.data);
 
           const tokenOwnerOf = await context.lsp8.tokenOwnerOf(txParams.tokenId);
           expect(tokenOwnerOf).to.equal(txParams.to);
@@ -664,12 +649,12 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         from: string;
         to: string;
         tokenId: BytesLike;
-        allowNonLSP1Recipient: boolean;
+        force: boolean;
         data: string;
       };
 
       const transferSuccessScenario = async (
-        { from, to, tokenId, allowNonLSP1Recipient, data }: TransferTxParams,
+        { from, to, tokenId, force, data }: TransferTxParams,
         operator: SignerWithAddress,
       ) => {
         // pre-conditions
@@ -692,12 +677,10 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         const preToBalanceOf = await context.lsp8.balanceOf(to);
 
         // effect
-        const tx = await context.lsp8
-          .connect(operator)
-          .transfer(from, to, tokenId, allowNonLSP1Recipient, data);
+        const tx = await context.lsp8.connect(operator).transfer(from, to, tokenId, force, data);
         await expect(tx)
           .to.emit(context.lsp8, 'Transfer')
-          .withArgs(operator.address, from, to, tokenId, allowNonLSP1Recipient, data);
+          .withArgs(operator.address, from, to, tokenId, force, data);
 
         await expect(tx)
           .to.emit(context.lsp8, 'RevokedOperator')
@@ -737,10 +720,10 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           operator = getOperator();
         });
 
-        describe('when using allowNonLSP1Recipient=true', () => {
-          const allowNonLSP1Recipient = true;
+        describe('when using force=true', () => {
+          const force = true;
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
+            ethers.utils.toUtf8Bytes('doing a transfer with force'),
           );
 
           describe('when `to` is an EOA', () => {
@@ -750,7 +733,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: context.accounts.owner.address,
                   to: ethers.constants.AddressZero,
                   tokenId: mintedTokenId,
-                  allowNonLSP1Recipient,
+                  force,
                   data,
                 };
 
@@ -761,7 +744,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                       txParams.from,
                       txParams.to,
                       txParams.tokenId,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToAddressZero');
@@ -773,7 +756,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 tokenId: mintedTokenId,
-                allowNonLSP1Recipient,
+                force,
                 data,
               };
 
@@ -789,7 +772,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: context.accounts.owner.address,
                   to: helperContracts.tokenReceiverWithLSP1.address,
                   tokenId: mintedTokenId,
-                  allowNonLSP1Recipient,
+                  force,
                   data,
                 };
 
@@ -814,7 +797,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: context.accounts.owner.address,
                   to: helperContracts.tokenReceiverWithoutLSP1.address,
                   tokenId: mintedTokenId,
-                  allowNonLSP1Recipient,
+                  force,
                   data,
                 };
 
@@ -829,7 +812,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 from: context.accounts.owner.address,
                 to: context.accounts.owner.address,
                 tokenId: mintedTokenId,
-                allowNonLSP1Recipient,
+                force,
                 data,
               };
 
@@ -840,7 +823,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
-                    txParams.allowNonLSP1Recipient,
+                    txParams.force,
                     txParams.data,
                   ),
               ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
@@ -848,10 +831,10 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe('when allowNonLSP1Recipient=false', () => {
-          const allowNonLSP1Recipient = false;
+        describe('when force=false', () => {
+          const force = false;
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
+            ethers.utils.toUtf8Bytes('doing a transfer without force'),
           );
 
           describe('when `to` is an EOA', () => {
@@ -860,7 +843,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 from: context.accounts.owner.address,
                 to: context.accounts.tokenReceiver.address,
                 tokenId: mintedTokenId,
-                allowNonLSP1Recipient,
+                force,
                 data,
               };
 
@@ -871,7 +854,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
-                    txParams.allowNonLSP1Recipient,
+                    txParams.force,
                     txParams.data,
                   ),
               )
@@ -888,7 +871,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: context.accounts.owner.address,
                   to: helperContracts.tokenReceiverWithLSP1.address,
                   tokenId: mintedTokenId,
-                  allowNonLSP1Recipient,
+                  force,
                   data,
                 };
 
@@ -913,7 +896,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: context.accounts.owner.address,
                   to: helperContracts.tokenReceiverWithoutLSP1.address,
                   tokenId: mintedTokenId,
-                  allowNonLSP1Recipient,
+                  force,
                   data,
                 };
 
@@ -924,7 +907,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                       txParams.from,
                       txParams.to,
                       txParams.tokenId,
-                      txParams.allowNonLSP1Recipient,
+                      txParams.force,
                       txParams.data,
                     ),
                 )
@@ -943,7 +926,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 from: context.accounts.owner.address,
                 to: context.accounts.owner.address,
                 tokenId: mintedTokenId,
-                allowNonLSP1Recipient,
+                force,
                 data,
               };
 
@@ -954,7 +937,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     txParams.from,
                     txParams.to,
                     txParams.tokenId,
-                    txParams.allowNonLSP1Recipient,
+                    txParams.force,
                     txParams.data,
                   ),
               ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
@@ -977,7 +960,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               from: context.accounts.owner.address,
               to: context.accounts.tokenReceiver.address,
               tokenId: mintedTokenId,
-              allowNonLSP1Recipient: true,
+              force: true,
               data: '0x',
             };
 
@@ -988,7 +971,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   txParams.from,
                   txParams.to,
                   txParams.tokenId,
-                  txParams.allowNonLSP1Recipient,
+                  txParams.force,
                   txParams.data,
                 ),
             )
@@ -1005,7 +988,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             from: context.accounts.anyone.address,
             to: context.accounts.tokenReceiver.address,
             tokenId: mintedTokenId,
-            allowNonLSP1Recipient: true,
+            force: true,
             data: '0x',
           };
 
@@ -1016,7 +999,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 txParams.from,
                 txParams.to,
                 txParams.tokenId,
-                txParams.allowNonLSP1Recipient,
+                txParams.force,
                 txParams.data,
               ),
           )
@@ -1032,7 +1015,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             from: context.accounts.owner.address,
             to: context.accounts.tokenReceiver.address,
             tokenId: neverMintedTokenId,
-            allowNonLSP1Recipient: true,
+            force: true,
             data: '0x',
           };
 
@@ -1043,7 +1026,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 txParams.from,
                 txParams.to,
                 txParams.tokenId,
-                txParams.allowNonLSP1Recipient,
+                txParams.force,
                 txParams.data,
               ),
           )
@@ -1082,12 +1065,12 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         from: string[];
         to: string[];
         tokenId: BytesLike[];
-        allowNonLSP1Recipient: boolean[];
+        force: boolean[];
         data: string[];
       };
 
       const transferBatchSuccessScenario = async (
-        { from, to, tokenId, allowNonLSP1Recipient, data }: TransferBatchTxParams,
+        { from, to, tokenId, force, data }: TransferBatchTxParams,
         operator: SignerWithAddress,
       ) => {
         // pre-conditions
@@ -1107,7 +1090,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
         // effect
         const tx = await context.lsp8
           .connect(operator)
-          .transferBatch(from, to, tokenId, allowNonLSP1Recipient, data);
+          .transferBatch(from, to, tokenId, force, data);
 
         await Promise.all(
           tokenId.map(async (_, index) => {
@@ -1118,7 +1101,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                 from[index],
                 to[index],
                 tokenId[index],
-                allowNonLSP1Recipient[index],
+                force[index],
                 data[index],
               );
             await expect(tx)
@@ -1150,7 +1133,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
       };
 
       const transferBatchFailScenario = async (
-        { from, to, tokenId, allowNonLSP1Recipient, data }: TransferBatchTxParams,
+        { from, to, tokenId, force, data }: TransferBatchTxParams,
         operator: SignerWithAddress,
         expectedError: ExpectedError,
       ) => {
@@ -1164,18 +1147,12 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
 
         // effect
         if (expectedError.args.length > 0)
-          await expect(
-            context.lsp8
-              .connect(operator)
-              .transferBatch(from, to, tokenId, allowNonLSP1Recipient, data),
-          )
+          await expect(context.lsp8.connect(operator).transferBatch(from, to, tokenId, force, data))
             .to.be.revertedWithCustomError(context.lsp8, expectedError.error)
             .withArgs(...expectedError.args);
         else
           await expect(
-            context.lsp8
-              .connect(operator)
-              .transferBatch(from, to, tokenId, allowNonLSP1Recipient, data),
+            context.lsp8.connect(operator).transferBatch(from, to, tokenId, force, data),
           ).to.be.revertedWithCustomError(context.lsp8, expectedError.error);
       };
 
@@ -1186,9 +1163,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           operator = getOperator();
         });
 
-        describe('when allowNonLSP1Recipient=true', () => {
+        describe('when force=true', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes('doing a transfer with allowNonLSP1Recipient'),
+            ethers.utils.toUtf8Bytes('doing a transfer with force'),
           );
 
           describe('when `to` is an EOA', () => {
@@ -1198,7 +1175,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [context.accounts.tokenReceiver.address, ethers.constants.AddressZero],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [true, true],
+                  force: [true, true],
                   data: [data, data],
                 };
                 const expectedError = 'LSP8CannotSendToAddressZero';
@@ -1218,7 +1195,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   context.accounts.tokenReceiver.address,
                 ],
                 tokenId: [mintedTokenId, anotherMintedTokenId],
-                allowNonLSP1Recipient: [true, true],
+                force: [true, true],
                 data: [data, data],
               };
 
@@ -1236,7 +1213,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [true, true],
+                  force: [true, true],
                   data: [data, data],
                 };
 
@@ -1273,7 +1250,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithoutLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [true, true],
+                  force: [true, true],
                   data: [data, data],
                 };
 
@@ -1283,9 +1260,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe('when allowNonLSP1Recipient=false', () => {
+        describe('when force=false', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
+            ethers.utils.toUtf8Bytes('doing a transfer without force'),
           );
 
           describe('when `to` is an EOA', () => {
@@ -1297,7 +1274,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   helperContracts.tokenReceiverWithLSP1.address,
                 ],
                 tokenId: [mintedTokenId, anotherMintedTokenId],
-                allowNonLSP1Recipient: [false, false],
+                force: [false, false],
                 data: [data, data],
               };
               const expectedError = 'LSP8NotifyTokenReceiverIsEOA';
@@ -1319,7 +1296,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [false, false],
+                  force: [false, false],
                   data: [data, data],
                 };
 
@@ -1336,7 +1313,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [false, false],
+                  force: [false, false],
                   data: [data, data],
                 };
                 const expectedError = 'LSP8NotifyTokenReceiverContractMissingLSP1Interface';
@@ -1350,9 +1327,9 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
           });
         });
 
-        describe('when allowNonLSP1Recipient is mixed(true/false) respectively', () => {
+        describe('when force is mixed(true/false) respectively', () => {
           const data = ethers.utils.hexlify(
-            ethers.utils.toUtf8Bytes('doing a transfer without allowNonLSP1Recipient'),
+            ethers.utils.toUtf8Bytes('doing a transfer without force'),
           );
 
           describe('when `to` is an EOA', () => {
@@ -1364,7 +1341,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                   context.accounts.tokenReceiver.address,
                 ],
                 tokenId: [mintedTokenId, anotherMintedTokenId],
-                allowNonLSP1Recipient: [true, false],
+                force: [true, false],
                 data: [data, data],
               };
               const expectedError = 'LSP8NotifyTokenReceiverIsEOA';
@@ -1386,7 +1363,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithoutLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [true, false],
+                  force: [true, false],
                   data: [data, data],
                 };
 
@@ -1400,7 +1377,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
             });
 
             describe('when receiving contract both support LSP1', () => {
-              it('should pass regardless of allowNonLSP1Recipient params', async () => {
+              it('should pass regardless of force params', async () => {
                 const txParams = {
                   from: [context.accounts.owner.address, context.accounts.owner.address],
                   to: [
@@ -1408,7 +1385,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
                     helperContracts.tokenReceiverWithLSP1.address,
                   ],
                   tokenId: [mintedTokenId, anotherMintedTokenId],
-                  allowNonLSP1Recipient: [true, false],
+                  force: [true, false],
                   data: [data, data],
                 };
 
@@ -1424,7 +1401,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               to: [context.accounts.anyone.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId],
-              allowNonLSP1Recipient: [true],
+              force: [true],
               data: ['0x'],
             };
             const expectedError = 'LSP8NotTokenOwner';
@@ -1446,7 +1423,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               to: [context.accounts.anyone.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [neverMintedTokenId],
-              allowNonLSP1Recipient: [true],
+              force: [true],
               data: ['0x'],
             };
             const expectedError = 'LSP8NonExistentTokenId';
@@ -1464,7 +1441,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               from: [context.accounts.owner.address, context.accounts.owner.address],
               to: [context.accounts.tokenReceiver.address, context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId, anotherMintedTokenId],
-              allowNonLSP1Recipient: [true],
+              force: [true],
               data: ['0x', '0x'],
             };
 
@@ -1501,7 +1478,7 @@ export const shouldBehaveLikeLSP8 = (buildContext: () => Promise<LSP8TestContext
               to: [context.accounts.owner.address],
               from: [context.accounts.tokenReceiver.address],
               tokenId: [mintedTokenId],
-              allowNonLSP1Recipient: [true],
+              force: [true],
               data: ['0x'],
             };
             const expectedError = 'LSP8NotTokenOperator';

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
@@ -54,7 +54,7 @@ export const shouldBehaveLikeLSP8Mintable = (
       await context.lsp8Mintable.mint(
         context.accounts.tokenReceiver.address,
         randomTokenId,
-        true, // beneficiary is an EOA, so we need to allowNonLSP1Recipient minting
+        true, // beneficiary is an EOA, so we need to force minting
         '0x',
       );
 


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ ♻️ Refactor +  🧪 Tests + 📄 Documentation

Change back the parameter name `allowNonLSP1Recipient` back to `force`:
- in all the Solidity files
- in all the test files
- regenerated the docs in Markdown with the new parameter name

### PR Checklist

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
