### PR TITLE
docs: fix incorrect Natspec comments

### DIFF
--- a/contracts/LSP3ProfileMetadata/LSP3Constants.sol
+++ b/contracts/LSP3ProfileMetadata/LSP3Constants.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 // bytes10(keccak256('SupportedStandards')) + bytes2(0) + bytes20(keccak256('LSP3Profile'))
 bytes32 constant _LSP3_SUPPORTED_STANDARDS_KEY = 0xeafec4d89fa9619884b600005ef83ad9559033e6e941db7d7c495acdce616347;
 
-// bytes4(keccak256('LSP3UniversalProfile'))
+// bytes4(keccak256('LSP3Profile'))
 bytes constant _LSP3_SUPPORTED_STANDARDS_VALUE = hex"5ef83ad9";
 
 // bytes32(keccak256("LSP3Profile"))

--- a/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4Constants.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.4;
 
 // Token types
-
 uint256 constant _LSP4_TOKEN_TYPE_TOKEN = 0;
 uint256 constant _LSP4_TOKEN_TYPE_NFT = 1;
 uint256 constant _LSP4_TOKEN_TYPE_COLLECTION = 2;

--- a/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
+++ b/contracts/LSP4DigitalAssetMetadata/LSP4DigitalAssetMetadata.sol
@@ -30,7 +30,7 @@ abstract contract LSP4DigitalAssetMetadata is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param initialOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      */
     constructor(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol
@@ -50,7 +50,7 @@ abstract contract LSP7DigitalAsset is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the the token-Metadata.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
      */
     constructor(

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20.sol
@@ -27,7 +27,7 @@ abstract contract LSP7CompatibleERC20 is IERC20Metadata, LSP7DigitalAsset {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      */
     constructor(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/extensions/LSP7CompatibleERC20InitAbstract.sol
@@ -33,7 +33,7 @@ abstract contract LSP7CompatibleERC20InitAbstract is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      */
     function _initialize(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.sol
@@ -14,7 +14,7 @@ contract LSP7CompatibleERC20Mintable is LSP7CompatibleERC20 {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      */
     constructor(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20MintableInit.sol
@@ -26,7 +26,7 @@ contract LSP7CompatibleERC20MintableInit is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      */
     function initialize(
         string memory name_,

--- a/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol
@@ -20,7 +20,7 @@ contract LSP7Mintable is LSP7DigitalAsset, ILSP7Mintable {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
      */
     constructor(

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInit.sol
@@ -23,7 +23,7 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
      */
     function initialize(

--- a/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
+++ b/contracts/LSP7DigitalAsset/presets/LSP7MintableInitAbstract.sol
@@ -24,7 +24,7 @@ abstract contract LSP7MintableInitAbstract is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
      */
     function _initialize(

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol
@@ -69,7 +69,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      *
      * @custom:warning Make sure the tokenId schema provided on deployment is correct, as it can only be set once

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -66,7 +66,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * @param name_ The name of the token
      * @param symbol_ The symbol of the token
      * @param newOwner_ The owner of the the token-Metadata
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      *
      * @custom:warning Make sure the tokenId schema provided on deployment is correct, as it can only be set once

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721.sol
@@ -64,7 +64,7 @@ abstract contract LSP8CompatibleERC721 is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     constructor(

--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CompatibleERC721InitAbstract.sol
@@ -64,7 +64,7 @@ abstract contract LSP8CompatibleERC721InitAbstract is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
 

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.sol
@@ -14,7 +14,7 @@ contract LSP8CompatibleERC721Mintable is LSP8CompatibleERC721 {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     constructor(

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721MintableInit.sol
@@ -26,7 +26,7 @@ contract LSP8CompatibleERC721MintableInit is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     function initialize(

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol
@@ -21,7 +21,7 @@ contract LSP8Mintable is LSP8IdentifiableDigitalAsset, ILSP8Mintable {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     constructor(

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInit.sol
@@ -23,7 +23,7 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     function initialize(

--- a/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8MintableInitAbstract.sol
@@ -23,7 +23,7 @@ abstract contract LSP8MintableInitAbstract is
      * @param name_ The name of the token.
      * @param symbol_ The symbol of the token.
      * @param newOwner_ The owner of the token contract.
-     * @param lsp4TokenType_ The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection).
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
      * @param lsp8TokenIdSchema_ The schema of tokenIds (= NFTs) that this contract will create.
      */
     function _initialize(

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7CompatibleERC20Mintable.md
@@ -48,7 +48,7 @@ _Deploying a `LSP7CompatibleERC20Mintable` token contract with: token name = `na
 | `name_`          | `string`  | The name of the token.                                                                               |
 | `symbol_`        | `string`  | The symbol of the token.                                                                             |
 | `newOwner_`      | `address` | The owner of the token contract.                                                                     |
-| `lsp4TokenType_` | `uint256` | The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection). |
+| `lsp4TokenType_` | `uint256` | The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection). |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -49,7 +49,7 @@ _Deploying a `LSP7Mintable` token contract with: token name = `name_`, token sym
 | `name_`           | `string`  | The name of the token.                                                                               |
 | `symbol_`         | `string`  | The symbol of the token.                                                                             |
 | `newOwner_`       | `address` | The owner of the token contract.                                                                     |
-| `lsp4TokenType_`  | `uint256` | The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection). |
+| `lsp4TokenType_`  | `uint256` | The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection). |
 | `isNonDivisible_` |  `bool`   | Specify if the LSP7 token is a fungible or non-fungible token.                                       |
 
 <br/>

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8CompatibleERC721Mintable.md
@@ -49,7 +49,7 @@ _Deploying a `LSP8CompatibleERC721Mintable` token contract with: token name = `n
 | `name_`              | `string`  | The name of the token.                                                                               |
 | `symbol_`            | `string`  | The symbol of the token.                                                                             |
 | `newOwner_`          | `address` | The owner of the token contract.                                                                     |
-| `lsp4TokenType_`     | `uint256` | The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection). |
+| `lsp4TokenType_`     | `uint256` | The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection). |
 | `lsp8TokenIdSchema_` | `uint256` | The schema of tokenIds (= NFTs) that this contract will create.                                      |
 
 <br/>

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -49,7 +49,7 @@ _Deploying a `LSP8Mintable` token contract with: token name = `name_`, token sym
 | `name_`              | `string`  | The name of the token.                                                                               |
 | `symbol_`            | `string`  | The symbol of the token.                                                                             |
 | `newOwner_`          | `address` | The owner of the token contract.                                                                     |
-| `lsp4TokenType_`     | `uint256` | The type of token this digital asset contract represents (`1` = Token, `2` = NFT, `3` = Collection). |
+| `lsp4TokenType_`     | `uint256` | The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection). |
 | `lsp8TokenIdSchema_` | `uint256` | The schema of tokenIds (= NFTs) that this contract will create.                                      |
 
 <br/>


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Natspec Docs Fixes

Fix incorrect comments across the code for:

<img width="569" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/079d9bf4-e21a-47d3-9ad5-072ded9fac02">


<img width="1090" alt="image" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/a0680035-3141-4d92-9790-6d59af5504d0">


