### PR TITLE
chore: [L-02] Missing virtual keyword on burn() in LSP8Burnable.sol

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol
@@ -21,7 +21,7 @@ abstract contract LSP8Burnable is LSP8IdentifiableDigitalAsset {
      * @param tokenId The tokenId to burn.
      * @param data Any extra data to be sent alongside burning the tokenId.
      */
-    function burn(bytes32 tokenId, bytes memory data) public {
+    function burn(bytes32 tokenId, bytes memory data) public virtual {
         if (!_isOperatorOrOwner(msg.sender, tokenId)) {
             revert LSP8NotTokenOperator(tokenId, msg.sender);
         }


### PR DESCRIPTION

# What does this PR introduce?
chore: add `virtual` keyword in burn() in LSP8Burnable

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
