### PR TITLE
fix: [M-03] allow setting 21 bytes under LSP17Extension data key in LSP6KeyManager

### DIFF
--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -322,7 +322,11 @@ abstract contract LSP6SetDataModule {
             // LSP17Extension:<bytes4>
         } else if (bytes12(inputDataKey) == _LSP17_EXTENSION_PREFIX) {
             // CHECK that `dataValue` contains exactly 20 bytes, which corresponds to an address for a LSP17 Extension
-            if (inputDataValue.length != 20 && inputDataValue.length != 0) {
+            if (
+                inputDataValue.length != 20 &&
+                inputDataValue.length != 21 &&
+                inputDataValue.length != 0
+            ) {
                 revert InvalidDataValuesForDataKeys(
                     inputDataKey,
                     inputDataValue

--- a/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
+++ b/contracts/LSP6KeyManager/LSP6Modules/LSP6SetDataModule.sol
@@ -321,7 +321,7 @@ abstract contract LSP6SetDataModule {
 
             // LSP17Extension:<bytes4>
         } else if (bytes12(inputDataKey) == _LSP17_EXTENSION_PREFIX) {
-            // CHECK that `dataValue` contains exactly 20 bytes, which corresponds to an address for a LSP17 Extension
+            // CHECK that `dataValue` contains exactly 20 or 21 bytes (if setting to forward value), which corresponds to an address for a LSP17 Extension
             if (
                 inputDataValue.length != 20 &&
                 inputDataValue.length != 21 &&

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
@@ -81,19 +81,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       let permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        context.mainController.address.substring(2),
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canAddAndChangeExtensions.address.substring(2),
+          canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlyAddExtensions.address.substring(2),
+          canOnlyAddExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlyChangeExtensions.address.substring(2),
+          canOnlyChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlySuperSetData.address.substring(2),
+          canOnlySuperSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlySetData.address.substring(2),
+          canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-        canOnlySetData.address.substring(2),
+          canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
@@ -931,7 +931,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-                canOnlySetData.address.substring(2),
+                  canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
             };

--- a/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP20CallVerification/LSP6/Admin/PermissionChangeAddExtensions.test.ts
@@ -81,19 +81,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       let permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          context.mainController.address.substring(2),
+        context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canAddAndChangeExtensions.address.substring(2),
+        canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyAddExtensions.address.substring(2),
+        canOnlyAddExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyChangeExtensions.address.substring(2),
+        canOnlyChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlySuperSetData.address.substring(2),
+        canOnlySuperSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlySetData.address.substring(2),
+        canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          canOnlySetData.address.substring(2),
+        canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
@@ -931,7 +931,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-                  canOnlySetData.address.substring(2),
+                canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
             };
@@ -960,6 +960,58 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             });
           });
         });
+      });
+    });
+
+    describe('when setting random bytes under the LSP17Extension data key ', () => {
+      it('should be allowed to set a 20 bytes long address', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+        await context.universalProfile.connect(context.mainController).setData(key, value);
+
+        const result = await context.universalProfile.getData(key);
+        expect(result).to.equal(value);
+      });
+
+      it('should be allowed to set a 21 bytes long address', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+        await context.universalProfile.connect(context.mainController).setData(key, value);
+
+        const result = await context.universalProfile.getData(key);
+        expect(result).to.equal(value);
+      });
+
+      it('should revert when setting a random 10 bytes value', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const randomValue = '0xcafecafecafecafecafe';
+
+        await expect(
+          context.universalProfile.connect(context.mainController).setData(key, randomValue),
+        )
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+          .withArgs(key, randomValue);
+      });
+
+      it('should revert when setting a random 30 bytes value', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+        await expect(
+          context.universalProfile.connect(context.mainController).setData(key, randomValue),
+        )
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+          .withArgs(key, randomValue);
       });
     });
   });

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -81,19 +81,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       let permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          context.mainController.address.substring(2),
+        context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canAddAndChangeExtensions.address.substring(2),
+        canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyAddExtensions.address.substring(2),
+        canOnlyAddExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlyChangeExtensions.address.substring(2),
+        canOnlyChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlySuperSetData.address.substring(2),
+        canOnlySuperSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-          canOnlySetData.address.substring(2),
+        canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-          canOnlySetData.address.substring(2),
+        canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
@@ -255,11 +255,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-                lsp20VerifyCallSelector.slice(2) +
-                '00000000000000000000000000000000',
+              lsp20VerifyCallSelector.slice(2) +
+              '00000000000000000000000000000000',
               ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-                lsp20VerifyCallResultSelector.slice(2) +
