### PR TITLE
docs: write manual Natspec docs for `4337Extension.sol` to fix Docusaurus build error

### DIFF
--- a/contracts/LSP17Extensions/Extension4337.sol
+++ b/contracts/LSP17Extensions/Extension4337.sol
@@ -41,7 +41,32 @@ contract Extension4337 is LSP17Extension, IAccount {
     }
 
     /**
-     * @inheritdoc IAccount
+     * @dev Validate user's signature and nonce.
+     * The entryPoint will make the call to the recipient only if this validation call returns successfully.
+     * Signature failure should be reported by returning `SIG_VALIDATION_FAILED` (`1`).
+     * This allows making a "simulation call" without a valid signature.
+     * Other failures (_e.g. nonce mismatch, or invalid signature format_) should still revert to signal failure.
+     *
+     * The third parameter (not mentioned but `missingAccountFunds` from the `IAccount` interface)
+     * describes the missing funds on the account's deposit in the entrypoint.
+     * This is the minimum amount to transfer to the sender(entryPoint) to be able to make the call.
+     * The excess is left as a deposit in the entrypoint, for future calls. Can be withdrawn anytime using "entryPoint.withdrawTo()"
+     * In case there is a paymaster in the request (or the current deposit is high enough), this value will be zero.
+     *
+     * @return validationData packaged ValidationData structure. use `_packValidationData` and `_unpackValidationData` to encode and decode
+     * - `<20-byte>` sigAuthorizer - 0 for valid signature, 1 to mark signature failure, otherwise, an address of an "authorizer" contract.
+     * - `<6-byte>` validUntil - last timestamp this operation is valid. 0 for "indefinite"
+     * - `<6-byte>` validAfter - first timestamp this operation is valid
+     * If an account doesn't use time-range, it is enough to return SIG_VALIDATION_FAILED value (1) for signature failure.
+     * Note that the validation code cannot use block.timestamp (or block.number) directly.
+     *
+     * @custom:info In addition to the logic of the `IAccount` interface from 4337, the permissions of the address that signed the user operation
+     * are checked to ensure that it has the permission `_4337_PERMISSION`.
+     *
+     * @custom:requirements
+     * - caller MUST be the **entrypoint contract**.
+     * - the signature and nonce must be valid.
+     *
      */
     function validateUserOp(
         UserOperation calldata userOp,

--- a/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
+++ b/contracts/LSP6KeyManager/LSP6KeyManagerCore.sol
@@ -236,7 +236,7 @@ abstract contract LSP6KeyManagerCore is
      * @custom:events {PermissionsVerified} event when the permissions related to `payload` have been verified successfully.
      *
      * @custom:hint If you are looking to learn how to sign and execute relay transactions via the Key Manager,
-     * see our Javascript step by step guide [_"Execute Relay Transactions"_](../../../guides/key-manager/execute-relay-transactions.md).
+     * see our Javascript step by step guide [_"Execute Relay Transactions"_](../../../learn/expert-guides/key-manager/execute-relay-transactions.md).
      * See the LSP6 Standard page for more details on how to
      * [generate a valid signature for Execute Relay Call](../../../standards/universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
      */

--- a/docs/contracts/LSP17Extensions/Extension4337.md
+++ b/docs/contracts/LSP17Extensions/Extension4337.md
@@ -132,6 +132,12 @@ See [`IERC165-supportsInterface`](#ierc165-supportsinterface).
 
 :::
 
+:::info
+
+In addition to the logic of the `IAccount` interface from 4337, the permissions of the address that signed the user operation are checked to ensure that it has the permission `_4337_PERMISSION`.
+
+:::
+
 ```solidity
 function validateUserOp(
   UserOperation userOp,
@@ -140,23 +146,30 @@ function validateUserOp(
 ) external nonpayable returns (uint256);
 ```
 
-_Validate user's signature and nonce the entryPoint will make the call to the recipient only if this validation call returns successfully. signature failure should be reported by returning SIG_VALIDATION_FAILED (1). This allows making a "simulation call" without a valid signature Other failures (e.g. nonce mismatch, or invalid signature format) should still revert to signal failure._
+Validate user's signature and nonce. The entryPoint will make the call to the recipient only if this validation call returns successfully. Signature failure should be reported by returning `SIG_VALIDATION_FAILED` (`1`). This allows making a "simulation call" without a valid signature. Other failures (_e.g. nonce mismatch, or invalid signature format_) should still revert to signal failure. The third parameter (not mentioned but `missingAccountFunds` from the `IAccount` interface) describes the missing funds on the account's deposit in the entrypoint. This is the minimum amount to transfer to the sender(entryPoint) to be able to make the call. The excess is left as a deposit in the entrypoint, for future calls. Can be withdrawn anytime using "entryPoint.withdrawTo()" In case there is a paymaster in the request (or the current deposit is high enough), this value will be zero.
 
-Must validate caller is the entryPoint. Must validate the signature and nonce
+<blockquote>
+
+**Requirements:**
+
+- caller MUST be the **entrypoint contract**.
+- the signature and nonce must be valid.
+
+</blockquote>
 
 #### Parameters
 
-| Name         |      Type       | Description                                                              |
-| ------------ | :-------------: | ------------------------------------------------------------------------ |
-| `userOp`     | `UserOperation` | the operation that is about to be executed.                              |
-| `userOpHash` |    `bytes32`    | hash of the user's request data. can be used as the basis for signature. |
-| `_2`         |    `uint256`    | -                                                                        |
+| Name         |      Type       | Description |
+| ------------ | :-------------: | ----------- |
+| `userOp`     | `UserOperation` | -           |
+| `userOpHash` |    `bytes32`    | -           |
+| `_2`         |    `uint256`    | -           |
 
 #### Returns
 
-| Name |   Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| ---- | :-------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `0`  | `uint256` | packaged ValidationData structure. use `_packValidationData` and `_unpackValidationData` to encode and decode <20-byte> sigAuthorizer - 0 for valid signature, 1 to mark signature failure, otherwise, an address of an "authorizer" contract. <6-byte> validUntil - last timestamp this operation is valid. 0 for "indefinite" <6-byte> validAfter - first timestamp this operation is valid If an account doesn't use time-range, it is enough to return SIG_VALIDATION_FAILED value (1) for signature failure. Note that the validation code cannot use block.timestamp (or block.number) directly. |
+| Name |   Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---- | :-------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | `uint256` | validationData packaged ValidationData structure. use `_packValidationData` and `_unpackValidationData` to encode and decode - `<20-byte>` sigAuthorizer - 0 for valid signature, 1 to mark signature failure, otherwise, an address of an "authorizer" contract. - `<6-byte>` validUntil - last timestamp this operation is valid. 0 for "indefinite" - `<6-byte>` validAfter - first timestamp this operation is valid If an account doesn't use time-range, it is enough to return SIG_VALIDATION_FAILED value (1) for signature failure. Note that the validation code cannot use block.timestamp (or block.number) directly. |
 
 <br/>
 

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -176,7 +176,7 @@ Same as [`execute`](#execute) but execute a batch of payloads (abi-encoded funct
 
 :::tip Hint
 
-If you are looking to learn how to sign and execute relay transactions via the Key Manager, see our Javascript step by step guide [_"Execute Relay Transactions"_](../../../guides/key-manager/execute-relay-transactions.md). See the LSP6 Standard page for more details on how to [generate a valid signature for Execute Relay Call](../../../standards/universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
+If you are looking to learn how to sign and execute relay transactions via the Key Manager, see our Javascript step by step guide [_"Execute Relay Transactions"_](../../../learn/expert-guides/key-manager/execute-relay-transactions.md). See the LSP6 Standard page for more details on how to [generate a valid signature for Execute Relay Call](../../../standards/universal-profile/lsp6-key-manager.md#how-to-sign-relay-transactions).
 
 :::
 


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

Docs pages generated by the latest Docusaurus 3 version cannot parse Markdown that contains characters like `<` or `{`.
This was the case in [docs.lukso.tech](https://docs.lukso.tech).

This problem occurs for the docs of the `4337Extension.sol` contract, where the Natspecs from the `validateUserOps` function are fetched from `IAccount.sol`. Fixes this by:
- re-writing the same Natspec comments in this contract
- encapsulate the special characters `<` between back ticks to fix the docusaurus build error.
- add extra note about permissions for this extension.

![image](https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/41cda9e5-3f9c-4d63-9b02-135cb232da12)

Also fix a small broken link in LSP6 Natspecs.
