### PR TITLE
tests: change name from `owner` to `mainController` in LSP6 tests

### DIFF
--- a/tests/Benchmark.test.ts
+++ b/tests/Benchmark.test.ts
@@ -35,7 +35,7 @@ import { BigNumber } from 'ethers';
 
 export type UniversalProfileContext = {
   accounts: SignerWithAddress[];
-  owner: SignerWithAddress;
+  mainController: SignerWithAddress;
   universalProfile: UniversalProfile;
   initialFunding?: BigNumber;
 };
@@ -46,27 +46,35 @@ function generateRandomData(length) {
 
 const buildLSP6TestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
   const accounts = await ethers.getSigners();
-  const owner = accounts[0];
+  const mainController = accounts[0];
 
-  const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address, {
-    value: initialFunding,
-  });
-  const keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+  const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+    mainController.address,
+    {
+      value: initialFunding,
+    },
+  );
+  const keyManager = await new LSP6KeyManager__factory(mainController).deploy(
+    universalProfile.address,
+  );
 
-  return { accounts, owner, universalProfile, keyManager };
+  return { accounts, mainController, universalProfile, keyManager };
 };
 
 const buildUniversalProfileContext = async (
   initialFunding?: BigNumber,
 ): Promise<UniversalProfileContext> => {
   const accounts = await ethers.getSigners();
-  const owner = accounts[0];
+  const mainController = accounts[0];
 
-  const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address, {
-    value: initialFunding,
-  });
+  const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+    mainController.address,
+    {
+      value: initialFunding,
+    },
+  );
 
