### PR TITLE
fix: [M-04 + L-02] improve empty call type checks for selector `0x00000000`

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -314,6 +314,7 @@ abstract contract LSP6ExecuteModule {
             requiredCallTypes |= _ALLOWEDCALLS_TRANSFERVALUE;
         }
 
+        // if we are doing a message call with some data
         if (!isEmptyCall) {
             if (operationType == OPERATION_0_CALL) {
                 requiredCallTypes |= _ALLOWEDCALLS_CALL;
@@ -322,6 +323,8 @@ abstract contract LSP6ExecuteModule {
             } else if (operationType == OPERATION_4_DELEGATECALL) {
                 requiredCallTypes |= _ALLOWEDCALLS_DELEGATECALL;
             }
+
+            // if we are doing an empty call without value
         } else if (value == 0) {
             if (operationType == OPERATION_0_CALL) {
                 requiredCallTypes |= _ALLOWEDCALLS_CALL;

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6ExecuteModule.sol
@@ -252,9 +252,6 @@ abstract contract LSP6ExecuteModule {
 
         bool isEmptyCall = data.length == 0;
 
-        // CHECK if there is at least a 4 bytes function selector
-        bytes4 selector = data.length >= 4 ? bytes4(data) : bytes4(0);
-
         bytes4 requiredCallTypes = _extractCallType(
             operationType,
             value,
@@ -294,11 +291,11 @@ abstract contract LSP6ExecuteModule {
                 _isAllowedCallType(allowedCall, requiredCallTypes) &&
                 _isAllowedAddress(allowedCall, to) &&
                 _isAllowedStandard(allowedCall, to) &&
-                _isAllowedFunction(allowedCall, selector)
+                _isAllowedFunction(allowedCall, data)
             ) return;
         }
 
-        revert NotAllowedCall(controllerAddress, to, selector);
+        revert NotAllowedCall(controllerAddress, to, bytes4(data));
     }
 
     /**
@@ -322,6 +319,12 @@ abstract contract LSP6ExecuteModule {
                 requiredCallTypes |= _ALLOWEDCALLS_CALL;
             } else if (operationType == OPERATION_3_STATICCALL) {
                 requiredCallTypes |= _ALLOWEDCALLS_STATICCALL;
+            } else if (operationType == OPERATION_4_DELEGATECALL) {
+                requiredCallTypes |= _ALLOWEDCALLS_DELEGATECALL;
+            }
+        } else if (value == 0) {
+            if (operationType == OPERATION_0_CALL) {
+                requiredCallTypes |= _ALLOWEDCALLS_CALL;
             } else if (operationType == OPERATION_4_DELEGATECALL) {
                 requiredCallTypes |= _ALLOWEDCALLS_DELEGATECALL;
             }
@@ -363,7 +366,7 @@ abstract contract LSP6ExecuteModule {
 
     function _isAllowedFunction(
         bytes memory allowedCall,
-        bytes4 requiredFunction
+        bytes memory data
     ) internal pure virtual returns (bool) {
         // <offset> = 28 bytes x 8 bits = 224 bits
         //
@@ -372,7 +375,9 @@ abstract contract LSP6ExecuteModule {
         // 0000000ncafecafecafecafecafecafecafecafecafecafe5a5a5a5af1f1f1f1
         bytes4 allowedFunction = bytes4(bytes32(allowedCall) << 224);
 
-        bool isFunctionCall = requiredFunction != bytes4(0);
+        bool isFunctionCall = data.length >= 4;
+
+        bytes4 requiredFunction = bytes4(data);
 
         // ANY function = 0xffffffff
         return

--- a/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
+++ b/contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol
@@ -33,7 +33,7 @@ contract KeyManagerInternalTester is LSP6KeyManager {
     }
 
     function verifyAllowedCall(
-        address _sender,
+        address controller,
         uint256 operationType,
         address to,
         uint256 value,
@@ -41,7 +41,7 @@ contract KeyManagerInternalTester is LSP6KeyManager {
     ) public view {
         super._verifyAllowedCall(
             _target,
-            _sender,
+            controller,
             operationType,
             to,
             value,

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -906,7 +906,7 @@ function _verifyAllowedCall(
 function _extractCallType(
   uint256 operationType,
   uint256 value,
-  bool isEmptyCall
+  bytes data
 ) internal pure returns (bytes4 requiredCallTypes);
 ```
 
@@ -918,7 +918,7 @@ extract the bytes4 representation of a single bit for the type of call according
 | --------------- | :-------: | -------------------------------------------- |
 | `operationType` | `uint256` | 0 = CALL, 3 = STATICCALL or 3 = DELEGATECALL |
 | `value`         | `uint256` | -                                            |
-| `isEmptyCall`   |  `bool`   | -                                            |
+| `data`          |  `bytes`  | -                                            |
 
 #### Returns
 
@@ -955,7 +955,7 @@ function _isAllowedStandard(
 ```solidity
 function _isAllowedFunction(
   bytes allowedCall,
-  bytes4 requiredFunction
+  bytes data
 ) internal pure returns (bool);
 ```
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,3 +8,4 @@ test = 'tests/foundry'
 solc_version = "0.8.17"
 [fuzz]
 runs = 10_000
+max_test_rejects = 200_000

--- a/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
+++ b/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { EIP191Signer } from '@lukso/eip191-signer.js';
-import { BigNumber, Signer } from 'ethers';
+import { BigNumber } from 'ethers';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 
 import {

--- a/tests/foundry/LSP6KeyManager/LSP6AllowedCallsTest.t.sol
+++ b/tests/foundry/LSP6KeyManager/LSP6AllowedCallsTest.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+// libraries
+import "forge-std/Test.sol";
+import {
+    LSP2Utils
+} from "../../../contracts/LSP2ERC725YJSONSchema/LSP2Utils.sol";
+
+// modules
+import {UniversalProfile} from "../../../contracts/UniversalProfile.sol";
+import {
+    KeyManagerInternalTester
+} from "../../../contracts/Mocks/KeyManager/KeyManagerInternalsTester.sol";
+
+// constants
+import {
+    OPERATION_0_CALL,
+    OPERATION_3_STATICCALL,
+    OPERATION_4_DELEGATECALL
+} from "@erc725/smart-contracts/contracts/constants.sol";
+import {
+    _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDCALLS_PREFIX,
+    _ALLOWEDCALLS_TRANSFERVALUE
+} from "../../../contracts/LSP6KeyManager/LSP6Constants.sol";
+
+// errors to test
+import {NotAllowedCall} from "../../../contracts/LSP6KeyManager/LSP6Errors.sol";
+
+// mock contracts for testing
+import {TargetContract} from "../../../contracts/Mocks/TargetContract.sol";
+
+contract LSP6AllowedCallsTest is Test {
+    using LSP2Utils for *;
+
+    UniversalProfile universalProfile;
+    KeyManagerInternalTester keyManager;
+
+    TargetContract targetContract;
+
+    function setUp() public {
+        universalProfile = new UniversalProfile(address(this));
+        keyManager = new KeyManagerInternalTester(address(universalProfile));
+
+        targetContract = new TargetContract();
+    }
+
+    function _setupCallTypes(bytes4 callTypesAllowed) internal {
+        // setup allowed calls for this controller, when we will read them from storage
+        bytes32 allowedCallsDataKey = LSP2Utils.generateMappingWithGroupingKey({
+            keyPrefix: _LSP6KEY_ADDRESSPERMISSIONS_ALLOWEDCALLS_PREFIX,
+            bytes20Value: bytes20(address(this))
+        });
+
+        bytes memory allowedCallsDataValue = abi.encodePacked(
+            hex"0020", // 2 bytes to specify the entry is 32 bytes long (32 = 0x0020 in hex)
+            callTypesAllowed, // restrictionOperations (= callTypes allowed)
+            targetContract,
+            bytes4(0),
+            bytes4(0)
+        );
+
+        universalProfile.setData(allowedCallsDataKey, allowedCallsDataValue);
+    }
+
+    function testShouldRevertWithEmptyMessageCallWithCallTypeAllowedValueOnly()
+        public
+    {
+        // setup allowed calls for this controller, when we will read them from storage
+        _setupCallTypes(_ALLOWEDCALLS_TRANSFERVALUE);
+
+        bytes memory expectedRevertData = abi.encodeWithSelector(
+            NotAllowedCall.selector,
+            address(this),
+            targetContract,
+            bytes4(0)
+        );
+
+        // Test with CALL
+        vm.expectRevert(expectedRevertData);
+        keyManager.verifyAllowedCall(
+            address(this),
+            OPERATION_0_CALL,
+            address(targetContract),
+            0,
+            ""
+        );
+
+        // Test with STATICCALL
+        vm.expectRevert(expectedRevertData);
+        keyManager.verifyAllowedCall(
+            address(this),
+            OPERATION_3_STATICCALL,
+            address(targetContract),
+            0,
+            ""
+        );
+
+        // Test with DELEGATECALL
+        vm.expectRevert(expectedRevertData);
+        keyManager.verifyAllowedCall(
+            address(this),
+            OPERATION_4_DELEGATECALL,
+            address(targetContract),
+            0,
+            ""
+        );
+    }
+
+    function testFail_ShouldRevertForAnyMessageCallToTargetWithNoCallTypeAllowed(
+        uint256 operationType,
+        uint256 value,
+        bytes memory callData
+    ) public {
+        _setupCallTypes(bytes4(0));
+
+        // we should use a valid operation type
+        vm.assume(operationType <= 4);
+
+        keyManager.verifyAllowedCall(
+            address(this),
+            operationType,
+            address(targetContract),
+            value,
+            callData
+        );
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## ♻️ Refactor

This PR allows `0x00000000` to be an allowed call and not be confused with an empty call.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
