### PR TITLE
refactor: [M-05] notify owner via LSP1 when confirming `renounceOwnership`

### DIFF
--- a/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
+++ b/contracts/LSP0ERC725Account/LSP0ERC725AccountCore.sol
@@ -638,27 +638,35 @@ abstract contract LSP0ERC725AccountCore is
 
         // If the caller is the owner perform renounceOwnership directly
         if (msg.sender == accountOwner) {
-            return LSP14Ownable2Step._renounceOwnership();
-        }
+            address previousOwner = owner();
+            LSP14Ownable2Step._renounceOwnership();
 
-        // If the caller is not the owner, call {lsp20VerifyCall} on the owner
-        // Depending on the returnedStatus, a second call is done after transferring ownership
-        bool verifyAfter = _verifyCall(accountOwner);
+            if (owner() == address(0)) {
+                previousOwner.notifyUniversalReceiver(
+                    _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
+                    ""
+                );
+            }
+        } else {
+            // If the caller is not the owner, call {lsp20VerifyCall} on the owner
+            // Depending on the returnedStatus, a second call is done after transferring ownership
+            bool verifyAfter = _verifyCall(accountOwner);
 
-        address previousOwner = owner();
-        LSP14Ownable2Step._renounceOwnership();
+            address previousOwner = owner();
+            LSP14Ownable2Step._renounceOwnership();
 
-        if (owner() == address(0)) {
-            previousOwner.notifyUniversalReceiver(
-                _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
-                ""
-            );
-        }
+            if (owner() == address(0)) {
+                previousOwner.notifyUniversalReceiver(
+                    _TYPEID_LSP0_OwnershipTransferred_SenderNotification,
+                    ""
+                );
+            }
 
-        // If verifyAfter is true, Call {lsp20VerifyCallResult} on the owner
-        // The transferOwnership function does not return, second parameter of {_verifyCallResult} will be empty
-        if (verifyAfter) {
-            _verifyCallResult(accountOwner, "");
+            // If verifyAfter is true, Call {lsp20VerifyCallResult} on the owner
+            // The transferOwnership function does not return, second parameter of {_verifyCallResult} will be empty
+            if (verifyAfter) {
+                _verifyCallResult(accountOwner, "");
+            }
         }
     }
 

--- a/contracts/Mocks/LSP20Owners/OwnerWIthURD.sol
+++ b/contracts/Mocks/LSP20Owners/OwnerWIthURD.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {
+    ILSP1UniversalReceiver
+} from "../../LSP1UniversalReceiver/ILSP1UniversalReceiver.sol";
+
+import {
+    ILSP14Ownable2Step
+} from "../../LSP14Ownable2Step/ILSP14Ownable2Step.sol";
+
+import {
+    ILSP20CallVerifier
+} from "../../LSP20CallVerification/ILSP20CallVerifier.sol";
+import {
+    _LSP20_VERIFY_CALL_SUCCESS_VALUE_WITH_POST_VERIFICATION,
+    _LSP20_VERIFY_CALL_RESULT_SUCCESS_VALUE
+} from "../../LSP20CallVerification/LSP20Constants.sol";
+
+contract OwnerWithURD is ILSP20CallVerifier, ILSP1UniversalReceiver {
+    address private immutable _OWNED_CONTRACT;
+
+    constructor(address ownedContract) {
+        _OWNED_CONTRACT = ownedContract;
+    }
+
+    function renounceOwnership() public {
+        ILSP14Ownable2Step(_OWNED_CONTRACT).renounceOwnership();
+    }
+
+    function acceptOwnership() public {
+        ILSP14Ownable2Step(_OWNED_CONTRACT).acceptOwnership();
+    }
+
+    function lsp20VerifyCall(
+        address,
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) public pure returns (bytes4 returnedStatus) {
+        return _LSP20_VERIFY_CALL_SUCCESS_VALUE_WITH_POST_VERIFICATION;
+    }
+
+    function lsp20VerifyCallResult(
+        bytes32,
+        bytes memory
+    ) external pure returns (bytes4) {
+        return _LSP20_VERIFY_CALL_RESULT_SUCCESS_VALUE;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(ILSP1UniversalReceiver).interfaceId;
+    }
+
+    function universalReceiver(
+        bytes32 typeId,
+        bytes memory receivedData
+    ) public payable virtual override returns (bytes memory returnedValues) {
+        emit UniversalReceiver(
+            msg.sender,
+            msg.value,
+            typeId,
+            receivedData,
+            returnedValues
+        );
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## ♻️ Refactor

This PR allows notifying the owner when ownership is renounced on owner call.

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
