### PR TITLE
feat: add `_afterTokenTransfer` internal function in LSP7 + LSP8

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -391,7 +391,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(address(0), to, amount);
+        _beforeTokenTransfer(address(0), to, amount, data);
 
         // tokens being minted
         _existingTokens += amount;
@@ -400,7 +400,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         emit Transfer(msg.sender, address(0), to, amount, force, data);
 
-        _afterTokenTransfer(address(0), to, amount);
+        _afterTokenTransfer(address(0), to, amount, data);
 
         bytes memory lsp1Data = abi.encode(address(0), to, amount, data);
         _notifyTokenReceiver(to, force, lsp1Data);
@@ -445,7 +445,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             revert LSP7AmountExceedsBalance(balance, from, amount);
         }
 
-        _beforeTokenTransfer(from, address(0), amount);
+        _beforeTokenTransfer(from, address(0), amount, data);
 
         // tokens being burnt
         _existingTokens -= amount;
@@ -462,7 +462,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             data: data
         });
 
-        _afterTokenTransfer(from, address(0), amount);
+        _afterTokenTransfer(from, address(0), amount, data);
 
         bytes memory lsp1Data = abi.encode(from, address(0), amount, data);
         _notifyTokenSender(from, lsp1Data);
@@ -551,14 +551,14 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             revert LSP7AmountExceedsBalance(balance, from, amount);
         }
 
-        _beforeTokenTransfer(from, to, amount);
+        _beforeTokenTransfer(from, to, amount, data);
 
         _tokenOwnerBalances[from] -= amount;
         _tokenOwnerBalances[to] += amount;
 
         emit Transfer(msg.sender, from, to, amount, force, data);
 
-        _afterTokenTransfer(from, to, amount);
+        _afterTokenTransfer(from, to, amount, data);
 
         bytes memory lsp1Data = abi.encode(from, to, amount, data);
 
@@ -573,11 +573,13 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 amount // solhint-disable-next-line no-empty-blocks
+        uint256 amount,
+        bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
     /**
@@ -587,11 +589,13 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
-        uint256 amount // solhint-disable-next-line no-empty-blocks
+        uint256 amount,
+        bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -367,6 +367,10 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
     /**
      * @dev Mints `amount` of tokens and transfers it to `to`.
      *
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances.
+     * - {_afterTokenTransfer} function will run after updating the balances, **but before notifying the recipient via LSP1**.
+     *
      * @param to The address to mint tokens for.
      * @param amount The amount of tokens to mint.
      * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
@@ -396,6 +400,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         emit Transfer(msg.sender, address(0), to, amount, force, data);
 
+        _afterTokenTransfer(address(0), to, amount);
+
         bytes memory lsp1Data = abi.encode(address(0), to, amount, data);
         _notifyTokenReceiver(to, force, lsp1Data);
     }
@@ -407,7 +413,9 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
      * all the parameters in the calldata packed encoded.
      *
-     * Any logic in the {_beforeTokenTransfer} function will run before updating the balances.
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances.
+     * - {_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender via LSP1**.
      *
      * @param from The address to burn tokens from its balance.
      * @param amount The amount of tokens to burn.
@@ -453,6 +461,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             force: false,
             data: data
         });
+
+        _afterTokenTransfer(from, address(0), amount);
 
         bytes memory lsp1Data = abi.encode(from, address(0), amount, data);
         _notifyTokenSender(from, lsp1Data);
@@ -508,7 +518,9 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
      * all the parameters in the calldata packed encoded.
      *
-     * Any logic in the {_beforeTokenTransfer} function will run before updating the balances.
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances.
+     * - {_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender/recipient via LSP1**.
      *
      * @param from The address to decrease the balance.
      * @param to The address to increase the balance.
@@ -546,6 +558,8 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         emit Transfer(msg.sender, from, to, amount, force, data);
 
+        _afterTokenTransfer(from, to, amount);
+
         bytes memory lsp1Data = abi.encode(from, to, amount, data);
 
         _notifyTokenSender(from, lsp1Data);
@@ -561,6 +575,20 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      * @param amount The amount of token to transfer
      */
     function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount // solhint-disable-next-line no-empty-blocks
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any token transfer, including minting and burning.
+     * Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
+     *
+     * @param from The sender address
+     * @param to The recipient address
+     * @param amount The amount of token to transfer
+     */
+    function _afterTokenTransfer(
         address from,
         address to,
         uint256 amount // solhint-disable-next-line no-empty-blocks

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -373,7 +373,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             revert LSP8CannotSendToAddressZero();
         }
 
