### PR TITLE
ci: add `.npmrc` config file + setup `publish` as environnment to access `NPM_PUBLISH_TOKEN` via npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment: publish
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_KEY }}
+
     steps:
       - uses: google-github-actions/release-please-action@v3
         id: release
@@ -61,5 +65,3 @@ jobs:
           END
           )
           node ./publish.mjs outputs.json
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
 
       - name: Use Node.js v20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: ${{ steps.release.outputs.releases_created }}
         with:
           node-version: "20.x"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/config/tsconfig/package.json
+++ b/config/tsconfig/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "files": [
     "contracts.json",
     "contracts.module.json"

--- a/packages/lsp-smart-contracts/scripts/ci/README.md
+++ b/packages/lsp-smart-contracts/scripts/ci/README.md
@@ -6,7 +6,7 @@ The following folder contains files that are usually used as part of the CI/CD o
 
 - `ci/check-deployer-balance.ts`: check if the deployer address has at least 1 LYX to deploy the contract via `ci/deploy-verify.sh`.
 - `ci/deploy-verify.sh`: shell utility command to deploy + verify a smart contract on a specified network.
-- `ci/docs-generate.ts`: used to generate the user and dev docs into separate JSON files (this is used as part of our release CI to prepare the package when publoishing it on [npmjs.org](https://www.npmjs.com/package/@lukso/lsp-smart-contracts)).
+- `ci/docs-generate.ts`: used to generate the user and dev docs into separate JSON files (this is used as part of our release CI to prepare the package when publishing it on [npmjs.org](https://www.npmjs.com/package/@lukso/lsp-smart-contracts)).
 - `fix_flattener.js`: utility file to remove duplicate
 
 ## `deploy-verify.sh`


### PR DESCRIPTION
Related to the following issues and solutions:
- https://github.com/github/vscode-github-actions/issues/222#issuecomment-1765301497
- https://github.com/github/vscode-github-actions/issues/222#issuecomment-1741993145

And adding the `.npmrc` file from Github docs:
- https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry