### PR TITLE
feat: LSP8Reference: An LSP8 extension that verifies if the LSP8 Collection Contract Address

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -87,3 +87,10 @@ error LSP8TokenContractCannotHoldValue();
  * It can be set only once inside the constructor/initializer when the identifiable digital asset contract is being deployed.
  */
 error LSP8TokenIdTypeNotEditable();
+
+/**
+ * @dev Reverts when trying to mint an Token with a `tokenId` - Address and its not properly refrenced back to the
+ * actual LP8 collection contract address.
+ */
+error InvalidReferenceAddress(address referenceAddress);
+

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Reference.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Reference.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../LSP8IdentifiableDigitalAsset.sol";
+
+import {
+    IERC725Y
+} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
+// contstants
+import {
+    _LSP8_REFERENCE_CONTRACT,
+    _LSP8_TOKENID_TYPE_KEY,
+    _LSP8_TOKENID_TYPE_ADDRESS
+} from "../LSP8Constants.sol";
+
+// errors
+import {InvalidReferenceAddress} from "../LSP8Errors.sol";
+
+/**
+ * @dev LSP8 token extension that verify if the referenced contract address
+ * from the tokenId - Address is the same as the contract address of the LSP8 collection.
+ */
+abstract contract LSP8Reference is LSP8IdentifiableDigitalAsset {
+    /**
+     * @dev modifier to be included in the mint function.
+     *
+     * @notice verify if the collection contracts address is the same as the referenced contract address
+     * when tokenId is _LSP8_TOKENID_TYPE_ADDRESS.
+     *
+     * @param tokenId The tokenId - Address of the token.
+     */
+    modifier onlyReferencedContract(bytes32 tokenId) {
+        bytes memory tokenIdType = getData(_LSP8_TOKENID_TYPE_KEY);
+        if (
+            keccak256(abi.encodePacked(tokenIdType)) ==
+            keccak256(abi.encodePacked(bytes32(_LSP8_TOKENID_TYPE_ADDRESS)))
+        ) {
+            address _tokenIdAddress = address(bytes20(tokenId));
+            if (!verifyReference(_tokenIdAddress))
+                revert InvalidReferenceAddress(_tokenIdAddress);
+        }
+        _;
+    }
+
+    /**
+     * @dev Verifies if the referenced contract address from the tokenId - Address
+     * is the same as the contract address of the LSP8 collection.
+     *
+     * @param tokenIdAddress The tokenId - Address of the token.
+     *
+     * @return bool True if the referenced contract address is the same as the
+     * contract address of the LSP8 collection.
+     */
+    function verifyReference(
+        address tokenIdAddress
+    ) public view returns (bool) {
+        /// @notice using IERC725Y since its not predictable if the tokenId contract is LSP8 or other LSP.
+        IERC725Y tokenIdContract = IERC725Y(tokenIdAddress);
+        bytes memory referencedContract = tokenIdContract.getData(
+            _LSP8_REFERENCE_CONTRACT
+        );
+        return
+            keccak256(abi.encodePacked(bytes20(referencedContract))) ==
+            keccak256(abi.encodePacked(bytes20(address(this))));
+    }
+}

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8ReferenceInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8ReferenceInitAbstract.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.4;
+
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+
+import {
+    IERC725Y
+} from "@erc725/smart-contracts/contracts/interfaces/IERC725Y.sol";
+
+// contstants
+import {
+    _LSP8_REFERENCE_CONTRACT,
+    _LSP8_TOKENID_TYPE_KEY,
+    _LSP8_TOKENID_TYPE_ADDRESS
+} from "../LSP8Constants.sol";
+
+// errors
+import {InvalidReferenceAddress} from "../LSP8Errors.sol";
+
+/**
+ * @dev LSP8 token extension (proxy version) that verify if the referenced contract address
+ * from the tokenId - Address is the same as the contract address of the LSP8 collection.
+ */
+abstract contract LSP8ReferenceInitAbstract is
+    LSP8IdentifiableDigitalAssetInitAbstract
+{
+    /**
+     * @dev modifier to be included in the mint function.
+     *
+     * @notice verify if the collection contracts address is the same as the referenced contract address
+     * when tokenId is _LSP8_TOKENID_TYPE_ADDRESS.
+     *
+     * @param tokenId The tokenId - Address of the token.
+     */
+    modifier onlyReferencedContract(bytes32 tokenId) {
+        bytes memory tokenIdType = getData(_LSP8_TOKENID_TYPE_KEY);
+        if (
+            keccak256(abi.encodePacked(tokenIdType)) ==
+            keccak256(abi.encodePacked(bytes32(_LSP8_TOKENID_TYPE_ADDRESS)))
+        ) {
+            address _tokenIdAddress = address(bytes20(tokenId));
+            if (!verifyReference(_tokenIdAddress))
+                revert InvalidReferenceAddress(_tokenIdAddress);
+        }
+        _;
+    }
+
+    /**
+     * @dev Verifies if the referenced contract address from the tokenId - Address
+     * is the same as the contract address of the LSP8 collection.
+     *
+     * @param tokenIdAddress The tokenId - Address of the token.
+     *
+     * @return bool True if the referenced contract address is the same as the
+     * contract address of the LSP8 collection.
+     */
+    function verifyReference(
+        address tokenIdAddress
+    ) public view returns (bool) {
+        /// @notice using IERC725Y since its not predictable if the tokenId contract is LSP8 or other LSP.
+        IERC725Y tokenIdContract = IERC725Y(tokenIdAddress);
+        bytes memory referencedContract = tokenIdContract.getData(
+            _LSP8_REFERENCE_CONTRACT
+        );
+
+        return
+            keccak256(abi.encodePacked(bytes20(referencedContract))) ==
+            keccak256(abi.encodePacked(bytes20(address(this))));
+    }
+}

