### PR TITLE
feat: allow `endingTimestamp` to be 0

### DIFF
--- a/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25MultiChannelNonce.sol
@@ -113,6 +113,10 @@ abstract contract LSP25MultiChannelNonce {
             revert RelayCallBeforeStartTime();
         }
 
+        // Allow `endingTimestamp` to be 0
+        // Allow execution anytime past `startingTimestamp`
+        if (endingTimestamp == 0) return;
+
         // solhint-disable-next-line not-rely-on-time
         if (block.timestamp > endingTimestamp) {
             revert RelayCallExpired();

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -727,11 +727,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
+              const randomNumber = 12345;
               const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
-                0,
+                OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -747,7 +748,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 .connect(relayer)
                 .executeRelayCall(signature, nonce, validityTimestamps, calldata);
 
-              expect(await targetContract.getNumber()).to.equal(nonce);
+              expect(await targetContract.getNumber()).to.equal(randomNumber);
             });
           });
 
@@ -825,11 +826,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
+              const randomNumber = 12345;
               const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
-                0,
+                OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -845,7 +847,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 .connect(relayer)
                 .executeRelayCall(signature, nonce, validityTimestamps, calldata);
 
-              expect(await targetContract.getNumber()).to.equal(nonce);
+              expect(await targetContract.getNumber()).to.equal(randomNumber);
             });
           });
 
@@ -862,11 +864,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
+              const randomNumber = 12345;
               const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
-                0,
+                OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -884,7 +887,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 .connect(relayer)
                 .executeRelayCall(signature, nonce, validityTimestamps, calldata);
 
-              expect(await targetContract.getNumber()).to.equal(nonce);
+              expect(await targetContract.getNumber()).to.equal(randomNumber);
             });
           });
         });
@@ -964,11 +967,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 startingTimestamp,
                 endingTimestamp,
               );
+              const randomNumber = 12345;
               const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
-                0,
+                OPERATION_TYPES.CALL,
                 targetContract.address,
                 0,
-                targetContract.interface.encodeFunctionData('setNumber', [nonce]),
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
               ]);
               const value = 0;
               const signature = await signLSP6ExecuteRelayCall(
@@ -986,7 +990,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
                 .connect(relayer)
                 .executeRelayCall(signature, nonce, validityTimestamps, calldata);
 
-              expect(await targetContract.getNumber()).to.equal(nonce);
+              expect(await targetContract.getNumber()).to.equal(randomNumber);
             });
           });
         });
@@ -995,11 +999,12 @@ export const shouldBehaveLikeExecuteRelayCall = (
           it('passes', async () => {
             const nonce = await context.keyManager.callStatic.getNonce(signer.address, 14);
             const validityTimestamps = 0;
+            const randomNumber = 12345;
             const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
-              0,
+              OPERATION_TYPES.CALL,
               targetContract.address,
               0,
-              targetContract.interface.encodeFunctionData('setNumber', [nonce]),
+              targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
             ]);
             const value = 0;
             const signature = await signLSP6ExecuteRelayCall(
@@ -1015,7 +1020,83 @@ export const shouldBehaveLikeExecuteRelayCall = (
               .connect(relayer)
               .executeRelayCall(signature, nonce, validityTimestamps, calldata);
 
-            expect(await targetContract.getNumber()).to.equal(nonce);
+            expect(await targetContract.getNumber()).to.equal(randomNumber);
+          });
+        });
+
+        describe('when `endingTimestamp == 0`', () => {
+          describe('`startingTimestamp` < now', () => {
+            it('passes', async () => {
+              const now = await time.latest();
+
+              const startingTimestamp = now - 100;
+              const endingTimestamp = 0;
+
+              const nonce = await context.keyManager.callStatic.getNonce(signer.address, 14);
+              const validityTimestamps = createValidityTimestamps(
+                startingTimestamp,
+                endingTimestamp,
+              );
+              const randomNumber = 12345;
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
+              ]);
+              const value = 0;
+              const signature = await signLSP6ExecuteRelayCall(
+                context.keyManager,
+                nonce.toString(),
+                validityTimestamps,
+                signerPrivateKey,
+                value,
+                calldata,
+              );
+
+              await context.keyManager
+                .connect(relayer)
+                .executeRelayCall(signature, nonce, validityTimestamps, calldata);
+
+              expect(await targetContract.getNumber()).to.equal(randomNumber);
+            });
+          });
+
+          describe('`startingTimestamp` > now', () => {
+            it('reverts', async () => {
+              const now = await time.latest();
+
+              const startingTimestamp = now + 100;
+              const endingTimestamp = 0;
+
+              const nonce = await context.keyManager.callStatic.getNonce(signer.address, 14);
+              const validityTimestamps = createValidityTimestamps(
+                startingTimestamp,
+                endingTimestamp,
+              );
+              const randomNumber = 12345;
+              const calldata = context.universalProfile.interface.encodeFunctionData('execute', [
+                OPERATION_TYPES.CALL,
+                targetContract.address,
+                0,
+                targetContract.interface.encodeFunctionData('setNumber', [randomNumber]),
+              ]);
+              const value = 0;
+              const signature = await signLSP6ExecuteRelayCall(
+                context.keyManager,
+                nonce.toString(),
+                validityTimestamps,
+                signerPrivateKey,
+                value,
+                calldata,
+              );
+
+              await expect(
+                context.keyManager
+                  .connect(relayer)
+                  .executeRelayCall(signature, nonce, validityTimestamps, calldata),
+              ).to.be.revertedWithCustomError(context.keyManager, 'RelayCallBeforeStartTime');
+            });
           });
         });
       });


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## 🚀 Feature

Allow the validity timestamp in a relay call to start but never end

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
