### PR TITLE
fix: update logic to check against controller permissions when setting its Allowed Calls or ERC725Y Data Keys

### DIFF
--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -616,22 +616,22 @@ function _getPermissionToSetAllowedCalls(
 ) internal view returns (bytes32);
 ```
 
-retrieve the permission required to set some AllowedCalls for a controller.
+Retrieve the permission required to set some AllowedCalls for a controller.
 
 #### Parameters
 
 | Name                                     |   Type    | Description                                                                                 |
 | ---------------------------------------- | :-------: | ------------------------------------------------------------------------------------------- |
-| `controlledContract`                     | `address` | the address of the ERC725Y contract where the data key is verified.                         |
-| `dataKey`                                | `bytes32` | `AddressPermissions:AllowedCalls:<controller-address>`.                                     |
-| `dataValue`                              |  `bytes`  | the updated value for the `dataKey`. MUST be a bytes28[CompactBytesArray] of Allowed Calls. |
+| `controlledContract`                     | `address` | The address of the ERC725Y contract from which to fetch the value of `dataKey`.             |
+| `dataKey`                                | `bytes32` | A data key ion the format `AddressPermissions:AllowedCalls:<controller-address>`.           |
+| `dataValue`                              |  `bytes`  | The updated value for the `dataKey`. MUST be a bytes32[CompactBytesArray] of Allowed Calls. |
 | `hasBothAddControllerAndEditPermissions` |  `bool`   | -                                                                                           |
 
 #### Returns
 
-| Name |   Type    | Description                       |
-| ---- | :-------: | --------------------------------- |
-| `0`  | `bytes32` | either ADD or CHANGE PERMISSIONS. |
+| Name |   Type    | Description                     |
+| ---- | :-------: | ------------------------------- |
+| `0`  | `bytes32` | Either ADD or EDIT PERMISSIONS. |
 
 <br/>
 
@@ -646,22 +646,22 @@ function _getPermissionToSetAllowedERC725YDataKeys(
 ) internal view returns (bytes32);
 ```
 
-retrieve the permission required to set some Allowed ERC725Y Data Keys for a controller.
+Retrieve the permission required to set some Allowed ERC725Y Data Keys for a controller.
 
 #### Parameters
 
 | Name                                     |   Type    | Description                                                                                           |
 | ---------------------------------------- | :-------: | ----------------------------------------------------------------------------------------------------- |
-| `controlledContract`                     | `address` | the address of the ERC725Y contract where the data key is verified.                                   |
-| `dataKey`                                | `bytes32` | or `AddressPermissions:AllowedERC725YDataKeys:<controller-address>`.                                  |
-| `dataValue`                              |  `bytes`  | the updated value for the `dataKey`. MUST be a bytes[CompactBytesArray] of Allowed ERC725Y Data Keys. |
+| `controlledContract`                     | `address` | the address of the ERC725Y contract from which to fetch the value of `dataKey`.                       |
+| `dataKey`                                | `bytes32` | A data key in the format `AddressPermissions:AllowedERC725YDataKeys:<controller-address>`.            |
+| `dataValue`                              |  `bytes`  | The updated value for the `dataKey`. MUST be a bytes[CompactBytesArray] of Allowed ERC725Y Data Keys. |
 | `hasBothAddControllerAndEditPermissions` |  `bool`   | -                                                                                                     |
 
 #### Returns
 
-| Name |   Type    | Description                       |
-| ---- | :-------: | --------------------------------- |
-| `0`  | `bytes32` | either ADD or CHANGE PERMISSIONS. |
+| Name |   Type    | Description                     |
+| ---- | :-------: | ------------------------------- |
+| `0`  | `bytes32` | Either ADD or EDIT PERMISSIONS. |
 
 <br/>
 