--- a/contracts/Mocks/Tokens/LSP8ReferenceContractCollectionInitTestet.sol
+++ b/contracts/Mocks/Tokens/LSP8ReferenceContractCollectionInitTestet.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.4;
+
+// modules
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    LSP8ReferenceInitAbstract
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8ReferenceInitAbstract.sol";
+
+contract LSP8ReferenceContractCollectionInitTester is
+    LSP8ReferenceInitAbstract
+{
+    function initialize(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_,
+        uint256 tokenIdType_
+    ) public virtual initializer {
+        LSP8IdentifiableDigitalAssetInitAbstract._initialize(
+            name_,
+            symbol_,
+            newOwner_,
+            tokenIdType_
+        );
+    }
+}

--- a/contracts/Mocks/Tokens/LSP8ReferenceContractCollectionTester.sol
+++ b/contracts/Mocks/Tokens/LSP8ReferenceContractCollectionTester.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.4;
+
+import {
+    LSP8Reference
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8Reference.sol";
+
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+
+contract LSP8ReferenceContractCollectionTester is
+    LSP8IdentifiableDigitalAsset,
+    LSP8Reference
+{
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_,
+        uint256 tokenIdType_
+    ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_, tokenIdType_) {}
+
+    function mintAndCheckFromModifier(
+        address to,
+        bytes32 tokenId
+    ) public onlyReferencedContract(tokenId) {
+        _mint(to, tokenId, true, "Minting and tokenId - Address");
+    }
+
+    function mintAndCheckInternally(address to, bytes32 tokenId) public {
+        require(
+            verifyReference(address(uint160(uint256(tokenId)))),
+            "Invalid reference address"
+        );
+        _mint(to, tokenId, true, "Minting and tokenId - Address");
+    }
+}

