### PR TITLE
refactor: remove operator logic from internal `_burn` function in LSP7

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -277,7 +277,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      *    indicating `operator` does not have any alauthorizedAmountForlowance left for `msg.sender`.
      *
      * @param operator The operator to decrease allowance for `msg.sender`
-     * @param substractedAmount The amount to decrease by in the operator's allowance.
+     * @param subtractedAmount The amount to decrease by in the operator's allowance.
      *
      * @custom:requirements
      *  - `operator` cannot be the zero address.
@@ -458,7 +458,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     }
 
     /**
-     * @dev Spend `amount` from the `operator`'s authorized on behalf of the `tokenOwner`.
+     * @dev Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
      *
      * @param operator The address of the operator to decrease the allowance of.
      * @param tokenOwner The address that granted an allowance on its balance to `operator`.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
@@ -4,12 +4,6 @@ pragma solidity ^0.8.4;
 // modules
 import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
 
-// errors
-import {
-    LSP7AmountExceedsAuthorizedAmount,
-    LSP7CannotSendWithAddressZero
-} from "../LSP7Errors.sol";
-
 /**
  * @title LSP7 token extension that allows token holders to destroy both
  * their own tokens and those that they have an allowance for as an operator.

--- a/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
@@ -4,6 +4,12 @@ pragma solidity ^0.8.4;
 // modules
 import {LSP7DigitalAsset} from "../LSP7DigitalAsset.sol";
 
+// errors
+import {
+    LSP7AmountExceedsAuthorizedAmount,
+    LSP7CannotSendWithAddressZero
+} from "../LSP7Errors.sol";
+
 /**
  * @title LSP7 token extension that allows token holders to destroy both
  * their own tokens and those that they have an allowance for as an operator.
@@ -17,6 +23,10 @@ abstract contract LSP7Burnable is LSP7DigitalAsset {
         uint256 amount,
         bytes memory data
     ) public virtual {
+        if (msg.sender != from) {
+            _spendAllowance(msg.sender, from, amount);
+        }
+
         _burn(from, amount, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
@@ -19,6 +19,9 @@ abstract contract LSP7BurnableInitAbstract is LSP7DigitalAssetInitAbstract {
         uint256 amount,
         bytes memory data
     ) public virtual {
+        if (msg.sender != from) {
+            _spendAllowance(msg.sender, from, amount);
+        }
         _burn(from, amount, data);
     }
 }

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -256,8 +256,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -411,8 +411,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -811,7 +811,7 @@ Save gas by emitting the [`DataChanged`](#datachanged) event with only the first
 function _updateOperator(
   address tokenOwner,
   address operator,
-  uint256 amount,
+  uint256 allowance,
   bytes operatorNotificationData
 ) internal nonpayable;
 ```
@@ -819,6 +819,15 @@ function _updateOperator(
 Changes token `amount` the `operator` has access to from `tokenOwner` tokens.
 If the amount is zero the operator is removed from the list of operators, otherwise he is added to the list of operators.
 If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+
+#### Parameters
+
+| Name                       |   Type    | Description                                                                            |
+| -------------------------- | :-------: | -------------------------------------------------------------------------------------- |
+| `tokenOwner`               | `address` | The address that will give `operator` an allowance for on its balance.                 |
+| `operator`                 | `address` | The address to grant an allowance to spend.                                            |
+| `allowance`                | `uint256` | The maximum amount of token that `operator` can spend from the `tokenOwner`'s balance. |
+| `operatorNotificationData` |  `bytes`  | -                                                                                      |
 
 <br/>
 
@@ -887,6 +896,28 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 | `from`   | `address` | The address to burn tokens from its balance.                                                                              |
 | `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -281,8 +281,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -436,8 +436,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -836,7 +836,7 @@ Save gas by emitting the [`DataChanged`](#datachanged) event with only the first
 function _updateOperator(
   address tokenOwner,
   address operator,
-  uint256 amount,
+  uint256 allowance,
   bytes operatorNotificationData
 ) internal nonpayable;
 ```
@@ -844,6 +844,15 @@ function _updateOperator(
 Changes token `amount` the `operator` has access to from `tokenOwner` tokens.
 If the amount is zero the operator is removed from the list of operators, otherwise he is added to the list of operators.
 If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+
+#### Parameters
+
+| Name                       |   Type    | Description                                                                            |
+| -------------------------- | :-------: | -------------------------------------------------------------------------------------- |
+| `tokenOwner`               | `address` | The address that will give `operator` an allowance for on its balance.                 |
+| `operator`                 | `address` | The address to grant an allowance to spend.                                            |
+| `allowance`                | `uint256` | The maximum amount of token that `operator` can spend from the `tokenOwner`'s balance. |
+| `operatorNotificationData` |  `bytes`  | -                                                                                      |
 
 <br/>
 
@@ -912,6 +921,28 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 | `from`   | `address` | The address to burn tokens from its balance.                                                                              |
 | `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -254,8 +254,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -409,8 +409,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -836,7 +836,7 @@ Save gas by emitting the [`DataChanged`](#datachanged) event with only the first
 function _updateOperator(
   address tokenOwner,
   address operator,
-  uint256 amount,
+  uint256 allowance,
   bytes operatorNotificationData
 ) internal nonpayable;
 ```
@@ -844,6 +844,15 @@ function _updateOperator(
 Changes token `amount` the `operator` has access to from `tokenOwner` tokens.
 If the amount is zero the operator is removed from the list of operators, otherwise he is added to the list of operators.
 If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+
+#### Parameters
+
+| Name                       |   Type    | Description                                                                            |
+| -------------------------- | :-------: | -------------------------------------------------------------------------------------- |
+| `tokenOwner`               | `address` | The address that will give `operator` an allowance for on its balance.                 |
+| `operator`                 | `address` | The address to grant an allowance to spend.                                            |
+| `allowance`                | `uint256` | The maximum amount of token that `operator` can spend from the `tokenOwner`'s balance. |
+| `operatorNotificationData` |  `bytes`  | -                                                                                      |
 
 <br/>
 
@@ -896,6 +905,28 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 | `from`   | `address` | The address to burn tokens from its balance.                                                                              |
 | `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -320,8 +320,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -475,8 +475,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -1028,6 +1028,28 @@ function _mint(
 ```solidity
 function _burn(address from, uint256 amount, bytes data) internal nonpayable;
 ```
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -321,8 +321,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -476,8 +476,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -1062,6 +1062,28 @@ function _mint(
 ```solidity
 function _burn(address from, uint256 amount, bytes data) internal nonpayable;
 ```
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -285,8 +285,8 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
-| `operator`                 | `address` | the operator to decrease allowance for `msg.sender`    |
-| `subtractedAmount`         | `uint256` | the amount to decrease by in the operator's allowance. |
+| `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
 <br/>
@@ -440,8 +440,8 @@ Atomically increases the allowance granted to `operator` by the caller. This is 
 
 | Name                       |   Type    | Description                                                             |
 | -------------------------- | :-------: | ----------------------------------------------------------------------- |
-| `operator`                 | `address` | the operator to increase the allowance for `msg.sender`                 |
-| `addedAmount`              | `uint256` | the additional amount to add on top of the current operator's allowance |
+| `operator`                 | `address` | The operator to increase the allowance for `msg.sender`                 |
+| `addedAmount`              | `uint256` | The additional amount to add on top of the current operator's allowance |
 | `operatorNotificationData` |  `bytes`  | -                                                                       |
 
 <br/>
@@ -873,7 +873,7 @@ Save gas by emitting the [`DataChanged`](#datachanged) event with only the first
 function _updateOperator(
   address tokenOwner,
   address operator,
-  uint256 amount,
+  uint256 allowance,
   bytes operatorNotificationData
 ) internal nonpayable;
 ```
@@ -881,6 +881,15 @@ function _updateOperator(
 Changes token `amount` the `operator` has access to from `tokenOwner` tokens.
 If the amount is zero the operator is removed from the list of operators, otherwise he is added to the list of operators.
 If the amount is zero then the operator is being revoked, otherwise the operator amount is being modified.
+
+#### Parameters
+
+| Name                       |   Type    | Description                                                                            |
+| -------------------------- | :-------: | -------------------------------------------------------------------------------------- |
+| `tokenOwner`               | `address` | The address that will give `operator` an allowance for on its balance.                 |
+| `operator`                 | `address` | The address to grant an allowance to spend.                                            |
+| `allowance`                | `uint256` | The maximum amount of token that `operator` can spend from the `tokenOwner`'s balance. |
+| `operatorNotificationData` |  `bytes`  | -                                                                                      |
 
 <br/>
 
@@ -949,6 +958,28 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 | `from`   | `address` | The address to burn tokens from its balance.                                                                              |
 | `amount` | `uint256` | The amount of tokens to burn.                                                                                             |
 | `data`   |  `bytes`  | Additional data the caller wants included in the emitted event, and sent in the LSP1 hook to the `from` and `to` address. |
+
+<br/>
+
+### \_spendAllowance
+
+```solidity
+function _spendAllowance(
+  address operator,
+  address tokenOwner,
+  uint256 amountToSpend
+) internal nonpayable;
+```
+
+Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOwner`.
+
+#### Parameters
+
+| Name            |   Type    | Description                                                         |
+| --------------- | :-------: | ------------------------------------------------------------------- |
+| `operator`      | `address` | The address of the operator to decrease the allowance of.           |
+| `tokenOwner`    | `address` | The address that granted an allowance on its balance to `operator`. |
+| `amountToSpend` | `uint256` | The amount of tokens to substract in allowance of `operator`.       |
 
 <br/>
 

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -1776,6 +1776,7 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           );
       });
     });
+
     describe('when caller is the `from` address', () => {
       describe('when using address(0) as `from` address', () => {
         it('should revert', async () => {

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -1785,7 +1785,14 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
           await expect(
             context.lsp7.connect(caller).burn(ethers.constants.AddressZero, amount, '0x'),
-          ).to.be.revertedWithCustomError(context.lsp7, 'LSP7CannotSendWithAddressZero');
+          )
+            .to.be.revertedWithCustomError(context.lsp7, 'LSP7AmountExceedsAuthorizedAmount')
+            .withArgs(
+              ethers.constants.AddressZero, // tokenOwner
+              0, // authorized amount
+              caller.address, // operator
+              amount, // amount
+            );
         });
       });
 
@@ -1943,6 +1950,22 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           expect(newAllowance).to.equal(0);
         });
 
+        it('operator should have been removed from the list of operators for the token owner', async () => {
+          const operator = context.accounts.operator;
+          const amount = operatorAllowance;
+
+          const operatorsList = await context.lsp7.getOperatorsOf(context.accounts.owner.address);
+          expect(operatorsList).to.include(operator.address);
+
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
+
+          const updatedOperatorList = await context.lsp7.getOperatorsOf(
+            context.accounts.owner.address,
+          );
+          expect(updatedOperatorList.length).to.equal(operatorsList.length - 1);
+          expect(updatedOperatorList).to.not.include(operator.address);
+        });
+
         it('token owner balance should have decreased', async () => {
           const operator = context.accounts.operator;
           const amount = operatorAllowance;
@@ -1982,6 +2005,20 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
               '0x',
             );
         });
+
+        it('should have emitted a `RevokedOperator` event', async () => {
+          const operator = context.accounts.operator;
+          const amount = operatorAllowance;
+
+          const operatorsList = await context.lsp7.getOperatorsOf(context.accounts.owner.address);
+          expect(operatorsList).to.include(operator.address);
+
+          await expect(
+            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x'),
+          )
+            .to.emit(context.lsp7, 'RevokedOperator')
+            .withArgs(operator.address, context.accounts.owner.address, '0x');
+        });
       });
 
       describe('when burning part of its allowance', () => {
@@ -2003,6 +2040,18 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
           );
 
           expect(newAllowance).to.equal(initialAllowance.sub(amount));
+        });
+
+        it('operator should still be in the list of operators for tokenOwner (and not have been removed)', async () => {
+          const amount = 10;
+          assert.isBelow(amount, operatorAllowance);
+
+          const operator = context.accounts.operator;
+
+          await context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x');
+
+          const operatorsList = await context.lsp7.getOperatorsOf(context.accounts.owner.address);
+          expect(operatorsList).to.include(operator.address);
         });
 
         it('token owner balance should have decreased', async () => {
@@ -2047,6 +2096,24 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
               ethers.constants.AddressZero,
               amount,
               false,
+              '0x',
+            );
+        });
+
+        it("should emit an `AuthorizedOperator` event with the updated operator's allowance", async () => {
+          const amount = 10;
+          assert.isBelow(amount, operatorAllowance);
+
+          const operator = context.accounts.operator;
+
+          await expect(
+            context.lsp7.connect(operator).burn(context.accounts.owner.address, amount, '0x'),
+          )
+            .to.emit(context.lsp7, 'AuthorizedOperator')
+            .withArgs(
+              operator.address,
+              context.accounts.owner.address,
+              operatorAllowance - amount,
               '0x',
             );
         });


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

- Remove the logic to check for the operator allowance inside the internal `_burn` function in LSP7 + move this function in the public `burn(...)` function in the extension `LSP7Burnable`.

- Create internal function `_spendAllowance`.


## 🧪 Tests

- Add tests to ensure operators is removed from list when burning all its allowance.
- Add tests to check for event emitted `AuthorizedOperator` and `RevokedOperator` when burning as an operator.
- Update the custom error when operator try to burn using `address(0)` as `from` (matches with OpenZeppelin logic on ERC20 implementation)

## 📄 Documentation

- Add Natspec comments + update auto-generated docs.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
