### PR TITLE
refactor: update contracts to allow compiling with solc versions `0.8.7`, `.6` and `.5`

### DIFF
--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -62,9 +62,16 @@ jobs:
           solc-select install ${{ matrix.solc }}
           solc-select use ${{ matrix.solc }}
 
+      - name: Compare versions to filter contracts to compile
+        uses: madhead/semver-utils@latest
+        id: comparison
+        with:
+          version: ${{ matrix.solc }}
+          compare-to: 0.8.12
+
       - name: Compile Smart Contracts
         run: |
-          if [[ ${{ matrix.solc }} < 0.8.12 ]]
+          if [[ "<" == "${{ steps.comparison.outputs.comparison-result }}" ]]
           then 
             solc $(ls contracts/**/*.sol | grep -v "Compatible" | grep -v "Extension4337") --allow-paths $(pwd)/node_modules/ \
               @=node_modules/@ \

--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -3,6 +3,14 @@
 name: Solidity Compiler Versions
 
 on:
+  # Used to check pragma settings for `.sol` files are correct before releasing
+  push:
+    branches:
+      - "develop"
+    # compare gas diff only when editing Solidity smart contract code
+    paths:
+      - "contracts/**/*.sol"
+
   pull_request:
     types: [opened]
 
@@ -16,10 +24,9 @@ jobs:
     strategy:
       matrix:
         solc: [
-            # TODO: wait for a patch release of @erc725/smart-contracts to compile on these 3 versions
-            # "0.8.5",
-            # "0.8.6",
-            # "0.8.7",
+            "0.8.5",
+            "0.8.6",
+            "0.8.7",
             "0.8.8",
             "0.8.9",
             "0.8.10",
@@ -59,13 +66,11 @@ jobs:
         run: |
           if [[ ${{ matrix.solc }} < 0.8.12 ]]
           then 
-            solc $(ls contracts/**/*.sol | grep -v "Compatible") --allow-paths $(pwd)/node_modules/ \
-              @erc725/smart-contracts/=node_modules/@erc725/smart-contracts/ \
-              @openzeppelin/=node_modules/@openzeppelin/ \
+            solc $(ls contracts/**/*.sol | grep -v "Compatible" | grep -v "Extension4337") --allow-paths $(pwd)/node_modules/ \
+              @=node_modules/@ \
               solidity-bytes-utils/=node_modules/solidity-bytes-utils/
           else
             solc contracts/**/*.sol \
-              @erc725/smart-contracts/=node_modules/@erc725/smart-contracts/ \
-              @openzeppelin/=node_modules/@openzeppelin/ \
+              @=node_modules/@ \
               solidity-bytes-utils/=node_modules/solidity-bytes-utils/
           fi;

--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -3,6 +3,8 @@
 name: Solidity Compiler Versions
 
 on:
+  workflow_dispatch:
+
   # Used to check pragma settings for `.sol` files are correct before releasing
   push:
     branches:

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -138,7 +138,7 @@ abstract contract LSP0ERC725AccountCore is
      */
     function batchCalls(
         bytes[] calldata data
-    ) public virtual returns (bytes[] memory results) {
+    ) public virtual override returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i; i < data.length; ) {
             (bool success, bytes memory result) = address(this).delegatecall(
@@ -415,7 +415,7 @@ abstract contract LSP0ERC725AccountCore is
     function universalReceiver(
         bytes32 typeId,
         bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    ) public payable virtual override returns (bytes memory returnedValues) {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }
@@ -678,7 +678,7 @@ abstract contract LSP0ERC725AccountCore is
     function isValidSignature(
         bytes32 dataHash,
         bytes memory signature
-    ) public view virtual returns (bytes4 magicValue) {
+    ) public view virtual override returns (bytes4 magicValue) {
         address _owner = owner();
 
         // If owner is a contract

--- a/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
+++ b/contracts/LSP11BasicSocialRecovery/LSP11BasicSocialRecoveryCore.sol
@@ -85,42 +85,68 @@ abstract contract LSP11BasicSocialRecoveryCore is
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function target() public view virtual returns (address) {
+    function target() public view virtual override returns (address) {
         return _target;
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function getRecoveryCounter() public view virtual returns (uint256) {
+    function getRecoveryCounter()
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return _recoveryCounter;
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function getGuardians() public view virtual returns (address[] memory) {
+    function getGuardians()
+        public
+        view
+        virtual
+        override
+        returns (address[] memory)
+    {
         return _guardians.values();
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function isGuardian(address _address) public view virtual returns (bool) {
+    function isGuardian(
+        address _address
+    ) public view virtual override returns (bool) {
         return _guardians.contains(_address);
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function getGuardiansThreshold() public view virtual returns (uint256) {
+    function getGuardiansThreshold()
+        public
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return _guardiansThreshold;
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function getRecoverySecretHash() public view virtual returns (bytes32) {
+    function getRecoverySecretHash()
+        public
+        view
+        virtual
+        override
+        returns (bytes32)
+    {
         return _recoverySecretHash;
     }
 
@@ -129,14 +155,16 @@ abstract contract LSP11BasicSocialRecoveryCore is
      */
     function getGuardianChoice(
         address guardian
-    ) public view virtual returns (address) {
+    ) public view virtual override returns (address) {
         return _guardiansChoice[_recoveryCounter][guardian];
     }
 
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function addGuardian(address newGuardian) public virtual onlyOwner {
+    function addGuardian(
+        address newGuardian
+    ) public virtual override onlyOwner {
         if (_guardians.contains(newGuardian))
             revert GuardianAlreadyExist(newGuardian);
 
@@ -147,7 +175,9 @@ abstract contract LSP11BasicSocialRecoveryCore is
     /**
      * @inheritdoc ILSP11BasicSocialRecovery
      */
-    function removeGuardian(address existingGuardian) public virtual onlyOwner {
+    function removeGuardian(
+        address existingGuardian
+    ) public virtual override onlyOwner {
         if (!_guardians.contains(existingGuardian))
             revert GuardianDoNotExist(existingGuardian);
         if (_guardians.length() == _guardiansThreshold)
@@ -162,7 +192,7 @@ abstract contract LSP11BasicSocialRecoveryCore is
      */
     function setGuardiansThreshold(
         uint256 newThreshold
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         if (newThreshold > _guardians.length())
             revert ThresholdCannotBeHigherThanGuardiansNumber(
                 newThreshold,
@@ -179,7 +209,7 @@ abstract contract LSP11BasicSocialRecoveryCore is
      */
     function setRecoverySecretHash(
         bytes32 newRecoverSecretHash
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         if (newRecoverSecretHash == bytes32(0)) revert SecretHashCannotBeZero();
 
         _recoverySecretHash = newRecoverSecretHash;
@@ -191,7 +221,7 @@ abstract contract LSP11BasicSocialRecoveryCore is
      */
     function selectNewController(
         address addressSelected
-    ) public virtual onlyGuardians {
+    ) public virtual override onlyGuardians {
         uint256 currentRecoveryCounter = _recoveryCounter;
 
         _guardiansChoice[currentRecoveryCounter][msg.sender] = addressSelected;
@@ -209,7 +239,7 @@ abstract contract LSP11BasicSocialRecoveryCore is
         address recoverer,
         string memory plainSecret,
         bytes32 newSecretHash
-    ) public virtual {
+    ) public virtual override {
         // caching storage variables
         uint256 currentRecoveryCounter = _recoveryCounter;
         address[] memory guardians = _guardians.values();

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -76,7 +76,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
      *
      * @custom:info If no ownership transfer is in progress, the pendingOwner will be `address(0).`.
      */
-    function pendingOwner() public view virtual returns (address) {
+    function pendingOwner() public view virtual override returns (address) {
         return _pendingOwner;
     }
 
@@ -110,7 +110,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
      *
      * @custom:requirements This function can only be called by the {pendingOwner()}.
      */
-    function acceptOwnership() public virtual NotInTransferOwnership {
+    function acceptOwnership() public virtual override NotInTransferOwnership {
         address previousOwner = owner();
 
         _acceptOwnership();

--- a/contracts/LSP17Extensions/Extension4337.sol
+++ b/contracts/LSP17Extensions/Extension4337.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.12;
 
 // interfaces
 import {IAccount} from "@account-abstraction/contracts/interfaces/IAccount.sol";

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -79,7 +79,7 @@ contract LSP1UniversalReceiverDelegateUP is ERC165, ILSP1UniversalReceiver {
     function universalReceiver(
         bytes32 typeId,
         bytes memory /* data */
-    ) public payable virtual returns (bytes memory) {
+    ) public payable virtual override returns (bytes memory) {
         // CHECK that we did not send any native tokens to the LSP1 Delegate, as it cannot transfer them back.
         if (msg.value != 0) {
             revert NativeTokensNotAccepted();

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -63,7 +63,7 @@ contract LSP1UniversalReceiverDelegateVault is ERC165, ILSP1UniversalReceiver {
     function universalReceiver(
         bytes32 typeId,
         bytes memory /* data */
-    ) public payable virtual returns (bytes memory) {
+    ) public payable virtual override returns (bytes memory) {
         // CHECK that we did not send any native tokens to the LSP1 Delegate, as it cannot transfer them back.
         if (msg.value != 0) {
             revert NativeTokensNotAccepted();

--- a/contracts/LSP23LinkedContractsFactory/LSP23LinkedContractsFactory.sol
+++ b/contracts/LSP23LinkedContractsFactory/LSP23LinkedContractsFactory.sol
@@ -23,6 +23,7 @@ contract LSP23LinkedContractsFactory is ILSP23LinkedContractsFactory {
     )
         public
         payable
+        override
         returns (
             address primaryContractAddress,
             address secondaryContractAddress
@@ -81,6 +82,7 @@ contract LSP23LinkedContractsFactory is ILSP23LinkedContractsFactory {
     )
         public
         payable
+        override
         returns (
             address primaryContractAddress,
             address secondaryContractAddress
@@ -140,6 +142,7 @@ contract LSP23LinkedContractsFactory is ILSP23LinkedContractsFactory {
     )
         public
         view
+        override
         returns (
             address primaryContractAddress,
             address secondaryContractAddress
@@ -187,6 +190,7 @@ contract LSP23LinkedContractsFactory is ILSP23LinkedContractsFactory {
     )
         public
         view
+        override
         returns (
             address primaryContractAddress,
             address secondaryContractAddress

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -101,7 +101,7 @@ abstract contract LSP6KeyManagerCore is
     /**
      * @inheritdoc ILSP6
      */
-    function target() public view returns (address) {
+    function target() public view override returns (address) {
         return _target;
     }
 
@@ -136,7 +136,7 @@ abstract contract LSP6KeyManagerCore is
     function getNonce(
         address from,
         uint128 channelId
-    ) public view virtual returns (uint256) {
+    ) public view virtual override returns (uint256) {
         return LSP25MultiChannelNonce._getNonce(from, channelId);
     }
 
@@ -151,7 +151,7 @@ abstract contract LSP6KeyManagerCore is
     function isValidSignature(
         bytes32 dataHash,
         bytes memory signature
-    ) public view virtual returns (bytes4 magicValue) {
+    ) public view virtual override returns (bytes4 magicValue) {
         // if isValidSignature fail, the error is catched in returnedError
         (address recoveredAddress, ECDSA.RecoverError returnedError) = ECDSA
             .tryRecover(dataHash, signature);
@@ -177,7 +177,7 @@ abstract contract LSP6KeyManagerCore is
      */
     function execute(
         bytes calldata payload
-    ) public payable virtual returns (bytes memory) {
+    ) public payable virtual override returns (bytes memory) {
         return _execute(msg.value, payload);
     }
 
@@ -189,7 +189,7 @@ abstract contract LSP6KeyManagerCore is
     function executeBatch(
         uint256[] calldata values,
         bytes[] calldata payloads
-    ) public payable virtual returns (bytes[] memory) {
+    ) public payable virtual override returns (bytes[] memory) {
         if (values.length != payloads.length) {
             revert BatchExecuteParamsLengthMismatch();
         }
@@ -237,7 +237,7 @@ abstract contract LSP6KeyManagerCore is
         uint256 nonce,
         uint256 validityTimestamps,
         bytes calldata payload
-    ) public payable virtual returns (bytes memory) {
+    ) public payable virtual override returns (bytes memory) {
         return
             _executeRelayCall(
                 signature,
@@ -267,7 +267,7 @@ abstract contract LSP6KeyManagerCore is
         uint256[] calldata validityTimestamps,
         uint256[] calldata values,
         bytes[] calldata payloads
-    ) public payable virtual returns (bytes[] memory) {
+    ) public payable virtual override returns (bytes[] memory) {
         if (
             signatures.length != nonces.length ||
             nonces.length != validityTimestamps.length ||
@@ -323,7 +323,7 @@ abstract contract LSP6KeyManagerCore is
         address caller,
         uint256 msgValue,
         bytes calldata data
-    ) external virtual returns (bytes4) {
+    ) external virtual override returns (bytes4) {
         bool isSetData = bytes4(data) == IERC725Y.setData.selector ||
             bytes4(data) == IERC725Y.setDataBatch.selector;
 
@@ -373,7 +373,7 @@ abstract contract LSP6KeyManagerCore is
     function lsp20VerifyCallResult(
         bytes32 /*callHash*/,
         bytes memory /*result*/
-    ) external virtual returns (bytes4) {
+    ) external virtual override returns (bytes4) {
         // If it's the target calling, set back the reentrancy guard
         // to false, if not return the magic value
         if (msg.sender == _target) {

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -71,14 +71,14 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function decimals() public view virtual returns (uint8) {
+    function decimals() public view virtual override returns (uint8) {
         return _isNonDivisible ? 0 : 18;
     }
 
     /**
      * @inheritdoc ILSP7DigitalAsset
      */
-    function totalSupply() public view virtual returns (uint256) {
+    function totalSupply() public view virtual override returns (uint256) {
         return _existingTokens;
     }
 
@@ -89,7 +89,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      */
     function balanceOf(
         address tokenOwner
-    ) public view virtual returns (uint256) {
+    ) public view virtual override returns (uint256) {
         return _tokenOwnerBalances[tokenOwner];
     }
 
@@ -111,7 +111,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         address operator,
         uint256 amount,
         bytes memory operatorNotificationData
-    ) public virtual {
+    ) public virtual override {
         _updateOperator(msg.sender, operator, amount, operatorNotificationData);
 
         bytes memory lsp1Data = abi.encode(
@@ -128,7 +128,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     function revokeOperator(
         address operator,
         bytes memory operatorNotificationData
-    ) public virtual {
+    ) public virtual override {
         _updateOperator(msg.sender, operator, 0, operatorNotificationData);
 
         bytes memory lsp1Data = abi.encode(
@@ -145,7 +145,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     function authorizedAmountFor(
         address operator,
         address tokenOwner
-    ) public view virtual returns (uint256) {
+    ) public view virtual override returns (uint256) {
         if (tokenOwner == operator) {
             return _tokenOwnerBalances[tokenOwner];
         } else {
@@ -158,7 +158,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      */
     function getOperatorsOf(
         address tokenOwner
-    ) public view virtual returns (address[] memory) {
+    ) public view virtual override returns (address[] memory) {
         return _operators[tokenOwner].values();
     }
 
@@ -173,7 +173,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 amount,
         bool force,
         bytes memory data
-    ) public virtual {
+    ) public virtual override {
         if (from == to) revert LSP7CannotSendToSelf();
 
         if (msg.sender != from) {
@@ -196,7 +196,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256[] memory amount,
         bool[] memory force,
         bytes[] memory data
-    ) public virtual {
+    ) public virtual override {
         uint256 fromLength = from.length;
         if (
             fromLength != to.length ||

--- a/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
@@ -36,7 +36,7 @@ contract LSP7Mintable is LSP7DigitalAsset, ILSP7Mintable {
         uint256 amount,
         bool force,
         bytes memory data
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -47,7 +47,7 @@ abstract contract LSP7MintableInitAbstract is
         uint256 amount,
         bool force,
         bytes memory data
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         _mint(to, amount, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -73,7 +73,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @inheritdoc ILSP8IdentifiableDigitalAsset
      */
-    function totalSupply() public view virtual returns (uint256) {
+    function totalSupply() public view virtual override returns (uint256) {
         return _existingTokens;
     }
 
@@ -84,7 +84,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      */
     function balanceOf(
         address tokenOwner
-    ) public view virtual returns (uint256) {
+    ) public view virtual override returns (uint256) {
         return _ownedTokens[tokenOwner].length();
     }
 
@@ -93,7 +93,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      */
     function tokenOwnerOf(
         bytes32 tokenId
-    ) public view virtual returns (address) {
+    ) public view virtual override returns (address) {
         address tokenOwner = _tokenOwners[tokenId];
 
         if (tokenOwner == address(0)) {
@@ -108,7 +108,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      */
     function tokenIdsOf(
         address tokenOwner
-    ) public view virtual returns (bytes32[] memory) {
+    ) public view virtual override returns (bytes32[] memory) {
         return _ownedTokens[tokenOwner].values();
     }
 
@@ -121,7 +121,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         address operator,
         bytes32 tokenId,
         bytes memory operatorNotificationData
-    ) public virtual {
+    ) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
         if (tokenOwner != msg.sender) {
@@ -161,7 +161,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         address operator,
         bytes32 tokenId,
         bytes memory operatorNotificationData
-    ) public virtual {
+    ) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
         if (tokenOwner != msg.sender) {
@@ -197,7 +197,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     function isOperatorFor(
         address operator,
         bytes32 tokenId
-    ) public view virtual returns (bool) {
+    ) public view virtual override returns (bool) {
         _existsOrError(tokenId);
 
         return _isOperatorOrOwner(operator, tokenId);
@@ -208,7 +208,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      */
     function getOperatorsOf(
         bytes32 tokenId
-    ) public view virtual returns (address[] memory) {
+    ) public view virtual override returns (address[] memory) {
         _existsOrError(tokenId);
 
         return _operators[tokenId].values();
@@ -237,7 +237,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public virtual {
+    ) public virtual override {
         if (!_isOperatorOrOwner(msg.sender, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, msg.sender);
         }
@@ -254,7 +254,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes32[] memory tokenId,
         bool[] memory force,
         bytes[] memory data
-    ) public virtual {
+    ) public virtual override {
         uint256 fromLength = from.length;
         if (
             fromLength != to.length ||

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
@@ -44,7 +44,7 @@ contract LSP8Mintable is LSP8IdentifiableDigitalAsset, ILSP8Mintable {
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -53,7 +53,7 @@ abstract contract LSP8MintableInitAbstract is
         bytes32 tokenId,
         bool force,
         bytes memory data
-    ) public virtual onlyOwner {
+    ) public virtual override onlyOwner {
         _mint(to, tokenId, force, data);
     }
 }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -138,7 +138,7 @@ contract LSP9VaultCore is
      */
     function batchCalls(
         bytes[] calldata data
-    ) public virtual returns (bytes[] memory results) {
+    ) public virtual override returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i; i < data.length; ) {
             (bool success, bytes memory result) = address(this).delegatecall(
@@ -321,7 +321,7 @@ contract LSP9VaultCore is
     function universalReceiver(
         bytes32 typeId,
         bytes calldata receivedData
-    ) public payable virtual returns (bytes memory returnedValues) {
+    ) public payable virtual override returns (bytes memory returnedValues) {
         if (msg.value != 0) {
             emit ValueReceived(msg.sender, msg.value);
         }

--- a/contracts/Mocks/FallbackExtensions/ERC165Extension.sol
+++ b/contracts/Mocks/FallbackExtensions/ERC165Extension.sol
@@ -11,7 +11,7 @@ contract ERC165Extension is IERC165 {
 
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual returns (bool) {
+    ) public pure override returns (bool) {
         return interfaceId == _RANDOM_INTERFACE_ID;
     }
 }

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateGasConsumer.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateGasConsumer.sol
@@ -23,7 +23,7 @@ contract UniversalReceiverDelegateGasConsumer is
     function universalReceiver(
         bytes32 /* typeId */,
         bytes memory /* data */
-    ) public payable virtual returns (bytes memory) {
+    ) public payable override returns (bytes memory) {
         // solhint-disable no-empty-blocks
         for (uint256 i = 0; ; i++) {
             // nothing

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateRevert.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateRevert.sol
@@ -20,7 +20,7 @@ contract UniversalReceiverDelegateRevert is ERC165, ILSP1UniversalReceiver {
     function universalReceiver(
         bytes32 /* typeId */,
         bytes memory /* data */
-    ) public payable virtual returns (bytes memory) {
+    ) public payable override returns (bytes memory) {
         revert("I Revert");
     }
 

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantA.sol
@@ -34,7 +34,7 @@ contract UniversalReceiverDelegateVaultReentrantA is
     function universalReceiver(
         bytes32 /* typeId */,
         bytes memory data
-    ) external payable returns (bytes memory) {
+    ) external payable override returns (bytes memory) {
         if (msg.value != 0) {
             revert NativeTokensNotAccepted();
         }

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateVaultReentrantB.sol
@@ -36,7 +36,7 @@ contract UniversalReceiverDelegateVaultReentrantB is
     function universalReceiver(
         bytes32 /* typeId */,
         bytes memory data
-    ) external payable returns (bytes memory) {
+    ) external payable override returns (bytes memory) {
         if (msg.value != 0) {
             revert NativeTokensNotAccepted();
         }

--- a/scripts/ci/gas_benchmark.ts
+++ b/scripts/ci/gas_benchmark.ts
@@ -180,7 +180,7 @@ task('gas-benchmark', 'Benchmark gas usage of the smart contracts based on prede
 ⛽ I am the Gas Bot Reporter. I keep track of the gas costs of common interactions using Universal Profiles 🆙 !
 📊 Here is a summary of the gas cost with the code introduced by this PR.
 
-## ⛽📊 Gas Benchmark Report
+## ⛽📊 Gas Benchmark Report
 
 ### Deployment Costs
 


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

Add the `override` keyword to allow compiling with older solc compiler versions before `0.8.8`.

## 🤖 CI

Uncomment versions in `solc_versions.yaml` to test for compiling with older solc versions:
- `0.8.7`
- `0.8.6`
- `0.8.5`

Update the CI to also run when changes are merged in the develop branch.


