### PR TITLE
refactor: add `operator` to the transfer notification functions in  LSP7 and LSP8

### DIFF
--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -132,7 +132,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             operatorNotificationData
         );
 
-        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
+        _notifyTokenOperator(operator, lsp1Data);
     }
 
     /**
@@ -158,10 +158,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
                 operatorNotificationData
             );
 
-            operator.notifyUniversalReceiver(
-                _TYPEID_LSP7_TOKENOPERATOR,
-                lsp1Data
-            );
+            _notifyTokenOperator(operator, lsp1Data);
         }
     }
 
@@ -216,7 +213,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             operatorNotificationData
         );
 
-        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
+        _notifyTokenOperator(operator, lsp1Data);
     }
 
     /**
@@ -250,7 +247,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
             operatorNotificationData
         );
 
-        operator.notifyUniversalReceiver(_TYPEID_LSP7_TOKENOPERATOR, lsp1Data);
+        _notifyTokenOperator(operator, lsp1Data);
     }
 
     // --- Transfer functionality
@@ -464,7 +461,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         _afterTokenTransfer(from, address(0), amount, data);
 
         bytes memory lsp1Data = abi.encode(from, address(0), amount, data);
-        from.notifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
+        _notifyTokenSender(from, lsp1Data);
     }
 
     /**
@@ -562,7 +559,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         bytes memory lsp1Data = abi.encode(from, to, amount, data);
 
-        from.notifyUniversalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
+        _notifyTokenSender(from, lsp1Data);
         _notifyTokenReceiver(to, force, lsp1Data);
     }
 
@@ -597,6 +594,53 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 amount,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
+
+    /**
+     * @dev Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+     * This is done by calling its {universalReceiver} function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+     * If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+     
+     * @param operator The address to call the {universalReceiver} function on.                                                                                                                                                                                   
+     * @param lsp1Data the data to be sent to the `operator` address in the `universalReceiver` call.
+     */
+    function _notifyTokenOperator(
+        address operator,
+        bytes memory lsp1Data
+    ) internal virtual {
+        if (
+            ERC165Checker.supportsERC165InterfaceUnchecked(
+                operator,
+                _INTERFACEID_LSP1
+            )
+        ) {
+            ILSP1(operator).universalReceiver(
+                _TYPEID_LSP7_TOKENOPERATOR,
+                lsp1Data
+            );
+        }
+    }
+
+    /**
+     * @dev Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+     * This is done by calling its {universalReceiver} function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+     * If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+     
+     * @param from The address to call the {universalReceiver} function on.                                                                                                                                                                                   
+     * @param lsp1Data the data to be sent to the `from` address in the `universalReceiver` call.
+     */
+    function _notifyTokenSender(
+        address from,
+        bytes memory lsp1Data
+    ) internal virtual {
+        if (
+            ERC165Checker.supportsERC165InterfaceUnchecked(
+                from,
+                _INTERFACEID_LSP1
+            )
+        ) {
+            ILSP1(from).universalReceiver(_TYPEID_LSP7_TOKENSSENDER, lsp1Data);
+        }
+    }
 
     /**
      * @dev Attempt to notify the token receiver `to` about the `amount` tokens being received.

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -53,8 +53,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 {
     using EnumerableSet for EnumerableSet.AddressSet;
     using EnumerableSet for EnumerableSet.Bytes32Set;
-    using ERC165Checker for address;
-    using LSP1Utils for address;
 
     // --- Storage
 
@@ -403,7 +401,13 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         _afterTokenTransfer(address(0), to, tokenId, data);
 
-        bytes memory lsp1Data = abi.encode(address(0), to, tokenId, data);
+        bytes memory lsp1Data = abi.encode(
+            msg.sender,
+            address(0),
+            to,
+            tokenId,
+            data
+        );
         _notifyTokenReceiver(to, force, lsp1Data);
     }
 
@@ -451,6 +455,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         _afterTokenTransfer(tokenOwner, address(0), tokenId, data);
 
         bytes memory lsp1Data = abi.encode(
+            msg.sender,
             tokenOwner,
             address(0),
             tokenId,
@@ -521,7 +526,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         _afterTokenTransfer(from, to, tokenId, data);
 
-        bytes memory lsp1Data = abi.encode(from, to, tokenId, data);
+        bytes memory lsp1Data = abi.encode(msg.sender, from, to, tokenId, data);
 
         _notifyTokenSender(from, lsp1Data);
         _notifyTokenReceiver(to, force, lsp1Data);
@@ -560,7 +565,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) internal virtual {}
 
     /**
-     * @dev Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+     * @dev Attempt to notify the operator `operator` about the `tokenId` being authorized.
      * This is done by calling its {universalReceiver} function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
      * If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
      
@@ -571,49 +576,55 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         address operator,
         bytes memory lsp1Data
     ) internal virtual {
-        if (
-            ERC165Checker.supportsERC165InterfaceUnchecked(
-                operator,
-                _INTERFACEID_LSP1
-            )
-        ) {
-            ILSP1(operator).universalReceiver(
-                _TYPEID_LSP8_TOKENOPERATOR,
-                lsp1Data
-            );
-        }
+        LSP1Utils.notifyUniversalReceiver(
+            operator,
+            _TYPEID_LSP8_TOKENOPERATOR,
+            lsp1Data
+        );
     }
 
     /**
-     * @dev An attempt is made to notify the token sender about the `tokenId` changing owners using
-     * LSP1 interface.
+     * @dev Attempt to notify the token sender `from` about the `tokenId` being transferred.
+     * This is done by calling its {universalReceiver} function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+     * If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+     
+     * @param from The address to call the {universalReceiver} function on.                                                                                                                                                                                   
+     * @param lsp1Data the data to be sent to the `from` address in the `universalReceiver` call.
      */
     function _notifyTokenSender(
         address from,
         bytes memory lsp1Data
     ) internal virtual {
-        if (
-            ERC165Checker.supportsERC165InterfaceUnchecked(
-                from,
-                _INTERFACEID_LSP1
-            )
-        ) {
-            ILSP1(from).universalReceiver(_TYPEID_LSP8_TOKENSSENDER, lsp1Data);
-        }
+        LSP1Utils.notifyUniversalReceiver(
+            from,
+            _TYPEID_LSP8_TOKENSSENDER,
+            lsp1Data
+        );
     }
 
     /**
-     * @dev An attempt is made to notify the token receiver about the `tokenId` changing owners
-     * using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
+     * @dev Attempt to notify the token receiver `to` about the `tokenId` being received.
+     * This is done by calling its {universalReceiver} function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
      *
-     * The receiver may revert when the token being sent is not wanted.
+     * If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+     * - if `force` is set to `true`, nothing will happen and no notification will be sent.
+     * - if `force` is set to `false, the transaction will revert.
+     *
+     * @param to The address to call the {universalReceiver} function on.
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
+     * @param lsp1Data The data to be sent to the `to` address in the `universalReceiver(...)` call.
      */
     function _notifyTokenReceiver(
         address to,
         bool force,
         bytes memory lsp1Data
     ) internal virtual {
-        if (to.supportsERC165InterfaceUnchecked(_INTERFACEID_LSP1)) {
+        if (
+            ERC165Checker.supportsERC165InterfaceUnchecked(
+                to,
+                _INTERFACEID_LSP1
+            )
+        ) {
             ILSP1(to).universalReceiver(_TYPEID_LSP8_TOKENSRECIPIENT, lsp1Data);
         } else if (!force) {
             if (to.code.length != 0) {

--- a/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
+++ b/contracts/Mocks/UniversalReceivers/UniversalReceiverDelegateTokenReentrant.sol
@@ -52,10 +52,10 @@ contract UniversalReceiverDelegateTokenReentrant is
             typeId == _TYPEID_LSP8_TOKENSRECIPIENT
         ) {
             // if the optional data field when minting/transferring is existing, re-execute the data on token contract
-            if (data.length > 160) {
-                (, , , bytes memory tokenPayload) = abi.decode(
+            if (data.length > 192) {
+                (, , , , bytes memory tokenPayload) = abi.decode(
                     data,
-                    (address, address, uint256, bytes)
+                    (address, address, address, uint256, bytes)
                 );
 
                 bytes memory executePayload = abi.encodeWithSelector(

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -995,6 +995,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -1020,6 +1020,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -994,6 +994,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.md
@@ -1083,6 +1083,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -1117,6 +1117,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -1057,6 +1057,47 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `amount` tokens being authorized with.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+Attempt to notify the token sender `from` about the `amount` of tokens being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP7_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -1003,7 +1003,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1022,8 +1022,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1037,9 +1045,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -994,6 +994,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1029,7 +1029,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1048,8 +1048,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1063,9 +1071,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1020,6 +1020,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -1003,7 +1003,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1022,8 +1022,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1037,9 +1045,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -994,6 +994,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1265,6 +1265,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity
@@ -1422,7 +1455,7 @@ Emitted when the allowance of a `spender` for an `owner` is set by a call to [`a
 event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 ```
 
-Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to `approved`.
+Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1274,7 +1274,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1293,8 +1293,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1308,9 +1316,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.md
@@ -1475,7 +1475,7 @@ Emitted when the allowance of a `spender` for an `owner` is set by a call to [`a
 event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 ```
 
-Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to `approved`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1022,6 +1022,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1031,7 +1031,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1050,8 +1050,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1065,9 +1073,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1307,6 +1307,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity
@@ -1464,7 +1497,7 @@ Emitted when the allowance of a `spender` for an `owner` is set by a call to [`a
 event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 ```
 
-Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to `approved`.
+Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1517,7 +1517,7 @@ Emitted when the allowance of a `spender` for an `owner` is set by a call to [`a
 event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 ```
 
-Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to `approved`.
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -1316,7 +1316,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1335,8 +1335,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1350,9 +1358,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1058,6 +1058,39 @@ Allows to run custom logic after updating balances, but **before notifiying send
 
 <br/>
 
+### \_notifyTokenOperator
+
+```solidity
+function _notifyTokenOperator(
+  address operator,
+  bytes lsp1Data
+) internal nonpayable;
+```
+
+Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
+If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                    |
+| ---------- | :-------: | ------------------------------------------------------------------------------ |
+| `operator` | `address` | The address to call the {universalReceiver} function on.                       |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `operator` address in the `universalReceiver` call. |
+
+<br/>
+
+### \_notifyTokenSender
+
+```solidity
+function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
+```
+
+An attempt is made to notify the token sender about the `tokenId` changing owners using
+LSP1 interface.
+
+<br/>
+
 ### \_notifyTokenReceiver
 
 ```solidity

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1067,7 +1067,7 @@ function _notifyTokenOperator(
 ) internal nonpayable;
 ```
 
-Attempt to notify the operator `operator` about the `tokenId` tokens being authorized.
+Attempt to notify the operator `operator` about the `tokenId` being authorized.
 This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENOPERATOR` as typeId, if `operator` is a contract that supports the LSP1 interface.
 If `operator` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
 
@@ -1086,8 +1086,16 @@ If `operator` is an EOA or a contract that does not support the LSP1 interface, 
 function _notifyTokenSender(address from, bytes lsp1Data) internal nonpayable;
 ```
 
-An attempt is made to notify the token sender about the `tokenId` changing owners using
-LSP1 interface.
+Attempt to notify the token sender `from` about the `tokenId` being transferred.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSSENDER` as typeId, if `from` is a contract that supports the LSP1 interface.
+If `from` is an EOA or a contract that does not support the LSP1 interface, nothing will happen and no notification will be sent.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                |
+| ---------- | :-------: | -------------------------------------------------------------------------- |
+| `from`     | `address` | The address to call the {universalReceiver} function on.                   |
+| `lsp1Data` |  `bytes`  | the data to be sent to the `from` address in the `universalReceiver` call. |
 
 <br/>
 
@@ -1101,9 +1109,21 @@ function _notifyTokenReceiver(
 ) internal nonpayable;
 ```
 
-An attempt is made to notify the token receiver about the `tokenId` changing owners
-using LSP1 interface. When force is FALSE the token receiver MUST support LSP1.
-The receiver may revert when the token being sent is not wanted.
+Attempt to notify the token receiver `to` about the `tokenId` being received.
+This is done by calling its [`universalReceiver`](#universalreceiver) function with the `_TYPEID_LSP8_TOKENSRECIPIENT` as typeId, if `to` is a contract that supports the LSP1 interface.
+If `to` is is an EOA or a contract that does not support the LSP1 interface, the behaviour will depend on the `force` boolean flag.
+
+- if `force` is set to `true`, nothing will happen and no notification will be sent.
+
+- if `force` is set to `false, the transaction will revert.
+
+#### Parameters
+
+| Name       |   Type    | Description                                                                                         |
+| ---------- | :-------: | --------------------------------------------------------------------------------------------------- |
+| `to`       | `address` | The address to call the {universalReceiver} function on.                                            |
+| `force`    |  `bool`   | A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not. |
+| `lsp1Data` |  `bytes`  | The data to be sent to the `to` address in the `universalReceiver(...)` call.                       |
 
 <br/>
 

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -973,8 +973,14 @@ export const shouldBehaveLikeLSP1Delegate = (
         // the call to the universalReceiver(...) in LSP7 sends the transfer details as `data` argument
         // all the params are packed/concatenated together.
         const expectedReceivedData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
-          [txParams.from, txParams.to, txParams.amount, txParams.data],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
+          [
+            context.universalProfile1.address,
+            txParams.from,
+            txParams.to,
+            txParams.amount,
+            txParams.data,
+          ],
         );
 
         // TODO: debug the 4th argument for the receivedData: why is it not empty?
@@ -1155,8 +1161,14 @@ export const shouldBehaveLikeLSP1Delegate = (
             0,
             LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification,
             abiCoder.encode(
-              ['address', 'address', 'uint256', 'bytes'],
-              [ethers.constants.AddressZero, context.universalProfile1.address, 10_000, '0x'],
+              ['address', 'address', 'address', 'uint256', 'bytes'],
+              [
+                context.accounts.random.address,
+                ethers.constants.AddressZero,
+                context.universalProfile1.address,
+                10_000,
+                '0x',
+              ],
             ),
             abiCoder.encode(
               ['bytes', 'bytes'],
@@ -1290,8 +1302,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.universalProfile1.address,
             context.universalProfile1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,
@@ -1373,8 +1386,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.universalProfile1.address,
             context.universalProfile1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,
@@ -1460,8 +1474,9 @@ export const shouldBehaveLikeLSP1Delegate = (
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.universalProfile1.address,
             context.universalProfile1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,

--- a/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
+++ b/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateVault.behaviour.ts
@@ -941,8 +941,9 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.lsp9Vault1.address,
             context.lsp9Vault1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,
@@ -1031,8 +1032,9 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.lsp9Vault1.address,
             context.lsp9Vault1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,
@@ -1121,8 +1123,9 @@ export const shouldBehaveLikeLSP1Delegate = (buildContext: () => Promise<LSP1Tes
         const tokensSentBytes32Value = ethers.utils.hexZeroPad(balance.toHexString(), 32);
 
         const tokenTransferData = abiCoder.encode(
-          ['address', 'address', 'uint256', 'bytes'],
+          ['address', 'address', 'address', 'uint256', 'bytes'],
           [
+            context.lsp9Vault1.address,
             context.lsp9Vault1.address,
             context.accounts.owner1.address,
             tokensSentBytes32Value,

--- a/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -891,8 +891,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = abiCoder.encode(
-                    ['address', 'address', 'uint256', 'bytes'],
-                    [txParams.from, txParams.to, txParams.amount, txParams.data],
+                    ['address', 'address', 'address', 'uint256', 'bytes'],
+                    [operator.address, txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
 
                   await expect(tx)
@@ -964,8 +964,8 @@ export const shouldBehaveLikeLSP7 = (buildContext: () => Promise<LSP7TestContext
 
                   const typeId = LSP1_TYPE_IDS.LSP7Tokens_RecipientNotification;
                   const packedData = abiCoder.encode(
-                    ['address', 'address', 'uint256', 'bytes'],
-                    [txParams.from, txParams.to, txParams.amount, txParams.data],
+                    ['address', 'address', 'address', 'uint256', 'bytes'],
+                    [operator.address, txParams.from, txParams.to, txParams.amount, txParams.data],
                   );
 
                   await expect(tx)

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -775,8 +775,8 @@ export const shouldBehaveLikeLSP8 = (
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                 const packedData = abiCoder.encode(
-                  ['address', 'address', 'bytes32', 'bytes'],
-                  [txParams.from, txParams.to, txParams.tokenId, txParams.data],
+                  ['address', 'address', 'address', 'bytes32', 'bytes'],
+                  [operator.address, txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
 
                 await expect(tx)
@@ -874,8 +874,8 @@ export const shouldBehaveLikeLSP8 = (
 
                 const typeId = LSP1_TYPE_IDS.LSP8Tokens_RecipientNotification;
                 const packedData = abiCoder.encode(
-                  ['address', 'address', 'bytes32', 'bytes'],
-                  [txParams.from, txParams.to, txParams.tokenId, txParams.data],
+                  ['address', 'address', 'address', 'bytes32', 'bytes'],
+                  [operator.address, txParams.from, txParams.to, txParams.tokenId, txParams.data],
                 );
 
                 await expect(tx)


### PR DESCRIPTION
# What does this PR introduce?
## ♻️ Refactor

- add internal notification functions in LSP7 and LSP8 to be able to override them easily 
- Add `operator` as part of the `lsp1Data` in a case of notifying using LSP1 for LSP7 and LSP8

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