--- a/tests/LSP6KeyManager/SetPermissions/SetAllowedERC725YDataKeys.test.ts
+++ b/tests/LSP6KeyManager/SetPermissions/SetAllowedERC725YDataKeys.test.ts
@@ -18,7 +18,8 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
   describe('setting Allowed ERC725YDataKeys', () => {
     let canOnlyAddController: SignerWithAddress, canOnlyEditPermissions: SignerWithAddress;
 
-    let beneficiary: SignerWithAddress,
+    let beneficiaryWithPermissions: SignerWithAddress,
+      beneficiaryNoPermissions: SignerWithAddress,
       invalidBeneficiary: SignerWithAddress,
       zero32Bytes: SignerWithAddress,
       zero40Bytes: SignerWithAddress;
@@ -29,33 +30,42 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
       canOnlyAddController = context.accounts[1];
       canOnlyEditPermissions = context.accounts[2];
 
-      beneficiary = context.accounts[3];
-      invalidBeneficiary = context.accounts[4];
-      zero32Bytes = context.accounts[5];
-      zero40Bytes = context.accounts[6];
+      beneficiaryWithPermissions = context.accounts[3];
+      beneficiaryNoPermissions = context.accounts[4];
+      invalidBeneficiary = context.accounts[5];
+      zero32Bytes = context.accounts[6];
+      zero40Bytes = context.accounts[7];
 
+      // prettier-ignore
       const permissionKeys = [
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyAddController.address.substring(2),
-        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyEditPermissions.address.substring(2),
-        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          beneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          invalidBeneficiary.address.substring(2),
-        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          zero32Bytes.address.substring(2),
-        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyAddController.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyEditPermissions.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + beneficiaryWithPermissions.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + invalidBeneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + zero40Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] + beneficiaryWithPermissions.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] + beneficiaryNoPermissions.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] + invalidBeneficiary.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] + zero32Bytes.address.substring(2),
+        ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] + zero40Bytes.address.substring(2),
       ];
 
       const permissionValues = [
         PERMISSIONS.ADDCONTROLLER,
         PERMISSIONS.EDITPERMISSIONS,
+        PERMISSIONS.SETDATA,
+        PERMISSIONS.SETDATA,
+        PERMISSIONS.SETDATA,
+        PERMISSIONS.SETDATA,
         encodeCompactBytesArray([
           ERC725YDataKeys.LSP3['LSP3Profile'],
           // prettier-ignore
           ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+        ]),
+        encodeCompactBytesArray([
+          ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+          ethers.utils.hexlify(ethers.utils.randomBytes(32)),
         ]),
         '0x11223344',
         '0x0000000000000000000000000000000000000000000000000000000000000000',
@@ -66,11 +76,142 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
     });
 
     describe('when caller has ADDCONTROLLER', () => {
-      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
-        it('should fail when adding an extra allowed ERC725Y data key', async () => {
+      describe('when controller / beneficiary had some permissions set', () => {
+        describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+          it('should fail when adding an extra allowed ERC725Y data key', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = encodeCompactBytesArray([
+              ERC725YDataKeys.LSP3['LSP3Profile'],
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
+            ]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          });
+
+          it('should fail when removing an allowed ERC725Y data key', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          });
+
+          it('should fail when trying to clear the CompactedBytesArray completely', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = '0x';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
+          });
+
+          it('should fail when setting an invalid CompactedBytesArray', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = '0xbadbadbadbad';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                'InvalidEncodedAllowedERC725YDataKeys',
+              )
+              .withArgs(value, "couldn't VALIDATE the data value");
+          });
+        });
+
+        describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+          it('should pass when setting a valid CompactedBytesArray', async () => {
+            const newController = ethers.Wallet.createRandom();
+
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              newController.address.substr(2);
+
+            const value = encodeCompactBytesArray([
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 1")),
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 2")),
+            ]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await context.keyManager.connect(canOnlyAddController).execute(payload);
+
+            // prettier-ignore
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should fail when setting an invalid CompactedBytesArray (random bytes)', async () => {
+            const newController = ethers.Wallet.createRandom();
+
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              newController.address.substr(2);
+
+            const value = '0xbadbadbadbad';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                'InvalidEncodedAllowedERC725YDataKeys',
+              )
+              .withArgs(value, "couldn't VALIDATE the data value");
+          });
+        });
+      });
+
+      describe('when controller / beneficiary had no permissions set', () => {
+        it('should pass and edit the list of Allowed ERC725Y Data Keys', async () => {
           const key =
             ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
+            beneficiaryNoPermissions.address.substring(2);
 
           const value = encodeCompactBytesArray([
             ERC725YDataKeys.LSP3['LSP3Profile'],
@@ -78,86 +219,6 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
-          ]);
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-        });
-
-        it('should fail when removing an allowed ERC725Y data key', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-        });
-
-        it('should fail when trying to clear the CompactedBytesArray completely', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = '0x';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
-            .withArgs(canOnlyAddController.address, 'EDITPERMISSIONS');
-        });
-
-        it('should fail when setting an invalid CompactedBytesArray', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = '0xbadbadbadbad';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              'InvalidEncodedAllowedERC725YDataKeys',
-            )
-            .withArgs(value, "couldn't VALIDATE the data value");
-        });
-      });
-
-      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
-        it('should pass when setting a valid CompactedBytesArray', async () => {
-          const newController = ethers.Wallet.createRandom();
-
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            newController.address.substr(2);
-
-          const value = encodeCompactBytesArray([
-            // prettier-ignore
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 1")),
-            // prettier-ignore
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes("My Custom Profile Key 2")),
           ]);
 
           const payload = context.universalProfile.interface.encodeFunctionData('setData', [
@@ -167,41 +228,150 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
 
           await context.keyManager.connect(canOnlyAddController).execute(payload);
 
-          // prettier-ignore
-          const result = await context.universalProfile.getData(key);
-          expect(result).to.equal(value);
-        });
-
-        it('should fail when setting an invalid CompactedBytesArray (random bytes)', async () => {
-          const newController = ethers.Wallet.createRandom();
-
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            newController.address.substr(2);
-
-          const value = '0xbadbadbadbad';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyAddController).execute(payload))
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              'InvalidEncodedAllowedERC725YDataKeys',
-            )
-            .withArgs(value, "couldn't VALIDATE the data value");
+          expect(await context.universalProfile.getData(key)).to.equal(value);
         });
       });
     });
 
     describe('when caller has EDITPERMISSIONS', () => {
-      describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
-        it('should pass when adding an extra allowed ERC725Y data key', async () => {
+      describe('when controller / beneficiary had some permissions set', () => {
+        describe('when beneficiary had some ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+          it('should pass when adding an extra allowed ERC725Y data key', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = encodeCompactBytesArray([
+              ERC725YDataKeys.LSP3['LSP3Profile'],
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
+              // prettier-ignore
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
+            ]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
+
+            // prettier-ignore
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should pass when removing an allowed ERC725Y data key', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
+
+            // prettier-ignore
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should pass when trying to clear the CompactedBytesArray completely', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = '0x';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
+
+            // prettier-ignore
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should fail when setting an invalid CompactedBytesArray', async () => {
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              beneficiaryWithPermissions.address.substring(2);
+
+            const value = '0xbadbadbadbad';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                'InvalidEncodedAllowedERC725YDataKeys',
+              )
+              .withArgs(value, "couldn't VALIDATE the data value");
+          });
+        });
+
+        describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
+          it('should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)', async () => {
+            const newController = ethers.Wallet.createRandom();
+
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              newController.address.substr(2);
+
+            const value = encodeCompactBytesArray([
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 1')),
+              ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 2')),
+            ]);
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
+              .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+              .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
+          });
+
+          it('should fail when setting an invalid CompactedBytesArray', async () => {
+            const newController = ethers.Wallet.createRandom();
+
+            const key =
+              ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
+              newController.address.substr(2);
+
+            const value = '0xbadbadbadbad';
+
+            const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+              key,
+              value,
+            ]);
+
+            await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
+              .to.be.revertedWithCustomError(
+                context.keyManager,
+                'InvalidEncodedAllowedERC725YDataKeys',
+              )
+              .withArgs(value, "couldn't VALIDATE the data value");
+          });
+        });
+      });
+
+      describe('when controller / beneficiary had no permissions set', () => {
+        it("should revert with error `NotAuthorised('ADDCONTROLLER')` when trying to add a list of allowed ERC725Y data keys", async () => {
           const key =
             ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
+            beneficiaryNoPermissions.address.substring(2);
 
           const value = encodeCompactBytesArray([
             ERC725YDataKeys.LSP3['LSP3Profile'],
@@ -209,90 +379,6 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Some Custom Profile Data Key")),
             // prettier-ignore
             ethers.utils.keccak256(ethers.utils.toUtf8Bytes("Another Custom Data Key")),
-          ]);
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
-
-          // prettier-ignore
-          const result = await context.universalProfile.getData(key);
-          expect(result).to.equal(value);
-        });
-
-        it('should pass when removing an allowed ERC725Y data key', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = encodeCompactBytesArray([ERC725YDataKeys.LSP3['LSP3Profile']]);
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
-
-          // prettier-ignore
-          const result = await context.universalProfile.getData(key);
-          expect(result).to.equal(value);
-        });
-
-        it('should pass when trying to clear the CompactedBytesArray completely', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = '0x';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await context.keyManager.connect(canOnlyEditPermissions).execute(payload);
-
-          // prettier-ignore
-          const result = await context.universalProfile.getData(key);
-          expect(result).to.equal(value);
-        });
-
-        it('should fail when setting an invalid CompactedBytesArray', async () => {
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            beneficiary.address.substring(2);
-
-          const value = '0xbadbadbadbad';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              'InvalidEncodedAllowedERC725YDataKeys',
-            )
-            .withArgs(value, "couldn't VALIDATE the data value");
-        });
-      });
-
-      describe('when beneficiary had no ERC725Y data keys set under AddressPermissions:AllowedERC725YDataKeys:...', () => {
-        it('should fail and not authorize to add a list of allowed ERC725Y data keys (not authorised)', async () => {
-          const newController = ethers.Wallet.createRandom();
-
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            newController.address.substr(2);
-
-          const value = encodeCompactBytesArray([
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 1')),
-            ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Custom Key 2')),
           ]);
 
           const payload = context.universalProfile.interface.encodeFunctionData('setData', [
@@ -303,28 +389,6 @@ export const shouldBehaveLikeSetAllowedERC725YDataKeys = (
           await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
             .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(canOnlyEditPermissions.address, 'ADDCONTROLLER');
-        });
-
-        it('should fail when setting an invalid CompactedBytesArray', async () => {
-          const newController = ethers.Wallet.createRandom();
-
-          const key =
-            ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-            newController.address.substr(2);
-
-          const value = '0xbadbadbadbad';
-
-          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
-            key,
-            value,
-          ]);
-
-          await expect(context.keyManager.connect(canOnlyEditPermissions).execute(payload))
-            .to.be.revertedWithCustomError(
-              context.keyManager,
-              'InvalidEncodedAllowedERC725YDataKeys',
-            )
-            .withArgs(value, "couldn't VALIDATE the data value");
         });
       });
     });


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug + ♻️ Refactor

This PR solves a small user bug.

When setting the Allowed Calls or Allowed ERC725Y Data Keys of a controller, currently the logic to check if the permission needed to set these values between `ADD_CONTROLLER` or `EDIT_PERMISSIONS` is to check against the value for the data key being set. This data key can be:

- `AddressPermissions:AllowedCalls:<controller>`
- `AddressPermissions:AllowedERC725YDataKeys:<controller>`

Update this logic to check now if the controller is actually a controller with some permission, by checking under the `AddressPermissions:Permissions:<controller>` instead.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
