### PR TITLE
refactor: adjust LSP7 storage layout like LSP8

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -50,21 +50,22 @@ import {
  */
 abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     using EnumerableSet for EnumerableSet.AddressSet;
+
     // --- Storage
+
+    bool internal _isNonDivisible;
+
+    uint256 internal _existingTokens;
 
     // Mapping from `tokenOwner` to an `amount` of tokens
     mapping(address => uint256) internal _tokenOwnerBalances;
 
-    // Mapping a `tokenOwner` to an `operator` to `amount` of tokens.
-    mapping(address => mapping(address => uint256))
-        internal _operatorAuthorizedAmount;
-
     // Mapping an `address` to its authorized operator addresses.
     mapping(address => EnumerableSet.AddressSet) internal _operators;
 
-    uint256 internal _existingTokens;
-
-    bool internal _isNonDivisible;
+    // Mapping a `tokenOwner` to an `operator` to `amount` of tokens.
+    mapping(address => mapping(address => uint256))
+        internal _operatorAuthorizedAmount;
 
     // --- Token queries
 


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

Minor change to adjust the storage layout of the token contracts so that they look similar between LSP7 and LSP8.

### LSP7 Before

<img width="1199" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/10632fbb-e43a-45b2-b78a-d71fc32ed0ae">


### LSP7 After

<img width="1185" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/9461cf3c-a041-4f62-af36-7dff346b4e63">

### LSP8 Storage 

<img width="1263" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/2b24d4de-fa97-4c20-a743-623bf4b4f074">

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
