### PR TITLE
feat!: allow Operator to revoke himself

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -29,7 +29,7 @@ export const INTERFACE_IDS = {
   LSP1UniversalReceiver: '0x6bb56a14',
   LSP1UniversalReceiverDelegate: '0xa245bbda',
   LSP6KeyManager: '0x23f34c62',
-  LSP7DigitalAsset: '0xb3c4928f',
+  LSP7DigitalAsset: '0xc52d6008',
   LSP8IdentifiableDigitalAsset: '0x3a271706',
   LSP9Vault: '0x28af17e6',
   LSP11BasicSocialRecovery: '0x049a28f1',

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -125,8 +125,8 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @dev Removes the `operator` address as an operator of callers tokens, disallowing it to send any amount of tokens
      * on behalf of the token owner (the caller of the function `msg.sender`). See also {authorizedAmountFor}.
      *
-     * @param operator The address of the token owner.
      * @param operator The address to revoke as an operator.
+     * @param tokenOwner The address of the token owner.
      * @param notify Boolean indicating whether to notify the operator or not.
      * @param operatorNotificationData The data to notify the operator about via LSP1.
      *
@@ -137,8 +137,8 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @custom:events {OperatorRevoked} event with address of the operator being revoked for the caller (token holder).
      */
     function revokeOperator(
-        address tokenOwner,
         address operator,
+        address tokenOwner,
         bool notify,
         bytes memory operatorNotificationData
     ) external;
@@ -185,8 +185,8 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *  - {OperatorRevoked} event if `subtractedAmount` is the full allowance,
      *    indicating `operator` does not have any alauthorizedAmountForlowance left for `msg.sender`.
      *
-     * @param operator The address of the token owner.
      * @param operator The operator to decrease allowance for `msg.sender`
+     * @param tokenOwner The address of the token owner.
      * @param subtractedAmount The amount to decrease by in the operator's allowance.
      *
      * @custom:requirements
@@ -194,8 +194,8 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *  - `operator` must have allowance for the caller of at least `subtractedAmount`.
      */
     function decreaseAllowance(
-        address tokenOwner,
         address operator,
+        address tokenOwner,
         uint256 subtractedAmount,
         bytes memory operatorNotificationData
     ) external;

--- a/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
+++ b/contracts/LSP7DigitalAsset/ILSP7DigitalAsset.sol
@@ -125,6 +125,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @dev Removes the `operator` address as an operator of callers tokens, disallowing it to send any amount of tokens
      * on behalf of the token owner (the caller of the function `msg.sender`). See also {authorizedAmountFor}.
      *
+     * @param operator The address of the token owner.
      * @param operator The address to revoke as an operator.
      * @param notify Boolean indicating whether to notify the operator or not.
      * @param operatorNotificationData The data to notify the operator about via LSP1.
@@ -136,6 +137,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      * @custom:events {OperatorRevoked} event with address of the operator being revoked for the caller (token holder).
      */
     function revokeOperator(
+        address tokenOwner,
         address operator,
         bool notify,
         bytes memory operatorNotificationData
@@ -183,6 +185,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *  - {OperatorRevoked} event if `subtractedAmount` is the full allowance,
      *    indicating `operator` does not have any alauthorizedAmountForlowance left for `msg.sender`.
      *
+     * @param operator The address of the token owner.
      * @param operator The operator to decrease allowance for `msg.sender`
      * @param subtractedAmount The amount to decrease by in the operator's allowance.
      *
@@ -191,6 +194,7 @@ interface ILSP7DigitalAsset is IERC165, IERC725Y {
      *  - `operator` must have allowance for the caller of at least `subtractedAmount`.
      */
     function decreaseAllowance(
+        address tokenOwner,
         address operator,
         uint256 subtractedAmount,
         bytes memory operatorNotificationData

--- a/contracts/LSP7DigitalAsset/LSP7Constants.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.4;
 
 // --- ERC165 interface ids
-bytes4 constant _INTERFACEID_LSP7 = 0xb3c4928f;
+bytes4 constant _INTERFACEID_LSP7 = 0xc52d6008;
 
 // --- Token Hooks
 

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -20,7 +20,6 @@ import {LSP1Utils} from "../LSP1UniversalReceiver/LSP1Utils.sol";
 
 // errors
 import {
-    LSP7CannotSendToSelf,
     LSP7AmountExceedsAuthorizedAmount,
     LSP7InvalidTransferBatch,
     LSP7AmountExceedsBalance,
@@ -31,7 +30,9 @@ import {
     LSP7NotifyTokenReceiverContractMissingLSP1Interface,
     LSP7NotifyTokenReceiverIsEOA,
     OperatorAllowanceCannotBeIncreasedFromZero,
-    LSP7BatchCallFailed
+    LSP7BatchCallFailed,
+    LSP7RevokeOperatorNotAuthorized,
+    LSP7DecreaseAllowanceNotAuthorized
 } from "./LSP7Errors.sol";
 
 // constants
@@ -173,11 +174,17 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      */
     function revokeOperator(
         address operator,
+        address tokenOwner,
         bool notify,
         bytes memory operatorNotificationData
     ) public virtual override {
+
+        if (msg.sender != tokenOwner && msg.sender != operator) {
+            revert LSP7RevokeOperatorNotAuthorized(msg.sender, tokenOwner, operator);
+        }
+        
         _updateOperator(
-            msg.sender,
+            tokenOwner,
             operator,
             0,
             notify,
@@ -186,7 +193,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
 
         if (notify) {
             bytes memory lsp1Data = abi.encode(
-                msg.sender,
+                tokenOwner,
                 0,
                 operatorNotificationData
             );
@@ -254,10 +261,16 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
      */
     function decreaseAllowance(
         address operator,
+        address tokenOwner,
         uint256 subtractedAmount,
         bytes memory operatorNotificationData
     ) public virtual override {
-        uint256 currentAllowance = authorizedAmountFor(operator, msg.sender);
+
+        if (msg.sender != tokenOwner && msg.sender != operator) {
+            revert LSP7DecreaseAllowanceNotAuthorized(msg.sender, tokenOwner, operator);
+        }
+
+        uint256 currentAllowance = authorizedAmountFor(operator, tokenOwner);
         if (currentAllowance < subtractedAmount) {
             revert LSP7DecreasedAllowanceBelowZero();
         }
@@ -266,7 +279,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         unchecked {
             newAllowance = currentAllowance - subtractedAmount;
             _updateOperator(
-                msg.sender,
+                tokenOwner,
                 operator,
                 newAllowance,
                 true,
@@ -275,7 +288,7 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         }
 
         bytes memory lsp1Data = abi.encode(
-            msg.sender,
+            tokenOwner,
             newAllowance,
             operatorNotificationData
         );
@@ -295,8 +308,6 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool force,
         bytes memory data
     ) public virtual override {
-        if (from == to) revert LSP7CannotSendToSelf();
-
         if (msg.sender != from) {
             _spendAllowance({
                 operator: msg.sender,

--- a/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
+++ b/contracts/LSP7DigitalAsset/LSP7DigitalAssetCore.sol
@@ -178,11 +178,14 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         bool notify,
         bytes memory operatorNotificationData
     ) public virtual override {
-
         if (msg.sender != tokenOwner && msg.sender != operator) {
-            revert LSP7RevokeOperatorNotAuthorized(msg.sender, tokenOwner, operator);
+            revert LSP7RevokeOperatorNotAuthorized(
+                msg.sender,
+                tokenOwner,
+                operator
+            );
         }
-        
+
         _updateOperator(
             tokenOwner,
             operator,
@@ -265,9 +268,12 @@ abstract contract LSP7DigitalAssetCore is ILSP7DigitalAsset {
         uint256 subtractedAmount,
         bytes memory operatorNotificationData
     ) public virtual override {
-
         if (msg.sender != tokenOwner && msg.sender != operator) {
-            revert LSP7DecreaseAllowanceNotAuthorized(msg.sender, tokenOwner, operator);
+            revert LSP7DecreaseAllowanceNotAuthorized(
+                msg.sender,
+                tokenOwner,
+                operator
+            );
         }
 
         uint256 currentAllowance = authorizedAmountFor(operator, tokenOwner);

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -37,11 +37,6 @@ error LSP7CannotUseAddressZeroAsOperator();
 error LSP7CannotSendWithAddressZero();
 
 /**
- * @dev reverts when specifying the same address for `from` or `to` in a token transfer.
- */
-error LSP7CannotSendToSelf();
-
-/**
  * @dev reverts when the array parameters used in {transferBatch} have different lengths.
  */
 error LSP7InvalidTransferBatch();
@@ -88,3 +83,14 @@ error OperatorAllowanceCannotBeIncreasedFromZero(address operator);
  * @notice Batch call failed.
  */
 error LSP7BatchCallFailed(uint256 callIndex);
+
+/**
+ * @dev Reverts when the call to revoke operator is not authorized.
+ */
+error LSP7RevokeOperatorNotAuthorized(address caller, address tokenOwner, address operator);
+
+
+/**
+ * @dev Reverts when the call to decrease allowance is not authorized.
+ */
+error LSP7DecreaseAllowanceNotAuthorized(address caller, address tokenOwner, address operator);

--- a/contracts/LSP7DigitalAsset/LSP7Errors.sol
+++ b/contracts/LSP7DigitalAsset/LSP7Errors.sol
@@ -87,10 +87,17 @@ error LSP7BatchCallFailed(uint256 callIndex);
 /**
  * @dev Reverts when the call to revoke operator is not authorized.
  */
-error LSP7RevokeOperatorNotAuthorized(address caller, address tokenOwner, address operator);
-
+error LSP7RevokeOperatorNotAuthorized(
+    address caller,
+    address tokenOwner,
+    address operator
+);
 
 /**
  * @dev Reverts when the call to decrease allowance is not authorized.
  */
-error LSP7DecreaseAllowanceNotAuthorized(address caller, address tokenOwner, address operator);
+error LSP7DecreaseAllowanceNotAuthorized(
+    address caller,
+    address tokenOwner,
+    address operator
+);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -108,8 +108,11 @@ error LSP8TokenOwnerChanged(
     address newOwner
 );
 
-
 /**
  * @dev Reverts when the call to revoke operator is not authorized.
  */
-error LSP8RevokeOperatorNotAuthorized(address caller, address tokenOwner, bytes32 tokenId);
+error LSP8RevokeOperatorNotAuthorized(
+    address caller,
+    address tokenOwner,
+    bytes32 tokenId
+);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8Errors.sol
@@ -34,11 +34,6 @@ error LSP8CannotUseAddressZeroAsOperator();
 error LSP8CannotSendToAddressZero();
 
 /**
- * @dev Reverts when specifying the same address for `from` and `to` in a token transfer.
- */
-error LSP8CannotSendToSelf();
-
-/**
  * @dev Reverts when `operator` is not an operator for the `tokenId`.
  */
 error LSP8NonExistingOperator(address operator, bytes32 tokenId);
@@ -112,3 +107,9 @@ error LSP8TokenOwnerChanged(
     address oldOwner,
     address newOwner
 );
+
+
+/**
+ * @dev Reverts when the call to revoke operator is not authorized.
+ */
+error LSP8RevokeOperatorNotAuthorized(address caller, address tokenOwner, bytes32 tokenId);

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -293,9 +293,16 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        if (msg.sender != tokenOwner){
-            if (!_operators[tokenId].contains(msg.sender) || operator != msg.sender) {
-                revert LSP8RevokeOperatorNotAuthorized(msg.sender, tokenOwner, tokenId);
+        if (msg.sender != tokenOwner) {
+            if (
+                !_operators[tokenId].contains(msg.sender) ||
+                operator != msg.sender
+            ) {
+                revert LSP8RevokeOperatorNotAuthorized(
+                    msg.sender,
+                    tokenOwner,
+                    tokenId
+                );
             }
         }
 

--- a/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
+++ b/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAssetCore.sol
@@ -36,13 +36,13 @@ import {
     LSP8NonExistingOperator,
     LSP8CannotSendToAddressZero,
     LSP8TokenIdAlreadyMinted,
-    LSP8CannotSendToSelf,
     LSP8NotifyTokenReceiverContractMissingLSP1Interface,
     LSP8NotifyTokenReceiverIsEOA,
     LSP8TokenIdsDataLengthMismatch,
     LSP8TokenIdsDataEmptyArray,
     LSP8BatchCallFailed,
-    LSP8TokenOwnerChanged
+    LSP8TokenOwnerChanged,
+    LSP8RevokeOperatorNotAuthorized
 } from "./LSP8Errors.sol";
 
 // constants
@@ -293,8 +293,10 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
     ) public virtual override {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        if (tokenOwner != msg.sender) {
-            revert LSP8NotTokenOwner(tokenOwner, tokenId, msg.sender);
+        if (msg.sender != tokenOwner){
+            if (!_operators[tokenId].contains(msg.sender) || operator != msg.sender) {
+                revert LSP8RevokeOperatorNotAuthorized(msg.sender, tokenOwner, tokenId);
+            }
         }
 
         if (operator == address(0)) {
@@ -315,7 +317,7 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
 
         if (notify) {
             bytes memory lsp1Data = abi.encode(
-                msg.sender,
+                tokenOwner,
                 tokenId,
                 false, // unauthorized
                 operatorNotificationData
@@ -625,10 +627,6 @@ abstract contract LSP8IdentifiableDigitalAssetCore is
         bool force,
         bytes memory data
     ) internal virtual {
-        if (from == to) {
-            revert LSP8CannotSendToSelf();
-        }
-
         address tokenOwner = tokenOwnerOf(tokenId);
         if (tokenOwner != from) {
             revert LSP8NotTokenOwner(tokenOwner, tokenId, from);

--- a/docs/_interface_ids_table.mdx
+++ b/docs/_interface_ids_table.mdx
@@ -8,7 +8,7 @@
 | **LSP1UniversalReceiver**         | `0x6bb56a14` | Interface of the LSP1 - Universal Receiver standard, an entry function for a contract to receive arbitrary information.                                  |
 | **LSP1UniversalReceiverDelegate** | `0xa245bbda` | Interface of the LSP1 - Universal Receiver Delegate standard.                                                                                            |
 | **LSP6KeyManager**                | `0x23f34c62` | Interface of the LSP6 - Key Manager standard, a contract acting as a controller of an ERC725 Account using predfined permissions.                        |
-| **LSP7DigitalAsset**              | `0xb3c4928f` | Interface of the LSP7 - Digital Asset standard, a fungible digital asset.                                                                                |
+| **LSP7DigitalAsset**              | `0xc52d6008` | Interface of the LSP7 - Digital Asset standard, a fungible digital asset.                                                                                |
 | **LSP8IdentifiableDigitalAsset**  | `0x3a271706` | Interface of the LSP8 - Identifiable Digital Asset standard, a non-fungible digital asset.                                                               |
 | **LSP9Vault**                     | `0x28af17e6` | Interface of LSP9 - Vault standard, a blockchain vault that can hold assets and interact with other smart contracts.                                     |
 | **LSP11BasicSocialRecovery**      | `0x049a28f1` | Interface of the LSP11 - Basic Social Recovery standard, a contract to recover access control into an account.                                           |

--- a/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
+++ b/docs/contracts/LSP7DigitalAsset/LSP7DigitalAsset.md
@@ -250,14 +250,15 @@ Returns the number of decimals used to get its user representation. If the asset
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#decreaseallowance)
 - Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
-- Function signature: `decreaseAllowance(address,uint256,bytes)`
-- Function selector: `0x7b204c4e`
+- Function signature: `decreaseAllowance(address,address,uint256,bytes)`
+- Function selector: `0x78381670`
 
 :::
 
 ```solidity
 function decreaseAllowance(
   address operator,
+  address tokenOwner,
   uint256 subtractedAmount,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -272,6 +273,7 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
 | `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `tokenOwner`               | `address` | The address of the token owner.                        |
 | `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
@@ -459,14 +461,15 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#revokeoperator)
 - Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
-- Function signature: `revokeOperator(address,bool,bytes)`
-- Function selector: `0x4521748e`
+- Function signature: `revokeOperator(address,address,bool,bytes)`
+- Function selector: `0x30d0dc37`
 
 :::
 
 ```solidity
 function revokeOperator(
   address operator,
+  address tokenOwner,
   bool notify,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -479,6 +482,7 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 | Name                       |   Type    | Description                                               |
 | -------------------------- | :-------: | --------------------------------------------------------- |
 | `operator`                 | `address` | The address to revoke as an operator.                     |
+| `tokenOwner`               | `address` | The address of the token owner.                           |
 | `notify`                   |  `bool`   | Boolean indicating whether to notify the operator or not. |
 | `operatorNotificationData` |  `bytes`  | The data to notify the operator about via LSP1.           |
 
@@ -1561,25 +1565,6 @@ Reverts when a batch call failed.
 
 <br/>
 
-### LSP7CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7cannotsendtoself)
-- Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
-- Error signature: `LSP7CannotSendToSelf()`
-- Error hash: `0xb9afb000`
-
-:::
-
-```solidity
-error LSP7CannotSendToSelf();
-```
-
-reverts when specifying the same address for `from` or `to` in a token transfer.
-
-<br/>
-
 ### LSP7CannotSendWithAddressZero
 
 :::note References
@@ -1621,6 +1606,37 @@ error LSP7CannotUseAddressZeroAsOperator();
 ```
 
 reverts when trying to set the zero address as an operator.
+
+<br/>
+
+### LSP7DecreaseAllowanceNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7decreaseallowancenotauthorized)
+- Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
+- Error signature: `LSP7DecreaseAllowanceNotAuthorized(address,address,address)`
+- Error hash: `0x98ce2945`
+
+:::
+
+```solidity
+error LSP7DecreaseAllowanceNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to decrease allowance is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 
@@ -1711,6 +1727,37 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7revokeoperatornotauthorized)
+- Solidity implementation: [`LSP7DigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/LSP7DigitalAsset.sol)
+- Error signature: `LSP7RevokeOperatorNotAuthorized(address,address,address)`
+- Error hash: `0x1a525b32`
+
+:::
+
+```solidity
+error LSP7RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.md
@@ -275,14 +275,15 @@ Returns the number of decimals used to get its user representation. If the asset
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#decreaseallowance)
 - Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
-- Function signature: `decreaseAllowance(address,uint256,bytes)`
-- Function selector: `0x7b204c4e`
+- Function signature: `decreaseAllowance(address,address,uint256,bytes)`
+- Function selector: `0x78381670`
 
 :::
 
 ```solidity
 function decreaseAllowance(
   address operator,
+  address tokenOwner,
   uint256 subtractedAmount,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -297,6 +298,7 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
 | `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `tokenOwner`               | `address` | The address of the token owner.                        |
 | `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
@@ -484,14 +486,15 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#revokeoperator)
 - Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
-- Function signature: `revokeOperator(address,bool,bytes)`
-- Function selector: `0x4521748e`
+- Function signature: `revokeOperator(address,address,bool,bytes)`
+- Function selector: `0x30d0dc37`
 
 :::
 
 ```solidity
 function revokeOperator(
   address operator,
+  address tokenOwner,
   bool notify,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -504,6 +507,7 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 | Name                       |   Type    | Description                                               |
 | -------------------------- | :-------: | --------------------------------------------------------- |
 | `operator`                 | `address` | The address to revoke as an operator.                     |
+| `tokenOwner`               | `address` | The address of the token owner.                           |
 | `notify`                   |  `bool`   | Boolean indicating whether to notify the operator or not. |
 | `operatorNotificationData` |  `bytes`  | The data to notify the operator about via LSP1.           |
 
@@ -1586,25 +1590,6 @@ Reverts when a batch call failed.
 
 <br/>
 
-### LSP7CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7cannotsendtoself)
-- Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
-- Error signature: `LSP7CannotSendToSelf()`
-- Error hash: `0xb9afb000`
-
-:::
-
-```solidity
-error LSP7CannotSendToSelf();
-```
-
-reverts when specifying the same address for `from` or `to` in a token transfer.
-
-<br/>
-
 ### LSP7CannotSendWithAddressZero
 
 :::note References
@@ -1646,6 +1631,37 @@ error LSP7CannotUseAddressZeroAsOperator();
 ```
 
 reverts when trying to set the zero address as an operator.
+
+<br/>
+
+### LSP7DecreaseAllowanceNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7decreaseallowancenotauthorized)
+- Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
+- Error signature: `LSP7DecreaseAllowanceNotAuthorized(address,address,address)`
+- Error hash: `0x98ce2945`
+
+:::
+
+```solidity
+error LSP7DecreaseAllowanceNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to decrease allowance is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 
@@ -1736,6 +1752,37 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7revokeoperatornotauthorized)
+- Solidity implementation: [`LSP7Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7Burnable.sol)
+- Error signature: `LSP7RevokeOperatorNotAuthorized(address,address,address)`
+- Error hash: `0x1a525b32`
+
+:::
+
+```solidity
+error LSP7RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
+++ b/docs/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.md
@@ -248,14 +248,15 @@ Returns the number of decimals used to get its user representation. If the asset
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#decreaseallowance)
 - Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
-- Function signature: `decreaseAllowance(address,uint256,bytes)`
-- Function selector: `0x7b204c4e`
+- Function signature: `decreaseAllowance(address,address,uint256,bytes)`
+- Function selector: `0x78381670`
 
 :::
 
 ```solidity
 function decreaseAllowance(
   address operator,
+  address tokenOwner,
   uint256 subtractedAmount,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -270,6 +271,7 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
 | `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `tokenOwner`               | `address` | The address of the token owner.                        |
 | `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
@@ -457,14 +459,15 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#revokeoperator)
 - Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
-- Function signature: `revokeOperator(address,bool,bytes)`
-- Function selector: `0x4521748e`
+- Function signature: `revokeOperator(address,address,bool,bytes)`
+- Function selector: `0x30d0dc37`
 
 :::
 
 ```solidity
 function revokeOperator(
   address operator,
+  address tokenOwner,
   bool notify,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -477,6 +480,7 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 | Name                       |   Type    | Description                                               |
 | -------------------------- | :-------: | --------------------------------------------------------- |
 | `operator`                 | `address` | The address to revoke as an operator.                     |
+| `tokenOwner`               | `address` | The address of the token owner.                           |
 | `notify`                   |  `bool`   | Boolean indicating whether to notify the operator or not. |
 | `operatorNotificationData` |  `bytes`  | The data to notify the operator about via LSP1.           |
 
@@ -1560,25 +1564,6 @@ Reverts when a batch call failed.
 
 <br/>
 
-### LSP7CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7cannotsendtoself)
-- Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
-- Error signature: `LSP7CannotSendToSelf()`
-- Error hash: `0xb9afb000`
-
-:::
-
-```solidity
-error LSP7CannotSendToSelf();
-```
-
-reverts when specifying the same address for `from` or `to` in a token transfer.
-
-<br/>
-
 ### LSP7CannotSendWithAddressZero
 
 :::note References
@@ -1662,6 +1647,37 @@ error LSP7CappedSupplyRequired();
 _The `tokenSupplyCap` must be set and cannot be `0`._
 
 Reverts when setting `0` for the [`tokenSupplyCap`](#tokensupplycap). The max token supply MUST be set to a number greater than 0.
+
+<br/>
+
+### LSP7DecreaseAllowanceNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7decreaseallowancenotauthorized)
+- Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
+- Error signature: `LSP7DecreaseAllowanceNotAuthorized(address,address,address)`
+- Error hash: `0x98ce2945`
+
+:::
+
+```solidity
+error LSP7DecreaseAllowanceNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to decrease allowance is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 
@@ -1752,6 +1768,37 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7revokeoperatornotauthorized)
+- Solidity implementation: [`LSP7CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/extensions/LSP7CappedSupply.sol)
+- Error signature: `LSP7RevokeOperatorNotAuthorized(address,address,address)`
+- Error hash: `0x1a525b32`
+
+:::
+
+```solidity
+error LSP7RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
+++ b/docs/contracts/LSP7DigitalAsset/presets/LSP7Mintable.md
@@ -281,14 +281,15 @@ Returns the number of decimals used to get its user representation. If the asset
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#decreaseallowance)
 - Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
-- Function signature: `decreaseAllowance(address,uint256,bytes)`
-- Function selector: `0x7b204c4e`
+- Function signature: `decreaseAllowance(address,address,uint256,bytes)`
+- Function selector: `0x78381670`
 
 :::
 
 ```solidity
 function decreaseAllowance(
   address operator,
+  address tokenOwner,
   uint256 subtractedAmount,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -303,6 +304,7 @@ Atomically decreases the allowance granted to `operator` by the caller. This is 
 | Name                       |   Type    | Description                                            |
 | -------------------------- | :-------: | ------------------------------------------------------ |
 | `operator`                 | `address` | The operator to decrease allowance for `msg.sender`    |
+| `tokenOwner`               | `address` | The address of the token owner.                        |
 | `subtractedAmount`         | `uint256` | The amount to decrease by in the operator's allowance. |
 | `operatorNotificationData` |  `bytes`  | -                                                      |
 
@@ -523,14 +525,15 @@ Leaves the contract without owner. It will not be possible to call `onlyOwner` f
 
 - Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#revokeoperator)
 - Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
-- Function signature: `revokeOperator(address,bool,bytes)`
-- Function selector: `0x4521748e`
+- Function signature: `revokeOperator(address,address,bool,bytes)`
+- Function selector: `0x30d0dc37`
 
 :::
 
 ```solidity
 function revokeOperator(
   address operator,
+  address tokenOwner,
   bool notify,
   bytes operatorNotificationData
 ) external nonpayable;
@@ -543,6 +546,7 @@ Removes the `operator` address as an operator of callers tokens, disallowing it 
 | Name                       |   Type    | Description                                               |
 | -------------------------- | :-------: | --------------------------------------------------------- |
 | `operator`                 | `address` | The address to revoke as an operator.                     |
+| `tokenOwner`               | `address` | The address of the token owner.                           |
 | `notify`                   |  `bool`   | Boolean indicating whether to notify the operator or not. |
 | `operatorNotificationData` |  `bytes`  | The data to notify the operator about via LSP1.           |
 
@@ -1625,25 +1629,6 @@ Reverts when a batch call failed.
 
 <br/>
 
-### LSP7CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7cannotsendtoself)
-- Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
-- Error signature: `LSP7CannotSendToSelf()`
-- Error hash: `0xb9afb000`
-
-:::
-
-```solidity
-error LSP7CannotSendToSelf();
-```
-
-reverts when specifying the same address for `from` or `to` in a token transfer.
-
-<br/>
-
 ### LSP7CannotSendWithAddressZero
 
 :::note References
@@ -1685,6 +1670,37 @@ error LSP7CannotUseAddressZeroAsOperator();
 ```
 
 reverts when trying to set the zero address as an operator.
+
+<br/>
+
+### LSP7DecreaseAllowanceNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7decreaseallowancenotauthorized)
+- Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
+- Error signature: `LSP7DecreaseAllowanceNotAuthorized(address,address,address)`
+- Error hash: `0x98ce2945`
+
+:::
+
+```solidity
+error LSP7DecreaseAllowanceNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to decrease allowance is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 
@@ -1775,6 +1791,37 @@ reverts if the `tokenReceiver` is an EOA when minting or transferring tokens wit
 | Name            |   Type    | Description |
 | --------------- | :-------: | ----------- |
 | `tokenReceiver` | `address` | -           |
+
+<br/>
+
+### LSP7RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-7-DigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-7-DigitalAsset.md#lsp7revokeoperatornotauthorized)
+- Solidity implementation: [`LSP7Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP7DigitalAsset/presets/LSP7Mintable.sol)
+- Error signature: `LSP7RevokeOperatorNotAuthorized(address,address,address)`
+- Error hash: `0x1a525b32`
+
+:::
+
+```solidity
+error LSP7RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  address operator
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `operator`   | `address` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.md
@@ -1730,25 +1730,6 @@ Reverts when trying to send token to the zero address.
 
 <br/>
 
-### LSP8CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8cannotsendtoself)
-- Solidity implementation: [`LSP8IdentifiableDigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol)
-- Error signature: `LSP8CannotSendToSelf()`
-- Error hash: `0x5d67d6c1`
-
-:::
-
-```solidity
-error LSP8CannotSendToSelf();
-```
-
-Reverts when specifying the same address for `from` and `to` in a token transfer.
-
-<br/>
-
 ### LSP8CannotUseAddressZeroAsOperator
 
 :::note References
@@ -1966,6 +1947,37 @@ Reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8revokeoperatornotauthorized)
+- Solidity implementation: [`LSP8IdentifiableDigitalAsset.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.sol)
+- Error signature: `LSP8RevokeOperatorNotAuthorized(address,address,bytes32)`
+- Error hash: `0x760b5acd`
+
+:::
+
+```solidity
+error LSP8RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  bytes32 tokenId
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `tokenId`    | `bytes32` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.md
@@ -1756,25 +1756,6 @@ Reverts when trying to send token to the zero address.
 
 <br/>
 
-### LSP8CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8cannotsendtoself)
-- Solidity implementation: [`LSP8Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol)
-- Error signature: `LSP8CannotSendToSelf()`
-- Error hash: `0x5d67d6c1`
-
-:::
-
-```solidity
-error LSP8CannotSendToSelf();
-```
-
-Reverts when specifying the same address for `from` and `to` in a token transfer.
-
-<br/>
-
 ### LSP8CannotUseAddressZeroAsOperator
 
 :::note References
@@ -1992,6 +1973,37 @@ Reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8revokeoperatornotauthorized)
+- Solidity implementation: [`LSP8Burnable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Burnable.sol)
+- Error signature: `LSP8RevokeOperatorNotAuthorized(address,address,bytes32)`
+- Error hash: `0x760b5acd`
+
+:::
+
+```solidity
+error LSP8RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  bytes32 tokenId
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `tokenId`    | `bytes32` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.md
@@ -1730,25 +1730,6 @@ Reverts when trying to send token to the zero address.
 
 <br/>
 
-### LSP8CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8cannotsendtoself)
-- Solidity implementation: [`LSP8CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol)
-- Error signature: `LSP8CannotSendToSelf()`
-- Error hash: `0x5d67d6c1`
-
-:::
-
-```solidity
-error LSP8CannotSendToSelf();
-```
-
-Reverts when specifying the same address for `from` and `to` in a token transfer.
-
-<br/>
-
 ### LSP8CannotUseAddressZeroAsOperator
 
 :::note References
@@ -2008,6 +1989,37 @@ Reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8revokeoperatornotauthorized)
+- Solidity implementation: [`LSP8CappedSupply.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8CappedSupply.sol)
+- Error signature: `LSP8RevokeOperatorNotAuthorized(address,address,bytes32)`
+- Error hash: `0x760b5acd`
+
+:::
+
+```solidity
+error LSP8RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  bytes32 tokenId
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `tokenId`    | `bytes32` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.md
@@ -1758,25 +1758,6 @@ Reverts when trying to send token to the zero address.
 
 <br/>
 
-### LSP8CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8cannotsendtoself)
-- Solidity implementation: [`LSP8Enumerable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol)
-- Error signature: `LSP8CannotSendToSelf()`
-- Error hash: `0x5d67d6c1`
-
-:::
-
-```solidity
-error LSP8CannotSendToSelf();
-```
-
-Reverts when specifying the same address for `from` and `to` in a token transfer.
-
-<br/>
-
 ### LSP8CannotUseAddressZeroAsOperator
 
 :::note References
@@ -1994,6 +1975,37 @@ Reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8revokeoperatornotauthorized)
+- Solidity implementation: [`LSP8Enumerable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/extensions/LSP8Enumerable.sol)
+- Error signature: `LSP8RevokeOperatorNotAuthorized(address,address,bytes32)`
+- Error hash: `0x760b5acd`
+
+:::
+
+```solidity
+error LSP8RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  bytes32 tokenId
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `tokenId`    | `bytes32` | -           |
 
 <br/>
 

--- a/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
+++ b/docs/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.md
@@ -1796,25 +1796,6 @@ Reverts when trying to send token to the zero address.
 
 <br/>
 
-### LSP8CannotSendToSelf
-
-:::note References
-
-- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8cannotsendtoself)
-- Solidity implementation: [`LSP8Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol)
-- Error signature: `LSP8CannotSendToSelf()`
-- Error hash: `0x5d67d6c1`
-
-:::
-
-```solidity
-error LSP8CannotSendToSelf();
-```
-
-Reverts when specifying the same address for `from` and `to` in a token transfer.
-
-<br/>
-
 ### LSP8CannotUseAddressZeroAsOperator
 
 :::note References
@@ -2032,6 +2013,37 @@ Reverts when `operator` is already authorized for the `tokenId`.
 | ---------- | :-------: | ----------- |
 | `operator` | `address` | -           |
 | `tokenId`  | `bytes32` | -           |
+
+<br/>
+
+### LSP8RevokeOperatorNotAuthorized
+
+:::note References
+
+- Specification details: [**LSP-8-IdentifiableDigitalAsset**](https://github.com/lukso-network/lips/tree/main/LSPs/LSP-8-IdentifiableDigitalAsset.md#lsp8revokeoperatornotauthorized)
+- Solidity implementation: [`LSP8Mintable.sol`](https://github.com/lukso-network/lsp-smart-contracts/blob/develop/contracts/LSP8IdentifiableDigitalAsset/presets/LSP8Mintable.sol)
+- Error signature: `LSP8RevokeOperatorNotAuthorized(address,address,bytes32)`
+- Error hash: `0x760b5acd`
+
+:::
+
+```solidity
+error LSP8RevokeOperatorNotAuthorized(
+  address caller,
+  address tokenOwner,
+  bytes32 tokenId
+);
+```
+
+Reverts when the call to revoke operator is not authorized.
+
+#### Parameters
+
+| Name         |   Type    | Description |
+| ------------ | :-------: | ----------- |
+| `caller`     | `address` | -           |
+| `tokenOwner` | `address` | -           |
+| `tokenId`    | `bytes32` | -           |
 
 <br/>
 

--- a/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -486,8 +486,8 @@ export const shouldBehaveLikeLSP8 = (
             .connect(context.accounts.anyone)
             .revokeOperator(context.accounts.operator.address, mintedTokenId, false, '0x'),
         )
-          .to.be.revertedWithCustomError(context.lsp8, 'LSP8NotTokenOwner')
-          .withArgs(context.accounts.owner.address, mintedTokenId, context.accounts.anyone.address);
+          .to.be.revertedWithCustomError(context.lsp8, 'LSP8RevokeOperatorNotAuthorized')
+          .withArgs(context.accounts.anyone.address, context.accounts.owner.address, mintedTokenId);
       });
     });
 
@@ -580,6 +580,32 @@ export const shouldBehaveLikeLSP8 = (
           await expect(
             context.lsp8.revokeOperator(operator, tokenId, true, '0xaabbccdd'),
           ).to.be.revertedWith('I reverted');
+        });
+      });
+    });
+
+    describe('when caller is operator of tokenId', () => {
+      describe('when operator is not the zero address', () => {
+        it('should succeed', async () => {
+          const operator = context.accounts.operator.address;
+          const tokenOwner = context.accounts.owner.address;
+          const tokenId = mintedTokenId;
+
+          // pre-conditions
+          await context.lsp8.authorizeOperator(operator, tokenId, '0x');
+          expect(await context.lsp8.isOperatorFor(operator, tokenId)).to.be.true;
+
+          // effects
+          const tx = await context.lsp8
+            .connect(context.accounts.operator)
+            .revokeOperator(operator, tokenId, false, '0x');
+
+          await expect(tx)
+            .to.emit(context.lsp8, 'OperatorRevoked')
+            .withArgs(operator, tokenOwner, tokenId, false, '0x');
+
+          // post-conditions
+          expect(await context.lsp8.isOperatorFor(operator, tokenId)).to.be.false;
         });
       });
     });
@@ -920,30 +946,6 @@ export const shouldBehaveLikeLSP8 = (
               });
             });
           });
-
-          describe("when `from == to` address (= sending to tokenId's owner itself)", () => {
-            it('should revert', async () => {
-              const txParams = {
-                from: context.accounts.owner.address,
-                to: context.accounts.owner.address,
-                tokenId: mintedTokenId,
-                force,
-                data,
-              };
-
-              await expect(
-                context.lsp8
-                  .connect(operator)
-                  .transfer(
-                    txParams.from,
-                    txParams.to,
-                    txParams.tokenId,
-                    txParams.force,
-                    txParams.data,
-                  ),
-              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
-            });
-          });
         });
 
         describe('when force=false', () => {
@@ -1055,7 +1057,7 @@ export const shouldBehaveLikeLSP8 = (
                     txParams.force,
                     txParams.data,
                   ),
-              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8CannotSendToSelf');
+              ).to.be.revertedWithCustomError(context.lsp8, 'LSP8NotifyTokenReceiverIsEOA');
             });
           });
         });


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES
## 🚀 Feature


- allow Operator to revoke himself from LSP7 and LSP8
- Allow sending tokens to self

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