--- a/contracts/Mocks/Tokens/LSP8ReferenceTokenIdContractTester.sol
+++ b/contracts/Mocks/Tokens/LSP8ReferenceTokenIdContractTester.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.4;
+
+import {
+    LSP8Reference
+} from "../../LSP8IdentifiableDigitalAsset/extensions/LSP8Reference.sol";
+
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol";
+
+import {
+    _LSP8_REFERENCE_CONTRACT
+} from "../../LSP8IdentifiableDigitalAsset/LSP8Constants.sol";
+
+contract LSP8ReferenceTokenIdContractTester is
+    LSP8IdentifiableDigitalAsset,
+    LSP8Reference
+{
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        address newOwner_,
+        uint256 tokenIdType_
+    ) LSP8IdentifiableDigitalAsset(name_, symbol_, newOwner_, tokenIdType_) {}
+
+    function setReferenceCollectionContract(address _referenceContract) public {
+        super._setData(
+            _LSP8_REFERENCE_CONTRACT,
+            abi.encodePacked(
+                _referenceContract,
+                bytes32(bytes20(address(this)))
+            )
+        );
+    }
+}

--- a/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
+++ b/docs/contracts/LSP6KeyManager/LSP6KeyManager.md
@@ -36,7 +36,7 @@ When marked as 'public', a method can be called both externally and internally, 
 constructor(address target_);
 ```
 
-_Deploying a LSP6KeyManager linked to the contract at address `target_`._
+_Deploying a LSP6KeyManager linked to the contract at address `target_`.\_
 
 Deploy a Key Manager and set the `target_` address in the contract storage, making this Key Manager linked to this `target_` contract.
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -34,7 +34,7 @@ When marked as 'public', a method can be called both externally and internally, 
 constructor(string name_, string symbol_, address newOwner_);
 ```
 
-_Deploying a `LSP7CompatibleERC20Mintable` token contract with: token name = `name_`, token symbol = `symbol_`, and address `newOwner_` as the token contract owner._
+_Deploying a `LSP7CompatibleERC20Mintable` token contract with: token name = `name_`, token symbol = `symbol*`, and address `newOwner*` as the token contract owner.\_
 
 #### Parameters
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -39,7 +39,7 @@ constructor(
 );
 ```
 
-_Deploying a `LSP7Mintable` token contract with: token name = `name_`, token symbol = `symbol_`, and address `newOwner_` as the token contract owner._
+_Deploying a `LSP7Mintable` token contract with: token name = `name_`, token symbol = `symbol*`, and address `newOwner*` as the token contract owner.\_
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -39,7 +39,7 @@ constructor(
 );
 ```
 
