### PR TITLE
perf: remove double `_exist` check in LSP8Core

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -285,6 +285,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) internal virtual {
         bool isRemoved = _operators[tokenId].remove(operator);
         if (!isRemoved) revert LSP8NonExistingOperator(operator, tokenId);
+
         emit RevokedOperator(
             operator,
             tokenOwner,
@@ -366,10 +367,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) internal virtual {
         if (to == address(0)) {
             revert LSP8CannotSendToAddressZero();
-        }
-
-        if (_exists(tokenId)) {
-            revert LSP8TokenIdAlreadyMinted(tokenId);
         }
 
         _beforeTokenTransfer(address(0), to, tokenId);


### PR DESCRIPTION
# What does this PR introduce?

## ⚡️ Performance

Reduce double check for `_exist` inside LSP8 Core internal `_mint` function.

### PR Checklist

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
