### PR TITLE
test: check that base contracts are initialized with `address(0)` as `owner()` and `target()`

### DIFF
--- a/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
+++ b/tests/LSP6KeyManager/LSP6KeyManagerInit.test.ts
@@ -35,6 +35,14 @@ describe('LSP6KeyManager with proxy', () => {
   };
 
   describe('when deploying the base LSP6KeyManagerInit implementation', () => {
+    it('`target()` of the base Key Manager contract MUST be `address(0)`', async () => {
+      const accounts = await ethers.getSigners();
+      const keyManagerBaseContract = await new LSP6KeyManagerInit__factory(accounts[0]).deploy();
+
+      const linkedTarget = await keyManagerBaseContract.target();
+      expect(linkedTarget).to.equal(ethers.constants.AddressZero);
+    });
+
     it('should prevent any address from calling the `initialize(...)` function on the base contract', async () => {
       const context = await buildProxyTestContext();
 

--- a/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
+++ b/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../LSP7Mintable.behaviour';
 
 import { deployProxy } from '../../utils/fixtures';
+import { ERC725YDataKeys } from '../../../constants';
 
 describe('LSP7MintableInit with proxy', () => {
   const buildTestContext = async () => {
@@ -43,6 +44,18 @@ describe('LSP7MintableInit with proxy', () => {
   };
 
   describe('when deploying the base implementation contract', () => {
+    it('should have initialized the tokenName + tokenSymbol to "" and contract owner to `address(0)`', async () => {
+      const accounts = await ethers.getSigners();
+
+      const lsp7MintableInit = await new LSP7MintableInit__factory(accounts[0]).deploy();
+
+      expect(await lsp7MintableInit.getData(ERC725YDataKeys.LSP4.LSP4TokenName)).to.equal('0x');
+      expect(await lsp7MintableInit.getData(ERC725YDataKeys.LSP4.LSP4TokenSymbol)).to.equal('0x');
+      expect(await lsp7MintableInit.getData(ERC725YDataKeys.LSP4.LSP4Metadata)).to.equal('0x');
+
+      expect(await lsp7MintableInit.owner()).to.equal(ethers.constants.AddressZero);
+    });
+
     it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../LSP8Mintable.behaviour';
 
 import { deployProxy } from '../../utils/fixtures';
-import { LSP8_TOKEN_ID_TYPES } from '../../../constants';
+import { ERC725YDataKeys, LSP8_TOKEN_ID_TYPES } from '../../../constants';
 
 describe('LSP8MintableInit with proxy', () => {
   const buildTestContext = async () => {
@@ -42,6 +42,19 @@ describe('LSP8MintableInit with proxy', () => {
   };
 
   describe('when deploying the base implementation contract', () => {
+    it('should have initialized the tokenName + tokenSymbol to "" and contract owner to `address(0)`', async () => {
+      const accounts = await ethers.getSigners();
+
+      const lsp8MintableInit = await new LSP8MintableInit__factory(accounts[0]).deploy();
+
+      expect(await lsp8MintableInit.getData(ERC725YDataKeys.LSP4.LSP4TokenName)).to.equal('0x');
+      expect(await lsp8MintableInit.getData(ERC725YDataKeys.LSP4.LSP4TokenSymbol)).to.equal('0x');
+      expect(await lsp8MintableInit.getData(ERC725YDataKeys.LSP4.LSP4Metadata)).to.equal('0x');
+      expect(await lsp8MintableInit.getData(ERC725YDataKeys.LSP8.LSP8TokenIdType)).to.equal('0x');
+
+      expect(await lsp8MintableInit.owner()).to.equal(ethers.constants.AddressZero);
+    });
+
     it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 

--- a/tests/LSP9Vault/LSP9VaultInit.test.ts
+++ b/tests/LSP9Vault/LSP9VaultInit.test.ts
@@ -70,6 +70,16 @@ describe('LSP9VaultInit with proxy', () => {
   };
 
   describe('when deploying the base implementation contract', () => {
+    it('`owner()` of the base contract MUST be `address(0)`', async () => {
+      const accounts = await ethers.getSigners();
+
+      const lsp9VaultInit = await new LSP9VaultInit__factory(accounts[0]).deploy();
+
+      const owner = await lsp9VaultInit.owner();
+
+      expect(owner).to.equal(ethers.constants.AddressZero);
+    });
+
     it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const accounts = await ethers.getSigners();
 

--- a/tests/UniversalProfileInit.test.ts
+++ b/tests/UniversalProfileInit.test.ts
@@ -124,6 +124,11 @@ describe('UniversalProfileInit with proxy', () => {
   };
 
   describe('when deploying the base implementation contract', () => {
+    it('`owner()` of the base contract MUST be `address(0)`', async () => {
+      const owner = await universalProfileInit.owner();
+      expect(owner).to.equal(ethers.constants.AddressZero);
+    });
+
     it('prevent any address from calling the initialize(...) function on the implementation', async () => {
       const randomCaller = accounts[1];
 


### PR DESCRIPTION
# What does this PR introduce?

## 🧪 Tests

Add extra sanity checks when deploying base contracts.
