### PR TITLE
ci: change event triggers for benchmark CI to include forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,7 +8,7 @@ on:
   # enable to run workflow manually
   workflow_dispatch:
 
-  pull_request:
+  pull_request_target:
     types: [opened]
 
     # compare gas diff only when editing Solidity smart contract code


### PR DESCRIPTION
# What does this PR introduce?
## 🤖 CI

This PR updates the GitHub Actions workflow event trigger from `pull_request` to `pull_request_target`. Below are the key differences and reasons for this change:

### Differences between `pull_request` and `pull_request_target`

- **Context of Execution**:
  - `pull_request`: The workflow runs in the context of the pull request itself, meaning it uses the code from the feature branch of the fork.
  - `pull_request_target`: The workflow runs in the context of the base repository, using the code from the base branch to which the PR is targeted.

- **Access to Secrets**:
  - `pull_request`: Has limited access to secrets, particularly when the PR is from a forked repository. This is a security measure to prevent exposing secrets to potentially unsafe code in forks.
  - `pull_request_target`: Has access to all secrets of the base repository, even for PRs from forks.

### Why the Change Enables Comment Posting from Forks

- **Permission to Comment**:
  - By using `pull_request_target`, the workflow gains the necessary write permissions to post comments on PRs. This is essential for PRs originating from forks, as `pull_request` does not provide sufficient permissions for this action.

- **Access to Repository Secrets**:
  - The workflow can now utilize repository secrets if needed for commenting or other operations, which is not possible with `pull_request` for forked PRs.

- **Security Considerations**:
  - While this change provides more access, it's important to ensure that the workflow does not execute code from the PR itself to maintain security. This PR's workflow is specifically designed to post comments without executing PR code.

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