-                '00000000000000000000000000000000',
+              lsp20VerifyCallResultSelector.slice(2) +
+              '00000000000000000000000000000000',
             ], // zero padded,
             dataValues: [context.accounts[2].address, context.accounts[3].address],
           };
@@ -1096,7 +1096,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-                  canOnlySetData.address.substring(2),
+                canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
             };
@@ -1131,6 +1131,58 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             });
           });
         });
+      });
+    });
+
+    describe('when setting random bytes under the LSP17Extension data key ', () => {
+      it('should be allowed to set a 20 bytes long address', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+        await context.universalProfile.connect(context.mainController).setData(key, value);
+
+        const result = await context.universalProfile.getData(key);
+        expect(result).to.equal(value);
+      });
+
+      it('should be allowed to set a 21 bytes long address', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+        await context.universalProfile.connect(context.mainController).setData(key, value);
+
+        const result = await context.universalProfile.getData(key);
+        expect(result).to.equal(value);
+      });
+
+      it('should revert when setting a random 10 bytes value', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const randomValue = '0xcafecafecafecafecafe';
+
+        await expect(
+          context.universalProfile.connect(context.mainController).setData(key, randomValue),
+        )
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+          .withArgs(key, randomValue);
+      });
+
+      it('should revert when setting a random 30 bytes value', async () => {
+        const key =
+          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+        const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+        await expect(
+          context.universalProfile.connect(context.mainController).setData(key, randomValue),
+        )
+          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+          .withArgs(key, randomValue);
       });
     });
   });

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -274,6 +274,58 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           const result = await context.universalProfile.getDataBatch(payloadParam.dataKeys);
           expect(result).to.deep.equal(payloadParam.dataValues);
         });
+
+        describe('when setting random bytes under the LSP17Extension data key ', () => {
+          it('should be allowed to set a 20 bytes long address', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+            await context.universalProfile.connect(context.mainController).setData(key, value);
+
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should be allowed to set a 21 bytes long address', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+            await context.universalProfile.connect(context.mainController).setData(key, value);
+
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should revert when setting a random 10 bytes value', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const randomValue = '0xcafecafecafecafecafe';
+
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+              .withArgs(key, randomValue);
+          });
+
+          it('should revert when setting a random 30 bytes value', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+            await expect(
+              context.universalProfile.connect(context.mainController).setData(key, randomValue),
+            )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+              .withArgs(key, randomValue);
+          });
+        });
       });
 
       describe('when caller is an address with ADD/CHANGE Extensions permission', () => {
@@ -327,10 +379,62 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
         });
