### PR TITLE
chore: [I-03] `_existsOrError()` check in `isOperatorFor()` is redundant in LSP8IdentifiableDigitalAssetCore

### DIFF
--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -327,8 +327,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         address operator,
         bytes32 tokenId
     ) public view virtual override returns (bool) {
-        _existsOrError(tokenId);
-
         return _isOperatorOrOwner(operator, tokenId);
     }
 


### PR DESCRIPTION

# What does this PR introduce?

- Remove duplicated check in isOperatorFor in LSP8

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