-        _beforeTokenTransfer(address(0), to, tokenId);
+        _beforeTokenTransfer(address(0), to, tokenId, data);
 
         // Check that `tokenId` was not minted inside the `_beforeTokenTransfer` hook
         if (_exists(tokenId)) {
@@ -388,7 +388,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, address(0), to, tokenId, force, data);
 
-        _afterTokenTransfer(address(0), to, tokenId);
+        _afterTokenTransfer(address(0), to, tokenId, data);
 
         bytes memory lsp1Data = abi.encode(address(0), to, tokenId, data);
         _notifyTokenReceiver(to, force, lsp1Data);
@@ -419,7 +419,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        _beforeTokenTransfer(tokenOwner, address(0), tokenId);
+        _beforeTokenTransfer(tokenOwner, address(0), tokenId, data);
 
         // Re-fetch and update `tokenOwner` in case `tokenId`
         // was transferred inside the `_beforeTokenTransfer` hook
@@ -435,7 +435,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, tokenOwner, address(0), tokenId, false, data);
 
-        _afterTokenTransfer(tokenOwner, address(0), tokenId);
+        _afterTokenTransfer(tokenOwner, address(0), tokenId, data);
 
         bytes memory lsp1Data = abi.encode(
             tokenOwner,
@@ -491,7 +491,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             revert LSP8CannotSendToAddressZero();
         }
 
-        _beforeTokenTransfer(from, to, tokenId);
+        _beforeTokenTransfer(from, to, tokenId, data);
 
         // Re-fetch and update `tokenOwner` in case `tokenId`
         // was transferred inside the `_beforeTokenTransfer` hook
@@ -505,7 +505,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, from, to, tokenId, force, data);
 
-        _afterTokenTransfer(from, to, tokenId);
+        _afterTokenTransfer(from, to, tokenId, data);
 
         bytes memory lsp1Data = abi.encode(from, to, tokenId, data);
 
@@ -520,11 +520,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId // solhint-disable-next-line no-empty-blocks
+        bytes32 tokenId,
+        bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
     /**
@@ -534,11 +536,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId // solhint-disable-next-line no-empty-blocks
+        bytes32 tokenId,
+        bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -348,15 +348,19 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     /**
      * @dev Create `tokenId` by minting it and transfers it to `to`.
      *
-     * @custom:requirements
-     * - `tokenId` must not exist and not have been already minted.
-     * - `to` cannot be the zero address.
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+     * - {_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the recipient via LSP1**.
      *
      * @param to The address that will receive the minted `tokenId`.
      * @param tokenId The token ID to create (= mint).
      * @param force When set to `true`, `to` may be any address. When set to `false`, `to` must be a contract that supports the LSP1 standard.
      * @param data Any additional data the caller wants included in the emitted event, and sent in the hook of the `to` address.
      *
+     * @custom:requirements
+     * - `tokenId` must not exist and not have been already minted.
+     * - `to` cannot be the zero address.
+
      * @custom:events {Transfer} event with `address(0)` as `from` address.
      */
     function _mint(
@@ -384,6 +388,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, address(0), to, tokenId, force, data);
 
+        _afterTokenTransfer(address(0), to, tokenId);
+
         bytes memory lsp1Data = abi.encode(address(0), to, tokenId, data);
         _notifyTokenReceiver(to, force, lsp1Data);
     }
@@ -396,7 +402,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      * function, if it is a contract that supports the LSP1 interface. Its {universalReceiver} function will receive
      * all the parameters in the calldata packed encoded.
      *
-     * Any logic in the {_beforeTokenTransfer} function will run before burning `tokenId` and updating the balances.
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+     * - {_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
      *
      * @param tokenId The token to burn.
      * @param data Any additional data the caller wants included in the emitted event, and sent in the LSP1 hook on the token owner's address.
@@ -427,6 +435,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, tokenOwner, address(0), tokenId, false, data);
 
