### PR TITLE
ci: cache Typescript `types/` of packages in CI

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v3
 
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-      - name: Use Node.js '16.15.0'
-        uses: actions/setup-node@v2
+      - name: Use Node.js v20
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.15.0"
+          node-version: "20.x"
           cache: "npm"
 
       - name: 📦 Install dependencies
@@ -38,13 +38,14 @@ jobs:
           npm run build:turbo
 
       - name: 📤 cache dependencies + build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             artifacts
             node_modules
             types
             contracts.ts
+            packages/**/types
           key: ${{ github.run_id }}
 
       - name: 📚 generate ABI docs
@@ -96,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: 📥 restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: "build-cache"
         with:
           path: |
@@ -104,12 +105,13 @@ jobs:
             node_modules
             types
             contracts.ts
+            packages/**/types
           key: ${{ github.run_id }}
 
-      - name: Use Node.js v16
-        uses: actions/setup-node@v2
+      - name: Use Node.js v20
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
This is necessary for the typechain types of #857 to pass.