### PR TITLE
refactor!: replace `ValueReceived` with `UniversalReceiver`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ E.g.:
 
 ```solidity
 /**
- * @custom:events {ValueReceived} event when someone tranfers native tokens to the contract.
+ * @custom:events {UniversalReceiver} event when someone tranfers native tokens to the contract.
  */
 ```
 
@@ -168,7 +168,7 @@ E.g.:
 ```solidity
 /**
  * @custom:events
- * - {ValueReceived} event when someone tranfers native tokens to the contract.
+ * - {UniversalReceiver} event when someone tranfers native tokens to the contract.
  * - {Executes} event when the function is executed without any issues.
  */
 ```

--- a/constants.ts
+++ b/constants.ts
@@ -316,6 +316,9 @@ export const PERMISSIONS = {
  * (e.g: token transfer, vault transfer, ownership transfer, etc...)
  */
 export const LSP1_TYPE_IDS = {
+  // keccak256('LSP0ValueReceived')
+  LSP0ValueReceived: '0x9c4705229491d365fb5434052e12a386d6771d976bea61070a8c694e8affea3d',
+
   // keccak256('LSP0OwnershipTransferStarted')
   LSP0OwnershipTransferStarted:
     '0xe17117c9d2665d1dbeb479ed8058bbebde3c50ac50e2e65619f60006caac6926',
@@ -351,6 +354,9 @@ export const LSP1_TYPE_IDS = {
   // keccak256('LSP8Tokens_OperatorNotification')
   LSP8Tokens_OperatorNotification:
     '0x8a1c15a8799f71b547e08e2bcb2e85257e81b0a07eee2ce6712549eef1f00970',
+
+  // keccak256('LSP9ValueReceived')
+  LSP9ValueReceived: '0x468cd1581d7bc001c3b685513d2b929b55437be34700410383d58f3aa1ea0abc',
 
   // keccak256('LSP9OwnershipTransferStarted')
   LSP9OwnershipTransferStarted:

--- a/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/ILSP0ERC725Account.sol
@@ -8,14 +8,6 @@ pragma solidity ^0.8.4;
  */
 interface ILSP0ERC725Account {
     /**
-     * @notice `value` native tokens received from `sender`.
-     * @dev Emitted when receiving native tokens.
-     * @param sender The address that sent some native tokens to this contract.
-     * @param value The amount of native tokens received.
-     */
-    event ValueReceived(address indexed sender, uint256 indexed value);
-
-    /**
      * @notice Executing the following batch of abi-encoded function calls on the contract: `data`.
      *
      * @dev Allows a caller to batch different function calls in one call. Perform a `delegatecall` on self, to call different functions with preserving the context.

--- a/contracts/LSP0ERC725Account/LSP0Constants.sol
+++ b/contracts/LSP0ERC725Account/LSP0Constants.sol
@@ -9,6 +9,11 @@ bytes4 constant _INTERFACEID_ERC1271 = 0x1626ba7e;
 bytes4 constant _ERC1271_SUCCESSVALUE = 0x1626ba7e;
 bytes4 constant _ERC1271_FAILVALUE = 0xffffffff;
 
+// --- Native Token Type Id
+
+// keccak256('LSP0ValueReceived')
+bytes32 constant _TYPEID_LSP0_VALUE_RECEIVED = 0x9c4705229491d365fb5434052e12a386d6771d976bea61070a8c694e8affea3d;
+
 // Ownerhsip Transfer Type IDs
 
 // keccak256('LSP0OwnershipTransferStarted')

--- a/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725Account.sol
@@ -7,6 +7,10 @@ import {
     OwnableUnset
 } from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
+// constants
+
+import {_TYPEID_LSP0_VALUE_RECEIVED} from "./LSP0Constants.sol";
+
 /**
  * @title Deployable Implementation of [LSP-0-ERC725Account] Standard.
  *
@@ -29,12 +33,18 @@ contract LSP0ERC725Account is LSP0ERC725AccountCore {
      * @param initialOwner The owner of the contract.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      */
     constructor(address initialOwner) payable {
         if (msg.value != 0) {
-            emit ValueReceived(msg.sender, msg.value);
+            emit UniversalReceiver(
+                msg.sender,
+                msg.value,
+                _TYPEID_LSP0_VALUE_RECEIVED,
+                "",
+                ""
+            );
         }
 
         OwnableUnset._setOwner(initialOwner);

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -764,7 +764,7 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Forwards the call to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the `address(0)` will be returned.
      * Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
      *
@@ -789,7 +789,7 @@ abstract contract LSP0ERC725AccountCore is
         (
             address extension,
             bool isForwardingValue
-        ) = _getExtensionAndFowardValue(msg.sig);
+        ) = _getExtensionAndForwardValue(msg.sig);
 
         // if value is associated with the extension call and extension function selector is not payable, use the universalReceiver
         if (msg.value != 0 && !isForwardingValue)
@@ -823,7 +823,7 @@ abstract contract LSP0ERC725AccountCore is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called
@@ -836,10 +836,13 @@ abstract contract LSP0ERC725AccountCore is
             mappedExtensionDataKey
         );
 
-        // Check if the extensionData is 21 bytes long (20 bytes of address + 1 byte as bool indicator to forwards the value)
+        // CHECK if the `extensionData` is 21 bytes long
+        // - 20 bytes = extension's address
+        // - 1 byte `0x01` as a boolean indicating if the contract should forward the value to the extension or not
         if (extensionData.length == 21) {
-            // Check if the last byte is 1 (true)
-            if (extensionData[20] == hex"01") {
+            // If the last byte is set to `0x01` (`true`)
+            // this indicates that the contract should forward the value to the extension
+            if (extensionData[20] == 0x01) {
                 // Return the address of the extension
                 return (address(bytes20(extensionData)), true);
             }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -126,11 +126,10 @@ abstract contract LSP0ERC725AccountCore is
     fallback(
         bytes calldata callData
     ) external payable virtual returns (bytes memory) {
-        // if value is associated with the extension call, use the universalReceiver
-        if (msg.value != 0)
-            universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, callData);
-
         if (msg.data.length < 4) {
+            // if value is associated with the extension call, use the universalReceiver
+            if (msg.value != 0)
+                universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, callData);
             return "";
         }
 
@@ -791,8 +790,14 @@ abstract contract LSP0ERC725AccountCore is
             msg.sig
         );
 
+        // if value is associated with the extension call and extension function selector is not payable, use the universalReceiver
+        if (msg.value != 0 && !isPayable)
+            universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, callData);
+
         // if no extension was found for bytes4(0) return don't revert
-        if (msg.sig == bytes4(0) && extension == address(0)) return "";
+        if (msg.sig == bytes4(0) && extension == address(0)) {
+            return "";
+        }
 
         // if no extension was found for other function selectors, revert
         if (extension == address(0))

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -120,7 +120,7 @@ abstract contract LSP0ERC725AccountCore is
      *
      * 2. If the data sent to this function is of length less than 4 bytes (not a function selector), return.
      *
-     * @custom:events {UniversalReceiver} event when receiving native tokens.
+     * @custom:events {UniversalReceiver} event when receiving native tokens and extension function selector is not found or not payable.
      */
     // solhint-disable-next-line no-complex-fallback
     fallback(
@@ -198,7 +198,7 @@ abstract contract LSP0ERC725AccountCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP0_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }
@@ -262,7 +262,7 @@ abstract contract LSP0ERC725AccountCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP0_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }
@@ -321,7 +321,7 @@ abstract contract LSP0ERC725AccountCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP0_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }
@@ -364,7 +364,7 @@ abstract contract LSP0ERC725AccountCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP0_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -126,8 +126,9 @@ abstract contract LSP0ERC725AccountCore is
     fallback(
         bytes calldata callData
     ) external payable virtual returns (bytes memory) {
-        // if value is associated with the extension call, react on the call
-        if (msg.value != 0) universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, "");
+        // if value is associated with the extension call, use the universalReceiver
+        if (msg.value != 0)
+            universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, callData);
 
         if (msg.data.length < 4) {
             return "";
@@ -446,37 +447,7 @@ abstract contract LSP0ERC725AccountCore is
         bytes memory receivedData
     ) public payable virtual override returns (bytes memory returnedValues) {
         if (msg.value != 0 && (typeId != _TYPEID_LSP0_VALUE_RECEIVED)) {
-            // Generate the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 _TYPEID_LSP0_VALUE_RECEIVED>}
-            bytes32 lsp1ValueReceivedtypeIdDelegateKey = LSP2Utils
-                .generateMappingKey(
-                    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
-                    bytes20(_TYPEID_LSP0_VALUE_RECEIVED)
-                );
-
-            // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX + <bytes32 _TYPEID_LSP0_VALUE_RECEIVED>}
-            bytes memory lsp1ValueReceivedtypeIdDelegateValue = _getData(
-                lsp1ValueReceivedtypeIdDelegateKey
-            );
-
-            if (lsp1ValueReceivedtypeIdDelegateValue.length >= 20) {
-                address lsp1Delegate = address(
-                    bytes20(lsp1ValueReceivedtypeIdDelegateValue)
-                );
-
-                // Checking LSP1 InterfaceId support
-                if (
-                    lsp1Delegate.supportsERC165InterfaceUnchecked(
-                        _INTERFACEID_LSP1_DELEGATE
-                    )
-                ) {
-                    ILSP1Delegate(lsp1Delegate).universalReceiverDelegate(
-                        msg.sender,
-                        msg.value,
-                        _TYPEID_LSP0_VALUE_RECEIVED,
-                        ""
-                    );
-                }
-            }
+            universalReceiver(_TYPEID_LSP0_VALUE_RECEIVED, msg.data);
         }
 
         // Query the ERC725Y storage with the data key {_LSP1_UNIVERSAL_RECEIVER_DELEGATE_KEY}

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -765,8 +765,9 @@ abstract contract LSP0ERC725AccountCore is
     /**
      * @dev Forwards the call to an extension mapped to a function selector.
      *
-     * Calls {_getExtension} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the `address(0)` will be returned.
+     * Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
      *
      * Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.
      *
@@ -786,7 +787,9 @@ abstract contract LSP0ERC725AccountCore is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        address extension = _getExtension(msg.sig);
+        (address extension, bool isPayable) = _getExtensionAndPayableBool(
+            msg.sig
+        );
 
         // if no extension was found for bytes4(0) return don't revert
         if (msg.sig == bytes4(0) && extension == address(0)) return "";
@@ -795,9 +798,9 @@ abstract contract LSP0ERC725AccountCore is
         if (extension == address(0))
             revert NoExtensionFoundForFunctionSelector(msg.sig);
 
-        (bool success, bytes memory result) = extension.call(
-            abi.encodePacked(callData, msg.sender, msg.value)
-        );
+        (bool success, bytes memory result) = extension.call{
+            value: isPayable ? msg.value : 0
+        }(abi.encodePacked(callData, msg.sender, msg.value));
 
         if (success) {
             return result;
@@ -816,21 +819,29 @@ abstract contract LSP0ERC725AccountCore is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
             functionSelector
         );
 
-        // Check if there is an extension stored under the generated data key
-        address extension = address(
-            bytes20(ERC725YCore._getData(mappedExtensionDataKey))
+        bytes memory extensionData = ERC725YCore._getData(
+            mappedExtensionDataKey
         );
 
-        return extension;
+        // Check if the extensionData is 21 bytes long (20 bytes of address + 1 byte as bool indicator to forwards the value)
+        if (extensionData.length == 21) {
+            // Check if the last byte is 1 (true)
+            if (extensionData[20] == hex"01") {
+                // Return the address of the extension
+                return (address(bytes20(extensionData)), true);
+            }
+        }
+
+        return (address(bytes20(extensionData)), false);
     }
 
     /**

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInit.sol
@@ -38,7 +38,7 @@ contract LSP0ERC725AccountInit is LSP0ERC725AccountInitAbstract {
      * @param initialOwner The owner of the contract.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      */
     function initialize(

--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountInitAbstract.sol
@@ -10,6 +10,9 @@ import {
     OwnableUnset
 } from "@erc725/smart-contracts/contracts/custom/OwnableUnset.sol";
 
+// constants
+import {_TYPEID_LSP0_VALUE_RECEIVED} from "./LSP0Constants.sol";
+
 /**
  * @title Inheritable Proxy Implementation of [LSP-0-ERC725Account] Standard.
  *
@@ -27,14 +30,20 @@ abstract contract LSP0ERC725AccountInitAbstract is
      * @custom:warning ERC725X & ERC725Y parent contracts are not initialised as they don't have non-zero initial state. If you decide to add non-zero initial state to any of those contracts, you must initialize them here.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      */
     function _initialize(
         address initialOwner
     ) internal virtual onlyInitializing {
         if (msg.value != 0) {
-            emit ValueReceived(msg.sender, msg.value);
+            emit UniversalReceiver(
+                msg.sender,
+                msg.value,
+                _TYPEID_LSP0_VALUE_RECEIVED,
+                "",
+                ""
+            );
         }
         OwnableUnset._setOwner(initialOwner);
     }

--- a/contracts/LSP17ContractExtension/LSP17Extendable.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extendable.sol
@@ -44,7 +44,7 @@ abstract contract LSP17Extendable is ERC165 {
     function _supportsInterfaceInERC165Extension(
         bytes4 interfaceId
     ) internal view virtual returns (bool) {
-        address erc165Extension = _getExtension(
+        (address erc165Extension, ) = _getExtensionAndPayableBool(
             ERC165.supportsInterface.selector
         );
         if (erc165Extension == address(0)) return false;
@@ -62,15 +62,16 @@ abstract contract LSP17Extendable is ERC165 {
      * To be overrided.
      * Up to the implementor contract to return an extension based on a function selector
      */
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view virtual returns (address);
+    ) internal view virtual returns (address, bool);
 
     /**
      * @dev Forwards the call to an extension mapped to a function selector.
      *
-     * Calls {_getExtension} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the `address(0)` will be returned.
+     * Forwards the value if the extension is payable.
      *
      * Reverts if there is no extension for the function being called.
      *
@@ -90,15 +91,17 @@ abstract contract LSP17Extendable is ERC165 {
         bytes calldata callData
     ) internal virtual returns (bytes memory) {
         // If there is a function selector
-        address extension = _getExtension(msg.sig);
+        (address extension, bool isPayable) = _getExtensionAndPayableBool(
+            msg.sig
+        );
 
         // if no extension was found, revert
         if (extension == address(0))
             revert NoExtensionFoundForFunctionSelector(msg.sig);
 
-        (bool success, bytes memory result) = extension.call(
-            abi.encodePacked(callData, msg.sender, msg.value)
-        );
+        (bool success, bytes memory result) = extension.call{
+            value: isPayable ? msg.value : 0
+        }(abi.encodePacked(callData, msg.sender, msg.value));
 
         if (success) {
             return result;

--- a/contracts/LSP17ContractExtension/LSP17Extendable.sol
+++ b/contracts/LSP17ContractExtension/LSP17Extendable.sol
@@ -44,7 +44,7 @@ abstract contract LSP17Extendable is ERC165 {
     function _supportsInterfaceInERC165Extension(
         bytes4 interfaceId
     ) internal view virtual returns (bool) {
-        (address erc165Extension, ) = _getExtensionAndFowardValue(
+        (address erc165Extension, ) = _getExtensionAndForwardValue(
             ERC165.supportsInterface.selector
         );
         if (erc165Extension == address(0)) return false;
@@ -62,14 +62,14 @@ abstract contract LSP17Extendable is ERC165 {
      * To be overrided.
      * Up to the implementor contract to return an extension based on a function selector
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual returns (address, bool);
 
     /**
      * @dev Forwards the call to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the `address(0)` will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -93,15 +93,15 @@ abstract contract LSP17Extendable is ERC165 {
         // If there is a function selector
         (
             address extension,
-            bool isForwardingValue
-        ) = _getExtensionAndFowardValue(msg.sig);
+            bool shouldForwardValue
+        ) = _getExtensionAndForwardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
             revert NoExtensionFoundForFunctionSelector(msg.sig);
 
         (bool success, bytes memory result) = extension.call{
-            value: isForwardingValue ? msg.value : 0
+            value: shouldForwardValue ? msg.value : 0
         }(abi.encodePacked(callData, msg.sender, msg.value));
 
         if (success) {

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -123,7 +123,7 @@ contract LSP1UniversalReceiverDelegateUP is
      */
     function _tokenSender(address notifier) internal returns (bytes memory) {
         // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
-        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // If it's EOA we revert (spam protection)
         // solhint-disable-next-line avoid-tx-origin
         if (notifier == tx.origin) {
             revert CannotRegisterEOAsAsAssets(notifier);
@@ -213,7 +213,7 @@ contract LSP1UniversalReceiverDelegateUP is
      */
     function _vaultSender(address notifier) internal returns (bytes memory) {
         // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
-        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // If it's EOA we revert (spam protection)
         // solhint-disable-next-line avoid-tx-origin
         if (notifier == tx.origin) {
             revert CannotRegisterEOAsAsAssets(notifier);

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP/LSP1UniversalReceiverDelegateUP.sol
@@ -84,13 +84,6 @@ contract LSP1UniversalReceiverDelegateUP is
         bytes32 typeId,
         bytes memory /* data */
     ) public virtual override returns (bytes memory) {
-        // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
-        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
-        // solhint-disable-next-line avoid-tx-origin
-        if (notifier == tx.origin) {
-            revert CannotRegisterEOAsAsAssets(notifier);
-        }
-
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             return _tokenSender(notifier);
         }
@@ -129,6 +122,13 @@ contract LSP1UniversalReceiverDelegateUP is
      * @param notifier The LSP7 or LSP8 token address.
      */
     function _tokenSender(address notifier) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
+        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         // if the amount sent is not the full balance, then do not update the keys
         try ILSP7DigitalAsset(notifier).balanceOf(msg.sender) returns (
             uint256 balance
@@ -167,6 +167,13 @@ contract LSP1UniversalReceiverDelegateUP is
         address notifier,
         bytes4 interfaceId
     ) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
+        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         // CHECK balance only when the Token contract is already deployed,
         // not when tokens are being transferred on deployment through the `constructor`
         if (notifier.code.length != 0) {
@@ -205,6 +212,13 @@ contract LSP1UniversalReceiverDelegateUP is
      * @param notifier The LSP9 vault address.
      */
     function _vaultSender(address notifier) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
+        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP10Utils
             .generateSentVaultKeys(msg.sender, notifier);
 
@@ -228,6 +242,13 @@ contract LSP1UniversalReceiverDelegateUP is
      * @param notifier The LSP9 vault address.
      */
     function _vaultRecipient(address notifier) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 or LSP9 contract
+        // If it's EOA we revert to avoid registering the EOA as asset or vault (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         (bytes32[] memory dataKeys, bytes[] memory dataValues) = LSP10Utils
             .generateReceivedVaultKeys(msg.sender, notifier);
 

--- a/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault/LSP1UniversalReceiverDelegateVault.sol
@@ -68,13 +68,6 @@ contract LSP1UniversalReceiverDelegateVault is
         bytes32 typeId,
         bytes memory /* data */
     ) public virtual override returns (bytes memory) {
-        // The notifier is supposed to be either the LSP7 or LSP8 contract
-        // If it's EOA we revert to avoid registering the EOA as asset (spam protection)
-        // solhint-disable-next-line avoid-tx-origin
-        if (notifier == tx.origin) {
-            revert CannotRegisterEOAsAsAssets(notifier);
-        }
-
         if (typeId == _TYPEID_LSP7_TOKENSSENDER) {
             return _tokenSender(notifier);
         }
@@ -105,6 +98,13 @@ contract LSP1UniversalReceiverDelegateVault is
      * @param notifier The LSP7 or LSP8 token address.
      */
     function _tokenSender(address notifier) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 contract
+        // If it's EOA we revert to avoid registering the EOA as asset (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         // if the amount sent is not the full balance, then do not update the keys
         try ILSP7DigitalAsset(notifier).balanceOf(msg.sender) returns (
             uint256 balance
@@ -143,6 +143,13 @@ contract LSP1UniversalReceiverDelegateVault is
         address notifier,
         bytes4 interfaceId
     ) internal returns (bytes memory) {
+        // The notifier is supposed to be either the LSP7 or LSP8 contract
+        // If it's EOA we revert to avoid registering the EOA as asset (spam protection)
+        // solhint-disable-next-line avoid-tx-origin
+        if (notifier == tx.origin) {
+            revert CannotRegisterEOAsAsAssets(notifier);
+        }
+
         // CHECK balance only when the Token contract is already deployed,
         // not when tokens are being transferred on deployment through the `constructor`
         if (notifier.code.length != 0) {

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -108,7 +108,7 @@ abstract contract LSP7DigitalAsset is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -125,7 +125,7 @@ abstract contract LSP7DigitalAsset is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
+        (address extension, ) = _getExtensionAndForwardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -155,7 +155,7 @@ abstract contract LSP7DigitalAsset is
      * - If no extension is stored, returns the address(0).
      * - we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -108,7 +108,7 @@ abstract contract LSP7DigitalAsset is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -125,7 +125,7 @@ abstract contract LSP7DigitalAsset is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
+        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -155,7 +155,7 @@ abstract contract LSP7DigitalAsset is
      * - If no extension is stored, returns the address(0).
      * - we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtensionAndPayableBool(
+    function _getExtensionAndFowardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -108,8 +108,9 @@ abstract contract LSP7DigitalAsset is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtension} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
+     * Forwards the value if the extension is payable.
      *
      * Reverts if there is no extension for the function being called.
      *
@@ -124,7 +125,7 @@ abstract contract LSP7DigitalAsset is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        address extension = _getExtension(msg.sig);
+        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -152,10 +153,11 @@ abstract contract LSP7DigitalAsset is
      * @dev Returns the extension address stored under the following data key:
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
+     * - we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
@@ -169,7 +171,7 @@ abstract contract LSP7DigitalAsset is
         if (extensionAddress.length != 20 && extensionAddress.length != 0)
             revert InvalidExtensionAddress(extensionAddress);
 
-        return address(bytes20(extensionAddress));
+        return (address(bytes20(extensionAddress)), true);
     }
 
     /**

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -103,7 +103,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -120,7 +120,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
+        (address extension, ) = _getExtensionAndForwardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -150,7 +150,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
      * - If no extension is stored, returns the address(0).
      * - We do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -103,7 +103,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -120,7 +120,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
+        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -150,7 +150,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
      * - If no extension is stored, returns the address(0).
      * - We do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtensionAndPayableBool(
+    function _getExtensionAndFowardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetInitAbstract.sol
@@ -103,8 +103,9 @@ abstract contract LSP7DigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtension} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
+     * Forwards the value if the extension is payable.
      *
      * Reverts if there is no extension for the function being called.
      *
@@ -119,7 +120,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        address extension = _getExtension(msg.sig);
+        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -147,10 +148,11 @@ abstract contract LSP7DigitalAssetInitAbstract is
      * @dev Returns the extension address stored under the following data key:
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
+     * - We do not check that payable bool as in lsp7 standard we will always forward the value to the extension
      */
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
@@ -164,7 +166,7 @@ abstract contract LSP7DigitalAssetInitAbstract is
         if (extensionAddress.length != 20 && extensionAddress.length != 0)
             revert InvalidExtensionAddress(extensionAddress);
 
-        return address(bytes20(extensionAddress));
+        return (address(bytes20(extensionAddress)), true);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -130,7 +130,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
      *
@@ -147,7 +147,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
+        (address extension, ) = _getExtensionAndForwardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -176,7 +176,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -130,7 +130,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
      *
@@ -147,7 +147,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
+        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -176,7 +176,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndPayableBool(
+    function _getExtensionAndFowardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -133,7 +133,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
      *
@@ -150,7 +150,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
+        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -179,7 +179,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndPayableBool(
+    function _getExtensionAndFowardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -133,7 +133,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
      * We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
      *
@@ -150,7 +150,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        (address extension, ) = _getExtensionAndFowardValue(msg.sig);
+        (address extension, ) = _getExtensionAndForwardValue(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -179,7 +179,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -133,8 +133,9 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
     /**
      * @dev Forwards the call with the received value to an extension mapped to a function selector.
      *
-     * Calls {_getExtension} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndPayableBool} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the address(0) will be returned.
+     * We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
      *
      * Reverts if there is no extension for the function being called.
      *
@@ -149,7 +150,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         bytes calldata callData
     ) internal virtual override returns (bytes memory) {
         // If there is a function selector
-        address extension = _getExtension(msg.sig);
+        (address extension, ) = _getExtensionAndPayableBool(msg.sig);
 
         // if no extension was found, revert
         if (extension == address(0))
@@ -178,9 +179,9 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view virtual override returns (address) {
+    ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called
         bytes32 mappedExtensionDataKey = LSP2Utils.generateMappingKey(
             _LSP17_EXTENSION_PREFIX,
@@ -194,7 +195,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
         if (extensionAddress.length != 20 && extensionAddress.length != 0)
             revert InvalidExtensionAddress(extensionAddress);
 
-        return address(bytes20(extensionAddress));
+        return (address(bytes20(extensionAddress)), true);
     }
 
     /**

--- a/contracts/LSP9Vault/ILSP9Vault.sol
+++ b/contracts/LSP9Vault/ILSP9Vault.sol
@@ -7,14 +7,6 @@ pragma solidity ^0.8.4;
  */
 interface ILSP9Vault {
     /**
-     * @notice `value` native tokens received from `sender`.
-     * @dev Emitted when receiving native tokens.
-     * @param sender The address that sent some native tokens to this contract.
-     * @param value The amount of native tokens received.
-     */
-    event ValueReceived(address indexed sender, uint256 indexed value);
-
-    /**
      * @notice Executing the following batch of abi-encoded function calls on the contract: `data`.
      *
      * @dev Allows a caller to batch different function calls in one call. Perform a `delegatecall` on self, to call different functions with preserving the context.

--- a/contracts/LSP9Vault/LSP9Constants.sol
+++ b/contracts/LSP9Vault/LSP9Constants.sol
@@ -12,6 +12,11 @@ bytes32 constant _LSP9_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b600007c033
 // bytes4(keccak256('LSP9Vault'))
 bytes constant _LSP9_SUPPORTED_STANDARDS_VALUE = hex"7c0334a1";
 
+// --- Native Token Type Id
+
+// keccak256('LSP9ValueReceived')
+bytes32 constant _TYPEID_LSP9_VALUE_RECEIVED = 0x468cd1581d7bc001c3b685513d2b929b55437be34700410383d58f3aa1ea0abc;
+
 // Ownerhsip Transfer Type IDs
 
 // keccak256('LSP9OwnershipTransferStarted')

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -14,6 +14,7 @@ import {LSP1Utils} from "../LSP1UniversalReceiver/LSP1Utils.sol";
 import {
     _LSP9_SUPPORTED_STANDARDS_KEY,
     _LSP9_SUPPORTED_STANDARDS_VALUE,
+    _TYPEID_LSP9_VALUE_RECEIVED,
     _TYPEID_LSP9_OwnershipTransferred_RecipientNotification
 } from "../LSP9Vault/LSP9Constants.sol";
 
@@ -32,13 +33,21 @@ contract LSP9Vault is LSP9VaultCore {
      * @param newOwner The new owner of the contract.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      * - {DataChanged} event when setting the {_LSP9_SUPPORTED_STANDARDS_KEY}.
      * - {UniversalReceiver} event when notifying the `initialOwner`.
      */
     constructor(address newOwner) payable {
-        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+        if (msg.value != 0) {
+            emit UniversalReceiver(
+                msg.sender,
+                msg.value,
+                _TYPEID_LSP9_VALUE_RECEIVED,
+                "",
+                ""
+            );
+        }
 
         OwnableUnset._setOwner(newOwner);
 

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -128,11 +128,10 @@ contract LSP9VaultCore is
     fallback(
         bytes calldata callData
     ) external payable virtual returns (bytes memory) {
-        // if value is associated with the extension call, use the universalReceiver
-        if (msg.value != 0)
-            universalReceiver(_TYPEID_LSP9_VALUE_RECEIVED, callData);
-
         if (msg.data.length < 4) {
+            // if value is associated with the extension call, use the universalReceiver
+            if (msg.value != 0)
+                universalReceiver(_TYPEID_LSP9_VALUE_RECEIVED, callData);
             return "";
         }
 
@@ -553,6 +552,10 @@ contract LSP9VaultCore is
         (address extension, bool isPayable) = _getExtensionAndPayableBool(
             msg.sig
         );
+
+        // if value is associated with the extension call and function selector is not payable, use the universalReceiver
+        if (msg.value != 0 && !isPayable)
+            universalReceiver(_TYPEID_LSP9_VALUE_RECEIVED, callData);
 
         // if no extension was found for bytes4(0) return don't revert
         if (msg.sig == bytes4(0) && extension == address(0)) return "";

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -122,7 +122,7 @@ contract LSP9VaultCore is
      *
      * 2. If the data sent to this function is of length less than 4 bytes (not a function selector), return.
      *
-     * @custom:events {UniversalReceiver} event when receiving native tokens.
+     * @custom:events {UniversalReceiver} event when receiving native tokens and extension function selector is not found or not payable.
      */
     // solhint-disable-next-line no-complex-fallback
     fallback(
@@ -202,7 +202,7 @@ contract LSP9VaultCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP9_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }
@@ -237,7 +237,7 @@ contract LSP9VaultCore is
                 msg.sender,
                 msg.value,
                 _TYPEID_LSP9_VALUE_RECEIVED,
-                "",
+                abi.encodePacked(msg.sig),
                 ""
             );
         }

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -527,7 +527,7 @@ contract LSP9VaultCore is
     /**
      * @dev Forwards the call to an extension mapped to a function selector.
      *
-     * Calls {_getExtensionAndFowardValue} to get the address of the extension mapped to the function selector being
+     * Calls {_getExtensionAndForwardValue} to get the address of the extension mapped to the function selector being
      * called on the account. If there is no extension, the `address(0)` will be returned.
      * Forwards the value if the extension is payable.
      *
@@ -552,7 +552,7 @@ contract LSP9VaultCore is
         (
             address extension,
             bool isForwardingValue
-        ) = _getExtensionAndFowardValue(msg.sig);
+        ) = _getExtensionAndForwardValue(msg.sig);
 
         // if value is associated with the extension call and function selector is not payable, use the universalReceiver
         if (msg.value != 0 && !isForwardingValue)
@@ -588,7 +588,7 @@ contract LSP9VaultCore is
      * - {_LSP17_EXTENSION_PREFIX} + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
      * - If no extension is stored, returns the address(0).
      */
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view virtual override returns (address, bool) {
         // Generate the data key relevant for the functionSelector being called

--- a/contracts/LSP9Vault/LSP9VaultInit.sol
+++ b/contracts/LSP9Vault/LSP9VaultInit.sol
@@ -24,7 +24,7 @@ contract LSP9VaultInit is LSP9VaultInitAbstract {
      * @param newOwner The new owner of the contract.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      * - {DataChanged} event when updating the {_LSP9_SUPPORTED_STANDARDS_KEY}.
      * - {UniversalReceiver} event when notifying the `initialOwner`.

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -17,6 +17,7 @@ import {LSP1Utils} from "../LSP1UniversalReceiver/LSP1Utils.sol";
 import {
     _LSP9_SUPPORTED_STANDARDS_KEY,
     _LSP9_SUPPORTED_STANDARDS_VALUE,
+    _TYPEID_LSP9_VALUE_RECEIVED,
     _TYPEID_LSP9_OwnershipTransferred_RecipientNotification
 } from "../LSP9Vault/LSP9Constants.sol";
 
@@ -36,13 +37,21 @@ abstract contract LSP9VaultInitAbstract is Initializable, LSP9VaultCore {
      * @custom:warning ERC725X & ERC725Y parent contracts are not initialised as they don't have non-zero initial state. If you decide to add non-zero initial state to any of those contracts, you must initialize them here.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      * - {DataChanged} event when updating the {_LSP9_SUPPORTED_STANDARDS_KEY}.
      * - {UniversalReceiver} event when notifying the `initialOwner`.
      */
     function _initialize(address newOwner) internal virtual onlyInitializing {
-        if (msg.value != 0) emit ValueReceived(msg.sender, msg.value);
+        if (msg.value != 0) {
+            emit UniversalReceiver(
+                msg.sender,
+                msg.value,
+                _TYPEID_LSP9_VALUE_RECEIVED,
+                "",
+                ""
+            );
+        }
         OwnableUnset._setOwner(newOwner);
 
         // set key SupportedStandards:LSP9Vault

--- a/contracts/Mocks/FallbackExtensions/TransferExtension.sol
+++ b/contracts/Mocks/FallbackExtensions/TransferExtension.sol
@@ -13,4 +13,7 @@ contract TransferExtension {
         );
         balances[msgSender] = amount;
     }
+
+    // solhint-disable-next-line no-empty-blocks
+    function receiveFund() public payable {}
 }

--- a/contracts/Mocks/LSP17ExtendableTester.sol
+++ b/contracts/Mocks/LSP17ExtendableTester.sol
@@ -35,7 +35,7 @@ contract LSP17ExtendableTester is LSP17Extendable {
     function getExtension(
         bytes4 functionSelector
     ) public view returns (address, bool) {
-        return _getExtensionAndFowardValue(functionSelector);
+        return _getExtensionAndForwardValue(functionSelector);
     }
 
     function setExtension(
@@ -63,7 +63,7 @@ contract LSP17ExtendableTester is LSP17Extendable {
         _anotherStorageData = newData;
     }
 
-    function _getExtensionAndFowardValue(
+    function _getExtensionAndForwardValue(
         bytes4 functionSelector
     ) internal view override returns (address, bool) {
         return (

--- a/contracts/Mocks/LSP17ExtendableTester.sol
+++ b/contracts/Mocks/LSP17ExtendableTester.sol
@@ -8,6 +8,7 @@ import {LSP17Extendable} from "../LSP17ContractExtension/LSP17Extendable.sol";
  */
 contract LSP17ExtendableTester is LSP17Extendable {
     mapping(bytes4 => address) internal _extensions;
+    mapping(bytes4 => bool) internal _payableExtensions;
 
     string internal _someStorageData;
     string internal _anotherStorageData;
@@ -33,15 +34,17 @@ contract LSP17ExtendableTester is LSP17Extendable {
 
     function getExtension(
         bytes4 functionSelector
-    ) public view returns (address) {
-        return _getExtension(functionSelector);
+    ) public view returns (address, bool) {
+        return _getExtensionAndPayableBool(functionSelector);
     }
 
     function setExtension(
         bytes4 functionSelector,
-        address extensionContract
+        address extensionContract,
+        bool isPayable
     ) public {
         _extensions[functionSelector] = extensionContract;
+        _payableExtensions[functionSelector] = isPayable;
     }
 
     function getStorageData() public view returns (string memory) {
@@ -60,9 +63,12 @@ contract LSP17ExtendableTester is LSP17Extendable {
         _anotherStorageData = newData;
     }
 
-    function _getExtension(
+    function _getExtensionAndPayableBool(
         bytes4 functionSelector
-    ) internal view override returns (address) {
-        return _extensions[functionSelector];
+    ) internal view override returns (address, bool) {
+        return (
+            _extensions[functionSelector],
+            _payableExtensions[functionSelector]
+        );
     }
 }

--- a/contracts/Mocks/LSP17ExtendableTester.sol
+++ b/contracts/Mocks/LSP17ExtendableTester.sol
@@ -35,16 +35,16 @@ contract LSP17ExtendableTester is LSP17Extendable {
     function getExtension(
         bytes4 functionSelector
     ) public view returns (address, bool) {
-        return _getExtensionAndPayableBool(functionSelector);
+        return _getExtensionAndFowardValue(functionSelector);
     }
 
     function setExtension(
         bytes4 functionSelector,
         address extensionContract,
-        bool isPayable
+        bool isForwardingValue
     ) public {
         _extensions[functionSelector] = extensionContract;
-        _payableExtensions[functionSelector] = isPayable;
+        _payableExtensions[functionSelector] = isForwardingValue;
     }
 
     function getStorageData() public view returns (string memory) {
@@ -63,7 +63,7 @@ contract LSP17ExtendableTester is LSP17Extendable {
         _anotherStorageData = newData;
     }
 
-    function _getExtensionAndPayableBool(
+    function _getExtensionAndFowardValue(
         bytes4 functionSelector
     ) internal view override returns (address, bool) {
         return (

--- a/contracts/Mocks/UPWithInstantAcceptOwnership.sol
+++ b/contracts/Mocks/UPWithInstantAcceptOwnership.sol
@@ -35,7 +35,7 @@ contract UPWithInstantAcceptOwnership is LSP0ERC725AccountCore {
 
     function universalReceiver(
         bytes32 typeId,
-        bytes calldata receivedData
+        bytes memory receivedData
     ) public payable virtual override returns (bytes memory) {
         if (
             typeId == _TYPEID_LSP0_OwnershipTransferStarted ||

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateDataLYX.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateDataLYX.sol
@@ -22,16 +22,14 @@ import {
     _INTERFACEID_LSP1_DELEGATE
 } from "../../LSP1UniversalReceiver/LSP1Constants.sol";
 
-import {
-    _TYPEID_LSP9_VALUE_RECEIVED
-} from "../../LSP9Vault/LSP9Constants.sol";
+import {_TYPEID_LSP9_VALUE_RECEIVED} from "../../LSP9Vault/LSP9Constants.sol";
 
 contract UniversalReceiverDelegateDataLYX is
     ERC165Storage,
     ILSP1UniversalReceiverDelegate
 {
+    mapping(address => uint256) public lastValueReceived;
 
-    mapping(address=> uint256) public lastValueReceived;
     constructor() {
         _registerInterface(_INTERFACEID_LSP1_DELEGATE);
     }
@@ -42,7 +40,10 @@ contract UniversalReceiverDelegateDataLYX is
         bytes32 typeId,
         bytes memory /* data */
     ) public virtual override returns (bytes memory) {
-        if (typeId == _TYPEID_LSP0_VALUE_RECEIVED || typeId == _TYPEID_LSP9_VALUE_RECEIVED) {
+        if (
+            typeId == _TYPEID_LSP0_VALUE_RECEIVED ||
+            typeId == _TYPEID_LSP9_VALUE_RECEIVED
+        ) {
             lastValueReceived[msg.sender] = value;
         }
 

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateDataLYX.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateDataLYX.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+
+import {
+    ILSP1UniversalReceiverDelegate
+} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiverDelegate.sol";
+
+// modules
+import {
+    ERC165Storage
+} from "@openzeppelin/contracts/utils/introspection/ERC165Storage.sol";
+
+// constants
+
+import {
+    _TYPEID_LSP0_VALUE_RECEIVED
+} from "../../LSP0ERC725Account/LSP0Constants.sol";
+
+import {
+    _INTERFACEID_LSP1_DELEGATE
+} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+import {
+    _TYPEID_LSP9_VALUE_RECEIVED
+} from "../../LSP9Vault/LSP9Constants.sol";
+
+contract UniversalReceiverDelegateDataLYX is
+    ERC165Storage,
+    ILSP1UniversalReceiverDelegate
+{
+
+    mapping(address=> uint256) public lastValueReceived;
+    constructor() {
+        _registerInterface(_INTERFACEID_LSP1_DELEGATE);
+    }
+
+    function universalReceiverDelegate(
+        address /*sender*/,
+        uint256 value,
+        bytes32 typeId,
+        bytes memory /* data */
+    ) public virtual override returns (bytes memory) {
+        if (typeId == _TYPEID_LSP0_VALUE_RECEIVED || typeId == _TYPEID_LSP9_VALUE_RECEIVED) {
+            lastValueReceived[msg.sender] = value;
+        }
+
+        return "";
+    }
+}

--- a/contracts/UniversalProfile.sol
+++ b/contracts/UniversalProfile.sol
@@ -24,7 +24,7 @@ contract UniversalProfile is LSP0ERC725Account {
      * @param initialOwner the owner of the contract
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      * - {DataChanged} event when setting the {_LSP3_SUPPORTED_STANDARDS_KEY}.
      */

--- a/contracts/UniversalProfileInit.sol
+++ b/contracts/UniversalProfileInit.sol
@@ -28,7 +28,7 @@ contract UniversalProfileInit is UniversalProfileInitAbstract {
      * @param initialOwner the owner of the contract
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      */
     function initialize(

--- a/contracts/UniversalProfileInitAbstract.sol
+++ b/contracts/UniversalProfileInitAbstract.sol
@@ -28,7 +28,7 @@ abstract contract UniversalProfileInitAbstract is
      * @custom:warning ERC725X & ERC725Y parent contracts are not initialised as they don't have non-zero initial state. If you decide to add non-zero initial state to any of those contracts, you must initialize them here.
      *
      * @custom:events
-     * - {ValueReceived} event when funding the contract on deployment.
+     * - {UniversalReceiver} event when funding the contract on deployment.
      * - {OwnershipTransferred} event when `initialOwner` is set as the contract {owner}.
      */
     function _initialize(

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -1172,10 +1172,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1210,7 +1210,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -1145,10 +1145,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1183,7 +1183,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -1145,10 +1145,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1181,8 +1183,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
+Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.
 If there is an extension for the function selector being called, it calls the extension with the
 `CALL` opcode, passing the `msg.data` appended with the 20 bytes of the [`msg.sender`](#msg.sender) and 32 bytes of the `msg.value`.

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -60,7 +60,7 @@ Set `initialOwner` as the contract owner. The `constructor` also allows funding 
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when funding the contract on deployment.
+- [`UniversalReceiver`](#universalreceiver) event when funding the contract on deployment.
 - [`OwnershipTransferred`](#ownershiptransferred) event when `initialOwner` is set as the contract [`owner`](#owner).
 
 </blockquote>
@@ -110,7 +110,7 @@ This function is executed when:
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -139,7 +139,7 @@ Executed:
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -318,7 +318,7 @@ Generic executor function to:
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0), `STATICCALL` (3) and `DELEGATECALL` (4).
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2).
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -387,7 +387,7 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0), `STATICCALL` (3) and `DELEGATECALL` (4). (each iteration)
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2) (each iteration)
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -651,7 +651,7 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event.
 
 </blockquote>
@@ -696,7 +696,7 @@ Batch data setting function that behaves the same as [`setData`](#setdata) but a
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event. (on each iteration of setting data)
 
 </blockquote>
@@ -818,7 +818,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) when receiving native tokens.
 - [`UniversalReceiver`](#universalreceiver) event with the function parameters, call options, and the response of the UniversalReceiverDelegates (URD) contract that was called.
 
 </blockquote>
@@ -1454,34 +1454,6 @@ Emitted when the [`universalReceiver`](#universalreceiver) function was called w
 | `typeId` **`indexed`** | `bytes32` | A `bytes32` unique identifier (= _"hook"_)that describe the type of notification, information or transaction received by the contract. Can be related to a specific standard or a hook. |
 | `receivedData`         |  `bytes`  | Any arbitrary data that was sent to the {universalReceiver(...)} function.                                                                                                              |
 | `returnedValue`        |  `bytes`  | The value returned by the {universalReceiver(...)} function.                                                                                                                            |
-
-<br/>
-
-### ValueReceived
-
-:::note References
-
-- Specification details: [**LSP-0-ERC725Account**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-0-ERC725Account.md#valuereceived)
-- Solidity implementation: [`LSP0ERC725Account.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP0ERC725Account/LSP0ERC725Account.sol)
-- Event signature: `ValueReceived(address,uint256)`
-- Event topic hash: `0x7e71433ddf847725166244795048ecf3e3f9f35628254ecbf736056664233493`
-
-:::
-
-```solidity
-event ValueReceived(address indexed sender, uint256 indexed value);
-```
-
-_`value` native tokens received from `sender`._
-
-Emitted when receiving native tokens.
-
-#### Parameters
-
-| Name                   |   Type    | Description                                                |
-| ---------------------- | :-------: | ---------------------------------------------------------- |
-| `sender` **`indexed`** | `address` | The address that sent some native tokens to this contract. |
-| `value` **`indexed`**  | `uint256` | The amount of native tokens received.                      |
 
 <br/>
 

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -110,7 +110,7 @@ This function is executed when:
 
 **Emitted events:**
 
-- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens and extension function selector is not found or not payable.
 
 </blockquote>
 

--- a/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
+++ b/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
@@ -78,10 +78,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension mapped to a specific function selector
@@ -113,8 +115,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 `CALL` opcode, passing the `msg.data` appended with the 20 bytes of the [`msg.sender`](#msg.sender) and 32 bytes of the `msg.value`.

--- a/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
+++ b/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
@@ -78,10 +78,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -115,7 +115,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
+++ b/docs/contracts/LSP17ContractExtension/LSP17Extendable.md
@@ -78,10 +78,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -115,7 +115,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -1123,10 +1123,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1134,6 +1136,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1153,8 +1157,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -1150,10 +1150,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1184,7 +1184,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -1123,10 +1123,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1157,7 +1157,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -1148,10 +1148,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1182,7 +1182,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -1175,10 +1175,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1209,7 +1209,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -1148,10 +1148,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1159,6 +1161,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1178,8 +1182,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -1122,10 +1122,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1133,6 +1135,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1152,8 +1156,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -1149,10 +1149,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1183,7 +1183,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -1122,10 +1122,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1156,7 +1156,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1239,10 +1239,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1273,7 +1273,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1212,10 +1212,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1223,6 +1225,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1242,8 +1246,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1212,10 +1212,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1246,7 +1246,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1246,10 +1246,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1257,6 +1259,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1276,8 +1280,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1246,10 +1246,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1280,7 +1280,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1273,10 +1273,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1307,7 +1307,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -1212,10 +1212,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1246,7 +1246,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -1185,10 +1185,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1196,6 +1198,8 @@ Returns the extension address stored under the following data key:
 - [`_LSP17_EXTENSION_PREFIX`](#_lsp17_extension_prefix) + `<bytes4>` (Check [LSP2-ERC725YJSONSchema] for encoding the data key).
 
 - If no extension is stored, returns the address(0).
+
+- we do not check that payable bool as in lsp7 standard we will always forward the value to the extension
 
 <br/>
 
@@ -1215,8 +1219,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -1185,10 +1185,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1219,7 +1219,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -1056,10 +1056,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1088,7 +1088,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -1083,10 +1083,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1115,7 +1115,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -1056,10 +1056,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1086,8 +1088,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1109,10 +1109,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1141,7 +1141,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1082,10 +1082,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1114,7 +1114,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1082,10 +1082,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1112,8 +1114,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -1056,10 +1056,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1088,7 +1088,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -1083,10 +1083,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1115,7 +1115,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -1056,10 +1056,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1086,8 +1088,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1327,10 +1327,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1359,7 +1359,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1354,10 +1354,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1386,7 +1386,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1327,10 +1327,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1357,8 +1359,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1111,10 +1111,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1143,7 +1143,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1084,10 +1084,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1116,7 +1116,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1084,10 +1084,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1114,8 +1116,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1369,10 +1369,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1401,7 +1401,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1369,10 +1369,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1399,8 +1401,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1396,10 +1396,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1428,7 +1428,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1147,10 +1147,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1179,7 +1179,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1120,10 +1120,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1150,8 +1152,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
+We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.
 If there is an extension for the function selector being called, it calls the extension with the
 CALL opcode, passing the [`msg.data`](#msg.data) appended with the 20 bytes of the [`msg.sender`](#msg.sender) and

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1120,10 +1120,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1152,7 +1152,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call with the received value to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the address(0) will be returned.
 We will always forward the value to the extension, as the LSP8 contract is not supposed to hold any native tokens.
 Reverts if there is no extension for the function being called.

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -1127,10 +1127,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1165,7 +1165,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -1100,10 +1100,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1138,7 +1138,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -96,7 +96,7 @@ This function is executed when:
 
 **Emitted events:**
 
-- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens and extension function selector is not found or not payable.
 
 </blockquote>
 

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -1100,10 +1100,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1136,8 +1138,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
+Forwards the value if the extension is payable.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.
 If there is an extension for the function selector being called, it calls the extension with the
 `CALL` opcode, passing the `msg.data` appended with the 20 bytes of the [`msg.sender`](#msg.sender) and 32 bytes of the `msg.value`.

--- a/docs/contracts/LSP9Vault/LSP9Vault.md
+++ b/docs/contracts/LSP9Vault/LSP9Vault.md
@@ -44,7 +44,7 @@ Sets `initialOwner` as the contract owner and the `SupportedStandards:LSP9Vault`
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when funding the contract on deployment.
+- [`UniversalReceiver`](#universalreceiver) event when funding the contract on deployment.
 - [`OwnershipTransferred`](#ownershiptransferred) event when `initialOwner` is set as the contract [`owner`](#owner).
 - [`DataChanged`](#datachanged) event when setting the [`_LSP9_SUPPORTED_STANDARDS_KEY`](#_lsp9_supported_standards_key).
 - [`UniversalReceiver`](#universalreceiver) event when notifying the `initialOwner`.
@@ -96,7 +96,7 @@ This function is executed when:
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -125,7 +125,7 @@ Executed:
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) when receiving native tokens.
 
 </blockquote>
 
@@ -310,7 +310,7 @@ Generic executor function to:
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0) and `STATICCALL` (3).
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2).
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -379,7 +379,7 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0) and `STATICCALL` (3). (each iteration)
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2). (each iteration)
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -594,7 +594,6 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event.
 
 </blockquote>
@@ -639,7 +638,6 @@ Batch data setting function that behaves the same as [`setData`](#setdata) but a
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event. (on each iteration of setting data)
 
 </blockquote>
@@ -761,7 +759,6 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) when receiving native tokens.
 - [`UniversalReceiver`](#universalreceiver) event with the function parameters, call options, and the response of the UniversalReceiverDelegates (URD) contract that was called.
 
 </blockquote>
@@ -1371,34 +1368,6 @@ Emitted when the [`universalReceiver`](#universalreceiver) function was called w
 | `typeId` **`indexed`** | `bytes32` | A `bytes32` unique identifier (= _"hook"_)that describe the type of notification, information or transaction received by the contract. Can be related to a specific standard or a hook. |
 | `receivedData`         |  `bytes`  | Any arbitrary data that was sent to the {universalReceiver(...)} function.                                                                                                              |
 | `returnedValue`        |  `bytes`  | The value returned by the {universalReceiver(...)} function.                                                                                                                            |
-
-<br/>
-
-### ValueReceived
-
-:::note References
-
-- Specification details: [**LSP-9-Vault**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-9-Vault.md#valuereceived)
-- Solidity implementation: [`LSP9Vault.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP9Vault/LSP9Vault.sol)
-- Event signature: `ValueReceived(address,uint256)`
-- Event topic hash: `0x7e71433ddf847725166244795048ecf3e3f9f35628254ecbf736056664233493`
-
-:::
-
-```solidity
-event ValueReceived(address indexed sender, uint256 indexed value);
-```
-
-_`value` native tokens received from `sender`._
-
-Emitted when receiving native tokens.
-
-#### Parameters
-
-| Name                   |   Type    | Description                                                |
-| ---------------------- | :-------: | ---------------------------------------------------------- |
-| `sender` **`indexed`** | `address` | The address that sent some native tokens to this contract. |
-| `value` **`indexed`**  | `uint256` | The amount of native tokens received.                      |
 
 <br/>
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -1115,10 +1115,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndFowardValue
+### \_getExtensionAndForwardValue
 
 ```solidity
-function _getExtensionAndFowardValue(
+function _getExtensionAndForwardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1153,7 +1153,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndForwardValue`](#_getextensionandforwardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -1088,10 +1088,12 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtension
+### \_getExtensionAndPayableBool
 
 ```solidity
-function _getExtension(bytes4 functionSelector) internal view returns (address);
+function _getExtensionAndPayableBool(
+  bytes4 functionSelector
+) internal view returns (address, bool);
 ```
 
 Returns the extension address stored under the following data key:
@@ -1124,8 +1126,9 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtension`](#_getextension) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
+Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.
 If there is an extension for the function selector being called, it calls the extension with the
 `CALL` opcode, passing the `msg.data` appended with the 20 bytes of the [`msg.sender`](#msg.sender) and 32 bytes of the `msg.value`.

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -1088,10 +1088,10 @@ extension if the extension is set, if not it returns false.
 
 <br/>
 
-### \_getExtensionAndPayableBool
+### \_getExtensionAndFowardValue
 
 ```solidity
-function _getExtensionAndPayableBool(
+function _getExtensionAndFowardValue(
   bytes4 functionSelector
 ) internal view returns (address, bool);
 ```
@@ -1126,7 +1126,7 @@ function _fallbackLSP17Extendable(
 ```
 
 Forwards the call to an extension mapped to a function selector.
-Calls [`_getExtensionAndPayableBool`](#_getextensionandpayablebool) to get the address of the extension mapped to the function selector being
+Calls [`_getExtensionAndFowardValue`](#_getextensionandfowardvalue) to get the address of the extension mapped to the function selector being
 called on the account. If there is no extension, the `address(0)` will be returned.
 Forwards the value sent with the call to the extension if the function selector is mapped to a payable extension.
 Reverts if there is no extension for the function being called, except for the `bytes4(0)` function selector, which passes even if there is no extension for it.

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -44,7 +44,7 @@ Set `initialOwner` as the contract owner and the `SupportedStandards:LSP3Univers
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when funding the contract on deployment.
+- [`UniversalReceiver`](#universalreceiver) event when funding the contract on deployment.
 - [`OwnershipTransferred`](#ownershiptransferred) event when `initialOwner` is set as the contract [`owner`](#owner).
 - [`DataChanged`](#datachanged) event when setting the [`_LSP3_SUPPORTED_STANDARDS_KEY`](#_lsp3_supported_standards_key).
 
@@ -261,7 +261,7 @@ Generic executor function to:
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0), `STATICCALL` (3) and `DELEGATECALL` (4).
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2).
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -330,7 +330,7 @@ Batch executor function that behaves the same as [`execute`](#execute) but allow
 
 - [`Executed`](#executed) event for each call that uses under `operationType`: `CALL` (0), `STATICCALL` (3) and `DELEGATECALL` (4). (each iteration)
 - [`ContractCreated`](#contractcreated) event, when a contract is created under `operationType`: `CREATE` (1) and `CREATE2` (2) (each iteration)
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 
 </blockquote>
 
@@ -594,7 +594,7 @@ Sets a single bytes value `dataValue` in the ERC725Y storage for a specific data
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event.
 
 </blockquote>
@@ -639,7 +639,7 @@ Batch data setting function that behaves the same as [`setData`](#setdata) but a
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) event when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) event when receiving native tokens.
 - [`DataChanged`](#datachanged) event. (on each iteration of setting data)
 
 </blockquote>
@@ -761,7 +761,7 @@ Achieves the goal of [LSP-1-UniversalReceiver] by allowing the account to be not
 
 **Emitted events:**
 
-- [`ValueReceived`](#valuereceived) when receiving native tokens.
+- [`UniversalReceiver`](#universalreceiver) when receiving native tokens.
 - [`UniversalReceiver`](#universalreceiver) event with the function parameters, call options, and the response of the UniversalReceiverDelegates (URD) contract that was called.
 
 </blockquote>
@@ -1397,34 +1397,6 @@ Emitted when the [`universalReceiver`](#universalreceiver) function was called w
 | `typeId` **`indexed`** | `bytes32` | A `bytes32` unique identifier (= _"hook"_)that describe the type of notification, information or transaction received by the contract. Can be related to a specific standard or a hook. |
 | `receivedData`         |  `bytes`  | Any arbitrary data that was sent to the {universalReceiver(...)} function.                                                                                                              |
 | `returnedValue`        |  `bytes`  | The value returned by the {universalReceiver(...)} function.                                                                                                                            |
-
-<br/>
-
-### ValueReceived
-
-:::note References
-
-- Specification details: [**UniversalProfile**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-3-UniversalProfile-Metadata.md#valuereceived)
-- Solidity implementation: [`UniversalProfile.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/UniversalProfile.sol)
-- Event signature: `ValueReceived(address,uint256)`
-- Event topic hash: `0x7e71433ddf847725166244795048ecf3e3f9f35628254ecbf736056664233493`
-
-:::
-
-```solidity
-event ValueReceived(address indexed sender, uint256 indexed value);
-```
-
-_`value` native tokens received from `sender`._
-
-Emitted when receiving native tokens.
-
-#### Parameters
-
-| Name                   |   Type    | Description                                                |
-| ---------------------- | :-------: | ---------------------------------------------------------- |
-| `sender` **`indexed`** | `address` | The address that sent some native tokens to this contract. |
-| `value` **`indexed`**  | `uint256` | The amount of native tokens received.                      |
 
 <br/>
 

--- a/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.behaviour.ts
@@ -30,7 +30,7 @@ import {
 import { abiCoder, provider } from '../utils/helpers';
 
 // constants
-import { ERC725YDataKeys } from '../../constants';
+import { ERC725YDataKeys, INTERFACE_IDS, LSP1_TYPE_IDS } from '../../constants';
 
 export type LSP17TestContext = {
   accounts: SignerWithAddress[];
@@ -152,26 +152,49 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
 
   describe('when calling the contract with empty calldata', () => {
     describe('when making a call without any value', () => {
-      it('should pass and not emit ValueReceived', async () => {
+      it('should pass and not emit UniversalReceiver', async () => {
         await expect(
           context.accounts[0].sendTransaction({
             to: context.contract.address,
           }),
-        ).to.not.be.reverted.to.not.emit(context.contract, 'ValueReceived');
+        ).to.not.be.reverted.to.not.emit(context.contract, 'UniversalReceiver');
       });
     });
 
     describe('when making a call with sending value', () => {
-      it('should pass and emit ValueReceived', async () => {
+      it('should pass and emit UniversalReceiver', async () => {
         const amountSent = 200;
-        await expect(
-          context.accounts[0].sendTransaction({
-            to: context.contract.address,
-            value: amountSent,
-          }),
-        )
-          .to.emit(context.contract, 'ValueReceived')
-          .withArgs(context.accounts[0].address, amountSent);
+
+        const tx = await context.accounts[0].sendTransaction({
+          to: context.contract.address,
+          value: amountSent,
+        });
+
+        const isSupportingLSP0 = await context.contract.supportsInterface(
+          INTERFACE_IDS.LSP0ERC725Account,
+        );
+
+        const isSupportingLSP9 = await context.contract.supportsInterface(INTERFACE_IDS.LSP9Vault);
+
+        let emittedTypeId;
+        if (isSupportingLSP0) {
+          emittedTypeId = LSP1_TYPE_IDS.LSP0ValueReceived;
+        } else if (isSupportingLSP9) {
+          emittedTypeId = LSP1_TYPE_IDS.LSP9ValueReceived;
+        }
+
+        expect(tx)
+          .to.emit(context.contract, 'UniversalReceiver')
+          .withArgs(
+            context.accounts[0].address,
+            amountSent,
+            emittedTypeId,
+            '0x',
+            abiCoder.encode(
+              ['bytes', 'bytes'],
+              [ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')), '0x'],
+            ),
+          );
       });
     });
   });
@@ -682,17 +705,45 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
         describe('when no extension is set for bytes4(0)', () => {
           describe('when the payload is `0x00000000`', () => {
             describe('with sending value', () => {
-              it('should pass and emit ValueReceived value', async () => {
+              it('should pass and emit UniversalReceiver', async () => {
                 const amountSent = 2;
-                await expect(
-                  context.accounts[0].sendTransaction({
-                    to: context.contract.address,
-                    data: '0x00000000',
-                    value: amountSent,
-                  }),
-                )
-                  .to.emit(context.contract, 'ValueReceived')
-                  .withArgs(context.accounts[0].address, amountSent);
+
+                const tx = await context.accounts[0].sendTransaction({
+                  to: context.contract.address,
+                  data: '0x00000000',
+                  value: amountSent,
+                });
+
+                const isSupportingLSP0 = await context.contract.supportsInterface(
+                  INTERFACE_IDS.LSP0ERC725Account,
+                );
+
+                const isSupportingLSP9 = await context.contract.supportsInterface(
+                  INTERFACE_IDS.LSP9Vault,
+                );
+
+                let emittedTypeId;
+                if (isSupportingLSP0) {
+                  emittedTypeId = LSP1_TYPE_IDS.LSP0ValueReceived;
+                } else if (isSupportingLSP9) {
+                  emittedTypeId = LSP1_TYPE_IDS.LSP9ValueReceived;
+                }
+
+                expect(tx)
+                  .to.emit(context.contract, 'UniversalReceiver')
+                  .withArgs(
+                    context.accounts[0].address,
+                    amountSent,
+                    emittedTypeId,
+                    '0x',
+                    abiCoder.encode(
+                      ['bytes', 'bytes'],
+                      [
+                        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
+                        '0x',
+                      ],
+                    ),
+                  );
               });
             });
 
@@ -718,15 +769,42 @@ export const shouldBehaveLikeLSP17 = (buildContext: () => Promise<LSP17TestConte
                     .hexlify(ethers.utils.toUtf8Bytes('This is a small tip for you!'))
                     .substring(2);
 
-                await expect(
-                  context.accounts[0].sendTransaction({
-                    to: context.contract.address,
-                    data: graffiti,
-                    value: amountSent,
-                  }),
-                )
-                  .to.emit(context.contract, 'ValueReceived')
-                  .withArgs(context.accounts[0].address, amountSent);
+                const tx = await context.accounts[0].sendTransaction({
+                  to: context.contract.address,
+                  data: graffiti,
+                  value: amountSent,
+                });
+
+                const isSupportingLSP0 = await context.contract.supportsInterface(
+                  INTERFACE_IDS.LSP0ERC725Account,
+                );
+
+                const isSupportingLSP9 = await context.contract.supportsInterface(
+                  INTERFACE_IDS.LSP9Vault,
+                );
+
+                let emittedTypeId;
+                if (isSupportingLSP0) {
+                  emittedTypeId = LSP1_TYPE_IDS.LSP0ValueReceived;
+                } else if (isSupportingLSP9) {
+                  emittedTypeId = LSP1_TYPE_IDS.LSP9ValueReceived;
+                }
+
+                expect(tx)
+                  .to.emit(context.contract, 'UniversalReceiver')
+                  .withArgs(
+                    context.accounts[0].address,
+                    amountSent,
+                    emittedTypeId,
+                    '0x',
+                    abiCoder.encode(
+                      ['bytes', 'bytes'],
+                      [
+                        ethers.utils.hexlify(ethers.utils.toUtf8Bytes('LSP1: typeId out of scope')),
+                        '0x',
+                      ],
+                    ),
+                  );
               });
             });
 

--- a/tests/LSP17ContractExtension/LSP17Extendable.test.ts
+++ b/tests/LSP17ContractExtension/LSP17Extendable.test.ts
@@ -17,7 +17,7 @@ describe('LSP17Extendable - Basic Implementation', () => {
   let exampleExtension: EmitEventExtension;
   let errorsExtension: RevertErrorsTestExtension;
 
-  const selectorWithExtension =
+  const selectorWithExtensionAndNoTransferValue =
     EmitEventExtension__factory.createInterface().getSighash('emitEvent');
   const selectorWithNoExtension = '0xdeadbeef';
 
@@ -43,12 +43,32 @@ describe('LSP17Extendable - Basic Implementation', () => {
     exampleExtension = await new EmitEventExtension__factory(accounts[0]).deploy();
     errorsExtension = await new RevertErrorsTestExtension__factory(accounts[0]).deploy();
 
-    await lsp17Implementation.setExtension(selectorWithExtension, exampleExtension.address);
+    await lsp17Implementation.setExtension(
+      selectorWithExtensionAndNoTransferValue,
+      exampleExtension.address,
+      false,
+    );
 
-    await lsp17Implementation.setExtension(selectorRevertCustomError, errorsExtension.address);
-    await lsp17Implementation.setExtension(selectorRevertErrorString, errorsExtension.address);
-    await lsp17Implementation.setExtension(selectorRevertPanicError, errorsExtension.address);
-    await lsp17Implementation.setExtension(selectorRevertNoErrorData, errorsExtension.address);
+    await lsp17Implementation.setExtension(
+      selectorRevertCustomError,
+      errorsExtension.address,
+      false,
+    );
+    await lsp17Implementation.setExtension(
+      selectorRevertErrorString,
+      errorsExtension.address,
+      false,
+    );
+    await lsp17Implementation.setExtension(
+      selectorRevertPanicError,
+      errorsExtension.address,
+      false,
+    );
+    await lsp17Implementation.setExtension(
+      selectorRevertNoErrorData,
+      errorsExtension.address,
+      false,
+    );
   });
 
   // make sure storage is cleared before running each test
@@ -74,7 +94,7 @@ describe('LSP17Extendable - Basic Implementation', () => {
         await expect(
           accounts[0].sendTransaction({
             to: lsp17Implementation.address,
-            data: selectorWithExtension,
+            data: selectorWithExtensionAndNoTransferValue,
           }),
         ).to.emit(exampleExtension, 'EventEmittedInExtension');
       });
@@ -89,7 +109,7 @@ describe('LSP17Extendable - Basic Implementation', () => {
 
           await accounts[0].sendTransaction({
             to: lsp17Implementation.address,
-            data: selectorWithExtension,
+            data: selectorWithExtensionAndNoTransferValue,
           });
 
           const storageAfter = await lsp17Implementation.getStorageData();

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -141,11 +141,19 @@ export const shouldBehaveLikeLSP1Delegate = (
 
     describe('when calling with random bytes32 typeId', () => {
       describe('when caller is an EOA', () => {
-        it('should revert with custom error `CannotRegisterEOAsAsAssets`', async () => {
+        it('should not revert with custom error `CannotRegisterEOAsAsAssets` if its a random typeId', async () => {
           await expect(
             context.universalProfile1
               .connect(context.accounts.any)
-              .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x'),
+              .universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x'),
+          ).to.not.be.reverted;
+        });
+
+        it('should revert with custom error `CannotRegisterEOAsAsAssets` if its a typeId of LSP7/LSP8', async () => {
+          await expect(
+            context.universalProfile1
+              .connect(context.accounts.any)
+              .callStatic.universalReceiver(LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification, '0x'),
           )
             .to.be.revertedWithCustomError(
               context.lsp1universalReceiverDelegateUP,

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -150,11 +150,19 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
 
     describe('when calling with random bytes32 typeId', () => {
       describe('when caller is an EOA', () => {
-        it('should revert with custom error `CannotRegisterEOAsAsAssets`', async () => {
+        it('should not revert with custom error `CannotRegisterEOAsAsAssets` if its a random typeId', async () => {
           await expect(
             context.lsp9Vault1
               .connect(context.accounts.any)
-              .callStatic.universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x'),
+              .universalReceiver(LSP1_HOOK_PLACEHOLDER, '0x'),
+          ).to.not.be.reverted;
+        });
+
+        it('should revert with custom error `CannotRegisterEOAsAsAssets` if its a typeId of LSP7/LSP8', async () => {
+          await expect(
+            context.lsp9Vault1
+              .connect(context.accounts.any)
+              .callStatic.universalReceiver(LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification, '0x'),
           )
             .to.be.revertedWithCustomError(
               context.lsp1universalReceiverDelegateVault,

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -432,7 +432,7 @@ export const shouldBehaveLikeLSP9 = (
     });
 
     describe('when calling the contract without any value or data', () => {
-      it('should pass and not emit the ValueReceived event', async () => {
+      it('should pass and not emit the UniversalReceiver event', async () => {
         const sender = context.accounts.anyone;
         const amount = 0;
 
@@ -443,7 +443,7 @@ export const shouldBehaveLikeLSP9 = (
             value: amount,
           })
         ).to.not.be.reverted
-          .to.not.emit(context.lsp9Vault, "ValueReceived");
+          .to.not.emit(context.lsp9Vault, "UniversalReceiver");
       });
     });
 
@@ -779,7 +779,7 @@ export const shouldBehaveLikeLSP9 = (
 
   describe('when using the batch `ERC725X.execute(uint256[],address[],uint256[],bytes[])` function', () => {
     describe('when specifying `msg.value`', () => {
-      it('should emit a `ValueReceived` event', async () => {
+      it('should emit a `UniversalReceiver` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts.friend.address,
@@ -796,13 +796,19 @@ export const shouldBehaveLikeLSP9 = (
         });
 
         await expect(tx)
-          .to.emit(context.lsp9Vault, 'ValueReceived')
-          .withArgs(context.deployParams.newOwner, msgValue);
+          .to.emit(context.lsp9Vault, 'UniversalReceiver')
+          .withArgs(
+            context.deployParams.newOwner,
+            msgValue,
+            LSP1_TYPE_IDS.LSP9ValueReceived,
+            '0x',
+            '0x',
+          );
       });
     });
 
     describe('when NOT sending any `msg.value`', () => {
-      it('should NOT emit a `ValueReceived` event', async () => {
+      it('should NOT emit a `UniversalReceiver` event', async () => {
         const operationsType = Array(3).fill(OPERATION_TYPES.CALL);
         const recipients = [
           context.accounts.friend.address,
@@ -818,7 +824,7 @@ export const shouldBehaveLikeLSP9 = (
           value: msgValue,
         });
 
-        await expect(tx).to.not.emit(context.lsp9Vault, 'ValueReceived');
+        await expect(tx).to.not.emit(context.lsp9Vault, 'UniversalReceiver');
       });
     });
   });

--- a/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -801,7 +801,7 @@ export const shouldBehaveLikeLSP9 = (
             context.deployParams.newOwner,
             msgValue,
             LSP1_TYPE_IDS.LSP9ValueReceived,
-            '0x',
+            context.universalProfile.interface.getSighash('executeBatch'),
             '0x',
           );
       });

--- a/tests/UniversalProfile.behaviour.ts
+++ b/tests/UniversalProfile.behaviour.ts
@@ -289,7 +289,7 @@ export const shouldBehaveLikeLSP3 = (
               context.accounts[0].address,
               msgValue,
               LSP1_TYPE_IDS.LSP0ValueReceived,
-              '0x',
+              context.universalProfile.interface.getSighash('setData'),
               '0x',
             );
 
@@ -314,7 +314,7 @@ export const shouldBehaveLikeLSP3 = (
               context.accounts[0].address,
               msgValue,
               LSP1_TYPE_IDS.LSP0ValueReceived,
-              '0x',
+              context.universalProfile.interface.getSighash('setDataBatch'),
               '0x',
             );
 
@@ -429,7 +429,7 @@ export const shouldBehaveLikeLSP3 = (
             context.deployParams.owner.address,
             msgValue,
             LSP1_TYPE_IDS.LSP0ValueReceived,
-            '0x',
+            context.universalProfile.interface.getSighash('executeBatch'),
             '0x',
           );
       });


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES
## ♻️ Refactor

- Emitting UniversalReceiver event instead of ValueReceived in owner functions (setData, execute, ..)
- Emitting UniversalReceiver event instead of ValueReceived and reacting on the call using UniversalReceiverDelegates in the `receive`, `fallback` and the `universalReceiver` function.
- Update `LSP17` to optionally forward value in `LSP0` and `LSP9`

### PR Checklist

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