+
+        describe('when setting random bytes under the LSP17Extension data key ', () => {
+          it('should be allowed to set a 20 bytes long address', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+            await context.universalProfile.connect(canAddAndChangeExtensions).setData(key, value);
+
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should be allowed to set a 21 bytes long address', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+            await context.universalProfile.connect(canAddAndChangeExtensions).setData(key, value);
+
+            const result = await context.universalProfile.getData(key);
+            expect(result).to.equal(value);
+          });
+
+          it('should revert when setting a random 10 bytes value', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const randomValue = '0xcafecafecafecafecafe';
+
+            await expect(
+              context.universalProfile.connect(canAddAndChangeExtensions).setData(key, randomValue),
+            )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+              .withArgs(key, randomValue);
+          });
+
+          it('should revert when setting a random 30 bytes value', async () => {
+            const key =
+              ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+              ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+            const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+            await expect(
+              context.universalProfile.connect(canAddAndChangeExtensions).setData(key, randomValue),
+            )
+              .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+              .withArgs(key, randomValue);
+          });
+        });
       });
 
       describe('when caller is an address with ADDExtensions permission', () => {
-        it('should be allowed to ADD a ExtensionHandler key', async () => {
+        it('should be allowed to ADD an ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey5,
             dataValue: extensionA,
@@ -345,6 +449,56 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
           const result = await context.universalProfile.getData(payloadParam.dataKey);
           expect(result).to.equal(payloadParam.dataValue);
+        });
+
+        it('should be allowed to set a 20 bytes long address for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+          await context.universalProfile.connect(canOnlyAddExtensions).setData(key, value);
+
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
+
+        it('should be allowed to set a 21 bytes long address for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+          await context.universalProfile.connect(canOnlyAddExtensions).setData(key, value);
+
+          const result = await context.universalProfile.getData(key);
+          expect(result).to.equal(value);
+        });
+
+        it('should revert with `InvalidDataValuesForDataKeys` when setting a random 10 bytes value for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const randomValue = '0xcafecafecafecafecafe';
+
+          await expect(
+            context.universalProfile.connect(canOnlyAddExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
+        });
+
+        it('should revert with `InvalidDataValuesForDataKeys` when setting a random 30 bytes value for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+          await expect(
+            context.universalProfile.connect(canOnlyAddExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
         });
 
         it("should NOT be allowed to edit the ExtensionHandler key set even if it's setting existing data", async () => {
@@ -394,6 +548,28 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(canOnlyAddExtensions.address, 'CHANGEEXTENSIONS');
         });
+
+        it('should revert with `InvalidDataValuesForDataKeys` error when setting a random 10 bytes value for an existing handler', async () => {
+          const key = extensionHandlerKey5;
+          const randomValue = '0xcafecafecafecafecafe';
+
+          await expect(
+            context.universalProfile.connect(canOnlyAddExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
+        });
+
+        it('should revert with `InvalidDataValuesForDataKeys` error when setting a random 30 bytes value for an existing handler', async () => {
+          const key = extensionHandlerKey5;
+          const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+          await expect(
+            context.universalProfile.connect(canOnlyAddExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
+        });
       });
 
       describe('when caller is an address with CHANGEExtensions permission', () => {
@@ -411,6 +587,64 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
             .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
             .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
+        });
+
+        it('should NOT be allowed to set a 20 bytes long address for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const value = ethers.Wallet.createRandom().address.toLowerCase();
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
+        });
+
+        it('should NOT be allowed to set a 21 bytes long address for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
+
+          const payload = context.universalProfile.interface.encodeFunctionData('setData', [
+            key,
+            value,
+          ]);
+
+          await expect(context.keyManager.connect(canOnlyChangeExtensions).execute(payload))
+            .to.be.revertedWithCustomError(context.keyManager, 'NotAuthorised')
+            .withArgs(canOnlyChangeExtensions.address, 'ADDEXTENSIONS');
+        });
+
+        it('should revert with `InvalidValueForDataKey` error when setting a random 10 bytes value for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const randomValue = '0xcafecafecafecafecafe';
+
+          await expect(
+            context.universalProfile.connect(canOnlyChangeExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
+        });
+
+        it('should revert with `InvalidValueForDataKey` error when setting a random 30 bytes value for a new handler', async () => {
+          const key =
+            ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
+            ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
+          const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
+
+          await expect(
+            context.universalProfile.connect(canOnlyChangeExtensions).setData(key, randomValue),
+          )
+            .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
+            .withArgs(key, randomValue);
         });
 
         it('should be allowed to edit the ExtensionHandler key set', async () => {
@@ -466,6 +700,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
           await context.keyManager.connect(context.mainController).execute(payload);
         });
+
         it('should NOT be allowed to ADD another ExtensionHandler key', async () => {
           const payloadParam = {
             dataKey: extensionHandlerKey1,
@@ -1029,6 +1264,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
               .withArgs(canOnlySuperSetData.address, 'ADDEXTENSIONS');
           });
         });
+
         describe('when Adding multiple ExtensionHandler keys with adding ERC725Y Data Key', () => {
           it("should revert because caller don't have ADDExtensions permission", async () => {
             const payloadParam = {
@@ -1108,6 +1344,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
             await context.keyManager.connect(context.mainController).execute(payload);
           });
+
           describe('When adding ExtensionHandler key and one of his allowedERC725Y Data Key', () => {
             it('should pass', async () => {
               const payloadParam = {
@@ -1131,58 +1368,6 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             });
           });
         });
-      });
-    });
-
-    describe('when setting random bytes under the LSP17Extension data key ', () => {
-      it('should be allowed to set a 20 bytes long address', async () => {
-        const key =
-          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
-        const value = ethers.Wallet.createRandom().address.toLowerCase();
-
-        await context.universalProfile.connect(context.mainController).setData(key, value);
-
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
-      });
-
-      it('should be allowed to set a 21 bytes long address', async () => {
-        const key =
-          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
-        const value = ethers.Wallet.createRandom().address.toLowerCase() + '00';
-
-        await context.universalProfile.connect(context.mainController).setData(key, value);
-
-        const result = await context.universalProfile.getData(key);
-        expect(result).to.equal(value);
-      });
-
-      it('should revert when setting a random 10 bytes value', async () => {
-        const key =
-          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
-        const randomValue = '0xcafecafecafecafecafe';
-
-        await expect(
-          context.universalProfile.connect(context.mainController).setData(key, randomValue),
-        )
-          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
-          .withArgs(key, randomValue);
-      });
-
-      it('should revert when setting a random 30 bytes value', async () => {
-        const key =
-          ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-          ethers.utils.hexlify(ethers.utils.randomBytes(20)).substring(2);
-        const randomValue = '0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef';
-
-        await expect(
-          context.universalProfile.connect(context.mainController).setData(key, randomValue),
-        )
-          .to.be.revertedWithCustomError(context.keyManager, 'InvalidDataValuesForDataKeys')
-          .withArgs(key, randomValue);
       });
     });
   });

