### PR TITLE
perf: use `try / catch` in LSP20 verification to optimise gas cost

### DIFF
--- a/contracts/LSP20CallVerification/LSP20CallVerification.sol
+++ b/contracts/LSP20CallVerification/LSP20CallVerification.sol
@@ -48,10 +48,10 @@ abstract contract LSP20CallVerification {
                 bytes3(returnedStatus) !=
                 bytes3(ILSP20.lsp20VerifyCall.selector)
             ) {
-                revert LSP20CallVerificationFailed(
-                    false,
-                    abi.encode(returnedStatus)
-                );
+                revert LSP20CallVerificationFailed({
+                    postCall: false,
+                    returnedStatus: returnedStatus
+                });
             }
 
             return returnedStatus[3] == 0x01;
@@ -90,7 +90,7 @@ abstract contract LSP20CallVerification {
             if (returnedStatus != ILSP20.lsp20VerifyCallResult.selector) {
                 revert LSP20CallVerificationFailed({
                     postCall: true,
-                    returnedData: abi.encode(returnedStatus)
+                    returnedStatus: returnedStatus
                 });
             }
 

--- a/contracts/LSP20CallVerification/LSP20CallVerification.sol
+++ b/contracts/LSP20CallVerification/LSP20CallVerification.sol
@@ -22,8 +22,8 @@ abstract contract LSP20CallVerification {
      * @dev Calls {lsp20VerifyCall} function on the logicVerifier.
      *
      * @custom:info
-     * - Reverts in case the value returned does not match the magic value (lsp20VerifyCall selector).
-     * - Returns whether a verification after the execution should happen based on the last byte of the magicValue.
+     * - Reverts in case the value returned does not match the returned status (lsp20VerifyCall selector).
+     * - Returns whether a verification after the execution should happen based on the last byte of the `returnedStatus`.
      * - Reverts with no reason if the  data returned by `ILSP20(logicVerifier).lsp20VerifyCall(...)` cannot be decoded (_e.g:_ any other data type besides `bytes4`).
      * See this link for more info: https://forum.soliditylang.org/t/call-for-feedback-the-future-of-try-catch-in-solidity/1497.
      */
@@ -43,15 +43,18 @@ abstract contract LSP20CallVerification {
                 msg.value,
                 msg.data
             )
-        returns (bytes4 magicValue) {
-            if (bytes3(magicValue) != bytes3(ILSP20.lsp20VerifyCall.selector)) {
+        returns (bytes4 returnedStatus) {
+            if (
+                bytes3(returnedStatus) !=
+                bytes3(ILSP20.lsp20VerifyCall.selector)
+            ) {
                 revert LSP20CallVerificationFailed(
                     false,
-                    abi.encode(magicValue)
+                    abi.encode(returnedStatus)
                 );
             }
 
-            return magicValue[3] == 0x01;
+            return returnedStatus[3] == 0x01;
         } catch (bytes memory errorData) {
             _revertWithLSP20DefaultError(false, errorData);
         }
@@ -61,8 +64,8 @@ abstract contract LSP20CallVerification {
      * @dev Calls {lsp20VerifyCallResult} function on the logicVerifier.
      *
      * @custom:info
-     * - Reverts in case the value returned does not match the magic value (lsp20VerifyCallResult selector).
-     * - Reverts with no reason if the  data returned by `ILSP20(logicVerifier).lsp20VerifyCallResult(...)` cannot be decoded (_e.g:_ any other data type besides `bytes4`).
+     * - Reverts in case the value returned does not match the returned status (lsp20VerifyCallResult selector).
+     * - Reverts with no reason if the data returned by `ILSP20(logicVerifier).lsp20VerifyCallResult(...)` cannot be decoded (_e.g:_ any other data type besides `bytes4`).
      * See this link for more info: https://forum.soliditylang.org/t/call-for-feedback-the-future-of-try-catch-in-solidity/1497.
      */
     function _verifyCallResult(
@@ -83,11 +86,11 @@ abstract contract LSP20CallVerification {
                 ),
                 callResult
             )
-        returns (bytes4 magicValue) {
-            if (magicValue != ILSP20.lsp20VerifyCallResult.selector) {
+        returns (bytes4 returnedStatus) {
+            if (returnedStatus != ILSP20.lsp20VerifyCallResult.selector) {
                 revert LSP20CallVerificationFailed({
                     postCall: true,
-                    returnedData: abi.encode(magicValue)
+                    returnedData: abi.encode(returnedStatus)
                 });
             }
 

--- a/contracts/LSP20CallVerification/LSP20CallVerification.sol
+++ b/contracts/LSP20CallVerification/LSP20CallVerification.sol
@@ -20,8 +20,12 @@ import {
 abstract contract LSP20CallVerification {
     /**
      * @dev Calls {lsp20VerifyCall} function on the logicVerifier.
-     * Reverts in case the value returned does not match the success value (lsp20VerifyCall selector)
-     * Returns whether a verification after the execution should happen based on the last byte of the returnedStatus
+     *
+     * @custom:info
+     * - Reverts in case the value returned does not match the magic value (lsp20VerifyCall selector).
+     * - Returns whether a verification after the execution should happen based on the last byte of the magicValue.
+     * - Reverts with no reason if the  data returned by `ILSP20(logicVerifier).lsp20VerifyCall(...)` cannot be decoded (_e.g:_ any other data type besides `bytes4`).
+     * See this link for more info: https://forum.soliditylang.org/t/call-for-feedback-the-future-of-try-catch-in-solidity/1497.
      */
     function _verifyCall(
         address logicVerifier
@@ -30,6 +34,7 @@ abstract contract LSP20CallVerification {
             revert LSP20EOACannotVerifyCall(logicVerifier);
         }
 
+        // Reverts with no reason if the returned data type is not a `bytes4` value
         try
             ILSP20(logicVerifier).lsp20VerifyCall(
                 msg.sender,
@@ -54,12 +59,17 @@ abstract contract LSP20CallVerification {
 
     /**
      * @dev Calls {lsp20VerifyCallResult} function on the logicVerifier.
-     * Reverts in case the value returned does not match the success value (lsp20VerifyCallResult selector)
+     *
+     * @custom:info
+     * - Reverts in case the value returned does not match the magic value (lsp20VerifyCallResult selector).
+     * - Reverts with no reason if the  data returned by `ILSP20(logicVerifier).lsp20VerifyCallResult(...)` cannot be decoded (_e.g:_ any other data type besides `bytes4`).
+     * See this link for more info: https://forum.soliditylang.org/t/call-for-feedback-the-future-of-try-catch-in-solidity/1497.
      */
     function _verifyCallResult(
         address logicVerifier,
         bytes memory callResult
     ) internal virtual {
+        // Reverts with no reason if the returned data type is not a `bytes4` value
         try
             ILSP20(logicVerifier).lsp20VerifyCallResult(
                 keccak256(

--- a/contracts/LSP20CallVerification/LSP20Errors.sol
+++ b/contracts/LSP20CallVerification/LSP20Errors.sol
@@ -10,9 +10,9 @@ error LSP20CallingVerifierFailed(bool postCall);
 /**
  * @dev reverts when the call to the owner does not return the LSP20 success value
  * @param postCall True if the execution call was done, False otherwise
- * @param returnedData The data returned by the call to the logic verifier
+ * @param returnedStatus The bytes4 decoded data returned by the logic verifier.
  */
-error LSP20CallVerificationFailed(bool postCall, bytes returnedData);
+error LSP20CallVerificationFailed(bool postCall, bytes4 returnedStatus);
 
 /**
  * @dev Reverts when the logic verifier is an Externally Owned Account (EOA) that cannot return the LSP20 success value.

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -1225,8 +1225,6 @@ function _verifyCall(
 ```
 
 Calls [`lsp20VerifyCall`](#lsp20verifycall) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCall selector)
-Returns whether a verification after the execution should happen based on the last byte of the returnedStatus
 
 <br/>
 
@@ -1240,19 +1238,6 @@ function _verifyCallResult(
 ```
 
 Calls [`lsp20VerifyCallResult`](#lsp20verifycallresult) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCallResult selector)
-
-<br/>
-
-### \_validateCall
-
-```solidity
-function _validateCall(
-  bool postCall,
-  bool success,
-  bytes returnedData
-) internal pure;
-```
 
 <br/>
 

--- a/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
+++ b/docs/contracts/LSP0ERC725Account/LSP0ERC725Account.md
@@ -1825,23 +1825,23 @@ Reverts when trying to renounce ownership before the initial confirmation delay.
 
 - Specification details: [**LSP-0-ERC725Account**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-0-ERC725Account.md#lsp20callverificationfailed)
 - Solidity implementation: [`LSP0ERC725Account.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP0ERC725Account/LSP0ERC725Account.sol)
-- Error signature: `LSP20CallVerificationFailed(bool,bytes)`
-- Error hash: `0x00c28d0f`
+- Error signature: `LSP20CallVerificationFailed(bool,bytes4)`
+- Error hash: `0x9d6741e3`
 
 :::
 
 ```solidity
-error LSP20CallVerificationFailed(bool postCall, bytes returnedData);
+error LSP20CallVerificationFailed(bool postCall, bytes4 returnedStatus);
 ```
 
 reverts when the call to the owner does not return the LSP20 success value
 
 #### Parameters
 
-| Name           |  Type   | Description                                          |
-| -------------- | :-----: | ---------------------------------------------------- |
-| `postCall`     | `bool`  | True if the execution call was done, False otherwise |
-| `returnedData` | `bytes` | The data returned by the call to the logic verifier  |
+| Name             |   Type   | Description                                             |
+| ---------------- | :------: | ------------------------------------------------------- |
+| `postCall`       |  `bool`  | True if the execution call was done, False otherwise    |
+| `returnedStatus` | `bytes4` | The bytes4 decoded data returned by the logic verifier. |
 
 <br/>
 

--- a/docs/contracts/LSP20CallVerification/LSP20CallVerification.md
+++ b/docs/contracts/LSP20CallVerification/LSP20CallVerification.md
@@ -33,8 +33,6 @@ function _verifyCall(
 ```
 
 Calls [`lsp20VerifyCall`](#lsp20verifycall) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCall selector)
-Returns whether a verification after the execution should happen based on the last byte of the returnedStatus
 
 <br/>
 
@@ -48,19 +46,6 @@ function _verifyCallResult(
 ```
 
 Calls [`lsp20VerifyCallResult`](#lsp20verifycallresult) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCallResult selector)
-
-<br/>
-
-### \_validateCall
-
-```solidity
-function _validateCall(
-  bool postCall,
-  bool success,
-  bytes returnedData
-) internal pure;
-```
 
 <br/>
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -1168,8 +1168,6 @@ function _verifyCall(
 ```
 
 Calls [`lsp20VerifyCall`](#lsp20verifycall) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCall selector)
-Returns whether a verification after the execution should happen based on the last byte of the returnedStatus
 
 <br/>
 
@@ -1183,19 +1181,6 @@ function _verifyCallResult(
 ```
 
 Calls [`lsp20VerifyCallResult`](#lsp20verifycallresult) function on the logicVerifier.
-Reverts in case the value returned does not match the success value (lsp20VerifyCallResult selector)
-
-<br/>
-
-### \_validateCall
-
-```solidity
-function _validateCall(
-  bool postCall,
-  bool success,
-  bytes returnedData
-) internal pure;
-```
 
 <br/>
 

--- a/docs/contracts/UniversalProfile.md
+++ b/docs/contracts/UniversalProfile.md
@@ -1768,23 +1768,23 @@ Reverts when trying to renounce ownership before the initial confirmation delay.
 
 - Specification details: [**UniversalProfile**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-3-UniversalProfile-Metadata.md#lsp20callverificationfailed)
 - Solidity implementation: [`UniversalProfile.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/UniversalProfile.sol)
-- Error signature: `LSP20CallVerificationFailed(bool,bytes)`
-- Error hash: `0x00c28d0f`
+- Error signature: `LSP20CallVerificationFailed(bool,bytes4)`
+- Error hash: `0x9d6741e3`
 
 :::
 
 ```solidity
-error LSP20CallVerificationFailed(bool postCall, bytes returnedData);
+error LSP20CallVerificationFailed(bool postCall, bytes4 returnedStatus);
 ```
 
 reverts when the call to the owner does not return the LSP20 success value
 
 #### Parameters
 
-| Name           |  Type   | Description                                          |
-| -------------- | :-----: | ---------------------------------------------------- |
-| `postCall`     | `bool`  | True if the execution call was done, False otherwise |
-| `returnedData` | `bytes` | The data returned by the call to the logic verifier  |
+| Name             |   Type   | Description                                             |
+| ---------------- | :------: | ------------------------------------------------------- |
+| `postCall`       |  `bool`  | True if the execution call was done, False otherwise    |
+| `returnedStatus` | `bytes4` | The bytes4 decoded data returned by the logic verifier. |
 
 <br/>
 

--- a/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
@@ -368,7 +368,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
 
           await expect(context.universalProfile.setData(dataKey, dataValue))
             .to.be.revertedWithCustomError(context.universalProfile, 'LSP20CallVerificationFailed')
-            .withArgs(false, '0xaabbccdd' + '0'.repeat(56));
+            .withArgs(false, '0xaabbccdd');
         });
       });
 

--- a/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
+++ b/tests/LSP20CallVerification/LSP20CallVerification.behaviour.ts
@@ -266,9 +266,9 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
           const dataKey = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('RandomKey1'));
           const dataValue = ethers.utils.hexlify(ethers.utils.randomBytes(50));
 
-          await expect(context.universalProfile.setData(dataKey, dataValue))
-            .to.be.revertedWithCustomError(context.universalProfile, 'LSP20CallVerificationFailed')
-            .withArgs(false, '0x');
+          await expect(
+            context.universalProfile.setData(dataKey, dataValue),
+          ).to.be.revertedWithoutReason();
         });
       });
 
@@ -335,7 +335,7 @@ export const shouldBehaveLikeLSP20 = (buildContext: () => Promise<LSP20TestConte
 
           await expect(
             context.universalProfile.setData(dataKey, dataValue),
-          ).to.be.revertedWithCustomError(context.universalProfile, 'LSP20CallVerificationFailed');
+          ).to.be.revertedWithoutReason();
         });
       });
 


### PR DESCRIPTION
# What does this PR introduce?

## ⚡️ Performance

Cherry picking the following commits from #744 :

180acccbe0110f8d80666f582dab96f5e3f4d894
495c4e69e2cc4a87c3c6773201d724d23332963c
548fbecd8323ccaba9330885cccc232ebdf4998c

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
