### PR TITLE
chore: use `Apache-2.0` license across all `.sol` files

### DIFF
--- a/contracts/Factories/Create2Factory.sol
+++ b/contracts/Factories/Create2Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // DO NOT TOUCH

--- a/contracts/LSP11BasicSocialRecovery/LSP11Constants.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // --- ERC165 interface ids

--- a/contracts/LSP11BasicSocialRecovery/LSP11Errors.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
 // --- Errors

--- a/contracts/LSP14Ownable2Step/ILSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/ILSP14Ownable2Step.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP14Ownable2Step/LSP14Constants.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 bytes4 constant _INTERFACEID_LSP14 = 0x94be5999;

--- a/contracts/LSP14Ownable2Step/LSP14Errors.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP16UniversalFactory/LSP16UniversalFactory.sol
+++ b/contracts/LSP16UniversalFactory/LSP16UniversalFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // libraries

--- a/contracts/LSP17ContractExtension/LSP17Errors.sol
+++ b/contracts/LSP17ContractExtension/LSP17Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
+++ b/contracts/LSP1UniversalReceiver/ILSP1UniversalReceiver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP20CallVerification/ILSP20CallVerifier.sol
+++ b/contracts/LSP20CallVerification/ILSP20CallVerifier.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP20CallVerification/LSP20Constants.sol
+++ b/contracts/LSP20CallVerification/LSP20Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // bytes4(keccak256("LSP20CallVerification"))