--- a/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
+++ b/tests/LSP6KeyManager/Admin/PermissionChangeAddExtensions.test.ts
@@ -81,19 +81,19 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
 
       let permissionKeys = [
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        context.mainController.address.substring(2),
+          context.mainController.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canAddAndChangeExtensions.address.substring(2),
+          canAddAndChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlyAddExtensions.address.substring(2),
+          canOnlyAddExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlyChangeExtensions.address.substring(2),
+          canOnlyChangeExtensions.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlySuperSetData.address.substring(2),
+          canOnlySuperSetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-        canOnlySetData.address.substring(2),
+          canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:AllowedERC725YDataKeys'] +
-        canOnlySetData.address.substring(2),
+          canOnlySetData.address.substring(2),
         ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] + canOnlyCall.address.substring(2),
       ];
 
@@ -255,11 +255,11 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
           const payloadParam = {
             dataKeys: [
               ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-              lsp20VerifyCallSelector.slice(2) +
-              '00000000000000000000000000000000',
+                lsp20VerifyCallSelector.slice(2) +
+                '00000000000000000000000000000000',
               ERC725YDataKeys.LSP17.LSP17ExtensionPrefix +
-              lsp20VerifyCallResultSelector.slice(2) +
-              '00000000000000000000000000000000',
+                lsp20VerifyCallResultSelector.slice(2) +
+                '00000000000000000000000000000000',
             ], // zero padded,
             dataValues: [context.accounts[2].address, context.accounts[3].address],
           };
@@ -1096,7 +1096,7 @@ export const shouldBehaveLikePermissionChangeOrAddExtensions = (
             const payloadParam = {
               dataKeys: [
                 ERC725YDataKeys.LSP6['AddressPermissions:Permissions'] +
-                canOnlySetData.address.substring(2),
+                  canOnlySetData.address.substring(2),
               ],
               dataValues: [combinePermissions(PERMISSIONS.ADDEXTENSIONS, PERMISSIONS.SETDATA)],
             };


### PR DESCRIPTION
# What does this PR introduce?
## 🐛 Bug

- allow setting 21 bytes under LSP17Extension data key in LSP6KeyManager


### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
