### PR TITLE
refactor: shorten LSP1Utils function to `notifyUniversalReceiver`

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -541,7 +541,7 @@ abstract contract LSP0ERC725AccountCore is
             emit OwnershipTransferStarted(currentOwner, pendingNewOwner);
 
             // notify the pending owner through LSP1
-            pendingNewOwner.tryNotifyUniversalReceiver(
+            pendingNewOwner.notifyUniversalReceiver(
                 _TYPEID_LSP0_OwnershipTransferStarted,
                 ""
             );
@@ -561,7 +561,7 @@ abstract contract LSP0ERC725AccountCore is
             emit OwnershipTransferStarted(currentOwner, pendingNewOwner);
 
             // notify the pending owner through LSP1
-            pendingNewOwner.tryNotifyUniversalReceiver(
+            pendingNewOwner.notifyUniversalReceiver(
                 _TYPEID_LSP0_OwnershipTransferStarted,
                 ""
             );
@@ -603,13 +603,13 @@ abstract contract LSP0ERC725AccountCore is
         }
 
         // notify the previous owner if supports LSP1
-        previousOwner.tryNotifyUniversalReceiver(
+        previousOwner.notifyUniversalReceiver(
             _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
             ""
         );
 
         // notify the pending owner if supports LSP1
-        pendingOwnerAddress.tryNotifyUniversalReceiver(
+        pendingOwnerAddress.notifyUniversalReceiver(
             _TYPEID_LSP0_OwnershipTransferred_RecipientNotification,
             ""
         );
@@ -649,7 +649,7 @@ abstract contract LSP0ERC725AccountCore is
         LSP14Ownable2Step._renounceOwnership();
 
         if (owner() == address(0)) {
-            previousOwner.tryNotifyUniversalReceiver(
+            previousOwner.notifyUniversalReceiver(
                 _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
                 ""
             );

--- a/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
+++ b/contracts/LSP14Ownable2Step/LSP14Ownable2Step.sol
@@ -97,7 +97,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
         address currentOwner = owner();
         emit OwnershipTransferStarted(currentOwner, newOwner);
 
-        newOwner.tryNotifyUniversalReceiver(
+        newOwner.notifyUniversalReceiver(
             _TYPEID_LSP14_OwnershipTransferStarted,
             ""
         );
@@ -116,12 +116,12 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
 
         _acceptOwnership();
 
-        previousOwner.tryNotifyUniversalReceiver(
+        previousOwner.notifyUniversalReceiver(
             _TYPEID_LSP14_OwnershipTransferred_SenderNotification,
             ""
         );
 
-        msg.sender.tryNotifyUniversalReceiver(
+        msg.sender.notifyUniversalReceiver(
             _TYPEID_LSP14_OwnershipTransferred_RecipientNotification,
             ""
         );
@@ -142,7 +142,7 @@ abstract contract LSP14Ownable2Step is ILSP14Ownable2Step, OwnableUnset {
         _renounceOwnership();
 
         if (owner() == address(0)) {
-            previousOwner.tryNotifyUniversalReceiver(
+            previousOwner.notifyUniversalReceiver(
                 _TYPEID_LSP14_OwnershipTransferred_SenderNotification,
                 ""
             );

--- a/contracts/LSP1UniversalReceiver/LSP1Utils.sol
+++ b/contracts/LSP1UniversalReceiver/LSP1Utils.sol
@@ -35,7 +35,7 @@ library LSP1Utils {
      * @param typeId A `bytes32` typeId.
      * @param data Any optional data to send to the `universalReceiver` function to the `lsp1Implementation` address.
      */
-    function tryNotifyUniversalReceiver(
+    function notifyUniversalReceiver(
         address lsp1Implementation,
         bytes32 typeId,
         bytes memory data

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -133,10 +133,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
             operatorNotificationData
         );
 
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP7_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
     }
 
     /**
@@ -162,7 +159,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
                 operatorNotificationData
             );
 
-            operator.tryNotifyUniversalReceiver(
+            operator.notifyUniversalReceiver(
                 _TYPEID_LSP7_TOKENOPERATOR,
                 lsp1Data
             );
@@ -220,10 +217,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
             operatorNotificationData
         );
 
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP7_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
     }
 
     /**
@@ -257,10 +251,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
             operatorNotificationData
         );
 
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP7_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
     }
 
     // --- Transfer functionality
@@ -474,7 +465,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
         _afterTokenTransfer(from, address(0), amount, data);
 
         bytes memory lsp1Data = abi.encode(from, address(0), amount, data);
-        from.tryNotifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
+        from.notifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
     }
 
     /**
@@ -572,7 +563,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset, Version {
 
         bytes memory lsp1Data = abi.encode(from, to, amount, data);
 
-        from.tryNotifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
+        from.notifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
         _notifyTokenReceiver(to, force, lsp1Data);
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -160,10 +160,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             operatorNotificationData
         );
 
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP8_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP8_TOKENOPERATOR, lsp1Data);
     }
 
     /**
@@ -205,7 +202,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
                 operatorNotificationData
             );
 
-            operator.tryNotifyUniversalReceiver(
+            operator.notifyUniversalReceiver(
                 _TYPEID_LSP8_TOKENOPERATOR,
                 lsp1Data
             );
@@ -467,10 +464,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
             data
         );
 
-        tokenOwner.tryNotifyUniversalReceiver(
-            _TYPEID_LSP8_TOKENSSENDER,
-            lsp1Data
-        );
+        tokenOwner.notifyUniversalReceiver(_TYPEID_LSP8_TOKENSSENDER, lsp1Data);
     }
 
     /**
@@ -536,7 +530,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         bytes memory lsp1Data = abi.encode(from, to, tokenId, data);
 
-        from.tryNotifyUniversalReceiver(_TYPEID_LSP8_TOKENSSENDER, lsp1Data);
+        from.notifyUniversalReceiver(_TYPEID_LSP8_TOKENSSENDER, lsp1Data);
         _notifyTokenReceiver(to, force, lsp1Data);
     }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -357,10 +357,7 @@ abstract contract LSP8CompatibleERC721 is
             tokenId,
             operatorNotificationData
         );
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP8_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP8_TOKENOPERATOR, lsp1Data);
     }
 
     /**

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -366,10 +366,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
             tokenId,
             operatorNotificationData
         );
-        operator.tryNotifyUniversalReceiver(
-            _TYPEID_LSP8_TOKENOPERATOR,
-            lsp1Data
-        );
+        operator.notifyUniversalReceiver(_TYPEID_LSP8_TOKENOPERATOR, lsp1Data);
     }
 
     /**

--- a/contracts/LSP9Vault/LSP9Vault.sol
+++ b/contracts/LSP9Vault/LSP9Vault.sol
@@ -57,7 +57,7 @@ contract LSP9Vault is LSP9VaultCore {
             _LSP9_SUPPORTED_STANDARDS_VALUE
         );
 
-        newOwner.tryNotifyUniversalReceiver(
+        newOwner.notifyUniversalReceiver(
             _TYPEID_LSP9_OwnershipTransferred_RecipientNotification,
             ""
         );

--- a/contracts/LSP9Vault/LSP9VaultCore.sol
+++ b/contracts/LSP9Vault/LSP9VaultCore.sol
@@ -438,7 +438,7 @@ contract LSP9VaultCore is
         address currentOwner = owner();
         emit OwnershipTransferStarted(currentOwner, newOwner);
 
-        newOwner.tryNotifyUniversalReceiver(
+        newOwner.notifyUniversalReceiver(
             _TYPEID_LSP9_OwnershipTransferStarted,
             ""
         );
@@ -460,12 +460,12 @@ contract LSP9VaultCore is
 
         _acceptOwnership();
 
-        previousOwner.tryNotifyUniversalReceiver(
+        previousOwner.notifyUniversalReceiver(
             _TYPEID_LSP9_OwnershipTransferred_SenderNotification,
             ""
         );
 
-        msg.sender.tryNotifyUniversalReceiver(
+        msg.sender.notifyUniversalReceiver(
             _TYPEID_LSP9_OwnershipTransferred_RecipientNotification,
             ""
         );
@@ -488,7 +488,7 @@ contract LSP9VaultCore is
         LSP14Ownable2Step._renounceOwnership();
 
         if (owner() == address(0)) {
-            previousOwner.tryNotifyUniversalReceiver(
+            previousOwner.notifyUniversalReceiver(
                 _TYPEID_LSP9_OwnershipTransferred_SenderNotification,
                 ""
             );

--- a/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
+++ b/contracts/LSP9Vault/LSP9VaultInitAbstract.sol
@@ -60,7 +60,7 @@ abstract contract LSP9VaultInitAbstract is Initializable, LSP9VaultCore {
             _LSP9_SUPPORTED_STANDARDS_VALUE
         );
 
-        newOwner.tryNotifyUniversalReceiver(
+        newOwner.notifyUniversalReceiver(
             _TYPEID_LSP9_OwnershipTransferred_RecipientNotification,
             ""
         );

--- a/docs/libraries/LSP1UniversalReceiver/LSP1Utils.md
+++ b/docs/libraries/LSP1UniversalReceiver/LSP1Utils.md
@@ -24,10 +24,10 @@ Any method labeled as `internal` serves as utility function within the contract.
 
 Internal functions cannot be called externally, whether from other smart contracts, dApp interfaces, or backend services. Their restricted accessibility ensures that they remain exclusively available within the context of the current contract, promoting controlled and encapsulated usage of these internal utilities.
 
-### tryNotifyUniversalReceiver
+### notifyUniversalReceiver
 
 ```solidity
-function tryNotifyUniversalReceiver(
+function notifyUniversalReceiver(
   address lsp1Implementation,
   bytes32 typeId,
   bytes data


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

The function in LSP1Utils is named `tryNotifiyUniversalReceiver`. The name is a bit weird and misleading, as it might give the assumption that the function does a `try catch`, while it doesn't and simply call the `universalReceiver` function and bubbles up whatever error occurs during the external call.

Change the name of the function to `notifyUniversalReceiver` to make the code more readable.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
