### PR TITLE
fix: remove unused state variable in LSP8

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -77,8 +77,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     // Mapping a `tokenId` to its authorized operator addresses.
     mapping(bytes32 => EnumerableSet.AddressSet) internal _operators;
 
-    mapping(address => EnumerableSet.Bytes32Set) internal _tokenIdsForOperator;
-
     // --- Token queries
 
     /**


### PR DESCRIPTION
# What does this PR introduce?

When running slither on contracts that inherit `LSP8IdentifiableDigitalAssetCore`, the following detector information warning is flagged.

<img width="1639" alt="Screenshot 2023-12-06 at 12 48 10" src="https://github.com/lukso-network/lsp-smart-contracts/assets/31145285/3557b98e-1122-4c37-be69-33d0974fa43b">

This was introduced, probably by mistake in the following old PR.
https://github.com/lukso-network/lsp-smart-contracts/pull/278/files#diff-6bf798baf12f747ced625661057bfe96098e44a49c261fc80bf1977038f45260

This PR removes this old unused state variable.

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