--- a/contracts/LSP20CallVerification/LSP20Errors.sol
+++ b/contracts/LSP20CallVerification/LSP20Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP23LinkedContractsFactory/ILSP23LinkedContractsFactory.sol
+++ b/contracts/LSP23LinkedContractsFactory/ILSP23LinkedContractsFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 interface ILSP23LinkedContractsFactory {

--- a/contracts/LSP23LinkedContractsFactory/IPostDeploymentModule.sol
+++ b/contracts/LSP23LinkedContractsFactory/IPostDeploymentModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 interface IPostDeploymentModule {

--- a/contracts/LSP23LinkedContractsFactory/LSP23Errors.sol
+++ b/contracts/LSP23LinkedContractsFactory/LSP23Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/LSP23LinkedContractsFactory/LSP23LinkedContractsFactory.sol
+++ b/contracts/LSP23LinkedContractsFactory/LSP23LinkedContractsFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";

--- a/contracts/LSP23LinkedContractsFactory/modules/UniversalProfileInitPostDeploymentModule.sol
+++ b/contracts/LSP23LinkedContractsFactory/modules/UniversalProfileInitPostDeploymentModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/LSP23LinkedContractsFactory/modules/UniversalProfilePostDeploymentModule.sol
+++ b/contracts/LSP23LinkedContractsFactory/modules/UniversalProfilePostDeploymentModule.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
+++ b/contracts/LSP25ExecuteRelayCall/LSP25Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids

--- a/contracts/LSP3ProfileMetadata/LSP3Constants.sol
+++ b/contracts/LSP3ProfileMetadata/LSP3Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // bytes10(keccak256('SupportedStandards')) + bytes2(0) + bytes20(keccak256('LSP3Profile'))

--- a/contracts/LSP4DigitalAssetMetadata/ILSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/ILSP4Compatibility.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Compatibility.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC725Y entries

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // modules

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadataInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // modules

--- a/contracts/LSP6KeyManager/LSP6Constants.sol
+++ b/contracts/LSP6KeyManager/LSP6Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/LSP7Constants.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- Errors

--- a/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/ILSP7CompatibleERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // modules

--- a/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7BurnableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // modules

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupplyInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // interfaces

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // interfaces

--- a/contracts/LSP7DigitalAsset/presets/ILSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/ILSP7Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import {LSP7CompatibleERC20} from "../extensions/LSP7CompatibleERC20.sol";

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // modules

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // modules

--- a/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/ILSP8IdentifiableDigitalAsset.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- Errors

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/ILSP8CompatibleERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8BurnableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupplyInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // interfaces

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/ILSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/ILSP8Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import {LSP8CompatibleERC721} from "../extensions/LSP8CompatibleERC721.sol";

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // modules

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 // modules

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/LSP9Vault/LSP9Constants.sol
+++ b/contracts/LSP9Vault/LSP9Constants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids

--- a/contracts/LSP9Vault/LSP9Errors.sol
+++ b/contracts/LSP9Vault/LSP9Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/Mocks/Executor.sol
+++ b/contracts/Mocks/Executor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/ExecutorLSP20.sol
+++ b/contracts/Mocks/ExecutorLSP20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/GenericExecutor.sol
+++ b/contracts/Mocks/GenericExecutor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/Mocks/GenericExecutorWithBalanceOfFunction.sol
+++ b/contracts/Mocks/GenericExecutorWithBalanceOfFunction.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/Mocks/ImplementationTester.sol
+++ b/contracts/Mocks/ImplementationTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/Mocks/KeyManagerInitWithExtraParams.sol
+++ b/contracts/Mocks/KeyManagerInitWithExtraParams.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {LSP6KeyManagerInit} from "../LSP6KeyManager/LSP6KeyManagerInit.sol";

--- a/contracts/Mocks/KeyManagerWithExtraParams.sol
+++ b/contracts/Mocks/KeyManagerWithExtraParams.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {LSP6KeyManager} from "../LSP6KeyManager/LSP6KeyManager.sol";

--- a/contracts/Mocks/LSP2UtilsLibraryTester.sol
+++ b/contracts/Mocks/LSP2UtilsLibraryTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {LSP2Utils} from "../LSP2ERC725YJSONSchema/LSP2Utils.sol";

--- a/contracts/Mocks/MaliciousERC1271Wallet.sol
+++ b/contracts/Mocks/MaliciousERC1271Wallet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {GenericExecutor} from "./GenericExecutor.sol";

--- a/contracts/Mocks/Reentrancy/BatchReentrancyRelayer.sol
+++ b/contracts/Mocks/Reentrancy/BatchReentrancyRelayer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/Reentrancy/LSP20ReentrantContract.sol
+++ b/contracts/Mocks/Reentrancy/LSP20ReentrantContract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/Reentrancy/ReentrantContract.sol
+++ b/contracts/Mocks/Reentrancy/ReentrantContract.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/Reentrancy/SingleReentrancyRelayer.sol
+++ b/contracts/Mocks/Reentrancy/SingleReentrancyRelayer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/Reentrancy/ThreeReentrancy.sol
+++ b/contracts/Mocks/Reentrancy/ThreeReentrancy.sol
@@ -1,5 +1,5 @@
 // solhint-disable one-contract-per-file
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {

--- a/contracts/Mocks/Tokens/LSP4CompatibilityTester.sol
+++ b/contracts/Mocks/Tokens/LSP4CompatibilityTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7CappedSupplyInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CappedSupplyInitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7CappedSupplyTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CappedSupplyTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7CompatibleERC20InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7CompatibleERC20InitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7CompatibleERC20Tester.sol
+++ b/contracts/Mocks/Tokens/LSP7CompatibleERC20Tester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP7InitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP7MintWhenDeployed.sol
+++ b/contracts/Mocks/Tokens/LSP7MintWhenDeployed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import {LSP7DigitalAsset} from "../../LSP7DigitalAsset/LSP7DigitalAsset.sol";

--- a/contracts/Mocks/Tokens/LSP7Tester.sol
+++ b/contracts/Mocks/Tokens/LSP7Tester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // modules

--- a/contracts/Mocks/Tokens/LSP8BurnableInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8BurnableInitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8BurnableTester.sol
+++ b/contracts/Mocks/Tokens/LSP8BurnableTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8CappedSupplyInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8CappedSupplyInitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8CappedSupplyTester.sol
+++ b/contracts/Mocks/Tokens/LSP8CappedSupplyTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
+++ b/contracts/Mocks/Tokens/LSP8CompatibleERC721Tester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8CompatibleERC721TesterInit.sol
+++ b/contracts/Mocks/Tokens/LSP8CompatibleERC721TesterInit.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8EnumerableInitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8EnumerableInitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8EnumerableTester.sol
+++ b/contracts/Mocks/Tokens/LSP8EnumerableTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8InitTester.sol
+++ b/contracts/Mocks/Tokens/LSP8InitTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/LSP8Tester.sol
+++ b/contracts/Mocks/Tokens/LSP8Tester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/Tokens/RequireCallbackToken.sol
+++ b/contracts/Mocks/Tokens/RequireCallbackToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 pragma solidity ^0.8.4;
 

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultSetter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 // interfaces

--- a/tests/foundry/GasTests/LSP6s/LSP6ExecuteRC.sol
+++ b/tests/foundry/GasTests/LSP6s/LSP6ExecuteRC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "../../../../contracts/LSP6KeyManager/LSP6KeyManager.sol";

--- a/tests/foundry/GasTests/LSP6s/LSP6ExecuteUC.sol
+++ b/tests/foundry/GasTests/LSP6s/LSP6ExecuteUC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/GasTests/LSP6s/LSP6SetDataRC.sol
+++ b/tests/foundry/GasTests/LSP6s/LSP6SetDataRC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/GasTests/LSP6s/LSP6SetDataUC.sol
+++ b/tests/foundry/GasTests/LSP6s/LSP6SetDataUC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/GasTests/UniversalProfileTestsHelper.sol
+++ b/tests/foundry/GasTests/UniversalProfileTestsHelper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/GasTests/execute/RestrictedController.sol
+++ b/tests/foundry/GasTests/execute/RestrictedController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "../LSP6s/LSP6ExecuteRC.sol";

--- a/tests/foundry/GasTests/execute/UnrestrictedController.sol
+++ b/tests/foundry/GasTests/execute/UnrestrictedController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "../LSP6s/LSP6ExecuteUC.sol";

--- a/tests/foundry/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.t.sol
+++ b/tests/foundry/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP11BasicSocialRecovery/LSP11Mock.sol
+++ b/tests/foundry/LSP11BasicSocialRecovery/LSP11Mock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "../../../contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecovery.sol";

--- a/tests/foundry/LSP14Ownable2Step/TwoStepOwnership.sol
+++ b/tests/foundry/LSP14Ownable2Step/TwoStepOwnership.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP14Ownable2Step/TwoStepRenounceOwnership.sol
+++ b/tests/foundry/LSP14Ownable2Step/TwoStepRenounceOwnership.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP16UniversalFactory/LSP16UniversalProfile.t.sol
+++ b/tests/foundry/LSP16UniversalFactory/LSP16UniversalProfile.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
+++ b/tests/foundry/LSP2ERC725YJSONSchema/LSP2Utils.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP6KeyManager/LSP6SetDataTest.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6SetDataTest.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.4;
 
 import "forge-std/Test.sol";

--- a/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6Utils.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
# What does this PR introduce?

Change the license used by all the `.sol` files to use `Apache-2.0`.