+        _afterTokenTransfer(tokenOwner, address(0), tokenId);
+
         bytes memory lsp1Data = abi.encode(
             tokenOwner,
             address(0),
@@ -443,7 +453,9 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
      * function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
      * all the parameters in the calldata packed encoded.
      *
-     * Any logic in the {_beforeTokenTransfer} function will run before changing the owner of `tokenId`.
+     * @custom:info Any logic in the:
+     * - {_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+     * - {_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
      *
      * @param from The sender address.
      * @param to The recipient address.
@@ -493,6 +505,8 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         emit Transfer(msg.sender, from, to, tokenId, force, data);
 
+        _afterTokenTransfer(from, to, tokenId);
+
         bytes memory lsp1Data = abi.encode(from, to, tokenId, data);
 
         _notifyTokenSender(from, lsp1Data);
@@ -501,13 +515,27 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
     /**
      * @dev Hook that is called before any token transfer, including minting and burning.
-     * * Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+     * Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
      *
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
      */
     function _beforeTokenTransfer(
+        address from,
+        address to,
+        bytes32 tokenId // solhint-disable-next-line no-empty-blocks
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any token transfer, including minting and burning.
+     * Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
+     *
+     * @param from The sender address
+     * @param to The recipient address
+     * @param tokenId The tokenId to transfer
+     */
+    function _afterTokenTransfer(
         address from,
         address to,
         bytes32 tokenId // solhint-disable-next-line no-empty-blocks

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol
@@ -4,11 +4,9 @@ pragma solidity ^0.8.4;
 
 // modules
 import {
-    LSP8IdentifiableDigitalAsset
-} from "../LSP8IdentifiableDigitalAsset.sol";
-import {
+    LSP8IdentifiableDigitalAsset,
     LSP8IdentifiableDigitalAssetCore
-} from "../LSP8IdentifiableDigitalAssetCore.sol";
+} from "../LSP8IdentifiableDigitalAsset.sol";
 
 /**
  * @dev LSP8 extension that enables to enumerate over all the `tokenIds` ever minted.
@@ -39,11 +37,13 @@ abstract contract LSP8Enumerable is LSP8IdentifiableDigitalAsset {
      * @param from The address sending the `tokenId` (`address(0)` when `tokenId` is being minted).
      * @param to The address receiving the `tokenId` (`address(0)` when `tokenId` is being burnt).
      * @param tokenId The bytes32 identifier of the token being transferred.
+     * @param data The data sent alongside the the token transfer.
      */
     function _beforeTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId
+        bytes32 tokenId,
+        bytes memory data
     ) internal virtual override(LSP8IdentifiableDigitalAssetCore) {
         // `tokenId` being minted
         if (from == address(0)) {
@@ -65,6 +65,6 @@ abstract contract LSP8Enumerable is LSP8IdentifiableDigitalAsset {
             delete _tokenIndex[tokenId];
         }
 
-        super._beforeTokenTransfer(from, to, tokenId);
+        super._beforeTokenTransfer(from, to, tokenId, data);
     }
 }

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8EnumerableInitAbstract.sol
@@ -4,11 +4,9 @@ pragma solidity ^0.8.4;
 
 // modules
 import {
-    LSP8IdentifiableDigitalAssetInitAbstract
-} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
-import {
+    LSP8IdentifiableDigitalAssetInitAbstract,
     LSP8IdentifiableDigitalAssetCore
-} from "../LSP8IdentifiableDigitalAssetCore.sol";
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
 
 /**
  * @dev LSP8 extension.
@@ -39,11 +37,13 @@ abstract contract LSP8EnumerableInitAbstract is
      * @param from The address sending the `tokenId` (`address(0)` when `tokenId` is being minted).
      * @param to The address receiving the `tokenId` (`address(0)` when `tokenId` is being burnt).
      * @param tokenId The bytes32 identifier of the token being transferred.
+     * @param data The data sent alongside the the token transfer.
      */
     function _beforeTokenTransfer(
         address from,
         address to,
-        bytes32 tokenId
+        bytes32 tokenId,
+        bytes memory data
     ) internal virtual override(LSP8IdentifiableDigitalAssetCore) {
         if (from == address(0)) {
             uint256 index = totalSupply();
@@ -60,6 +60,6 @@ abstract contract LSP8EnumerableInitAbstract is
             delete _indexToken[lastIndex];
             delete _tokenIndex[tokenId];
         }
-        super._beforeTokenTransfer(from, to, tokenId);
+        super._beforeTokenTransfer(from, to, tokenId, data);
     }
 }

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -833,6 +833,16 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -865,6 +875,16 @@ Mints `amount` of tokens and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which address is burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -879,7 +899,6 @@ Burns (= destroys) `amount` of tokens, decrease the `from` balance. This is done
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -923,6 +942,16 @@ Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOw
 
 ### \_transfer
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender/recipient via LSP1**.
+
+:::
+
 ```solidity
 function _transfer(
   address from,
@@ -938,7 +967,6 @@ of `to` by `+amount`.
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -972,6 +1000,29 @@ function _beforeTokenTransfer(
 
 Hook that is called before any token transfer, including minting and burning.
 Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -994,7 +994,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1003,11 +1004,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1017,7 +1019,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1026,11 +1029,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -858,6 +858,16 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -890,6 +900,16 @@ Mints `amount` of tokens and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which address is burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -904,7 +924,6 @@ Burns (= destroys) `amount` of tokens, decrease the `from` balance. This is done
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -948,6 +967,16 @@ Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOw
 
 ### \_transfer
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender/recipient via LSP1**.
+
+:::
+
 ```solidity
 function _transfer(
   address from,
@@ -963,7 +992,6 @@ of `to` by `+amount`.
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -997,6 +1025,29 @@ function _beforeTokenTransfer(
 
 Hook that is called before any token transfer, including minting and burning.
 Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -1019,7 +1019,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1028,11 +1029,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1042,7 +1044,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1051,11 +1054,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -874,6 +874,16 @@ after `amount` of tokens have been minted.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which address is burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -888,7 +898,6 @@ Burns (= destroys) `amount` of tokens, decrease the `from` balance. This is done
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -932,6 +941,16 @@ Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOw
 
 ### \_transfer
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender/recipient via LSP1**.
+
+:::
+
 ```solidity
 function _transfer(
   address from,
@@ -947,7 +966,6 @@ of `to` by `+amount`.
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -981,6 +999,29 @@ function _beforeTokenTransfer(
 
 Hook that is called before any token transfer, including minting and burning.
 Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -993,7 +993,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1002,11 +1003,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1016,7 +1018,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1025,11 +1028,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1073,7 +1073,8 @@ function _transfer(
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1082,11 +1083,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1096,7 +1098,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1105,11 +1108,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1090,6 +1090,29 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 <br/>
 
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
 ### \_notifyTokenOperator
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1124,6 +1124,29 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 <br/>
 
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
 ### \_notifyTokenOperator
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1107,7 +1107,8 @@ function _transfer(
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1116,11 +1117,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1130,7 +1132,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1139,11 +1142,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -895,6 +895,16 @@ If the amount is zero then the operator is being revoked, otherwise the operator
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -927,6 +937,16 @@ Mints `amount` of tokens and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which address is burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -941,7 +961,6 @@ Burns (= destroys) `amount` of tokens, decrease the `from` balance. This is done
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -985,6 +1004,16 @@ Spend `amountToSpend` from the `operator`'s authorized on behalf of the `tokenOw
 
 ### \_transfer
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances.
+
+- {\_afterTokenTransfer} function will run after updating the balances, **but before notifying the sender/recipient via LSP1**.
+
+:::
+
 ```solidity
 function _transfer(
   address from,
@@ -1000,7 +1029,6 @@ of `to` by `+amount`.
 Both the sender and recipient will be notified of the token transfer through the LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before updating the balances.
 
 <blockquote>
 
@@ -1034,6 +1062,29 @@ function _beforeTokenTransfer(
 
 Hook that is called before any token transfer, including minting and burning.
 Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+
+#### Parameters
+
+| Name     |   Type    | Description                     |
+| -------- | :-------: | ------------------------------- |
+| `from`   | `address` | The sender address              |
+| `to`     | `address` | The recipient address           |
+| `amount` | `uint256` | The amount of token to transfer |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  uint256 amount
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -1056,7 +1056,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1065,11 +1066,12 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 
@@ -1079,7 +1081,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  uint256 amount
+  uint256 amount,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1088,11 +1091,12 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 #### Parameters
 
-| Name     |   Type    | Description                     |
-| -------- | :-------: | ------------------------------- |
-| `from`   | `address` | The sender address              |
-| `to`     | `address` | The recipient address           |
-| `amount` | `uint256` | The amount of token to transfer |
+| Name     |   Type    | Description                          |
+| -------- | :-------: | ------------------------------------ |
+| `from`   | `address` | The sender address                   |
+| `to`     | `address` | The recipient address                |
+| `amount` | `uint256` | The amount of token to transfer      |
+| `data`   |  `bytes`  | The data sent alongside the transfer |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -947,7 +947,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -961,6 +962,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -970,7 +972,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -984,6 +987,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -803,6 +803,16 @@ When `tokenId` does not exist then revert with an error.
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -835,6 +845,16 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which addresses are burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -850,7 +870,6 @@ This will also clear all the operators allowed to transfer the `tokenId`.
 The owner of the `tokenId` will be notified about the `tokenId` being transferred through its LSP1 [`universalReceiver`](#universalreceiver)
 function, if it is a contract that supports the LSP1 interface. Its [`universalReceiver`](#universalreceiver) function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before burning `tokenId` and updating the balances.
 
 <blockquote>
 
@@ -870,6 +889,16 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 <br/>
 
 ### \_transfer
+
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
+
+:::
 
 :::danger
 
@@ -891,7 +920,6 @@ Change the owner of the `tokenId` from `from` to `to`.
 Both the sender and recipient will be notified of the `tokenId` being transferred through their LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before changing the owner of `tokenId`.
 
 <blockquote>
 
@@ -924,8 +952,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -829,6 +829,16 @@ When `tokenId` does not exist then revert with an error.
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -861,6 +871,16 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which addresses are burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -876,7 +896,6 @@ This will also clear all the operators allowed to transfer the `tokenId`.
 The owner of the `tokenId` will be notified about the `tokenId` being transferred through its LSP1 [`universalReceiver`](#universalreceiver)
 function, if it is a contract that supports the LSP1 interface. Its [`universalReceiver`](#universalreceiver) function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before burning `tokenId` and updating the balances.
 
 <blockquote>
 
@@ -896,6 +915,16 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 <br/>
 
 ### \_transfer
+
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
+
+:::
 
 :::danger
 
@@ -917,7 +946,6 @@ Change the owner of the `tokenId` from `from` to `to`.
 Both the sender and recipient will be notified of the `tokenId` being transferred through their LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before changing the owner of `tokenId`.
 
 <blockquote>
 
@@ -950,8 +978,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -973,7 +973,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -987,6 +988,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -996,7 +998,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1010,6 +1013,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -947,7 +947,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -961,6 +962,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -970,7 +972,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -984,6 +987,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -845,6 +845,16 @@ after a new `tokenId` has of tokens have been minted.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which addresses are burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -860,7 +870,6 @@ This will also clear all the operators allowed to transfer the `tokenId`.
 The owner of the `tokenId` will be notified about the `tokenId` being transferred through its LSP1 [`universalReceiver`](#universalreceiver)
 function, if it is a contract that supports the LSP1 interface. Its [`universalReceiver`](#universalreceiver) function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before burning `tokenId` and updating the balances.
 
 <blockquote>
 
@@ -880,6 +889,16 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 <br/>
 
 ### \_transfer
+
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
+
+:::
 
 :::danger
 
@@ -901,7 +920,6 @@ Change the owner of the `tokenId` from `from` to `to`.
 Both the sender and recipient will be notified of the `tokenId` being transferred through their LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before changing the owner of `tokenId`.
 
 <blockquote>
 
@@ -934,8 +952,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1202,8 +1202,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1197,7 +1197,8 @@ function _transfer(
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1211,6 +1212,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -1220,7 +1222,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1234,6 +1237,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -834,6 +834,16 @@ When `tokenId` does not exist then revert with an error.
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -866,6 +876,16 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which addresses are burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -881,7 +901,6 @@ This will also clear all the operators allowed to transfer the `tokenId`.
 The owner of the `tokenId` will be notified about the `tokenId` being transferred through its LSP1 [`universalReceiver`](#universalreceiver)
 function, if it is a contract that supports the LSP1 interface. Its [`universalReceiver`](#universalreceiver) function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before burning `tokenId` and updating the balances.
 
 <blockquote>
 
@@ -901,6 +920,16 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 <br/>
 
 ### \_transfer
+
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
+
+:::
 
 :::danger
 
@@ -922,7 +951,6 @@ Change the owner of the `tokenId` from `from` to `to`.
 Both the sender and recipient will be notified of the `tokenId` being transferred through their LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before changing the owner of `tokenId`.
 
 <blockquote>
 
@@ -961,6 +989,29 @@ function _beforeTokenTransfer(
 | `from`    | `address` | The address sending the `tokenId` (`address(0)` when `tokenId` is being minted). |
 | `to`      | `address` | @param tokenId The bytes32 identifier of the token being transferred.            |
 | `tokenId` | `bytes32` | The bytes32 identifier of the token being transferred.                           |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
+
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -978,7 +978,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -989,6 +990,7 @@ function _beforeTokenTransfer(
 | `from`    | `address` | The address sending the `tokenId` (`address(0)` when `tokenId` is being minted). |
 | `to`      | `address` | @param tokenId The bytes32 identifier of the token being transferred.            |
 | `tokenId` | `bytes32` | The bytes32 identifier of the token being transferred.                           |
+| `data`    |  `bytes`  | The data sent alongside the the token transfer.                                  |
 
 <br/>
 
@@ -998,7 +1000,8 @@ function _beforeTokenTransfer(
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1012,6 +1015,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1239,7 +1239,8 @@ function _transfer(
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1253,6 +1254,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -1262,7 +1264,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1276,6 +1279,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1244,8 +1244,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1011,7 +1011,8 @@ all the parameters in the calldata packed encoded.
 function _beforeTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1025,6 +1026,7 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 
@@ -1034,7 +1036,8 @@ Allows to run custom logic before updating balances and notifiying sender/recipi
 function _afterTokenTransfer(
   address from,
   address to,
-  bytes32 tokenId
+  bytes32 tokenId,
+  bytes data
 ) internal nonpayable;
 ```
 
@@ -1048,6 +1051,7 @@ Allows to run custom logic after updating balances, but **before notifiying send
 | `from`    | `address` | The sender address                     |
 | `to`      | `address` | @param tokenId The tokenId to transfer |
 | `tokenId` | `bytes32` | The tokenId to transfer                |
+| `data`    |  `bytes`  | The data sent alongside the transfer   |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -867,6 +867,16 @@ When `tokenId` does not exist then revert with an error.
 
 ### \_mint
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the recipient via LSP1**.
+
+:::
+
 ```solidity
 function _mint(
   address to,
@@ -899,6 +909,16 @@ Create `tokenId` by minting it and transfers it to `to`.
 
 ### \_burn
 
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender via LSP1**.
+
+:::
+
 :::tip Hint
 
 In dApps, you can know which addresses are burning tokens by listening for the `Transfer` event and filter with the zero address as `to`.
@@ -914,7 +934,6 @@ This will also clear all the operators allowed to transfer the `tokenId`.
 The owner of the `tokenId` will be notified about the `tokenId` being transferred through its LSP1 [`universalReceiver`](#universalreceiver)
 function, if it is a contract that supports the LSP1 interface. Its [`universalReceiver`](#universalreceiver) function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before burning `tokenId` and updating the balances.
 
 <blockquote>
 
@@ -934,6 +953,16 @@ Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will r
 <br/>
 
 ### \_transfer
+
+:::info
+
+Any logic in the:
+
+- {\_beforeTokenTransfer} function will run before updating the balances and ownership of `tokenId`s.
+
+- {\_afterTokenTransfer} function will run after updating the balances and ownership of `tokenId`s, **but before notifying the sender/recipient via LSP1**.
+
+:::
 
 :::danger
 
@@ -955,7 +984,6 @@ Change the owner of the `tokenId` from `from` to `to`.
 Both the sender and recipient will be notified of the `tokenId` being transferred through their LSP1 [`universalReceiver`](#universalreceiver)
 function, if they are contracts that support the LSP1 interface. Their `universalReceiver` function will receive
 all the parameters in the calldata packed encoded.
-Any logic in the [`_beforeTokenTransfer`](#_beforetokentransfer) function will run before changing the owner of `tokenId`.
 
 <blockquote>
 
@@ -988,8 +1016,30 @@ function _beforeTokenTransfer(
 ```
 
 Hook that is called before any token transfer, including minting and burning.
+Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
 
-- Allows to run custom logic before updating balances and notifiying sender/recipient by overriding this function.
+#### Parameters
+
+| Name      |   Type    | Description                            |
+| --------- | :-------: | -------------------------------------- |
+| `from`    | `address` | The sender address                     |
+| `to`      | `address` | @param tokenId The tokenId to transfer |
+| `tokenId` | `bytes32` | The tokenId to transfer                |
+
+<br/>
+
+### \_afterTokenTransfer
+
+```solidity
+function _afterTokenTransfer(
+  address from,
+  address to,
+  bytes32 tokenId
+) internal nonpayable;
+```
+
+Hook that is called after any token transfer, including minting and burning.
+Allows to run custom logic after updating balances, but **before notifiying sender/recipient via LSP1** by overriding this function.
 
 #### Parameters
 


### PR DESCRIPTION
# What does this PR introduce?

## 🚀 Feature

Add internal function `_afterTokenTransfer` that can be overriden to run logic after tokens have been transferred + event `Transfer` has been emitted.

## 📄 Documentation

Update auto-generated docs.
### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
