### PR TITLE
docs: fix incorrect Natspec for LSP8 function `tokenOwnerOf`

### DIFF
--- a/packages/lsp8-contracts/contracts/ILSP8IdentifiableDigitalAsset.sol
+++ b/packages/lsp8-contracts/contracts/ILSP8IdentifiableDigitalAsset.sol
@@ -92,9 +92,9 @@ interface ILSP8IdentifiableDigitalAsset is IERC165, IERC725Y {
     function balanceOf(address tokenOwner) external view returns (uint256);
 
     /**
-     * @dev Returns the list of `tokenIds` for the `tokenOwner` address.
+     * @dev Returns the address that owns a given `tokenId`.
      *
-     * @param tokenId tokenOwner The address to query owned tokens
+     * @param tokenId The token ID to query the owner for.
      * @return The owner address of the given `tokenId`.
      *
      * @custom:requirements `tokenId` must exist.


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

The Natspec comments description of the function `tokenOwnerOf` is incorrect and is a duplicate of `tokenIdsOf` in the `ILSP8` interface. Fix the comment with a correct one.