-_Deploying a `LSP8CompatibleERC721Mintable` token contract with: token name = `name_`, token symbol = `symbol_`, and address `newOwner_` as the token contract owner._
+_Deploying a `LSP8CompatibleERC721Mintable` token contract with: token name = `name_`, token symbol = `symbol*`, and address `newOwner*` as the token contract owner.\_
 
 #### Parameters
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -39,7 +39,7 @@ constructor(
 );
 ```
 
-_Deploying a `LSP8Mintable` token contract with: token name = `name_`, token symbol = `symbol_`, and address `newOwner_` as the token contract owner._
+_Deploying a `LSP8Mintable` token contract with: token name = `name_`, token symbol = `symbol*`, and address `newOwner*` as the token contract owner.\_
 
 #### Parameters
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8Reference.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8Reference.behaviour.ts
@@ -1,0 +1,78 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import {
+  LSP8ReferenceContractCollectionTester,
+  LSP8ReferenceTokenIdContractTester,
+} from '../../types';
+
+export type LPS8ReferenceTestAccounts = {
+  owner: SignerWithAddress;
+  tokenReceiver: SignerWithAddress;
+};
+
+export const getNamedAccounts = async (): Promise<LPS8ReferenceTestAccounts> => {
+  const [owner, tokenReceiver] = await ethers.getSigners();
+  return { owner, tokenReceiver };
+};
+
+export type LSP8ReferenceDeployParams = {
+  name: string;
+  symbol: string;
+  newOwner: string;
+  tokenIdType: number;
+};
+
+export type LSP8ReferenceTestContext = {
+  accounts: LPS8ReferenceTestAccounts;
+  lsp8Collection: LSP8ReferenceContractCollectionTester;
+  lsp8TokenId: LSP8ReferenceTokenIdContractTester;
+  deployParams: LSP8ReferenceDeployParams;
+};
+
+export const shouldBehaveLikeLSP8Reference = (
+  buildContext: () => Promise<LSP8ReferenceTestContext>,
+) => {
+  let context: LSP8ReferenceTestContext;
+
+  beforeEach(async () => {
+    context = await buildContext();
+  });
+
+  describe('when minting a tokenId - Address', () => {
+    it('Should mint a tokenId as lsp8tokenId Contract address using the modifier', async () => {
+      await context.lsp8TokenId.setReferenceCollectionContract(context.lsp8Collection.address);
+      const tokenId = context.lsp8TokenId.address + '00'.repeat(12);
+      const tx = context.lsp8Collection.mintAndCheckFromModifier(
+        context.accounts.tokenReceiver.address,
+        tokenId,
+      );
+      await expect(tx).to.be.not.revertedWithCustomError(
+        context.lsp8Collection,
+        'InvalidReferenceAddress',
+      );
+    });
+    it('Should mint a tokenId as lsp8tokenId Contract address using the internal validator', async () => {
+      await context.lsp8TokenId.setReferenceCollectionContract(context.lsp8Collection.address);
+      const tokenId = context.lsp8TokenId.address + '00'.repeat(12);
+      const tx = context.lsp8Collection.mintAndCheckInternally(
+        context.accounts.tokenReceiver.address,
+        tokenId,
+      );
+      await expect(tx).to.be.not.revertedWith('Invalid reference address');
+    });
+    it('Should not mint a tokenId as lsp8tokenId Contract address with another reference address', async () => {
+      const randomAddress = ethers.Wallet.createRandom().address;
+      await context.lsp8TokenId.setReferenceCollectionContract(randomAddress);
+      const tokenId = context.lsp8TokenId.address + '00'.repeat(12);
+      await expect(
+        context.lsp8Collection.mintAndCheckFromModifier(
+          context.accounts.tokenReceiver.address,
+          tokenId,
+        ),
+      )
+        .to.be.revertedWithCustomError(context.lsp8Collection, 'InvalidReferenceAddress')
+        .withArgs(context.lsp8TokenId.address);
+    });
+  });
+};

--- a/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8ReferenceInit.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8ReferenceInit.test.ts
@@ -1,0 +1,81 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+import {
+  LSP8ReferenceContractCollectionInitTester,
+  LSP8ReferenceContractCollectionInitTester__factory,
+} from '../../../types';
+
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
+
+import { deployProxy } from '../../utils/fixtures';
+import { LSP8_TOKEN_ID_TYPES } from '../../../constants';
+
+type LSP8ReferenceContractCollectionInitTesterContext = {
+  accounts: SignerWithAddress[];
+  lsp8Reference: LSP8ReferenceContractCollectionInitTester;
+  deployParams: {
+    name: string;
+    symbol: string;
+    newOwner: string;
+    tokenIdType: number;
+  };
+};
+
+describe('LSP8ReferenceInit with proxy', () => {
+  const buildTestContext = async () => {
+    const accounts = await ethers.getSigners();
+    const deployParams = {
+      name: 'LSP8 Reference - deployed with constructor',
+      symbol: 'BRN',
+      newOwner: accounts[0].address,
+      tokenIdType: LSP8_TOKEN_ID_TYPES.NUMBER,
+    };
+
+    const lsp8ReferenceImplementation =
+      await new LSP8ReferenceContractCollectionInitTester__factory(accounts[0]).deploy();
+    const lsp8ReferenceProxy = await deployProxy(lsp8ReferenceImplementation.address, accounts[0]);
+    const lsp8Reference = lsp8ReferenceImplementation.attach(lsp8ReferenceProxy);
+
+    return { accounts, lsp8Reference, deployParams };
+  };
+
+  const initializeProxy = async (context: LSP8ReferenceContractCollectionInitTesterContext) => {
+    return context.lsp8Reference.initialize(
+      context.deployParams.name,
+      context.deployParams.symbol,
+      context.deployParams.newOwner,
+      context.deployParams.tokenIdType,
+    );
+  };
+
+  describe('when deploying the contract as proxy', () => {
+    let context: LSP8ReferenceContractCollectionInitTesterContext;
+
+    before(async () => {
+      context = await buildTestContext();
+    });
+
+    describe('when initializing the contract', () => {
+      shouldInitializeLikeLSP8(async () => {
+        const { lsp8Reference: lsp8, deployParams } = context;
+        const initializeTransaction = await initializeProxy(context);
+
+        return {
+          lsp8,
+          deployParams,
+          initializeTransaction,
+        };
+      });
+    });
+
+    describe('when calling initialize more than once', () => {
+      it('should revert', async () => {
+        await expect(initializeProxy(context)).to.be.revertedWith(
+          'Initializable: contract is already initialized',
+        );
+      });
+    });
+  });
+});

--- a/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Reference.test.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Reference.test.ts
@@ -1,0 +1,69 @@
+import { LSP8_TOKEN_ID_TYPES } from '../../../constants';
+import {
+  LSP8ReferenceContractCollectionTester,
+  LSP8ReferenceContractCollectionTester__factory,
+  LSP8ReferenceTokenIdContractTester,
+  LSP8ReferenceTokenIdContractTester__factory,
+} from '../../../types';
+
+import { shouldInitializeLikeLSP8 } from '../LSP8IdentifiableDigitalAsset.behaviour';
+
+import {
+  shouldBehaveLikeLSP8Reference,
+  LSP8ReferenceTestContext,
+  getNamedAccounts,
+} from '../LSP8Reference.behaviour';
+
+describe('LSP8Reference with constructor', () => {
+  const buildTestContext = async () => {
+    const accounts = await getNamedAccounts();
+
+    const deployParams = {
+      name: 'LSP8 Reference Collection - deployed with constructor',
+      symbol: 'LSP8 RFRC',
+      newOwner: accounts.owner.address,
+      tokenIdType: LSP8_TOKEN_ID_TYPES.ADDRESS,
+    };
+
+    const lsp8Collection: LSP8ReferenceContractCollectionTester =
+      await new LSP8ReferenceContractCollectionTester__factory(accounts.owner).deploy(
+        deployParams.name,
+        deployParams.symbol,
+        deployParams.newOwner,
+        deployParams.tokenIdType,
+      );
+
+    const lsp8TokenId: LSP8ReferenceTokenIdContractTester =
+      await new LSP8ReferenceTokenIdContractTester__factory(accounts.owner).deploy(
+        'LSP8 TokenId Address - deployed with constructor',
+        'LSP8 RFRCTIA',
+        deployParams.newOwner,
+        deployParams.tokenIdType,
+      );
+
+    return { accounts, lsp8Collection, lsp8TokenId, deployParams };
+  };
+
+  describe('when deploying the contract', () => {
+    let context: LSP8ReferenceTestContext;
+
+    before(async () => {
+      context = await buildTestContext();
+    });
+
+    shouldInitializeLikeLSP8(async () => {
+      const { lsp8Collection: lsp8, lsp8TokenId, deployParams } = context;
+
+      return {
+        lsp8,
+        lsp8TokenId,
+        deployParams,
+        initializeTransaction: context.lsp8Collection.deployTransaction,
+      };
+    });
+  });
+
+  describe('when testing deployed contract', () => {
+    shouldBehaveLikeLSP8Reference(buildTestContext);
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->
## 🚀 Feature
- LSP8Reference.sol
- LSP8ReferenceInitAbstract.sol
<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->
Created a new LSP8 contract under extensions/ that verifies if the LSP8 Collection Contract Address is well referenced from the tokenId Address 
<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->
When creating an **LSP8IdentifiableDigitalAsset** Collection that uses **tokenId** as Address (Smart Contract) is needed a way to check if the tokenId Contract properly referenced the Collection Contract address with **_LSP8_REFERENCE_CONTRACT**

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
