### PR TITLE
refactor: replace `BytesLib` in LSP8 with assembly block

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -15,7 +15,6 @@ import {
 import {
     EnumerableSet
 } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 
 // modules
 import {
@@ -111,15 +110,25 @@ abstract contract LSP8CompatibleERC721InitAbstract is
     ) public view virtual returns (string memory) {
         bytes memory data = _getData(_LSP4_METADATA_KEY);
 
-        // offset = bytes4(hashSig) + bytes32(contentHash) -> 4 + 32 = 36
-        uint256 offset = 36;
+        if (data.length <= 36) return "";
 
-        bytes memory uriBytes = BytesLib.slice(
-            data,
-            offset,
-            data.length - offset
-        );
-        return string(uriBytes);
+        uint256 requiredLength = data.length - 36;
+
+        string memory result = new string(requiredLength);
+
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // set the actual value that will be returned
+            for {
+                let i := 0
+            } lt(i, requiredLength) {
+                i := add(i, 32)
+            } {
+                mstore(add(result, add(i, 32)), mload(add(data, add(i, 68))))
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -106,8 +106,7 @@
     "@account-abstraction/contracts": "^0.6.0",
     "@erc725/smart-contracts": "^5.2.0",
     "@openzeppelin/contracts": "^4.9.2",
-    "@openzeppelin/contracts-upgradeable": "^4.9.2",
-    "solidity-bytes-utils": "0.8.0"
+    "@openzeppelin/contracts-upgradeable": "^4.9.2"
   },
   "devDependencies": {
     "@b00ste/hardhat-dodoc": "^0.3.15",


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## ♻️ Refactor

Add an assembly block in order to remove `BytesLib` usage from `LSP8CompatibleERC721.sol` & `LSP8CompatibleERC721InitAbstract.sol`

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
