### PR TITLE
feat: extract verification metadata

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -124,7 +124,7 @@ export type MetadataVerification = {
   method: string;
   data: string;
   source?: string;
-}
+};
 
 export type ImageMetadata = {
   width: number;

--- a/constants.ts
+++ b/constants.ts
@@ -120,14 +120,16 @@ export type LSP4DigitalAssetMetadata = {
   icon: ImageMetadata[];
 };
 
+export type MetadataVerification = {
+  method: string;
+  data: string;
+  source?: string;
+}
+
 export type ImageMetadata = {
   width: number;
   height: number;
-  verification?: {
-    method: string;
-    data: string;
-    source?: string;
-  };
+  verification?: MetadataVerification;
   url: string;
 };
 
@@ -137,11 +139,7 @@ export type LinkMetadata = {
 };
 
 export type AssetMetadata = {
-  verification?: {
-    method: string;
-    data: string;
-    source?: string;
-  };
+  verification?: MetadataVerification;
   url: string;
   fileType: string;
 };

--- a/constants.ts
+++ b/constants.ts
@@ -120,7 +120,7 @@ export type LSP4DigitalAssetMetadata = {
   icon: ImageMetadata[];
 };
 
-export type MetadataVerification = {
+export type Verification = {
   method: string;
   data: string;
   source?: string;
@@ -129,7 +129,7 @@ export type MetadataVerification = {
 export type ImageMetadata = {
   width: number;
   height: number;
-  verification?: MetadataVerification;
+  verification?: Verification;
   url: string;
 };
 
@@ -139,7 +139,7 @@ export type LinkMetadata = {
 };
 
 export type AssetMetadata = {
-  verification?: MetadataVerification;
+  verification?: Verification;
   url: string;
   fileType: string;
 };


### PR DESCRIPTION
Move `verification` object to own type so it allow to import it by 3rd parties.