### PR TITLE
refactor: [L-05] tokenIds and dataKeys can have different lengths in getDataBatchForTokenIds()

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -140,6 +140,10 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bytes32[] memory tokenIds,
         bytes32[] memory dataKeys
     ) public view virtual override returns (bytes[] memory dataValues) {
+        if (tokenIds.length != dataKeys.length) {
+            revert LSP8TokenIdsDataLengthMismatch();
+        }
+
         dataValues = new bytes[](tokenIds.length);
 
         for (uint256 i; i < tokenIds.length; ) {

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -188,6 +188,23 @@ export const shouldBehaveLikeLSP8 = (
     });
   });
 
+  describe('when getting data for a tokenId', () => {
+    const tokenIdsLength3 = [tokenIdAsBytes32(42), tokenIdAsBytes32(43), tokenIdAsBytes32(44)];
+
+    const dataKeysLength2 = [
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My First Key')),
+      ethers.utils.keccak256(ethers.utils.toUtf8Bytes('My Second Key')),
+    ];
+
+    it('should revert when providing arrays of tokenIds and data keys of different length', async () => {
+      await expect(
+        context.lsp8
+          .connect(context.accounts.owner)
+          .getDataBatchForTokenIds(tokenIdsLength3, dataKeysLength2),
+      ).to.be.revertedWithCustomError(context.lsp8, 'LSP8TokenIdsDataLengthMismatch');
+    });
+  });
+
   describe('when minting tokens', () => {
     before(async () => {
       await context.lsp8.mint(


### PR DESCRIPTION
# What does this PR introduce?

## ♻️ Refactor

- add array length check for getDataBatchForTokenIds in LSP8
- add tests for array length check for getDataBatchForTokenIds in LSP8

### PR Checklist

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