-  return { accounts, owner, universalProfile };
+  return { accounts, mainController, universalProfile };
 };
 
 describe('⛽📊 Gas Benchmark', () => {
@@ -154,7 +162,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 1 LYX to an EOA without data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(
               OPERATION_TYPES.CALL,
               context.accounts[1].address,
@@ -170,7 +178,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 1 LYX to a UP without data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(
               OPERATION_TYPES.CALL,
               context.universalProfile.address,
@@ -186,7 +194,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 1 LYX to an EOA with 256 bytes of data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(
               OPERATION_TYPES.CALL,
               context.accounts[1].address,
@@ -202,7 +210,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 1 LYX to a UP with 256 bytes of data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(
               OPERATION_TYPES.CALL,
               context.universalProfile.address,
@@ -223,22 +231,22 @@ describe('⛽📊 Gas Benchmark', () => {
         before(async () => {
           context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
 
-          universalProfile1 = await new UniversalProfile__factory(context.owner).deploy(
+          universalProfile1 = await new UniversalProfile__factory(context.mainController).deploy(
             context.accounts[2].address,
           );
 
-          universalProfile2 = await new UniversalProfile__factory(context.owner).deploy(
+          universalProfile2 = await new UniversalProfile__factory(context.mainController).deploy(
             context.accounts[3].address,
           );
 
-          universalProfile3 = await new UniversalProfile__factory(context.owner).deploy(
+          universalProfile3 = await new UniversalProfile__factory(context.mainController).deploy(
             context.accounts[4].address,
           );
         });
 
         it('Transfer 0.1 LYX to 3x EOA without data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeBatch(
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [
@@ -262,7 +270,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 0.1 LYX to 3x UP without data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeBatch(
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [universalProfile1.address, universalProfile2.address, universalProfile3.address],
@@ -282,7 +290,7 @@ describe('⛽📊 Gas Benchmark', () => {
 
         it('Transfer 0.1 LYX to 3x EOA with 256 bytes of data', async () => {
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeBatch(
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [
@@ -311,7 +319,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ]);
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeBatch(
               [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
               [universalProfile1.address, universalProfile2.address, universalProfile3.address],
@@ -539,22 +547,22 @@ describe('⛽📊 Gas Benchmark', () => {
       before(async () => {
         context = await buildUniversalProfileContext(ethers.utils.parseEther('50'));
         // deploy a LSP7 token
-        lsp7Token = await new LSP7Mintable__factory(context.owner).deploy(
+        lsp7Token = await new LSP7Mintable__factory(context.mainController).deploy(
           'Token',
           'MTKN',
-          context.owner.address,
+          context.mainController.address,
           false,
         );
 
         // deploy a LSP8 token
-        lsp8Token = await new LSP8Mintable__factory(context.owner).deploy(
+        lsp8Token = await new LSP8Mintable__factory(context.mainController).deploy(
           'My NFT',
           'MNFT',
-          context.owner.address,
+          context.mainController.address,
           LSP8_TOKEN_ID_TYPES.UNIQUE_ID,
         );
 
-        universalProfile1 = await new UniversalProfile__factory(context.owner).deploy(
+        universalProfile1 = await new UniversalProfile__factory(context.mainController).deploy(
           context.accounts[2].address,
         );
       });
@@ -588,7 +596,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ]);
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(OPERATION_TYPES.CALL, lsp7Token.address, 0, lsp7TransferPayload);
 
           const receipt = await tx.wait();
@@ -639,7 +647,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ]);
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(OPERATION_TYPES.CALL, lsp8Token.address, 0, lsp8TransferPayload);
 
           const receipt = await tx.wait();
@@ -691,18 +699,18 @@ describe('⛽📊 Gas Benchmark', () => {
           );
 
           // deploy a LSP7 token
-          lsp7MetaCoin = await new LSP7Mintable__factory(context.owner).deploy(
+          lsp7MetaCoin = await new LSP7Mintable__factory(context.mainController).deploy(
             'MetaCoin',
             'MTC',
-            context.owner.address,
+            context.mainController.address,
             false,
           );
 
           // deploy a LSP8 NFT
-          lsp8MetaNFT = await new LSP8Mintable__factory(context.owner).deploy(
+          lsp8MetaNFT = await new LSP8Mintable__factory(context.mainController).deploy(
             'MetaNFT',
             'MNF',
-            context.owner.address,
+            context.mainController.address,
             LSP8_TOKEN_ID_TYPES.UNIQUE_ID,
           );
 
@@ -719,7 +727,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const lyxAmount = ethers.utils.parseEther('3');
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(OPERATION_TYPES.CALL, recipientEOA.address, lyxAmount, "0x");
+          const tx = await context.universalProfile.connect(context.mainController).execute(OPERATION_TYPES.CALL, recipientEOA.address, lyxAmount, "0x");
           const receipt = await tx.wait();
 
           gasBenchmark['runtime_costs']['KeyManager_owner']['execute']['case_1'][
@@ -731,7 +739,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const lyxAmount = ethers.utils.parseEther('3');
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(OPERATION_TYPES.CALL, aliceUP.address, lyxAmount, "0x");
+          const tx = await context.universalProfile.connect(context.mainController).execute(OPERATION_TYPES.CALL, aliceUP.address, lyxAmount, "0x");
           const receipt = await tx.wait();
 
           gasBenchmark['runtime_costs']['KeyManager_owner']['execute']['case_2'][
@@ -743,7 +751,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const tokenAmount = 100;
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(
+          const tx = await context.universalProfile.connect(context.mainController).execute(
             OPERATION_TYPES.CALL,
             lsp7MetaCoin.address,
             0,
@@ -766,7 +774,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const tokenAmount = 100;
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(
+          const tx = await context.universalProfile.connect(context.mainController).execute(
             OPERATION_TYPES.CALL,
             lsp7MetaCoin.address,
             0,
@@ -789,7 +797,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const nftId = nftList[0];
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(
+          const tx = await context.universalProfile.connect(context.mainController).execute(
             OPERATION_TYPES.CALL,
             lsp8MetaNFT.address,
             0,
@@ -812,7 +820,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const nftId = nftList[1];
 
           // prettier-ignore
-          const tx = await context.universalProfile.connect(context.owner).execute(
+          const tx = await context.universalProfile.connect(context.mainController).execute(
             OPERATION_TYPES.CALL,
             lsp8MetaNFT.address,
             0,
@@ -878,17 +886,17 @@ describe('⛽📊 Gas Benchmark', () => {
           // LSP7 token transfer scenarios
           canTransferTwoTokens = context.accounts[3];
 
-          lsp7MetaCoin = await new LSP7Mintable__factory(context.owner).deploy(
+          lsp7MetaCoin = await new LSP7Mintable__factory(context.mainController).deploy(
             'MetaCoin',
             'MTC',
-            context.owner.address,
+            context.mainController.address,
             false,
           );
 
-          lsp7LyxDai = await new LSP7Mintable__factory(context.owner).deploy(
+          lsp7LyxDai = await new LSP7Mintable__factory(context.mainController).deploy(
             'LyxDai',
             'LDAI',
-            context.owner.address,
+            context.mainController.address,
             false,
           );
 
@@ -899,17 +907,17 @@ describe('⛽📊 Gas Benchmark', () => {
           // LSP8 NFT transfer scenarios
           canTransferTwoNFTs = context.accounts[4];
 
-          lsp8MetaNFT = await new LSP8Mintable__factory(context.owner).deploy(
+          lsp8MetaNFT = await new LSP8Mintable__factory(context.mainController).deploy(
             'MetaNFT',
             'MNF',
-            context.owner.address,
+            context.mainController.address,
             LSP8_TOKEN_ID_TYPES.UNIQUE_ID,
           );
 
-          lsp8LyxPunks = await new LSP8Mintable__factory(context.owner).deploy(
+          lsp8LyxPunks = await new LSP8Mintable__factory(context.mainController).deploy(
             'LyxPunks',
             'LPK',
-            context.owner.address,
+            context.mainController.address,
             LSP8_TOKEN_ID_TYPES.UNIQUE_ID,
           );
 
@@ -1123,10 +1131,10 @@ describe('⛽📊 Gas Benchmark', () => {
           // Set some JSONURL for LSP3Profile metadata to test gas cost of updating your profile details
           '0x6f357c6a70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3697066733a2f2f516d65637247656a555156587057347a53393438704e76636e51724a314b69416f4d36626466725663575a736e35',
           ethers.utils.hexZeroPad(ethers.BigNumber.from(3).toHexString(), 16),
-          context.owner.address,
+          context.mainController.address,
         ];
 
-        // The `context.owner` is given `ALL_PERMISSIONS` as the first data key through `setupKeyManager` method.
+        // The `context.mainController` is given `ALL_PERMISSIONS` as the first data key through `setupKeyManager` method.
         await setupKeyManager(context, permissionKeys, permissionValues);
       });
 
@@ -1137,7 +1145,7 @@ describe('⛽📊 Gas Benchmark', () => {
             '0x6f357c6a820464ddfac1bec070cc14a8daf04129871d458f2ca94368aae8391311af6361696670733a2f2f516d597231564a4c776572673670456f73636468564775676f3339706136727963455a4c6a7452504466573834554178';
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(dataKey, dataValue);
 
           const receipt = await tx.wait();
@@ -1180,7 +1188,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1202,7 +1210,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const dataValue = combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.SUPER_SETDATA);
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(dataKey, dataValue);
 
           const receipt = await tx.wait();
@@ -1243,7 +1251,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1276,7 +1284,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(issuedAssetsDataKeys, issuedAssetsDataValues);
 
           const receipt = await tx.wait();
@@ -1295,7 +1303,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const dataValue = '0xaabbccdd';
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(dataKey, dataValue);
 
           const receipt = await tx.wait();
@@ -1310,7 +1318,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1325,7 +1333,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1340,7 +1348,7 @@ describe('⛽📊 Gas Benchmark', () => {
           const dataValues = ['0xaabbccdd', '0xaabbccdd', '0xaabbccdd'];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1411,7 +1419,7 @@ describe('⛽📊 Gas Benchmark', () => {
           ];
 
           const tx = await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(dataKeys, dataValues);
 
           const receipt = await tx.wait();
@@ -1459,7 +1467,7 @@ describe('⛽📊 Gas Benchmark', () => {
             // Set some JSONURL for LSP3Profile metadata to test gas cost of updating your profile details
             '0x6f357c6a70546a2accab18748420b63c63b5af4cf710848ae83afc0c51dd8ad17fb5e8b3697066733a2f2f516d65637247656a555156587057347a53393438704e76636e51724a314b69416f4d36626466725663575a736e35',
             ethers.utils.hexZeroPad(ethers.BigNumber.from(6).toHexString(), 16),
-            context.owner.address,
+            context.mainController.address,
             PERMISSIONS.SETDATA,
             encodeCompactBytesArray([
               ERC725YDataKeys.LSP3.LSP3Profile,
@@ -1477,7 +1485,7 @@ describe('⛽📊 Gas Benchmark', () => {
             ]),
           ];
 
-          // The `context.owner` is given `ALL_PERMISSIONS` as the first data key through `setupKeyManager` method.
+          // The `context.mainController` is given `ALL_PERMISSIONS` as the first data key through `setupKeyManager` method.
           await setupKeyManager(context, permissionKeys, permissionValues);
         });
 

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -2785,7 +2785,7 @@ export const shouldBehaveLikeLSP1Delegate = (
 
       testContext = {
         accounts: signerAddresses,
-        owner: profileOwner,
+        mainController: profileOwner,
         universalProfile: deployedUniversalProfile,
         keyManager: deployedKeyManager,
       };
@@ -2803,7 +2803,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         [ERC725YDataKeys.LSP1.LSP1UniversalReceiverDelegate, lsp1Delegate.address],
       );
 
-      await testContext.keyManager.connect(testContext.owner).execute(setLSP1DelegatePayload);
+      await testContext.keyManager
+        .connect(testContext.mainController)
+        .execute(setLSP1DelegatePayload);
     });
 
     it('check that the LSP9Vault address is not set under LSP10', async () => {
@@ -2848,7 +2850,7 @@ export const shouldBehaveLikeLSP1Delegate = (
           [OPERATION_TYPES.CALL, vault.address, 0, transferOwnershipPayload],
         );
 
-        await testContext.keyManager.connect(testContext.owner).execute(executePayload);
+        await testContext.keyManager.connect(testContext.mainController).execute(executePayload);
 
         // check that the new vault owner is the pending owner
         expect(await vault.pendingOwner()).to.equal(newVaultOwner.address);

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
@@ -80,7 +80,8 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -126,7 +127,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-        context.owner.address,
+        context.mainController.address,
         canAddAndChangeExtensions.address,
         canOnlyAddExtensions.address,
         canOnlyChangeExtensions.address,
@@ -150,7 +151,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -164,7 +165,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -178,7 +179,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -348,7 +349,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
         it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
@@ -407,7 +408,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
@@ -467,7 +468,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
@@ -535,7 +536,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -558,7 +559,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -577,7 +578,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -661,7 +662,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
         });
         describe('when adding multiple ExtensionHandler keys', () => {
@@ -936,7 +937,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             };
 
             await context.universalProfile
-              .connect(context.owner)
+              .connect(context.mainController)
               .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
           });
           describe('When adding ExtensionHandler key and one of his allowedERC725Y Data Key', () => {

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddURD.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddURD.test.ts
@@ -78,7 +78,8 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeUniversalReceiverDelegate.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -128,7 +129,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-        context.owner.address,
+        context.mainController.address,
         canAddAndChangeUniversalReceiverDelegate.address,
         canOnlyAddUniversalReceiverDelegate.address,
         canOnlyChangeUniversalReceiverDelegate.address,
@@ -152,7 +153,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -166,7 +167,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -180,7 +181,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
@@ -362,7 +363,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
         it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
@@ -421,7 +422,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
@@ -481,7 +482,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(payloadParam.dataKey, payloadParam.dataValue);
         });
 
@@ -549,7 +550,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -572,7 +573,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -591,7 +592,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
@@ -678,7 +679,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
           };
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
         });
         describe('when adding multiple UniversalReceiverDelegate keys', () => {
@@ -981,7 +982,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             };
 
             await context.universalProfile
-              .connect(context.owner)
+              .connect(context.mainController)
               .setDataBatch(payloadParam.dataKeys, payloadParam.dataValues);
           });
           describe('When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key', () => {

--- a/tests/LSP20CallVerification/LSP6/Interactions/AllowedAddresses.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/AllowedAddresses.test.ts
@@ -52,7 +52,8 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     notAllowedTargetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         canCallOnlyTwoAddresses.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -83,7 +84,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
 
-    await context.owner.sendTransaction({
+    await context.mainController.sendTransaction({
       to: context.universalProfile.address,
       value: ethers.utils.parseEther('10'),
     });
@@ -101,7 +102,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
           const amount = ethers.utils.parseEther('1');
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(OPERATION_TYPES.CALL, recipient, amount, EMPTY_PAYLOAD);
 
           const newBalanceUP = await provider.getBalance(context.universalProfile.address);

--- a/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
@@ -64,7 +64,8 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     );
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -95,7 +96,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
 
-    await context.owner.sendTransaction({
+    await context.mainController.sendTransaction({
       to: context.universalProfile.address,
       value: ethers.utils.parseEther('10'),
     });
@@ -107,7 +108,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
       const targetPayload = targetContract.interface.encodeFunctionData('setName', [newName]);
 
       await context.universalProfile
-        .connect(context.owner)
+        .connect(context.mainController)
         .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload);
       const result = await targetContract.callStatic.getName();
 
@@ -117,7 +118,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     describe('should allow to interact with a contract that implement (+ register) any interface', () => {
       it('ERC1271', async () => {
         const sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
-        const sampleSignature = await context.owner.signMessage('Sample Message');
+        const sampleSignature = await context.mainController.signMessage('Sample Message');
 
         const payload = signatureValidatorContract.interface.encodeFunctionData(
           'isValidSignature',
@@ -125,7 +126,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         );
 
         const data = await context.universalProfile
-          .connect(context.owner)
+          .connect(context.mainController)
           .callStatic.execute(OPERATION_TYPES.CALL, signatureValidatorContract.address, 0, payload);
 
         const [result] = abiCoder.decode(['bytes4'], data);
@@ -136,7 +137,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Key'));
         const value = '0xcafecafecafecafe';
 
-        await context.universalProfile.connect(context.owner).setData(key, value);
+        await context.universalProfile.connect(context.mainController).setData(key, value);
 
         const result = await context.universalProfile.callStatic['getData(bytes32)'](key);
         expect(result).to.equal(value);

--- a/tests/LSP20CallVerification/LSP6/Interactions/OtherScenarios.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/OtherScenarios.test.ts
@@ -24,7 +24,8 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeCall.address.substring(2),
     ];
@@ -42,7 +43,7 @@ export const otherTestScenarios = (buildContext: () => Promise<LSP6TestContext>)
 
       await expect(
         context.universalProfile
-          .connect(context.owner)
+          .connect(context.mainController)
           .execute(INVALID_OPERATION_TYPE, targetContract.address, 0, targetPayload),
       ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionCall.test.ts
@@ -330,7 +330,8 @@ export const shouldBehaveLikePermissionCall = (
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -365,7 +366,7 @@ export const shouldBehaveLikePermissionCall = (
           const targetPayload = targetContract.interface.encodeFunctionData('setName', [argument]);
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .execute(OPERATION_TYPES.CALL, targetContract.address, 0, targetPayload);
 
           const result = await targetContract.callStatic.getName();
@@ -379,7 +380,7 @@ export const shouldBehaveLikePermissionCall = (
             const targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
             const result = await context.universalProfile
-              .connect(context.owner)
+              .connect(context.mainController)
               .callStatic.execute(
                 OPERATION_TYPES.CALL,
                 targetContract.address,
@@ -397,7 +398,7 @@ export const shouldBehaveLikePermissionCall = (
             const targetContractPayload = targetContract.interface.encodeFunctionData('getNumber');
 
             const result = await context.universalProfile
-              .connect(context.owner)
+              .connect(context.mainController)
               .callStatic.execute(
                 OPERATION_TYPES.CALL,
                 targetContract.address,
@@ -486,7 +487,8 @@ export const shouldBehaveLikePermissionCall = (
       context = await buildContext();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
       ];
 
       const permissionValues = [ALL_PERMISSIONS];

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionDelegateCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionDelegateCall.test.ts
@@ -35,12 +35,13 @@ export const shouldBehaveLikePermissionDelegateCall = (
       addressCanDelegateCall = context.accounts[1];
       addressCannotDelegateCall = context.accounts[2];
 
-      erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(context.owner).deploy(
-        context.universalProfile.address,
-      );
+      erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(
+        context.mainController,
+      ).deploy(context.universalProfile.address);
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanDelegateCall.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -70,7 +71,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
 
       await expect(
         context.universalProfile
-          .connect(context.owner)
+          .connect(context.mainController)
           .execute(
             OPERATION_TYPES.DELEGATECALL,
             erc725YDelegateCallContract.address,

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionDeploy.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionDeploy.test.ts
@@ -29,7 +29,8 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
     addressCannotDeploy = context.accounts[2];
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeploy.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -53,7 +54,7 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
       );
 
       await expect(
-        context.universalProfile.connect(context.owner).execute(
+        context.universalProfile.connect(context.mainController).execute(
           OPERATION_TYPES.CREATE, // operation type
           ethers.constants.AddressZero, // recipient
           0, // value
@@ -81,7 +82,7 @@ export const shouldBehaveLikePermissionDeploy = (buildContext: () => Promise<LSP
 
       await expect(
         context.universalProfile
-          .connect(context.owner)
+          .connect(context.mainController)
           .execute(
             OPERATION_TYPES.CREATE2,
             ethers.constants.AddressZero,

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionStaticCall.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionStaticCall.test.ts
@@ -40,7 +40,8 @@ export const shouldBehaveLikePermissionStaticCall = (
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCall.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -74,7 +75,7 @@ export const shouldBehaveLikePermissionStaticCall = (
       const targetContractPayload = targetContract.interface.encodeFunctionData('getName');
 
       const result = await context.universalProfile
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(
           OPERATION_TYPES.STATICCALL,
           targetContract.address,

--- a/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
@@ -86,7 +86,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       ).to.equal(graffitiExtension.address);
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValue.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -138,7 +139,7 @@ export const shouldBehaveLikePermissionTransferValue = (
              */
             await expect(() =>
               context.universalProfile
-                .connect(context.owner)
+                .connect(context.mainController)
                 .execute(OPERATION_TYPES.CALL, recipient.address, amount, data),
             ).to.changeEtherBalances(
               [context.universalProfile.address, recipient.address],
@@ -207,7 +208,7 @@ export const shouldBehaveLikePermissionTransferValue = (
             const initialBalanceRecipient = await provider.getBalance(recipient.address);
 
             await context.universalProfile
-              .connect(context.owner)
+              .connect(context.mainController)
               .execute(OPERATION_TYPES.CALL, recipient.address, ethers.utils.parseEther('3'), data);
 
             const newBalanceUP = await provider.getBalance(context.universalProfile.address);
@@ -396,7 +397,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanTransferValue.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.test.ts
@@ -10,15 +10,20 @@ import { shouldBehaveLikeLSP6 } from './LSP20WithLSP6.behaviour';
 describe('LSP20 + LSP6 with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address, {
-      value: initialFunding,
-    });
+    const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+      mainController.address,
+      {
+        value: initialFunding,
+      },
+    );
 
-    const keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+    const keyManager = await new LSP6KeyManager__factory(mainController).deploy(
+      universalProfile.address,
+    );
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   describe('when testing deployed contract', () => {

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6Init.test.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6Init.test.ts
@@ -12,21 +12,21 @@ import { shouldBehaveLikeLSP6 } from './LSP20WithLSP6.behaviour';
 describe('LSP20 Init + LSP6 Init with proxy', () => {
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const baseUP = await new UniversalProfileInit__factory(owner).deploy();
-    const upProxy = await deployProxy(baseUP.address, owner);
+    const baseUP = await new UniversalProfileInit__factory(mainController).deploy();
+    const upProxy = await deployProxy(baseUP.address, mainController);
     const universalProfile = await baseUP.attach(upProxy);
 
-    const baseKM = await new LSP6KeyManagerInit__factory(owner).deploy();
-    const kmProxy = await deployProxy(baseKM.address, owner);
+    const baseKM = await new LSP6KeyManagerInit__factory(mainController).deploy();
+    const kmProxy = await deployProxy(baseKM.address, mainController);
     const keyManager = await baseKM.attach(kmProxy);
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   const initializeProxy = async (context: LSP6TestContext) => {
-    await context.universalProfile['initialize(address)'](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.mainController.address, {
       value: context.initialFunding,
     });
 

--- a/tests/LSP20CallVerification/LSP6/SetData/AllowedERC725YDataKeys.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetData/AllowedERC725YDataKeys.test.ts
@@ -38,7 +38,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetManyKeys = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetOneKey.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -653,7 +654,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           const key = ethers.utils.hexlify(ethers.utils.randomBytes(32));
           const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data'));
 
-          await context.universalProfile.connect(context.owner).setData(key, value);
+          await context.universalProfile.connect(context.mainController).setData(key, value);
 
           const result = await context.universalProfile.getData(key);
           expect(result).to.equal(value);
@@ -673,7 +674,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Some data 3')),
           ];
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           const result = await context.universalProfile.getDataBatch(keys);
 
@@ -704,7 +705,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetMappingKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetMappingKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -897,7 +899,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           );
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setData(randomMappingKey, randomMappingValue);
 
           const result = await context.universalProfile.getData(randomMappingKey);
@@ -919,7 +921,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
           ];
 
           await context.universalProfile
-            .connect(context.owner)
+            .connect(context.mainController)
             .setDataBatch(randomMappingKeys, randomMappingValues);
 
           const result = await context.universalProfile.getDataBatch(randomMappingKeys);
@@ -952,7 +954,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetArrayKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetArrayKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1101,7 +1104,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         const permissionKeys = [
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1228,7 +1231,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         const permissionKeys = [
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1373,7 +1376,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetSomeKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetSomeKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +

--- a/tests/LSP20CallVerification/LSP6/SetData/PermissionSetData.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetData/PermissionSetData.test.ts
@@ -64,7 +64,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       cannotSetData = context.accounts[3];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -101,7 +102,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           const key = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key'));
           const value = ethers.utils.hexlify(ethers.utils.toUtf8Bytes('Hello Lukso!'));
 
-          await context.universalProfile.connect(context.owner).setData(key, value);
+          await context.universalProfile.connect(context.mainController).setData(key, value);
 
           const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
@@ -167,7 +168,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             ethers.utils.hexlify(ethers.utils.toUtf8Bytes('eeeeeeeeee')),
           ];
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           const fetchedResult = await context.universalProfile.callStatic.getDataBatch(keys);
 
@@ -181,7 +182,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
           const { keys, values } = encodeData(data, BasicUPSetup_Schema);
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           const fetchedResult = await context.universalProfile.callStatic.getDataBatch(keys);
           expect(fetchedResult).to.deep.equal(values);
@@ -212,7 +213,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
 
           const { keys, values } = encodeData(basicUPSetup, BasicUPSetup_Schema);
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           const fetchedResult = await context.universalProfile.callStatic.getDataBatch(keys);
           expect(fetchedResult).to.deep.equal(values);
@@ -444,12 +445,13 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     before(async () => {
       context = await buildContext();
 
-      contractCanSetData = await new ExecutorLSP20__factory(context.owner).deploy(
+      contractCanSetData = await new ExecutorLSP20__factory(context.mainController).deploy(
         context.universalProfile.address,
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +

--- a/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP20CallVerification/LSP6/SetPermissions/PermissionChangeAddController.test.ts
@@ -18,7 +18,7 @@ async function setupPermissions(
   permissionValues: string[],
 ) {
   await context.universalProfile
-    .connect(context.owner)
+    .connect(context.mainController)
     .setDataBatch(permissionsKeys, permissionValues);
 }
 
@@ -27,7 +27,7 @@ async function setupPermissions(
  */
 async function resetPermissions(context: LSP6TestContext, permissionsKeys: string[]) {
   await context.universalProfile
-    .connect(context.owner)
+    .connect(context.mainController)
     .setDataBatch(permissionsKeys, Array(permissionsKeys.length).fill('0x'));
 }
 
@@ -47,7 +47,10 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
     await setupKeyManager(
       context,
-      [ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2)],
+      [
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
+      ],
       [ALL_PERMISSIONS],
     );
   });
@@ -106,7 +109,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(6), 16),
-        context.owner.address,
+        context.mainController.address,
         canOnlyAddController.address,
         canOnlyEditPermissions.address,
         canOnlySetData.address,
@@ -143,7 +146,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             newController.address.substr(2);
 
-          await context.universalProfile.connect(context.owner).setData(key, PERMISSIONS.SETDATA);
+          await context.universalProfile
+            .connect(context.mainController)
+            .setData(key, PERMISSIONS.SETDATA);
 
           // prettier-ignore
           const result = await context.universalProfile.getData(key);
@@ -157,7 +162,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
           const value = PERMISSIONS.SETDATA;
 
-          await context.universalProfile.connect(context.owner).setData(key, value);
+          await context.universalProfile.connect(context.mainController).setData(key, value);
 
           // prettier-ignore
           const result = await context.universalProfile.getData(key);
@@ -174,7 +179,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            await context.universalProfile.connect(context.owner).setData(key, value);
+            await context.universalProfile.connect(context.mainController).setData(key, value);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -190,7 +195,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const value = ethers.utils.hexZeroPad(ethers.utils.hexlify(newLength), 16);
 
-            await context.universalProfile.connect(context.owner).setData(key, value);
+            await context.universalProfile.connect(context.mainController).setData(key, value);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -205,7 +210,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               '00000000000000000000000000000006';
             const value = ethers.Wallet.createRandom().address.toLowerCase();
 
-            await context.universalProfile.connect(context.owner).setData(key, value);
+            await context.universalProfile.connect(context.mainController).setData(key, value);
 
             const result = await context.universalProfile.getData(key);
             expect(result).to.equal(value);
@@ -219,7 +224,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             // set some random bytes under AddressPermissions[7]
 
-            await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -232,7 +239,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             // set some random bytes under AddressPermissions[7]
 
-            await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -248,7 +257,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const value = randomWallet.address;
 
-            await context.universalProfile.connect(context.owner).setData(key, value);
+            await context.universalProfile.connect(context.mainController).setData(key, value);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -263,7 +272,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             // set some random bytes under AddressPermissions[7]
 
-            await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -276,7 +287,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             // set some random bytes under AddressPermissions[7]
 
-            await expect(context.universalProfile.connect(context.owner).setData(key, randomValue))
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -290,7 +303,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
             const value = '0x';
 
-            await context.universalProfile.connect(context.owner).setData(key, value);
+            await context.universalProfile.connect(context.mainController).setData(key, value);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -309,7 +322,9 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             // the value does not matter in the case of the test here
             const value = '0x0000000000000000000000000000000000000000000000000000000000000008';
 
-            await expect(context.universalProfile.connect(context.owner).setData(key, value))
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, value),
+            )
               .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
@@ -906,7 +921,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             PERMISSIONS.SETDATA,
           ];
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);
@@ -930,7 +945,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);
@@ -956,7 +971,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             combinePermissions(PERMISSIONS.SETDATA, PERMISSIONS.TRANSFERVALUE),
           ];
 
-          await context.universalProfile.connect(context.owner).setDataBatch(keys, values);
+          await context.universalProfile.connect(context.mainController).setDataBatch(keys, values);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -80,7 +80,8 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -126,7 +127,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-        context.owner.address,
+        context.mainController.address,
         canAddAndChangeExtensions.address,
         canOnlyAddExtensions.address,
         canOnlyChangeExtensions.address,
@@ -154,7 +155,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -171,7 +172,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -188,7 +189,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -212,7 +213,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           ]);
 
           await expect(
-            context.keyManager.connect(context.owner).execute(payload),
+            context.keyManager.connect(context.mainController).execute(payload),
           ).to.be.revertedWithCustomError(
             context.keyManager,
             'KeyManagerCannotBeSetAsExtensionForLSP20Functions',
@@ -237,7 +238,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           ]);
 
           await expect(
-            context.keyManager.connect(context.owner).execute(payload),
+            context.keyManager.connect(context.mainController).execute(payload),
           ).to.be.revertedWithCustomError(
             context.keyManager,
             'KeyManagerCannotBeSetAsExtensionForLSP20Functions',
@@ -268,7 +269,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
           expect(result).to.deep.equal(payloadParam.dataValues);
@@ -463,7 +464,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
         it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
@@ -528,7 +529,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
 
         it('should NOT be allowed to ADD another ExtensionHandler key even when ExtensionHandler key is allowed in AllowedERC725YDataKey', async () => {
@@ -594,7 +595,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
 
         it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
@@ -668,7 +669,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -694,7 +695,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -716,7 +717,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -808,7 +809,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
         describe('when adding multiple ExtensionHandler keys', () => {
           it('should pass', async () => {
@@ -1105,7 +1106,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               payloadParam.dataValues,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
           });
           describe('When adding ExtensionHandler key and one of his allowedERC725Y Data Key', () => {
             it('should pass', async () => {

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddURD.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddURD.test.ts
@@ -78,7 +78,8 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
       canOnlyCall = context.accounts[6];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canAddAndChangeUniversalReceiverDelegate.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -128,7 +129,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(7), 16),
-        context.owner.address,
+        context.mainController.address,
         canAddAndChangeUniversalReceiverDelegate.address,
         canOnlyAddUniversalReceiverDelegate.address,
         canOnlyChangeUniversalReceiverDelegate.address,
@@ -156,7 +157,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -173,7 +174,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -190,7 +191,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
@@ -411,7 +412,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
         it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
           const payloadParam = {
@@ -476,7 +477,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
 
         it('should NOT be allowed to ADD another UniversalReceiverDelegate key even when UniversalReceiverDelegate key is allowed in AllowedERC725YDataKey', async () => {
@@ -542,7 +543,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
 
         it('should NOT be allowed to ADD another UniversalReceiverDelegate key', async () => {
@@ -616,7 +617,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -642,7 +643,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -664,7 +665,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
 
@@ -765,7 +766,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
             payloadParam.dataValues,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
         });
         describe('when adding multiple UniversalReceiverDelegate keys', () => {
           it('should pass', async () => {
@@ -1106,7 +1107,7 @@ export const shouldBehaveLikePermissionChangeOrAddURD = (
               payloadParam.dataValues,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
           });
           describe('When adding UniversalReceiverDelegate key and one of his allowedERC725Y Data Key', () => {
             it('should pass', async () => {

--- a/tests/LSP6KeyManager/Admin/PermissionSign.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionSign.test.ts
@@ -26,7 +26,8 @@ export const shouldBehaveLikePermissionSign = (buildContext: () => Promise<LSP6T
     nonSigner = context.accounts[2];
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + nonSigner.address.substring(2),
     ];

--- a/tests/LSP6KeyManager/Interactions/AllowedAddresses.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedAddresses.test.ts
@@ -53,7 +53,8 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
     notAllowedTargetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         canCallOnlyTwoAddresses.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -84,7 +85,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
 
-    await context.owner.sendTransaction({
+    await context.mainController.sendTransaction({
       to: context.universalProfile.address,
       value: ethers.utils.parseEther('10'),
     });
@@ -108,7 +109,7 @@ export const shouldBehaveLikeAllowedAddresses = (buildContext: () => Promise<LSP
             EMPTY_PAYLOAD,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(transferPayload);
+          await context.keyManager.connect(context.mainController).execute(transferPayload);
 
           const newBalanceUP = await provider.getBalance(context.universalProfile.address);
           expect(newBalanceUP).to.be.lt(initialBalanceUP);

--- a/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
+++ b/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
@@ -64,7 +64,8 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     );
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanInteractOnlyWithERC1271.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -95,7 +96,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
 
     await setupKeyManager(context, permissionsKeys, permissionsValues);
 
-    await context.owner.sendTransaction({
+    await context.mainController.sendTransaction({
       to: context.universalProfile.address,
       value: ethers.utils.parseEther('10'),
     });
@@ -113,7 +114,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
         targetPayload,
       ]);
 
-      await context.keyManager.connect(context.owner).execute(upPayload);
+      await context.keyManager.connect(context.mainController).execute(upPayload);
       const result = await targetContract.callStatic.getName();
 
       expect(result).to.equal(newName);
@@ -122,7 +123,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
     describe('should allow to interact with a contract that implement (+ register) any interface', () => {
       it('ERC1271', async () => {
         const sampleHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Message'));
-        const sampleSignature = await context.owner.signMessage('Sample Message');
+        const sampleSignature = await context.mainController.signMessage('Sample Message');
 
         const payload = signatureValidatorContract.interface.encodeFunctionData(
           'isValidSignature',
@@ -136,7 +137,9 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           payload,
         ]);
 
-        const data = await context.keyManager.connect(context.owner).callStatic.execute(upPayload);
+        const data = await context.keyManager
+          .connect(context.mainController)
+          .callStatic.execute(upPayload);
         const [result] = abiCoder.decode(['bytes4'], data);
         expect(result).to.equal(ERC1271_VALUES.MAGIC_VALUE);
       });
@@ -150,7 +153,7 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           value,
         ]);
 
-        await context.keyManager.connect(context.owner).execute(setDataPayload);
+        await context.keyManager.connect(context.mainController).execute(setDataPayload);
 
         const result = await context.universalProfile.callStatic['getData(bytes32)'](key);
         expect(result).to.equal(value);

--- a/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
@@ -28,7 +28,8 @@ export const shouldBehaveLikeBatchExecute = (
     context = await buildContext(ethers.utils.parseEther('50'));
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
     ];
 
     const permissionsValues = [ALL_PERMISSIONS];
@@ -88,7 +89,7 @@ export const shouldBehaveLikeBatchExecute = (
       });
 
       const tx = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .executeBatch([0, 0, 0], batchExecutePayloads);
 
       await expect(tx).to.changeEtherBalance(
@@ -128,7 +129,9 @@ export const shouldBehaveLikeBatchExecute = (
         ]),
       ];
 
-      const tx = await context.keyManager.connect(context.owner).executeBatch([0, 0], payloads);
+      const tx = await context.keyManager
+        .connect(context.mainController)
+        .executeBatch([0, 0], payloads);
 
       await expect(tx).to.changeEtherBalance(recipient, lyxAmount);
       expect(await lyxDaiToken.balanceOf(recipient)).to.equal(lyxDaiAmount);
@@ -184,7 +187,7 @@ export const shouldBehaveLikeBatchExecute = (
         ]),
       ];
 
-      await context.keyManager.connect(context.owner).executeBatch([0, 0, 0], payloads);
+      await context.keyManager.connect(context.mainController).executeBatch([0, 0, 0], payloads);
 
       expect(await lyxDaiToken.balanceOf(recipient)).to.equal(
         recipientLyxDaiBalanceBefore.add(lyxDaiAmount),
@@ -210,7 +213,7 @@ export const shouldBehaveLikeBatchExecute = (
       );
 
       const futureTokenAddress = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(lsp7ProxyDeploymentPayload);
       const futureTokenInstance = await new LSP7MintableInit__factory(context.accounts[0]).attach(
         futureTokenAddress,
@@ -243,7 +246,7 @@ export const shouldBehaveLikeBatchExecute = (
         [OPERATION_TYPES.CALL, futureTokenAddress, 0, lsp7SetDataPayload],
       );
 
-      const tx = await context.keyManager.connect(context.owner).executeBatch(
+      const tx = await context.keyManager.connect(context.mainController).executeBatch(
         [0, 0, 0],
         [
           // Step 1 - deploy Token contract as proxy
@@ -302,7 +305,7 @@ export const shouldBehaveLikeBatchExecute = (
       // so that we can then pass the token address to the `to` parameter of ERC725X.execute(...)
       // in the 2nd and 3rd payloads of the LSP6 batch `execute(bytes[])`
       const futureTokenAddress = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(lsp7DeploymentPayload);
 
       // step 2 - mint some tokens
@@ -350,7 +353,9 @@ export const shouldBehaveLikeBatchExecute = (
         ]),
       ];
 
-      const tx = await context.keyManager.connect(context.owner).executeBatch([0, 0, 0], payloads);
+      const tx = await context.keyManager
+        .connect(context.mainController)
+        .executeBatch([0, 0, 0], payloads);
 
       // CHECK for `ContractCreated` event
       await expect(tx)
@@ -404,7 +409,7 @@ export const shouldBehaveLikeBatchExecute = (
           // since these functions on ERC725Y are not payable
           await expect(
             context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .executeBatch([0, 0], [firstSetDataPayload, secondSetDataPayload], {
                 value: amountToFund,
               }),
@@ -452,7 +457,7 @@ export const shouldBehaveLikeBatchExecute = (
           // since these functions on ERC725Y are not payable
           await expect(
             context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .executeBatch([1, 1], [firstSetDataPayload, secondSetDataPayload], {
                 value: amountToFund,
               }),
@@ -496,7 +501,7 @@ export const shouldBehaveLikeBatchExecute = (
           );
 
           await expect(
-            context.keyManager.connect(context.owner).executeBatch(msgValues, payloads, {
+            context.keyManager.connect(context.mainController).executeBatch(msgValues, payloads, {
               value: totalValues,
             }),
           ).to.changeEtherBalances(
@@ -531,7 +536,7 @@ export const shouldBehaveLikeBatchExecute = (
           );
 
           await expect(
-            context.keyManager.connect(context.owner).executeBatch(msgValues, payloads, {
+            context.keyManager.connect(context.mainController).executeBatch(msgValues, payloads, {
               value: totalValues,
             }),
           ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
@@ -587,7 +592,7 @@ export const shouldBehaveLikeBatchExecute = (
           ];
 
           await expect(
-            context.keyManager.connect(context.owner).executeBatch(values, payloads, {
+            context.keyManager.connect(context.mainController).executeBatch(values, payloads, {
               value: msgValue,
             }),
           )
@@ -643,7 +648,7 @@ export const shouldBehaveLikeBatchExecute = (
           ];
 
           await expect(
-            context.keyManager.connect(context.owner).executeBatch(values, payloads, {
+            context.keyManager.connect(context.mainController).executeBatch(values, payloads, {
               value: msgValue,
             }),
           )
@@ -696,7 +701,7 @@ export const shouldBehaveLikeBatchExecute = (
           ];
 
           const tx = await context.keyManager
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeBatch(values, payloads, {
               value: totalValues,
             });
@@ -739,7 +744,7 @@ export const shouldBehaveLikeBatchExecute = (
 
       await expect(
         context.keyManager
-          .connect(context.owner)
+          .connect(context.mainController)
           .executeBatch(
             [0, 0, 0],
             [failingTransferPayload, firstTransferPayload, secondTransferPayload],
@@ -775,7 +780,7 @@ export const shouldBehaveLikeBatchExecute = (
 
       await expect(
         context.keyManager
-          .connect(context.owner)
+          .connect(context.mainController)
           .executeBatch(
             [0, 0, 0],
             [firstTransferPayload, secondTransferPayload, failingTransferPayload],

--- a/tests/LSP6KeyManager/Interactions/InvalidExecutePayloads.test.ts
+++ b/tests/LSP6KeyManager/Interactions/InvalidExecutePayloads.test.ts
@@ -24,7 +24,8 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionsKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeCall.address.substring(2),
     ];
@@ -77,7 +78,7 @@ export const testInvalidExecutePayloads = (buildContext: () => Promise<LSP6TestC
       ]);
 
       await expect(
-        context.keyManager.connect(context.owner).execute(payload),
+        context.keyManager.connect(context.mainController).execute(payload),
       ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_UnknownOperationType');
     });
 

--- a/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionCall.test.ts
@@ -390,7 +390,8 @@ export const shouldBehaveLikePermissionCall = (
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanMakeCallNoAllowedCalls.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -431,7 +432,7 @@ export const shouldBehaveLikePermissionCall = (
             targetPayload,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const result = await targetContract.callStatic.getName();
           expect(result).to.equal(argument);
@@ -449,7 +450,7 @@ export const shouldBehaveLikePermissionCall = (
             );
 
             const result = await context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .callStatic.execute(executePayload);
 
             const [decodedResult] = abiCoder.decode(['string'], result);
@@ -467,7 +468,7 @@ export const shouldBehaveLikePermissionCall = (
             );
 
             const result = await context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .callStatic.execute(executePayload);
 
             const [decodedResult] = abiCoder.decode(['uint256'], result);
@@ -573,7 +574,7 @@ export const shouldBehaveLikePermissionCall = (
               newName,
             ]);
             const nonce = await context.keyManager.callStatic.getNonce(
-              context.owner.address,
+              context.mainController.address,
               channelId,
             );
 
@@ -628,7 +629,7 @@ export const shouldBehaveLikePermissionCall = (
               newName,
             ]);
             const nonce = await context.keyManager.callStatic.getNonce(
-              context.owner.address,
+              context.mainController.address,
               channelId,
             );
 
@@ -656,7 +657,7 @@ export const shouldBehaveLikePermissionCall = (
               ],
             );
 
-            const signature = await context.owner.signMessage(encodedMessage);
+            const signature = await context.mainController.signMessage(encodedMessage);
 
             const incorrectSignerAddress = eip191Signer.recover(
               eip191Signer.hashDataWithIntendedValidator(
@@ -995,7 +996,8 @@ export const shouldBehaveLikePermissionCall = (
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
       ];
 
       const permissionValues = [ALL_PERMISSIONS];
@@ -1034,7 +1036,7 @@ export const shouldBehaveLikePermissionCall = (
       ]);
 
       await expect(
-        context.keyManager.connect(context.owner).execute(executePayload),
+        context.keyManager.connect(context.mainController).execute(executePayload),
       ).to.be.revertedWithCustomError(context.keyManager, 'CallingKeyManagerNotAllowed');
     });
 

--- a/tests/LSP6KeyManager/Interactions/PermissionDelegateCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionDelegateCall.test.ts
@@ -35,12 +35,13 @@ export const shouldBehaveLikePermissionDelegateCall = (
       addressCanDelegateCall = context.accounts[1];
       addressCannotDelegateCall = context.accounts[2];
 
-      erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(context.owner).deploy(
-        context.universalProfile.address,
-      );
+      erc725YDelegateCallContract = await new ERC725YDelegateCall__factory(
+        context.mainController,
+      ).deploy(context.universalProfile.address);
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanDelegateCall.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -76,7 +77,7 @@ export const shouldBehaveLikePermissionDelegateCall = (
       ]);
 
       await expect(
-        context.keyManager.connect(context.owner).execute(executePayload),
+        context.keyManager.connect(context.mainController).execute(executePayload),
       ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
     });
 

--- a/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionDeploy.test.ts
@@ -41,7 +41,8 @@ export const shouldBehaveLikePermissionDeploy = (
     addressCannotDeploy = context.accounts[4];
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanDeploy.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -85,10 +86,10 @@ export const shouldBehaveLikePermissionDeploy = (
       // do first a callstatic to retrieve the address of the contract expected to be deployed
       // so we can check it against the address emitted in the ContractCreated event
       const expectedContractAddress = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(payload);
 
-      await expect(context.keyManager.connect(context.owner).execute(payload))
+      await expect(context.keyManager.connect(context.mainController).execute(payload))
         .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
@@ -100,7 +101,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should be allowed to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -120,10 +121,10 @@ export const shouldBehaveLikePermissionDeploy = (
       // do first a callstatic to retrieve the address of the contract expected to be deployed
       // so we can check it against the address emitted in the ContractCreated event
       const expectedContractAddress = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(payload);
 
-      await expect(context.keyManager.connect(context.owner).execute(payload))
+      await expect(context.keyManager.connect(context.mainController).execute(payload))
         .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE,
@@ -159,14 +160,14 @@ export const shouldBehaveLikePermissionDeploy = (
         contractBytecodeToDeploy,
       ).toLowerCase();
 
-      await expect(context.keyManager.connect(context.owner).execute(payload))
+      await expect(context.keyManager.connect(context.mainController).execute(payload))
         .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(OPERATION_TYPES.CREATE2, ethers.utils.getAddress(preComputedAddress), 0, salt);
     });
 
     it('should be allowed to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -191,7 +192,7 @@ export const shouldBehaveLikePermissionDeploy = (
         contractBytecodeToDeploy,
       ).toLowerCase();
 
-      await expect(context.keyManager.connect(context.owner).execute(payload))
+      await expect(context.keyManager.connect(context.mainController).execute(payload))
         .to.emit(context.universalProfile, 'ContractCreated')
         .withArgs(
           OPERATION_TYPES.CREATE2,
@@ -237,7 +238,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -283,7 +284,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -337,7 +338,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -383,7 +384,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should revert with error `NotAuthorised(SUPER_TRANSFERVALUE)` when trying to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -439,7 +440,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should be allowed to deploy + fund a contract with CREATE', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(
@@ -509,7 +510,7 @@ export const shouldBehaveLikePermissionDeploy = (
 
     it('should be allowed to deploy + fund a contract with CREATE2', async () => {
       // deploy a UP from another UP and check that the new UP is funded + its owner was set
-      const initialUpOwner = context.owner.address;
+      const initialUpOwner = context.mainController.address;
 
       // generate the init code that contains the constructor args with the initial UP owner
       const upDeploymentTx = new UniversalProfile__factory(

--- a/tests/LSP6KeyManager/Interactions/PermissionStaticCall.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionStaticCall.test.ts
@@ -62,7 +62,8 @@ export const shouldBehaveLikePermissionStaticCall = (
     ).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
         addressCanMakeStaticCall.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -107,7 +108,7 @@ export const shouldBehaveLikePermissionStaticCall = (
       ]);
 
       const result = await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .callStatic.execute(executePayload);
 
       const [decodedResult] = abiCoder.decode(['string'], result);
@@ -162,7 +163,7 @@ export const shouldBehaveLikePermissionStaticCall = (
       describe('when calling `isValidSignature(bytes32,bytes)` on a contract', () => {
         it('should pass and return data when `value` param is 0', async () => {
           const message = 'some message to sign';
-          const signature = await context.owner.signMessage(message);
+          const signature = await context.mainController.signMessage(message);
           const messageHash = ethers.utils.hashMessage(message);
 
           const erc1271ContractPayload = signatureValidator.interface.encodeFunctionData(
@@ -189,7 +190,7 @@ export const shouldBehaveLikePermissionStaticCall = (
           const lyxAmount = ethers.utils.parseEther('3');
 
           const message = 'some message to sign';
-          const signature = await context.owner.signMessage(message);
+          const signature = await context.mainController.signMessage(message);
           const messageHash = ethers.utils.hashMessage(message);
 
           const erc1271ContractPayload = signatureValidator.interface.encodeFunctionData(
@@ -219,8 +220,8 @@ export const shouldBehaveLikePermissionStaticCall = (
           const onERC721Payload = onERC721ReceivedContract.interface.encodeFunctionData(
             'onERC721Received',
             [
-              context.owner.address,
-              context.owner.address,
+              context.mainController.address,
+              context.mainController.address,
               1,
               ethers.utils.toUtf8Bytes('some data'),
             ],
@@ -251,7 +252,12 @@ export const shouldBehaveLikePermissionStaticCall = (
         // the params are not relevant for this test and just used as placeholders.
         const onERC721Payload = onERC721ReceivedContract.interface.encodeFunctionData(
           'onERC721Received',
-          [context.owner.address, context.owner.address, 1, ethers.utils.toUtf8Bytes('some data')],
+          [
+            context.mainController.address,
+            context.mainController.address,
+            1,
+            ethers.utils.toUtf8Bytes('some data'),
+          ],
         );
 
         const executePayload = context.universalProfile.interface.encodeFunctionData('execute', [

--- a/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
@@ -91,7 +91,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       ).to.equal(graffitiExtension.address);
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canTransferValue.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -149,7 +150,7 @@ export const shouldBehaveLikePermissionTransferValue = (
              * @see https://hardhat.org/hardhat-chai-matchers/docs/reference#.changeetherbalances
              */
             await expect(
-              context.keyManager.connect(context.owner).execute(transferPayload),
+              context.keyManager.connect(context.mainController).execute(transferPayload),
             ).to.changeEtherBalances(
               [context.universalProfile.address, recipient.address],
               [`-${amount}`, amount],
@@ -231,7 +232,7 @@ export const shouldBehaveLikePermissionTransferValue = (
               data,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(transferPayload);
+            await context.keyManager.connect(context.mainController).execute(transferPayload);
 
             const newBalanceUP = await provider.getBalance(context.universalProfile.address);
             expect(newBalanceUP).to.be.lt(initialBalanceUP);
@@ -384,7 +385,7 @@ export const shouldBehaveLikePermissionTransferValue = (
           );
 
           // ethereum signed message prefix
-          const signature = await context.owner.signMessage(encodedMessage);
+          const signature = await context.mainController.signMessage(encodedMessage);
 
           await expect(
             context.keyManager.executeRelayCall(
@@ -434,7 +435,7 @@ export const shouldBehaveLikePermissionTransferValue = (
 
           await expect(
             context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .executeRelayCall(signature, 0, validityTimestamps, executeRelayCallPayload, {
                 value: valueToSend,
               }),
@@ -525,7 +526,8 @@ export const shouldBehaveLikePermissionTransferValue = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanTransferValue.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +

--- a/tests/LSP6KeyManager/LSP6KeyManager.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManager.test.ts
@@ -18,15 +18,20 @@ import {
 describe('LSP6KeyManager with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address, {
-      value: initialFunding,
-    });
+    const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+      mainController.address,
+      {
+        value: initialFunding,
+      },
+    );
 
-    const keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+    const keyManager = await new LSP6KeyManager__factory(mainController).deploy(
+      universalProfile.address,
+    );
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   describe('when deploying the contract', () => {
@@ -42,14 +47,16 @@ describe('LSP6KeyManager with constructor', () => {
   describe('testing internal functions', () => {
     testLSP6InternalFunctions(async () => {
       const accounts = await ethers.getSigners();
-      const owner = accounts[0];
+      const mainController = accounts[0];
 
-      const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
-      const keyManagerInternalTester = await new KeyManagerInternalTester__factory(owner).deploy(
-        universalProfile.address,
+      const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+        mainController.address,
       );
+      const keyManagerInternalTester = await new KeyManagerInternalTester__factory(
+        mainController,
+      ).deploy(universalProfile.address);
 
-      return { owner, accounts, universalProfile, keyManagerInternalTester };
+      return { mainController, accounts, universalProfile, keyManagerInternalTester };
     });
   });
 });

--- a/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
@@ -11,21 +11,21 @@ describe('LSP6KeyManager with proxy', () => {
 
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const baseUP = await new UniversalProfileInit__factory(owner).deploy();
-    const upProxy = await deployProxy(baseUP.address, owner);
+    const baseUP = await new UniversalProfileInit__factory(mainController).deploy();
+    const upProxy = await deployProxy(baseUP.address, mainController);
     const universalProfile = await baseUP.attach(upProxy);
 
-    const baseKM = await new LSP6KeyManagerInit__factory(owner).deploy();
-    const kmProxy = await deployProxy(baseKM.address, owner);
+    const baseKM = await new LSP6KeyManagerInit__factory(mainController).deploy();
+    const kmProxy = await deployProxy(baseKM.address, mainController);
     const keyManager = await baseKM.attach(kmProxy);
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   const initializeProxies = async (context: LSP6TestContext) => {
-    await context.universalProfile['initialize(address)'](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.mainController.address, {
       value: context.initialFunding,
     });
 

--- a/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -64,7 +64,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
       targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -1204,7 +1205,8 @@ export const shouldBehaveLikeExecuteRelayCall = (
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
       ];
 
       const permissionsValues = [ALL_PERMISSIONS];
@@ -1222,7 +1224,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
       await expect(
         context.keyManager
-          .connect(context.owner)
+          .connect(context.mainController)
           .executeRelayCallBatch(signatures, nonces, validityTimestamps, values, payloads),
       ).to.be.revertedWithCustomError(
         context.keyManager,
@@ -1241,7 +1243,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
         '0x',
       ]);
 
-      const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+      const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
       const validityTimestamps = 0;
 
@@ -1292,7 +1294,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
       // the incorrectly recovered address (as explained above)
       await expect(
         context.keyManager
-          .connect(context.owner)
+          .connect(context.mainController)
           .executeRelayCallBatch(
             [transferLyxSignature, transferLyxSignature],
             [ownerNonce, ownerNonce.add(1)],
@@ -1330,7 +1332,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
         ],
       );
 
-      const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+      const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
       const ownerGivePermissionsSignature = await signLSP6ExecuteRelayCall(
         context.keyManager,
@@ -1389,7 +1391,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
       );
 
       await context.keyManager
-        .connect(context.owner)
+        .connect(context.mainController)
         .executeRelayCallBatch(
           [ownerGivePermissionsSignature, minterMintSignature, ownerRemovePermissionsSignature],
           [ownerNonce, minterNonce, newOwnerNonce],
@@ -1456,7 +1458,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
-          const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+          const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
           const validityTimestamps = 0;
 
@@ -1487,7 +1489,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
           await expect(
             context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .executeRelayCallBatch(
                 [firstTransferLyxSignature, secondTransferLyxSignature, thirdTransferLyxSignature],
                 [ownerNonce, ownerNonce.add(1), ownerNonce.add(2)],
@@ -1542,7 +1544,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
-          const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+          const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
           const validityTimestamps = 0;
 
@@ -1573,7 +1575,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
           await expect(
             context.keyManager
-              .connect(context.owner)
+              .connect(context.mainController)
               .executeRelayCallBatch(
                 [firstTransferLyxSignature, secondTransferLyxSignature, thirdTransferLyxSignature],
                 [ownerNonce, ownerNonce.add(1), ownerNonce.add(2)],
@@ -1625,7 +1627,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
             [OPERATION_TYPES.CALL, thirdRecipient, transferAmounts[2], '0x'],
           );
 
-          const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+          const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
           const validityTimestamps = 0;
 
@@ -1655,7 +1657,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
           );
 
           const tx = await context.keyManager
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeRelayCallBatch(
               [firstTransferLyxSignature, secondTransferLyxSignature, thirdTransferLyxSignature],
               [ownerNonce, ownerNonce.add(1), ownerNonce.add(2)],
@@ -1700,7 +1702,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
           [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
-        const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+        const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
         const nonces = [ownerNonce, ownerNonce.add(1), ownerNonce.add(2)];
 
@@ -1738,7 +1740,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
         await expect(
           context.keyManager
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeRelayCallBatch(
               signatures,
               nonces,
@@ -1775,7 +1777,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
           [OPERATION_TYPES.CALL, randomRecipient, validAmount, '0x'],
         );
 
-        const ownerNonce = await context.keyManager.getNonce(context.owner.address, 0);
+        const ownerNonce = await context.keyManager.getNonce(context.mainController.address, 0);
 
         const nonces = [ownerNonce, ownerNonce.add(1), ownerNonce.add(2)];
         const values = [0, 0, 0];
@@ -1814,7 +1816,7 @@ export const shouldBehaveLikeExecuteRelayCall = (
 
         await expect(
           context.keyManager
-            .connect(context.owner)
+            .connect(context.mainController)
             .executeRelayCallBatch(
               signatures,
               nonces,

--- a/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
+++ b/tests/LSP6KeyManager/Relay/MultiChannelNonce.test.ts
@@ -35,7 +35,8 @@ export const shouldBehaveLikeMultiChannelNonce = (buildContext: () => Promise<LS
     targetContract = await new TargetContract__factory(context.accounts[0]).deploy();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + signer.address.substring(2),
       ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] + signer.address.substring(2),
     ];

--- a/tests/LSP6KeyManager/SetData/AllowedERC725YDataKeys.test.ts
+++ b/tests/LSP6KeyManager/SetData/AllowedERC725YDataKeys.test.ts
@@ -38,7 +38,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetManyKeys = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetOneKey.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -767,7 +768,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             key,
             value,
           ]);
-          await context.keyManager.connect(context.owner).execute(setDataPayload);
+          await context.keyManager.connect(context.mainController).execute(setDataPayload);
 
           const result = await context.universalProfile.getData(key);
           expect(result).to.equal(value);
@@ -791,7 +792,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             'setDataBatch',
             [keys, values],
           );
-          await context.keyManager.connect(context.owner).execute(setDataPayload);
+          await context.keyManager.connect(context.mainController).execute(setDataPayload);
 
           const result = await context.universalProfile.getDataBatch(keys);
 
@@ -822,7 +823,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetMappingKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetMappingKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1051,7 +1053,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             randomMappingValue,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(setDataPayload);
+          await context.keyManager.connect(context.mainController).execute(setDataPayload);
 
           const result = await context.universalProfile.getData(randomMappingKey);
           expect(result).to.equal(randomMappingValue);
@@ -1075,7 +1077,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
             'setDataBatch',
             [randomMappingKeys, randomMappingValues],
           );
-          await context.keyManager.connect(context.owner).execute(setDataPayload);
+          await context.keyManager.connect(context.mainController).execute(setDataPayload);
 
           const result = await context.universalProfile.getDataBatch(randomMappingKeys);
 
@@ -1107,7 +1109,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetArrayKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetArrayKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1290,7 +1293,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         const permissionKeys = [
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1446,7 +1449,7 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
 
         const permissionKeys = [
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             controllerCanSetSomeKeys.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1627,7 +1630,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetSomeKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetSomeKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -1724,7 +1728,8 @@ export const shouldBehaveLikeAllowedERC725YDataKeys = (
       controllerCanSetSomeKeys = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           controllerCanSetSomeKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +

--- a/tests/LSP6KeyManager/SetData/PermissionSetData.test.ts
+++ b/tests/LSP6KeyManager/SetData/PermissionSetData.test.ts
@@ -59,7 +59,8 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
       cannotSetData = context.accounts[3];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canSetDataWithAllowedERC725YDataKeys.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
@@ -101,7 +102,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             value,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
           const fetchedResult = await context.universalProfile.callStatic['getData(bytes32)'](key);
           expect(fetchedResult).to.equal(value);
         });
@@ -200,7 +201,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const fetchedResult = await context.universalProfile.getDataBatch(keys);
 
@@ -219,7 +220,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const fetchedResult = await context.universalProfile.callStatic.getDataBatch(keys);
           expect(fetchedResult).to.deep.equal(values);
@@ -255,7 +256,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           const fetchedResult = await context.universalProfile.callStatic.getDataBatch(keys);
           expect(fetchedResult).to.deep.equal(values);
@@ -527,7 +528,7 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
           ]);
 
           await expect(
-            context.keyManager.connect(context.owner).execute(payload, { value: 12 }),
+            context.keyManager.connect(context.mainController).execute(payload, { value: 12 }),
           ).to.be.revertedWithCustomError(context.keyManager, 'CannotSendValueToSetData');
         });
       });
@@ -550,13 +551,14 @@ export const shouldBehaveLikePermissionSetData = (buildContext: () => Promise<LS
     before(async () => {
       context = await buildContext();
 
-      contractCanSetData = await new Executor__factory(context.owner).deploy(
+      contractCanSetData = await new Executor__factory(context.mainController).deploy(
         context.universalProfile.address,
         context.keyManager.address,
       );
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           contractCanSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +

--- a/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/PermissionChangeAddController.test.ts
@@ -22,7 +22,7 @@ async function setupPermissions(
     permissionValues,
   ]);
 
-  await context.keyManager.connect(context.owner).execute(setupPayload);
+  await context.keyManager.connect(context.mainController).execute(setupPayload);
 }
 
 /**
@@ -34,7 +34,7 @@ async function resetPermissions(context: LSP6TestContext, permissionsKeys: strin
     Array(permissionsKeys.length).fill('0x'),
   ]);
 
-  await context.keyManager.connect(context.owner).execute(teardownPayload);
+  await context.keyManager.connect(context.mainController).execute(teardownPayload);
 }
 
 export const shouldBehaveLikePermissionChangeOrAddController = (
@@ -135,7 +135,8 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
     await setupKeyManager(
       context,
       [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ...firstSetupPermissionsKeys,
       ],
       [ALL_PERMISSIONS, ...firstSetupPermissionsValues],
@@ -200,7 +201,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
 
       permissionArrayValues = [
         ethers.utils.hexZeroPad(ethers.utils.hexlify(6), 16),
-        context.owner.address,
+        context.mainController.address,
         canOnlyAddController.address,
         canOnlyEditPermissions.address,
         canOnlySetData.address,
@@ -243,7 +244,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             PERMISSIONS.SETDATA,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           // prettier-ignore
           const result = await context.universalProfile.getData(key);
@@ -262,7 +263,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             value,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           // prettier-ignore
           const result = await context.universalProfile.getData(key);
@@ -280,7 +281,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             value,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
           expect(await context.universalProfile.getData(key)).to.equal(value);
         });
 
@@ -295,7 +296,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             value,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
           expect(await context.universalProfile.getData(key)).to.equal(value);
         });
 
@@ -314,7 +315,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -335,7 +336,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -353,7 +354,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
 
             const result = await context.universalProfile.getData(key);
             expect(result).to.equal(value);
@@ -369,7 +370,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               randomValue,
             ]);
 
-            await expect(context.keyManager.connect(context.owner).execute(setupPayload))
+            await expect(context.keyManager.connect(context.mainController).execute(setupPayload))
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -384,7 +385,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               randomValue,
             ]);
 
-            await expect(context.keyManager.connect(context.owner).execute(setupPayload))
+            await expect(context.keyManager.connect(context.mainController).execute(setupPayload))
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -403,7 +404,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -420,7 +421,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               randomValue,
             ]);
 
-            await expect(context.keyManager.connect(context.owner).execute(setupPayload))
+            await expect(context.keyManager.connect(context.mainController).execute(setupPayload))
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -435,7 +436,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               randomValue,
             ]);
 
-            await expect(context.keyManager.connect(context.owner).execute(setupPayload))
+            await expect(context.keyManager.connect(context.mainController).execute(setupPayload))
               .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
               .withArgs(key, randomValue);
           });
@@ -452,7 +453,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await context.keyManager.connect(context.owner).execute(payload);
+            await context.keyManager.connect(context.mainController).execute(payload);
 
             // prettier-ignore
             const result = await context.universalProfile.getData(key);
@@ -476,7 +477,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
               value,
             ]);
 
-            await expect(context.keyManager.connect(context.owner).execute(payload))
+            await expect(context.keyManager.connect(context.mainController).execute(payload))
               .to.be.revertedWithCustomError(context.keyManager, 'NotRecognisedPermissionKey')
               .withArgs(key.toLowerCase());
           });
@@ -1285,7 +1286,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);
@@ -1314,7 +1315,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);
@@ -1345,7 +1346,7 @@ export const shouldBehaveLikePermissionChangeOrAddController = (
             values,
           ]);
 
-          await context.keyManager.connect(context.owner).execute(payload);
+          await context.keyManager.connect(context.mainController).execute(payload);
 
           // prettier-ignore
           const fetchedResult = await context.universalProfile.getDataBatch(keys);

--- a/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
+++ b/tests/LSP6KeyManager/internals/AllowedCalls.internal.ts
@@ -29,7 +29,7 @@ async function teardownKeyManagerHelper(
     Array(permissionsKeys.length).fill('0x'),
   ]);
 
-  await context.keyManagerInternalTester.connect(context.owner).execute(teardownPayload);
+  await context.keyManagerInternalTester.connect(context.mainController).execute(teardownPayload);
 }
 
 export const testAllowedCallsInternals = (
@@ -157,7 +157,8 @@ export const testAllowedCallsInternals = (
       );
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           canCallOnlyTwoAddresses.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
@@ -184,13 +185,13 @@ export const testAllowedCallsInternals = (
 
       it('should return no bytes when no allowed calls were set', async () => {
         const bytesResult = await context.keyManagerInternalTester.getAllowedCallsFor(
-          context.owner.address,
+          context.mainController.address,
         );
         expect(bytesResult).to.equal('0x');
 
         const resultFromAccount = await context.universalProfile['getData(bytes32)'](
           ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
         );
         expect(resultFromAccount).to.equal('0x');
       });
@@ -333,7 +334,7 @@ export const testAllowedCallsInternals = (
           permissionValues,
         ]);
 
-        await context.keyManagerInternalTester.connect(context.owner).execute(setup);
+        await context.keyManagerInternalTester.connect(context.mainController).execute(setup);
       });
 
       after('reset permissions', async () => {
@@ -444,7 +445,7 @@ export const testAllowedCallsInternals = (
           permissionValues,
         ]);
 
-        await context.keyManagerInternalTester.connect(context.owner).execute(setup);
+        await context.keyManagerInternalTester.connect(context.mainController).execute(setup);
       });
 
       after('reset permissions', async () => {
@@ -555,7 +556,7 @@ export const testAllowedCallsInternals = (
           permissionValues,
         ]);
 
-        await context.keyManagerInternalTester.connect(context.owner).execute(setup);
+        await context.keyManagerInternalTester.connect(context.mainController).execute(setup);
       });
 
       after('reset permissions', async () => {
@@ -674,7 +675,8 @@ export const testAllowedCallsInternals = (
       ];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ...Object.values(controllers).map(
           (controller) =>
             ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -775,7 +777,8 @@ export const testAllowedCallsInternals = (
       context = await buildContext();
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           context.accounts[1].address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -837,7 +840,8 @@ export const testAllowedCallsInternals = (
       anyAllowedCalls = context.accounts[1];
 
       const permissionsKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           anyAllowedCalls.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedCalls'] +

--- a/tests/LSP6KeyManager/internals/Execute.internal.ts
+++ b/tests/LSP6KeyManager/internals/Execute.internal.ts
@@ -14,7 +14,8 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
     context = await buildContext();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
     ];
 
     const permissionValues = [ALL_PERMISSIONS];
@@ -39,7 +40,11 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
       ]);
 
       await expect(
-        context.keyManagerInternalTester.verifyPermissions(context.owner.address, 0, calldata),
+        context.keyManagerInternalTester.verifyPermissions(
+          context.mainController.address,
+          0,
+          calldata,
+        ),
       ).to.not.be.reverted;
     });
 
@@ -72,7 +77,7 @@ export const testExecuteInternals = (buildContext: () => Promise<LSP6InternalsTe
       // resulting in a revert without any error data
       await expect(
         context.keyManagerInternalTester.verifyPermissions(
-          context.owner.address,
+          context.mainController.address,
           0,
           invalidCalldata,
         ),

--- a/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
+++ b/tests/LSP6KeyManager/internals/ReadPermissions.internal.ts
@@ -27,7 +27,8 @@ export const testReadingPermissionsInternals = (
       addressCanSetDataAndCall = context.accounts[2];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -45,7 +46,7 @@ export const testReadingPermissionsInternals = (
 
     it('Should return ALL_PERMISSIONS for owner', async () => {
       expect(
-        await context.keyManagerInternalTester.getPermissionsFor(context.owner.address),
+        await context.keyManagerInternalTester.getPermissionsFor(context.mainController.address),
       ).to.equal(ALL_PERMISSIONS); // ALL_PERMISSIONS = "0xffff..."
     });
 
@@ -125,7 +126,8 @@ export const testReadingPermissionsInternals = (
       addressCanSetData = context.accounts[1];
 
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           addressCanSetData.address.substring(2),
       ];
@@ -164,7 +166,8 @@ export const testReadingPermissionsInternals = (
       fourthBeneficiary = context.accounts[4];
 
       let permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
           firstBeneficiary.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -196,7 +199,7 @@ export const testReadingPermissionsInternals = (
       // set AddressPermissions array values
       permissionArrayValues = [
         '0x05',
-        context.owner.address,
+        context.mainController.address,
         firstBeneficiary.address,
         secondBeneficiary.address,
         thirdBeneficiary.address,

--- a/tests/LSP6KeyManager/internals/SetData.internal.ts
+++ b/tests/LSP6KeyManager/internals/SetData.internal.ts
@@ -13,7 +13,8 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
     context = await buildContext();
 
     const permissionKeys = [
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        context.mainController.address.substring(2),
     ];
 
     const permissionValues = [ALL_PERMISSIONS];
@@ -38,7 +39,7 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
 
           await expect(
             context.keyManagerInternalTester.verifyCanSetData(
-              context.owner.address,
+              context.mainController.address,
               ALL_PERMISSIONS,
               dataKeys,
               dataValues,
@@ -63,7 +64,7 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
 
           await expect(
             context.keyManagerInternalTester.verifyCanSetData(
-              context.owner.address,
+              context.mainController.address,
               ALL_PERMISSIONS,
               dataKeys,
               dataValues,
@@ -91,7 +92,7 @@ export const testSetDataInternals = (buildContext: () => Promise<LSP6InternalsTe
 
           await expect(
             context.keyManagerInternalTester.verifyCanSetData(
-              context.owner.address,
+              context.mainController.address,
               ALL_PERMISSIONS,
               dataKeys,
               dataValues,

--- a/tests/Mocks/KeyManagerExecutionCosts.test.ts
+++ b/tests/Mocks/KeyManagerExecutionCosts.test.ts
@@ -26,12 +26,16 @@ describe('Key Manager gas cost interactions', () => {
   describe('when using LSP6KeyManager with constructor', () => {
     const buildLSP6TestContext = async (): Promise<LSP6TestContext> => {
       const accounts = await ethers.getSigners();
-      const owner = accounts[0];
+      const mainController = accounts[0];
 
-      const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address);
-      const keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+      const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+        mainController.address,
+      );
+      const keyManager = await new LSP6KeyManager__factory(mainController).deploy(
+        universalProfile.address,
+      );
 
-      return { accounts, owner, universalProfile, keyManager };
+      return { accounts, mainController, universalProfile, keyManager };
     };
 
     describe('after deploying the contract', () => {
@@ -54,7 +58,7 @@ describe('Key Manager gas cost interactions', () => {
 
         const permissionKeys = [
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-            context.owner.address.substring(2),
+            context.mainController.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
             restrictedToOneAddress.address.substring(2),
           ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
@@ -85,7 +89,7 @@ describe('Key Manager gas cost interactions', () => {
 
         await setupKeyManager(context, permissionKeys, permissionValues);
 
-        await context.owner.sendTransaction({
+        await context.mainController.sendTransaction({
           to: context.universalProfile.address,
           value: ethers.utils.parseEther('10'),
         });
@@ -107,7 +111,9 @@ describe('Key Manager gas cost interactions', () => {
             ],
           );
 
-          const tx = await context.keyManager.connect(context.owner).execute(transferLyxPayload);
+          const tx = await context.keyManager
+            .connect(context.mainController)
+            .execute(transferLyxPayload);
 
           const receipt = await tx.wait();
 

--- a/tests/Reentrancy/LSP20/reentrancyHelpers.ts
+++ b/tests/Reentrancy/LSP20/reentrancyHelpers.ts
@@ -662,5 +662,5 @@ export const loadTestCase = async (
     'setDataBatch',
     [permissionKeys, permissionValues],
   );
-  await context.keyManager.connect(context.owner).execute(permissionsPayload);
+  await context.keyManager.connect(context.mainController).execute(permissionsPayload);
 };

--- a/tests/Reentrancy/LSP6/reentrancyHelpers.ts
+++ b/tests/Reentrancy/LSP6/reentrancyHelpers.ts
@@ -664,5 +664,5 @@ export const loadTestCase = async (
     'setDataBatch',
     [permissionKeys, permissionValues],
   );
-  await context.keyManager.connect(context.owner).execute(permissionsPayload);
+  await context.keyManager.connect(context.mainController).execute(permissionsPayload);
 };

--- a/tests/Reentrancy/Reentrancy.test.ts
+++ b/tests/Reentrancy/Reentrancy.test.ts
@@ -11,15 +11,20 @@ import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from './LSP20/LSP20W
 describe('Reentrancy scenarios with constructor', () => {
   const buildTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const universalProfile = await new UniversalProfile__factory(owner).deploy(owner.address, {
-      value: initialFunding,
-    });
+    const universalProfile = await new UniversalProfile__factory(mainController).deploy(
+      mainController.address,
+      {
+        value: initialFunding,
+      },
+    );
 
-    const keyManager = await new LSP6KeyManager__factory(owner).deploy(universalProfile.address);
+    const keyManager = await new LSP6KeyManager__factory(mainController).deploy(
+      universalProfile.address,
+    );
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   describe('when testing Reentrancy scenarios for LSP6', () => {

--- a/tests/Reentrancy/ReentrancyInit.test.ts
+++ b/tests/Reentrancy/ReentrancyInit.test.ts
@@ -12,21 +12,21 @@ import { shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios } from './LSP20/LSP20W
 describe('Reentrancy scenarios with proxy', () => {
   const buildProxyTestContext = async (initialFunding?: BigNumber): Promise<LSP6TestContext> => {
     const accounts = await ethers.getSigners();
-    const owner = accounts[0];
+    const mainController = accounts[0];
 
-    const baseUP = await new UniversalProfileInit__factory(owner).deploy();
-    const upProxy = await deployProxy(baseUP.address, owner);
+    const baseUP = await new UniversalProfileInit__factory(mainController).deploy();
+    const upProxy = await deployProxy(baseUP.address, mainController);
     const universalProfile = await baseUP.attach(upProxy);
 
-    const baseKM = await new LSP6KeyManagerInit__factory(owner).deploy();
-    const kmProxy = await deployProxy(baseKM.address, owner);
+    const baseKM = await new LSP6KeyManagerInit__factory(mainController).deploy();
+    const kmProxy = await deployProxy(baseKM.address, mainController);
     const keyManager = await baseKM.attach(kmProxy);
 
-    return { accounts, owner, universalProfile, keyManager, initialFunding };
+    return { accounts, mainController, universalProfile, keyManager, initialFunding };
   };
 
   const initializeProxies = async (context: LSP6TestContext) => {
-    await context.universalProfile['initialize(address)'](context.owner.address, {
+    await context.universalProfile['initialize(address)'](context.mainController.address, {
       value: context.initialFunding,
     });
 

--- a/tests/utils/context.ts
+++ b/tests/utils/context.ts
@@ -4,7 +4,7 @@ import { KeyManagerInternalTester, LSP6KeyManager, UniversalProfile } from '../.
 
 export type LSP6TestContext = {
   accounts: SignerWithAddress[];
-  owner: SignerWithAddress;
+  mainController: SignerWithAddress;
   universalProfile: UniversalProfile;
   keyManager: LSP6KeyManager;
   initialFunding?: BigNumber;
@@ -12,7 +12,7 @@ export type LSP6TestContext = {
 
 export type LSP6InternalsTestContext = {
   accounts: SignerWithAddress[];
-  owner: SignerWithAddress;
+  mainController: SignerWithAddress;
   universalProfile: UniversalProfile;
   keyManagerInternalTester: KeyManagerInternalTester;
 };

--- a/tests/utils/fixtures.ts
+++ b/tests/utils/fixtures.ts
@@ -49,24 +49,25 @@ export async function setupKeyManager(
   _dataKeys: string[],
   _dataValues: string[],
 ) {
-  await _context.universalProfile.connect(_context.owner).setDataBatch(
+  await _context.universalProfile.connect(_context.mainController).setDataBatch(
     [
-      // required to set owner permission so that it can acceptOwnership(...) via the KeyManager
-      // otherwise, the KeyManager will flag the calling owner as not having the permission CHANGEOWNER
+      // required to set main controller permission so that it can acceptOwnership(...) via the KeyManager
+      // otherwise, the KeyManager will flag the calling main controller as not having the permission CHANGEOWNER
       // when trying to setup the KeyManager
-      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + _context.owner.address.substring(2),
+      ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
+        _context.mainController.address.substring(2),
       ..._dataKeys,
     ],
     [ALL_PERMISSIONS, ..._dataValues],
   );
 
   await _context.universalProfile
-    .connect(_context.owner)
+    .connect(_context.mainController)
     .transferOwnership(_context.keyManager.address);
 
   const payload = _context.universalProfile.interface.getSighash('acceptOwnership');
 
-  await _context.keyManager.connect(_context.owner).execute(payload);
+  await _context.keyManager.connect(_context.mainController).execute(payload);
 }
 
 export async function setupKeyManagerHelper(
@@ -75,23 +76,23 @@ export async function setupKeyManagerHelper(
   _permissionsValues: string[],
 ) {
   await _context.universalProfile
-    .connect(_context.owner)
+    .connect(_context.mainController)
     .setDataBatch(
       [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          _context.owner.address.substring(2),
+          _context.mainController.address.substring(2),
         ..._permissionsKeys,
       ],
       [ALL_PERMISSIONS, ..._permissionsValues],
     );
 
   await _context.universalProfile
-    .connect(_context.owner)
+    .connect(_context.mainController)
     .transferOwnership(_context.keyManagerInternalTester.address);
 
   const payload = _context.universalProfile.interface.getSighash('acceptOwnership');
 
-  await _context.keyManagerInternalTester.connect(_context.owner).execute(payload);
+  await _context.keyManagerInternalTester.connect(_context.mainController).execute(payload);
 }
 
 /**


### PR DESCRIPTION
# What does this PR introduce?

Improve the naming in the test suites of LSP6 to use the term `mainController` ✅  instead of `owner` ❌ .
The owner of a UP being technically in the Key Manager contract's address (retrieved by the `owner()` function), the naming in the tests can lead to ambiguity when using `context.owner`.