### PR TITLE
fix: [M-02] reset `_renounceOwnershipStartedAt` on `acceptOwnership(..)` in LSP14

### DIFF
--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -175,6 +175,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
 
         _setOwner(msg.sender);
         delete _pendingOwner;
+        delete _renounceOwnershipStartedAt;
     }
 
     /**

--- a/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
+++ b/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
@@ -12,7 +12,7 @@ import {
 contract LSP0Implementation is LSP0ERC725Account {
     constructor(address _addr) LSP0ERC725Account(_addr) {}
 
-    function renounceOwnershipStartedAt() public view returns(uint256){
+    function renounceOwnershipStartedAt() public view returns (uint256) {
         return _renounceOwnershipStartedAt;
     }
 }
@@ -22,13 +22,14 @@ contract Implementation {
     bytes32[2] __gap;
     uint256 _renounceOwnershipStartedAt;
 
-    function setRenounceOwnershipStartedAt(uint256 newRenounceOwnershipStartedAt) external {
+    function setRenounceOwnershipStartedAt(
+        uint256 newRenounceOwnershipStartedAt
+    ) external {
         _renounceOwnershipStartedAt = newRenounceOwnershipStartedAt;
     }
 }
 
 contract OwnershipAccepter {
-
     function acceptOwnership(address _account) public {
         LSP0Implementation(payable(_account)).acceptOwnership();
     }
@@ -45,7 +46,6 @@ contract TwoStepRenounceOwnershipTest is Test {
     }
 
     function testRenounceOwnershipVariableClearedAfterAcceptOwnership() public {
-
         // Call transferOwnership so we can check acceptOwnership behavior
         account.transferOwnership(address(ownershipAccepter));
 

--- a/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
+++ b/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
@@ -17,7 +17,7 @@ contract LSP0Implementation is LSP0ERC725Account {
     }
 }
 
-contract Implementation {
+contract LSP0StorageUpdater {
     // _renounceOwnershipStartedAt is at slot 2 for LSP0ERC725Account
     bytes32[2] __gap;
     uint256 _renounceOwnershipStartedAt;
@@ -50,21 +50,27 @@ contract TwoStepRenounceOwnershipTest is Test {
         account.transferOwnership(address(ownershipAccepter));
 
         // Overwrite _renounceOwnershipAt using a delegatecall
-        Implementation implementation = new Implementation();
+        LSP0StorageUpdater implementation = new LSP0StorageUpdater();
+
+        uint256 newRenounceOwnershipStartedAt = 10_000_000; // number of blocks
+
         account.execute(
             OPERATION_4_DELEGATECALL,
             address(implementation),
             0,
             abi.encodeWithSelector(
-                Implementation.setRenounceOwnershipStartedAt.selector,
-                10000000
+                LSP0StorageUpdater.setRenounceOwnershipStartedAt.selector,
+                newRenounceOwnershipStartedAt
             )
         );
 
         // _renounceOwnershipAt is now set to this value
-        assertEq(account.renounceOwnershipStartedAt(), 10000000);
+        assertEq(
+            account.renounceOwnershipStartedAt(),
+            newRenounceOwnershipStartedAt
+        );
 
-        // Will call LSP0's accceptOwnership function that
+        // Calling LSP0's `acceptOwnership()` function that
         // should reset _renounceOwnershipAt variable
         ownershipAccepter.acceptOwnership(address(account));
 

--- a/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
+++ b/tests/foundry/LSP14Ownable2Step/AcceptOwnershipCleanState.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "@erc725/smart-contracts/contracts/constants.sol";
+import "../../../contracts/LSP0ERC725Account/LSP0ERC725Account.sol";
+
+import {
+    LSP20EOACannotVerifyCall
+} from "../../../contracts/LSP20CallVerification/LSP20Errors.sol";
+
+contract LSP0Implementation is LSP0ERC725Account {
+    constructor(address _addr) LSP0ERC725Account(_addr) {}
+
+    function renounceOwnershipStartedAt() public view returns(uint256){
+        return _renounceOwnershipStartedAt;
+    }
+}
+
+contract Implementation {
+    // _renounceOwnershipStartedAt is at slot 2 for LSP0ERC725Account
+    bytes32[2] __gap;
+    uint256 _renounceOwnershipStartedAt;
+
+    function setRenounceOwnershipStartedAt(uint256 newRenounceOwnershipStartedAt) external {
+        _renounceOwnershipStartedAt = newRenounceOwnershipStartedAt;
+    }
+}
+
+contract OwnershipAccepter {
+
+    function acceptOwnership(address _account) public {
+        LSP0Implementation(payable(_account)).acceptOwnership();
+    }
+}
+
+contract TwoStepRenounceOwnershipTest is Test {
+    LSP0Implementation account;
+    OwnershipAccepter ownershipAccepter;
+
+    function setUp() public {
+        // Deploy LSP0 account with this address as owner
+        account = new LSP0Implementation(address(this));
+        ownershipAccepter = new OwnershipAccepter();
+    }
+
+    function testRenounceOwnershipVariableClearedAfterAcceptOwnership() public {
+
+        // Call transferOwnership so we can check acceptOwnership behavior
+        account.transferOwnership(address(ownershipAccepter));
+
+        // Overwrite _renounceOwnershipAt using a delegatecall
+        Implementation implementation = new Implementation();
+        account.execute(
+            OPERATION_4_DELEGATECALL,
+            address(implementation),
+            0,
+            abi.encodeWithSelector(
+                Implementation.setRenounceOwnershipStartedAt.selector,
+                10000000
+            )
+        );
+
+        // _renounceOwnershipAt is now set to this value
+        assertEq(account.renounceOwnershipStartedAt(), 10000000);
+
+        // Will call LSP0's accceptOwnership function that
+        // should reset _renounceOwnershipAt variable
+        ownershipAccepter.acceptOwnership(address(account));
+
+        // Make sure the _renounceOwnershipAt is reset after acceptOwnership call
+        assertEq(account.renounceOwnershipStartedAt(), 0);
+    }
+}


### PR DESCRIPTION
# What does this PR introduce?
## 🐛 Bug

> From Milo's report

Ownership of LSP0 accounts are transferred through a two-step process.

First, the owner calls [transferOwnership()](https://github.com/lukso-network/lsp-smart-contracts/blob/0c1738619818bcf2e01636f31782886b26fb91d7/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L84-L107) to nominate a pendingOwner:

[LSP14Ownable2Step.sol#L165-L166](https://github.com/lukso-network/lsp-smart-contracts/blob/0c1738619818bcf2e01636f31782886b26fb91d7/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L165-L166)

        _pendingOwner = newOwner;
        delete _renounceOwnershipStartedAt;
Afterwards, the pending owner calls [acceptOwnership()](https://github.com/lukso-network/lsp-smart-contracts/blob/0c1738619818bcf2e01636f31782886b26fb91d7/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L109-L128) to becomes the new owner:

[LSP14Ownable2Step.sol#L176-L177](https://github.com/lukso-network/lsp-smart-contracts/blob/0c1738619818bcf2e01636f31782886b26fb91d7/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L176-L177)

        _setOwner(msg.sender);
        delete _pendingOwner;
However, as _renounceOwnershipStartedAt is only deleted when transferOwnership() is called, LSP0 accounts can be transferred to new owners with a non-zero _renounceOwnershipStartedAt by doing the following:

Call transferOwnership() to nominate a pending owner.
Using execute(), perform a delegate call that overwrites _renounceOwnershipStartedAt to any value.
The pending owner calls acceptOwnership() to gain ownership of the LSP0 account.
This could be problematic depending on what _renounceOwnershipStartedAt is set to.

If it is set to an extremely large value, such as close to type(uint256).max, renounceOwnership() will always revert due to [this check](https://github.com/lukso-network/lsp-smart-contracts/blob/0c1738619818bcf2e01636f31782886b26fb91d7/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol#L202-L207), making the function DOSed.

If it is set to block.number - RENOUNCE_OWNERSHIP_CONFIRMATION_DELAY, renounceOwnership() will be in the confirmation period for the next 200 blocks. If the new owner accidentally calls renounceOwnership(), he will instantly lose ownership of the account rather than initiate the process.


The fix just ensures a clean state transfer between 2 addresses.

### PR Checklist


- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
