### PR TITLE
refactor!: update LS8 Metadata keys to new LSP8 standard specs

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -230,6 +230,9 @@ export const ERC725YDataKeys = {
   },
   LSP8: {
     LSP8TokenIdType: '0x715f248956de7ce65e94d9d836bfead479f7e70d69b718d47bfe7b00e05b4fe4',
+    LSP8MetadataTokenURI: '0x1339e76a390b7b9ec9010000',
+    LSP8TokenMetadataBaseURI: '0x1a7628600c3bac7101f53697f48df381ddc36b9015e7d7c9c5633d1252aa2843',
+    LSP8ReferenceContract: '0x708e7b881795f2e6b6c2752108c177ec89248458de3bf69d0d43480b3e5034e6',
   },
   LSP9: {
     SupportedStandards_LSP9: SupportedStandards.LSP9Vault.key,

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Constants.sol
@@ -9,11 +9,14 @@ bytes4 constant _INTERFACEID_LSP8 = 0x1ae9ba1f;
 // keccak256('LSP8TokenIdType')
 bytes32 constant _LSP8_TOKENID_TYPE_KEY = 0x715f248956de7ce65e94d9d836bfead479f7e70d69b718d47bfe7b00e05b4fe4;
 
-// bytes10(keccak256('LSP8MetadataAddress')) + bytes2(0)
-bytes12 constant _LSP8_METADATA_ADDRESS_KEY_PREFIX = 0x73dcc7c3c4096cdc7f8a0000;
+// bytes10(keccak256('LSP8MetadataTokenURI')) + bytes2(0)
+bytes12 constant _LSP8_METADATA_TOKEN_URI_PREFIX = 0x1339e76a390b7b9ec9010000;
 
-// bytes10(keccak256('LSP8MetadataJSON')) + bytes2(0)
-bytes12 constant _LSP8_METADATA_JSON_KEY_PREFIX = 0x9a26b4060ae7f7d5e3cd0000;
+// keccak256('LSP8TokenMetadataBaseURI')
+bytes32 constant _LSP8_TOKEN_METADATA_BASE_URI = 0x1a7628600c3bac7101f53697f48df381ddc36b9015e7d7c9c5633d1252aa2843;
+
+// keccak256('LSP8ReferenceContract')
+bytes32 constant _LSP8_REFERENCE_CONTRACT = 0x708e7b881795f2e6b6c2752108c177ec89248458de3bf69d0d43480b3e5034e6;
 
 // --- Token Hooks
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,6 @@ libs = ['node_modules','lib']
 gas_reports = ["LSP6ExecuteRestrictedController", "LSP6ExecuteUnrestrictedController", "LSP6SetDataRestrictedController", "LSP6SetDataUnrestrictedController"]
 cache_path = 'forge-cache'
 test = 'tests/foundry'
-solc_version = "0.8.15"
+solc_version = "0.8.17"
 [fuzz]
 runs = 10_000


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

The data keys related to LSP8 are not up to date in the `.sol` files + are not present in `constants.ts`.

Update to the right values from LSP8 specs in the Solidity files and add them in the `constants.ts` file.
