### PR TITLE
refactor: use gas estimate in deployements scripts

### DIFF
--- a/deploy/001_deploy_universal_profile.ts
+++ b/deploy/001_deploy_universal_profile.ts
@@ -9,10 +9,12 @@ const deployUniversalProfile: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('UniversalProfile', {
     from: owner,
     args: [owner],
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     log: true,
   });
 };

--- a/deploy/002_deploy_key_manager.ts
+++ b/deploy/002_deploy_key_manager.ts
@@ -11,10 +11,12 @@ const deployKeyManager: DeployFunction = async ({
 
   const UniversalProfile = await deployments.get('UniversalProfile');
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP6KeyManager', {
     from: owner,
     args: [UniversalProfile.address],
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     log: true,
   });
 };

--- a/deploy/003_deploy_universal_receiver_delegate.ts
+++ b/deploy/003_deploy_universal_receiver_delegate.ts
@@ -10,9 +10,11 @@ const deployUniversalReceiverDelegateUPDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP1UniversalReceiverDelegateUP', {
     from: deployer,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     log: true,
     deterministicDeployment: SALT,
   });

--- a/deploy/005_deploy_universal_receiver_delegate_vault.ts
+++ b/deploy/005_deploy_universal_receiver_delegate_vault.ts
@@ -10,9 +10,11 @@ const deployUniversalReceiverDelegateVaultDeterministic: DeployFunction = async 
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP1UniversalReceiverDelegateVault', {
     from: deployer,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     log: true,
     deterministicDeployment: SALT,
   });

--- a/deploy/006_deploy_base_universal_profile.ts
+++ b/deploy/006_deploy_base_universal_profile.ts
@@ -10,10 +10,12 @@ const deployBaseUniversalProfileDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('UniversalProfileInit', {
     from: deployer,
     log: true,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     deterministicDeployment: SALT,
   });
 };

--- a/deploy/007_deploy_base_key_manager.ts
+++ b/deploy/007_deploy_base_key_manager.ts
@@ -10,11 +10,13 @@ const deployBaseKeyManagerDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP6KeyManagerInit', {
     from: deployer,
     log: true,
     gasLimit: 5_000_000,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     deterministicDeployment: SALT,
   });
 };

--- a/deploy/008_deploy_lsp7_mintable.ts
+++ b/deploy/008_deploy_lsp7_mintable.ts
@@ -9,10 +9,12 @@ const deployLSP7Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP7Mintable', {
     from: owner,
     args: ['LSP7 Mintable', 'LSP7M', owner, false],
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
+    gasPrice,
     log: true,
   });
 };

--- a/deploy/009_deploy_lsp8_mintable.ts
+++ b/deploy/009_deploy_lsp8_mintable.ts
@@ -9,10 +9,12 @@ const deployLSP8MintableDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP8Mintable', {
     from: deployer,
     args: ['LSP8 Mintable', 'LSP8M', deployer],
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
+    gasPrice,
     log: true,
     deterministicDeployment: true,
   });

--- a/deploy/010_deploy_base_lsp7_mintable.ts
+++ b/deploy/010_deploy_base_lsp7_mintable.ts
@@ -10,9 +10,11 @@ const deployBaseLSP7MintableDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP7MintableInit', {
     from: deployer,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
+    gasPrice,
     log: true,
     deterministicDeployment: SALT,
   });

--- a/deploy/011_deploy_base_lsp8_mintable.ts
+++ b/deploy/011_deploy_base_lsp8_mintable.ts
@@ -10,9 +10,11 @@ const deployBaseLSP8Mintable: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP8MintableInit', {
     from: owner,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei,
+    gasPrice,
     log: true,
     deterministicDeployment: SALT,
   });

--- a/deploy/012_deploy_vault.ts
+++ b/deploy/012_deploy_vault.ts
@@ -9,10 +9,12 @@ const deployVault: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP9Vault', {
     from: owner,
     args: [owner],
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     log: true,
   });
 };

--- a/deploy/013_deploy_base_vault.ts
+++ b/deploy/013_deploy_base_vault.ts
@@ -10,10 +10,12 @@ const deployBaseVaultDeterministic: DeployFunction = async ({
   const { deploy } = deployments;
   const { owner: deployer } = await getNamedAccounts();
 
+  const gasPrice = await ethers.provider.getGasPrice();
+
   await deploy('LSP9VaultInit', {
     from: deployer,
     log: true,
-    gasPrice: ethers.BigNumber.from(20_000_000_000), // in wei
+    gasPrice,
     deterministicDeployment: SALT,
   });
 };


### PR DESCRIPTION
# What does this PR introduce? 

- [x] Use `gasEstimate` instead of hardcoded value in deployement scripts