### PR TITLE
feat!: Allows `ERC725X.executeBatch` path in LSP6 Key Manager

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -8,9 +8,6 @@ import {
 
 // modules
 import {ERC725Y} from "@erc725/smart-contracts/contracts/ERC725Y.sol";
-import {
-    ERC725Y_DataKeysValuesLengthMismatch
-} from "@erc725/smart-contracts/contracts/errors.sol";
 
 // libraries
 import {LSP6Utils} from "../LSP6Utils.sol";
@@ -41,6 +38,9 @@ import {
 } from "../../LSP17ContractExtension/LSP17Constants.sol";
 
 // errors
+import {
+    ERC725Y_DataKeysValuesLengthMismatch
+} from "@erc725/smart-contracts/contracts/errors.sol";
 import {
     NotRecognisedPermissionKey,
     InvalidEncodedAllowedCalls,

--- a/contracts/Mocks/Reentrancy/LSP20ReentrantContractBatch.sol
+++ b/contracts/Mocks/Reentrancy/LSP20ReentrantContractBatch.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// interfaces
+import {
+    IERC725Y
+} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+import {
+    IERC725X
+} from "@erc725/smart-contracts/contracts/interfaces/IERC725X.sol";
+
+// constants
+import {
+    _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX
+} from "../../LSP1UniversalReceiver/LSP1Constants.sol";
+
+import {
+    _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
+    ALL_REGULAR_PERMISSIONS
+} from "../../LSP6KeyManager/LSP6Constants.sol";
+
+contract LSP20ReentrantContractBatch {
+    event ValueReceived(uint256);
+    mapping(string => function() internal returns (bytes[] memory))
+        private _functionCall;
+
+    address private _newControllerAddress;
+    bytes32 private _newURDTypeId;
+    address private _newURDAddress;
+
+    constructor(
+        address _newControllerAddress_,
+        bytes32 _newURDTypeId_,
+        address _newURDAddress_
+    ) {
+        _newControllerAddress = _newControllerAddress_;
+        _newURDTypeId = _newURDTypeId_;
+        _newURDAddress = _newURDAddress_;
+
+        _functionCall["TRANSFERVALUE"] = _transferValue;
+        _functionCall["SETDATA"] = _setData;
+        _functionCall["ADDCONTROLLER"] = _addController;
+        _functionCall["EDITPERMISSIONS"] = _editPermissions;
+        _functionCall[
+            "ADDUNIVERSALRECEIVERDELEGATE"
+        ] = _addUniversalReceiverDelegate;
+        _functionCall[
+            "CHANGEUNIVERSALRECEIVERDELEGATE"
+        ] = _changeUniversalReceiverDelegate;
+    }
+
+    receive() external payable {
+        emit ValueReceived(msg.value);
+    }
+
+    function callThatReenters(
+        string memory payloadType
+    ) external returns (bytes[] memory) {
+        return _functionCall[payloadType]();
+    }
+
+    // --- Internal Methods
+
+    function _transferValue() internal returns (bytes[] memory) {
+        uint256[] memory operationTypes = new uint256[](1);
+        operationTypes[0] = 0;
+        address[] memory callees = new address[](1);
+        callees[0] = address(this);
+        uint256[] memory values = new uint256[](1);
+        values[0] = 1 ether;
+        bytes[] memory callDatas = new bytes[](1);
+        callDatas[0] = "";
+
+        return
+            IERC725X(msg.sender).executeBatch(
+                operationTypes,
+                callees,
+                values,
+                callDatas
+            );
+    }
+
+    function _setData() internal returns (bytes[] memory) {
+        bytes32[] memory dataKeys = new bytes32[](1);
+        dataKeys[0] = keccak256(bytes("SomeRandomTextUsed"));
+        bytes[] memory dataValues = new bytes[](1);
+        dataValues[0] = bytes("SomeRandomTextUsed");
+
+        IERC725Y(msg.sender).setDataBatch(dataKeys, dataValues);
+
+        return new bytes[](0);
+    }
+
+    function _addController() internal returns (bytes[] memory) {
+        bytes32[] memory dataKeys = new bytes32[](1);
+        dataKeys[0] = bytes32(
+            bytes.concat(
+                _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
+                bytes2(0),
+                bytes20(_newControllerAddress)
+            )
+        );
+        bytes[] memory dataValues = new bytes[](1);
+        dataValues[0] = bytes.concat(ALL_REGULAR_PERMISSIONS);
+
+        IERC725Y(msg.sender).setDataBatch(dataKeys, dataValues);
+
+        return new bytes[](0);
+    }
+
+    function _editPermissions() internal returns (bytes[] memory) {
+        bytes32[] memory dataKeys = new bytes32[](1);
+        dataKeys[0] = bytes32(
+            bytes.concat(
+                _LSP6KEY_ADDRESSPERMISSIONS_PERMISSIONS_PREFIX,
+                bytes2(0),
+                bytes20(_newControllerAddress)
+            )
+        );
+        bytes[] memory dataValues = new bytes[](1);
+        dataValues[0] = "";
+
+        IERC725Y(msg.sender).setDataBatch(dataKeys, dataValues);
+
+        return new bytes[](0);
+    }
+
+    function _addUniversalReceiverDelegate() internal returns (bytes[] memory) {
+        bytes32[] memory dataKeys = new bytes32[](1);
+        dataKeys[0] = bytes32(
+            bytes.concat(
+                _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+                bytes2(0),
+                bytes20(_newURDTypeId)
+            )
+        );
+        bytes[] memory dataValues = new bytes[](1);
+        dataValues[0] = bytes.concat(bytes20(_newURDAddress));
+
+        IERC725Y(msg.sender).setDataBatch(dataKeys, dataValues);
+
+        return new bytes[](0);
+    }
+
+    function _changeUniversalReceiverDelegate()
+        internal
+        returns (bytes[] memory)
+    {
+        bytes32[] memory dataKeys = new bytes32[](1);
+        dataKeys[0] = bytes32(
+            bytes.concat(
+                _LSP1_UNIVERSAL_RECEIVER_DELEGATE_PREFIX,
+                bytes2(0),
+                bytes20(_newURDTypeId)
+            )
+        );
+        bytes[] memory dataValues = new bytes[](1);
+        dataValues[0] = "";
+
+        IERC725Y(msg.sender).setDataBatch(dataKeys, dataValues);
+
+        return new bytes[](0);
+    }
+}

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -1358,6 +1358,44 @@ Reverts when trying to do a `delegatecall` via the ERC725X.execute(uint256,addre
 
 <br/>
 
+### ERC725X_ExecuteParametersEmptyArray
+
+:::note References
+
+- Specification details: [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#erc725x_executeparametersemptyarray)
+- Solidity implementation: [`LSP6KeyManager.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `ERC725X_ExecuteParametersEmptyArray()`
+- Error hash: `0xe9ad2b5f`
+
+:::
+
+```solidity
+error ERC725X_ExecuteParametersEmptyArray();
+```
+
+Reverts when one of the array parameter provided to the [`executeBatch`](#executebatch) function is an empty array.
+
+<br/>
+
+### ERC725X_ExecuteParametersLengthMismatch
+
+:::note References
+
+- Specification details: [**LSP-6-KeyManager**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-6-KeyManager.md#erc725x_executeparameterslengthmismatch)
+- Solidity implementation: [`LSP6KeyManager.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP6KeyManager/LSP6KeyManager.sol)
+- Error signature: `ERC725X_ExecuteParametersLengthMismatch()`
+- Error hash: `0x3ff55f4d`
+
+:::
+
+```solidity
+error ERC725X_ExecuteParametersLengthMismatch();
+```
+
+Reverts when there is not the same number of elements in the `operationTypes`, `targets` addresses, `values`, and `datas` array parameters provided when calling the [`executeBatch`](#executebatch) function.
+
+<br/>
+
 ### ERC725Y_DataKeysValuesLengthMismatch
 
 :::note References

--- a/tests/LSP20CallVerification/LSP6/Interactions/ERC725XExecuteBatch.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Interactions/ERC725XExecuteBatch.test.ts
@@ -1,0 +1,510 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { BigNumber } from 'ethers';
+
+// constants
+import { ERC725YDataKeys, OPERATION_TYPES } from '../../../../constants';
+
+// setup
+import { LSP6TestContext } from '../../../utils/context';
+import { setupKeyManager } from '../../../utils/fixtures';
+import { abiCoder, provider } from '../../../utils/helpers';
+import { LSP7Mintable, LSP7MintableInit__factory, LSP7Mintable__factory } from '../../../../types';
+
+export const shouldBehaveLikeBatchExecute = (
+  buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
+) => {
+  let context: LSP6TestContext;
+
+  // a fictional DAI token on LUKSO
+  let lyxDaiToken: LSP7Mintable,
+    // a basic sample token
+    metaCoin: LSP7Mintable,
+    // a token that can be used as credits for a LUKSO relay service.
+    // Inspired from https://github.com/lykhonis/relayer
+    rLyxToken: LSP7Mintable;
+
+  before(async () => {
+    context = await buildContext(ethers.utils.parseEther('50'));
+
+    // main controller permissions are already set in the fixture
+    await setupKeyManager(context, [], []);
+
+    // deploy some sample LSP7 tokens and mint some tokens to the UP
+    lyxDaiToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
+      'LYX DAI Invented Token',
+      'LYXDAI',
+      context.accounts[0].address,
+      false,
+    );
+
+    metaCoin = await new LSP7Mintable__factory(context.accounts[0]).deploy(
+      'Meta Coin',
+      'MTC',
+      context.accounts[0].address,
+      false,
+    );
+
+    rLyxToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
+      'LUKSO Relay Token',
+      'rLYX',
+      context.accounts[0].address,
+      false,
+    );
+
+    await lyxDaiToken.mint(context.universalProfile.address, 100, false, '0x');
+    await metaCoin.mint(context.universalProfile.address, 100, false, '0x');
+    await rLyxToken.mint(context.universalProfile.address, 100, false, '0x');
+  });
+
+  describe('example scenarios', () => {
+    it('should send LYX to 3x different addresses', async () => {
+      const { universalProfile } = context;
+
+      const operations = [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL];
+
+      const recipients = [
+        context.accounts[1].address,
+        context.accounts[2].address,
+        context.accounts[3].address,
+      ];
+
+      const amounts = [
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('2'),
+        ethers.utils.parseEther('3'),
+      ];
+
+      const data = ['0x', '0x', '0x'];
+
+      const tx = await universalProfile
+        .connect(context.mainController)
+        .executeBatch(operations, recipients, amounts, data);
+
+      await expect(tx).to.changeEtherBalance(
+        context.universalProfile.address,
+        ethers.utils.parseEther('-6'),
+      );
+      await expect(tx).to.changeEtherBalances(recipients, amounts);
+    });
+
+    it('should send LYX + some LSP7 tokens to the same address', async () => {
+      const { universalProfile } = context;
+
+      const recipient = context.accounts[1].address;
+      const lyxAmount = ethers.utils.parseEther('3');
+      const daiAmount = 25;
+
+      // CHECK balance fo LYX and DAI before transfer
+      expect(await lyxDaiToken.balanceOf(context.universalProfile.address)).to.equal(100);
+      expect(await lyxDaiToken.balanceOf(recipient)).to.equal(0);
+
+      const lyxDaiTransferPayload = lyxDaiToken.interface.encodeFunctionData('transfer', [
+        context.universalProfile.address,
+        recipient,
+        daiAmount,
+        true,
+        '0x',
+      ]);
+
+      const operationTypes = [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL];
+
+      const targets = [recipient, lyxDaiToken.address];
+
+      const values = [lyxAmount, 0];
+
+      const payloads = [
+        // LYX transfer (no data)
+        '0x',
+        // token transfer payload
+        lyxDaiTransferPayload,
+      ];
+
+      const tx = await universalProfile
+        .connect(context.mainController)
+        .executeBatch(operationTypes, targets, values, payloads);
+
+      await expect(tx).to.changeEtherBalances(
+        [recipient, universalProfile.address],
+        [lyxAmount, `-${lyxAmount}`],
+      );
+      expect(await lyxDaiToken.balanceOf(recipient)).to.equal(daiAmount);
+      expect(await lyxDaiToken.balanceOf(universalProfile.address)).to.equal(75);
+    });
+
+    it('should send 3x different tokens to the same recipient', async () => {
+      const { universalProfile } = context;
+
+      const recipient = context.accounts[1].address;
+
+      const universalProfileLyxDaiBalanceBefore = await lyxDaiToken.balanceOf(
+        universalProfile.address,
+      );
+      const recipientLyxDaiBalanceBefore = await lyxDaiToken.balanceOf(recipient);
+      const universalProfileMetaCoinBalanceBefore = await metaCoin.balanceOf(
+        universalProfile.address,
+      );
+      const recipientMetaCoinBalanceBefore = await metaCoin.balanceOf(recipient);
+      const universalProfileRLyxBalanceBefore = await rLyxToken.balanceOf(universalProfile.address);
+      const recipientRLyxBalanceBefore = await rLyxToken.balanceOf(recipient);
+
+      const lyxDaiAmount = 25;
+      const metaCoinAmount = 50;
+      const rLyxAmount = 75;
+
+      // prettier-ignore
+      const lyxDaiTransferPayload = lyxDaiToken.interface.encodeFunctionData(
+        "transfer",
+        [context.universalProfile.address, recipient, lyxDaiAmount, true, "0x"]
+      );
+
+      // prettier-ignore
+      const metaCoinTransferPayload = metaCoin.interface.encodeFunctionData(
+        "transfer",
+        [context.universalProfile.address, recipient, metaCoinAmount, true, "0x"]
+      );
+
+      const rLYXTransferPayload = metaCoin.interface.encodeFunctionData('transfer', [
+        context.universalProfile.address,
+        recipient,
+        rLyxAmount,
+        true,
+        '0x',
+      ]);
+
+      const operationTypes = [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL];
+
+      const targets = [lyxDaiToken.address, metaCoin.address, rLyxToken.address];
+
+      const values = [0, 0, 0];
+
+      const payloads = [lyxDaiTransferPayload, metaCoinTransferPayload, rLYXTransferPayload];
+
+      await universalProfile
+        .connect(context.mainController)
+        .executeBatch(operationTypes, targets, values, payloads);
+
+      expect(await lyxDaiToken.balanceOf(universalProfile.address)).to.equal(
+        universalProfileLyxDaiBalanceBefore.sub(lyxDaiAmount),
+      );
+      expect(await lyxDaiToken.balanceOf(recipient)).to.equal(
+        recipientLyxDaiBalanceBefore.add(lyxDaiAmount),
+      );
+      expect(await metaCoin.balanceOf(universalProfile.address)).to.equal(
+        universalProfileMetaCoinBalanceBefore.sub(metaCoinAmount),
+      );
+      expect(await metaCoin.balanceOf(recipient)).to.equal(
+        recipientMetaCoinBalanceBefore.add(metaCoinAmount),
+      );
+      expect(await rLyxToken.balanceOf(universalProfile.address)).to.equal(
+        universalProfileRLyxBalanceBefore.sub(rLyxAmount),
+      );
+      expect(await rLyxToken.balanceOf(recipient)).to.equal(
+        recipientRLyxBalanceBefore.add(rLyxAmount),
+      );
+    });
+
+    it('should 1) deploy a LSP7 Token (as minimal proxy), 2) initialize it, and 3) set the token metadata', async () => {
+      const lsp7MintableBase = await new LSP7MintableInit__factory(context.accounts[0]).deploy();
+
+      const lsp7TokenProxyBytecode = String(
+        '0x3d602d80600a3d3981f3363d3d373d3d3d363d73bebebebebebebebebebebebebebebebebebebebe5af43d82803e903d91602b57fd5bf3',
+      ).replace('bebebebebebebebebebebebebebebebebebebebe', lsp7MintableBase.address.substring(2));
+
+      const futureTokenAddress = await context.universalProfile
+        .connect(context.mainController)
+        .callStatic.execute(
+          OPERATION_TYPES.CREATE,
+          ethers.constants.AddressZero,
+          0,
+          lsp7TokenProxyBytecode,
+        );
+
+      const futureTokenInstance = new LSP7MintableInit__factory(context.accounts[0]).attach(
+        futureTokenAddress,
+      );
+
+      const lsp7InitializePayload = futureTokenInstance.interface.encodeFunctionData('initialize', [
+        'My LSP7 UP Token',
+        'UPLSP7',
+        context.universalProfile.address,
+        false,
+      ]);
+
+      // use interface of an existing token contract
+      const tokenMetadataValue =
+        '0x6f357c6aba20e595da5f38e6c75326802bbf871b4d98b5bfab27812a5456139e3ec087f4697066733a2f2f516d6659696d3146647a645a6747314a50484c46785a3964575a7761616f68596e4b626174797871553144797869';
+
+      const lsp7SetDataPayload = futureTokenInstance.interface.encodeFunctionData('setData', [
+        ERC725YDataKeys.LSP4['LSP4Metadata'],
+        tokenMetadataValue,
+      ]);
+
+      const tx = await context.universalProfile
+        .connect(context.mainController)
+        .executeBatch(
+          [OPERATION_TYPES.CREATE, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
+          [ethers.constants.AddressZero, futureTokenAddress, futureTokenAddress],
+          [0, 0, 0],
+          [lsp7TokenProxyBytecode, lsp7InitializePayload, lsp7SetDataPayload],
+        );
+
+      // CHECK that token contract has been deployed
+      await expect(tx).to.emit(context.universalProfile, 'ContractCreated').withArgs(
+        OPERATION_TYPES.CREATE,
+        ethers.utils.getAddress(futureTokenAddress),
+        0,
+        ethers.utils.hexZeroPad('0x00', 32), // salt
+      );
+
+      // CHECK initialize parameters have been set correctly
+      const nameResult = await futureTokenInstance.getData(ERC725YDataKeys.LSP4['LSP4TokenName']);
+      const symbolResult = await futureTokenInstance.getData(
+        ERC725YDataKeys.LSP4['LSP4TokenSymbol'],
+      );
+
+      expect(ethers.utils.toUtf8String(nameResult)).to.equal('My LSP7 UP Token');
+      expect(ethers.utils.toUtf8String(symbolResult)).to.equal('UPLSP7');
+      expect(await futureTokenInstance.owner()).to.equal(context.universalProfile.address);
+
+      // CHECK LSP4 token metadata has been set
+      expect(await futureTokenInstance.getData(ERC725YDataKeys.LSP4['LSP4Metadata'])).to.equal(
+        tokenMetadataValue,
+      );
+    });
+
+    it('should 1) deploy a LSP7 token, 2) mint some tokens, 3) `transferBatch(...)` to multiple recipients', async () => {
+      // step 1 - deploy token contract
+      const lsp7ConstructorArguments = abiCoder.encode(
+        ['string', 'string', 'address', 'bool'],
+        ['My UP LSP7 Token', 'UPLSP7', context.universalProfile.address, false],
+      );
+
+      // we simulate deploying the token contract to know the future address of the LSP7 Token contract,
+      // so that we can then pass the token address to the `to` parameter of ERC725X.execute(...)
+      // in the 2nd and 3rd payloads of the LSP6 batch `execute(bytes[])`
+      const futureTokenAddress = await context.universalProfile
+        .connect(context.mainController)
+        .callStatic.execute(
+          OPERATION_TYPES.CREATE,
+          ethers.constants.AddressZero,
+          0,
+          LSP7Mintable__factory.bytecode + lsp7ConstructorArguments.substring(2),
+        );
+
+      // step 2 - mint some tokens
+      // use the interface of an existing token for encoding the function call
+      const lsp7MintingPayload = lyxDaiToken.interface.encodeFunctionData('mint', [
+        context.universalProfile.address,
+        3_000,
+        false,
+        '0x',
+      ]);
+
+      // step 3 - transfer batch to multiple addresses
+      const sender = context.universalProfile.address;
+      const recipients = [
+        context.accounts[1].address,
+        context.accounts[2].address,
+        context.accounts[3].address,
+      ];
+      const amounts = [1_000, 1_000, 1_000];
+
+      const lsp7TransferBatchPayload = lyxDaiToken.interface.encodeFunctionData('transferBatch', [
+        [sender, sender, sender], // address[] memory from,
+        recipients, // address[] memory to,
+        amounts, // uint256[] memory amount,
+        [true, true, true], // bool[] memory force,
+        ['0x', '0x', '0x'], // bytes[] memory data
+      ]);
+
+      const tx = await context.universalProfile
+        .connect(context.mainController)
+        .executeBatch(
+          [OPERATION_TYPES.CREATE, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
+          [ethers.constants.AddressZero, futureTokenAddress, futureTokenAddress],
+          [0, 0, 0],
+          [
+            LSP7Mintable__factory.bytecode + lsp7ConstructorArguments.substring(2),
+            lsp7MintingPayload,
+            lsp7TransferBatchPayload,
+          ],
+        );
+
+      // CHECK for `ContractCreated` event
+      await expect(tx).to.emit(context.universalProfile, 'ContractCreated').withArgs(
+        OPERATION_TYPES.CREATE,
+        ethers.utils.getAddress(futureTokenAddress),
+        0,
+        ethers.utils.hexZeroPad('0x00', 32), // salt
+      );
+
+      // CHECK for tokens balances of recipients
+      const createdTokenContract = await new LSP7Mintable__factory(context.accounts[0]).attach(
+        futureTokenAddress,
+      );
+      expect([
+        await createdTokenContract.balanceOf(recipients[0]),
+        await createdTokenContract.balanceOf(recipients[1]),
+        await createdTokenContract.balanceOf(recipients[2]),
+      ]).to.deep.equal(amounts);
+    });
+  });
+
+  describe('when wrong parameters are passed', () => {
+    it('should revert if the passed arrays are empty', async () => {
+      await expect(
+        context.universalProfile.executeBatch([], [], [], []),
+      ).to.be.revertedWithCustomError(context.keyManager, 'ERC725X_ExecuteParametersEmptyArray');
+    });
+
+    it('should revert if an array length is different than others', async () => {
+      const operationTypes = [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL];
+      const calees = [
+        context.accounts[0].address,
+        context.accounts[1].address,
+        context.accounts[2].address,
+      ];
+      const values = [0, 0, 0];
+      const callDatas = ['0x', '0x', '0x'];
+
+      await expect(
+        context.universalProfile.executeBatch(
+          operationTypes.slice(0, -1),
+          calees,
+          values,
+          callDatas,
+        ),
+      ).to.be.revertedWithCustomError(
+        context.keyManager,
+        'ERC725X_ExecuteParametersLengthMismatch',
+      );
+
+      await expect(
+        context.universalProfile.executeBatch(
+          operationTypes,
+          calees.slice(0, -1),
+          values,
+          callDatas,
+        ),
+      ).to.be.revertedWithCustomError(
+        context.keyManager,
+        'ERC725X_ExecuteParametersLengthMismatch',
+      );
+
+      await expect(
+        context.universalProfile.executeBatch(
+          operationTypes,
+          calees,
+          values.slice(0, -1),
+          callDatas,
+        ),
+      ).to.be.revertedWithCustomError(
+        context.keyManager,
+        'ERC725X_ExecuteParametersLengthMismatch',
+      );
+
+      await expect(
+        context.universalProfile.executeBatch(
+          operationTypes,
+          calees,
+          values,
+          callDatas.slice(0, -1),
+        ),
+      ).to.be.revertedWithCustomError(
+        context.keyManager,
+        'ERC725X_ExecuteParametersLengthMismatch',
+      );
+    });
+  });
+
+  describe('when one of the payload reverts', () => {
+    it('should revert the whole transaction if first payload reverts', async () => {
+      const upBalance = await provider.getBalance(context.universalProfile.address);
+
+      const validAmount = ethers.utils.parseEther('1');
+      expect(validAmount).to.be.lt(upBalance); // sanity check
+
+      // make it revert by sending too much value than the actual balance
+      const invalidAmount = upBalance.add(10);
+
+      const randomRecipient = ethers.Wallet.createRandom().address;
+
+      await expect(
+        context.universalProfile
+          .connect(context.mainController)
+          .executeBatch(
+            [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
+            [randomRecipient, randomRecipient, randomRecipient],
+            [invalidAmount, validAmount, validAmount],
+            ['0x', '0x', '0x'],
+          ),
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
+    });
+
+    it('should revert the whole transaction if last payload reverts', async () => {
+      const upBalance = await provider.getBalance(context.universalProfile.address);
+
+      const validAmount = ethers.utils.parseEther('1');
+      expect(validAmount).to.be.lt(upBalance); // sanity check
+
+      // make it revert by sending too much value than the actual balance
+      const invalidAmount = upBalance.add(10);
+
+      const randomRecipient = ethers.Wallet.createRandom().address;
+
+      await expect(
+        context.universalProfile
+          .connect(context.mainController)
+          .executeBatch(
+            [OPERATION_TYPES.CALL, OPERATION_TYPES.CALL, OPERATION_TYPES.CALL],
+            [randomRecipient, randomRecipient, randomRecipient],
+            [invalidAmount, validAmount, validAmount],
+            ['0x', '0x', '0x'],
+          ),
+      ).to.be.revertedWithCustomError(context.universalProfile, 'ERC725X_InsufficientBalance');
+    });
+  });
+
+  describe('when one of the payload is a delegate call', () => {
+    it('should revert the whole transaction', async () => {
+      const upBalance = await provider.getBalance(context.universalProfile.address);
+
+      const validAmount = ethers.utils.parseEther('1');
+      expect(validAmount).to.be.lt(upBalance); // sanity check
+
+      const randomRecipient = ethers.Wallet.createRandom().address;
+
+      await expect(
+        context.universalProfile
+          .connect(context.mainController)
+          .executeBatch(
+            [OPERATION_TYPES.CALL, OPERATION_TYPES.DELEGATECALL, OPERATION_TYPES.CALL],
+            [randomRecipient, randomRecipient, randomRecipient],
+            [validAmount, validAmount, validAmount],
+            ['0x', '0x', '0x'],
+          ),
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
+    });
+
+    it('should revert the whole transaction when calling through `batchCalls`', async () => {
+      const upBalance = await provider.getBalance(context.universalProfile.address);
+
+      const validAmount = ethers.utils.parseEther('1');
+      expect(validAmount).to.be.lt(upBalance); // sanity check
+
+      const randomRecipient = ethers.Wallet.createRandom().address;
+
+      const calldata = context.universalProfile.interface.encodeFunctionData('executeBatch', [
+        [OPERATION_TYPES.CALL, OPERATION_TYPES.DELEGATECALL, OPERATION_TYPES.CALL],
+        [randomRecipient, randomRecipient, randomRecipient],
+        [validAmount, validAmount, validAmount],
+        ['0x', '0x', '0x'],
+      ]);
+
+      await expect(
+        context.universalProfile.connect(context.mainController).batchCalls([calldata]),
+      ).to.be.revertedWithCustomError(context.keyManager, 'DelegateCallDisallowedViaKeyManager');
+    });
+  });
+};

--- a/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP6/LSP20WithLSP6.behaviour.ts
@@ -21,6 +21,7 @@ import {
   shouldBehaveLikeAllowedAddresses,
   shouldBehaveLikeAllowedFunctions,
   shouldBehaveLikeAllowedStandards,
+  shouldBehaveLikeBatchExecute,
 
   // Set Data
   shouldBehaveLikeAllowedERC725YDataKeys,
@@ -84,6 +85,10 @@ export const shouldBehaveLikeLSP6 = (
     shouldBehaveLikeAllowedAddresses(buildContext);
     shouldBehaveLikeAllowedFunctions(buildContext);
     shouldBehaveLikeAllowedStandards(buildContext);
+  });
+
+  describe('`ERC725X.executeBatch([],[],[],[])`', () => {
+    shouldBehaveLikeBatchExecute(buildContext);
   });
 
   describe('miscellaneous', () => {

--- a/tests/LSP20CallVerification/LSP6/index.ts
+++ b/tests/LSP20CallVerification/LSP6/index.ts
@@ -19,6 +19,7 @@ export * from './Interactions/AllowedFunctions.test';
 export * from './Interactions/AllowedStandards.test';
 export * from './Interactions/OtherScenarios.test';
 export * from './Interactions/Security.test';
+export * from './Interactions/ERC725XExecuteBatch.test';
 
 // SetData
 export * from './SetData/PermissionSetData.test';

--- a/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
+++ b/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
@@ -500,7 +500,7 @@ export const shouldBehaveLikeBatchExecute = (
       });
 
       describe('when `msgValues[1]` is NOT zero for `setData(...)`', () => {
-        it('should revert with default LSP6 `executePayload(...)` error message', async () => {
+        it('should pass and increase the UP balance', async () => {
           const recipient = context.accounts[5].address;
 
           const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('Sample Data Key'));

--- a/tests/Reentrancy/LSP20/ERC725XExecuteToERC725XBatchExecute.test.ts
+++ b/tests/Reentrancy/LSP20/ERC725XExecuteToERC725XBatchExecute.test.ts
@@ -25,10 +25,10 @@ import {
   loadTestCase,
 } from './reentrancyHelpers';
 
-import { LSP20ReentrantContract__factory } from '../../../types';
+import { LSP20ReentrantContractBatch__factory } from '../../../types';
 import { Interface } from 'ethers/lib/utils';
 
-export const testERC725XBatchExecuteToERC725XExecute = (
+export const testERC725XExecuteToERC725XExecuteBatch = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
   buildReentrancyContext: (context: LSP6TestContext) => Promise<ReentrancyContext>,
 ) => {
@@ -39,7 +39,7 @@ export const testERC725XBatchExecuteToERC725XExecute = (
   before(async () => {
     context = await buildContext(ethers.utils.parseEther('10'));
     reentrancyContext = await buildReentrancyContext(context);
-    reentrantContractInterface = new LSP20ReentrantContract__factory().interface;
+    reentrantContractInterface = new LSP20ReentrantContractBatch__factory().interface;
   });
 
   describe('when reentering and transferring value', () => {

--- a/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
+++ b/tests/Reentrancy/LSP20/LSP20WithLSP6Reentrancy.test.ts
@@ -11,21 +11,25 @@ import { testERC725XExecuteToLSP6ExecuteRelayCall } from './ERC725XExecuteToLSP6
 
 import { testERC725XBatchExecuteToERC725XExecute } from './ERC725XBatchExecuteToERC725XExecute.test';
 import { testERC725XExecuteToLSP6BatchExecuteRelayCall } from './ERC725XExecuteToLSP6BatchExecuteRelayCall.test';
+import { testERC725XExecuteToERC725XExecuteBatch } from './ERC725XExecuteToERC725XBatchExecute.test';
 
 export const shouldBehaveLikeLSP20WithLSP6ReentrancyScenarios = (
   buildContext: (initialFunding?: BigNumber) => Promise<LSP6TestContext>,
 ) => {
-  describe('first call through `execute(bytes)`, second call through `execute(bytes)`', () => {
+  describe('first call through `execute(uint256,address,uint256,bytes)`, second call through `execute(uint256,address,uint256,bytes)`', () => {
     testERC725XExecuteToERC725XExecute(buildContext, buildReentrancyContext);
   });
 
-  describe('first call through `execute(bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`', () => {
+  describe('first call through `execute(uint256,address,uint256,bytes)`, second call through `executeRelayCall(bytes,uint256,bytes)`', () => {
     testERC725XExecuteToLSP6ExecuteRelayCall(buildContext, buildReentrancyContext);
   });
 
-  // TODO: enable these tests once we allow `ERC725X.execute(uint256[],address[],uint256[],bytes[])` in the LSP6.execute(bytes)
-  describe.skip('first call through `execute(bytes)`, second call through `execute(uint256[],bytes[])`', () => {
+  describe('first call through `execute(uint256[],address[],uint256[],bytes[])`, second call through `execute(uint256,address,uint256,bytes)`', () => {
     testERC725XBatchExecuteToERC725XExecute(buildContext, buildReentrancyContext);
+  });
+
+  describe('first call through `execute(uint256,address,uint256,bytes)`, second call through `execute(uint256[],address[],uint256[],bytes[])`', () => {
+    testERC725XExecuteToERC725XExecuteBatch(buildContext, buildReentrancyContext);
   });
 
   describe('first call through `ERC725X.execute(bytes)`, second call through `LSP6.executeRelayCall(bytes[],uint256[],uint256[],bytes[])`', () => {


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## 🚀 Feature

This PR Introduces the verification for the path`ERC725X.executeBatch` in the LSP6 Key Manager.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
