### PR TITLE
fix: add missing `"package"` commands to generate artifacts + unify interface ID constant names

### DIFF
--- a/packages/lsp-smart-contracts/constants.ts
+++ b/packages/lsp-smart-contracts/constants.ts
@@ -4,13 +4,13 @@
  */
 // export * from './contracts';
 
-import { INTERFACE_ID_LSP0ERC725Account, LSP0_TYPE_IDS } from '@lukso/lsp0-contracts';
+import { INTERFACE_ID_LSP0, LSP0_TYPE_IDS } from '@lukso/lsp0-contracts';
 import { INTERFACE_ID_LSP1, LSP1DataKeys } from '@lukso/lsp1-contracts';
 import { INTERFACE_ID_LSP1DELEGATE } from '@lukso/lsp1delegate-contracts';
 import { LSP3DataKeys } from '@lukso/lsp3-contracts';
 import { LSP4DataKeys } from '@lukso/lsp4-contracts';
 import { LSP5DataKeys } from '@lukso/lsp5-contracts';
-import { INTERFACE_ID_LSP6KEYMANAGER, LSP6DataKeys } from '@lukso/lsp6-contracts';
+import { INTERFACE_ID_LSP6, LSP6DataKeys } from '@lukso/lsp6-contracts';
 import { INTERFACE_ID_LSP7, LSP7_TYPE_IDS } from '@lukso/lsp7-contracts';
 import { INTERFACE_ID_LSP8, LSP8DataKeys, LSP8_TYPE_IDS } from '@lukso/lsp8-contracts';
 import { INTERFACE_ID_LSP9, LSP9DataKeys, LSP9_TYPE_IDS } from '@lukso/lsp9-contracts';
@@ -58,10 +58,10 @@ export const INTERFACE_IDS = {
   ERC1155: '0xd9b67a26',
   ERC725X: '0x7545acac',
   ERC725Y: '0x629aa694',
-  LSP0ERC725Account: INTERFACE_ID_LSP0ERC725Account,
+  LSP0ERC725Account: INTERFACE_ID_LSP0,
   LSP1UniversalReceiver: INTERFACE_ID_LSP1,
   LSP1UniversalReceiverDelegate: INTERFACE_ID_LSP1DELEGATE,
-  LSP6KeyManager: INTERFACE_ID_LSP6KEYMANAGER,
+  LSP6KeyManager: INTERFACE_ID_LSP6,
   LSP7DigitalAsset: INTERFACE_ID_LSP7,
   LSP8IdentifiableDigitalAsset: INTERFACE_ID_LSP8,
   LSP9Vault: INTERFACE_ID_LSP9,

--- a/packages/lsp0-contracts/constants.ts
+++ b/packages/lsp0-contracts/constants.ts
@@ -1,6 +1,6 @@
 // ERC165 Interface ID
 // ----------
-export const INTERFACE_ID_LSP0ERC725Account = '0x24871b3d';
+export const INTERFACE_ID_LSP0 = '0x24871b3d';
 
 // ERC1271
 // ----------

--- a/packages/lsp0-contracts/package.json
+++ b/packages/lsp0-contracts/package.json
@@ -36,14 +36,14 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp1-contracts/hardhat.config.ts
+++ b/packages/lsp1-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: [],
+    contracts: ['ILSP1UniversalReceiver', 'ILSP1UniversalReceiverDelegate'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp1-contracts/package.json
+++ b/packages/lsp1-contracts/package.json
@@ -36,10 +36,12 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.3",

--- a/packages/lsp14-contracts/hardhat.config.ts
+++ b/packages/lsp14-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: ['LSP14Ownable2Step'],
+    contracts: ['ILSP14Ownable2Step', 'LSP14Ownable2Step'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp14-contracts/package.json
+++ b/packages/lsp14-contracts/package.json
@@ -36,10 +36,12 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp16-contracts/package.json
+++ b/packages/lsp16-contracts/package.json
@@ -35,13 +35,15 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:foundry": "forge build",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
     "test:foundry": "FOUNDRY_PROFILE=lsp16 forge test --no-match-test Skip -vvv",
-    "test:coverage": "hardhat coverage"
+    "test:coverage": "hardhat coverage",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.2",

--- a/packages/lsp17-contracts/hardhat.config.ts
+++ b/packages/lsp17-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: [],
+    contracts: ['Extension4337', 'OnERC721ReceivedExtension'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp17-contracts/package.json
+++ b/packages/lsp17-contracts/package.json
@@ -36,10 +36,12 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp17contractextension-contracts/hardhat.config.ts
+++ b/packages/lsp17contractextension-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: [],
+    contracts: ['LSP17Extendable', 'LSP17Extension'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp17contractextension-contracts/package.json
+++ b/packages/lsp17contractextension-contracts/package.json
@@ -36,10 +36,12 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp1delegate-contracts/package.json
+++ b/packages/lsp1delegate-contracts/package.json
@@ -36,14 +36,14 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp20-contracts/hardhat.config.ts
+++ b/packages/lsp20-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: [],
+    contracts: ['ILSP20CallVerifier', 'LSP20CallVerification'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp20-contracts/package.json
+++ b/packages/lsp20-contracts/package.json
@@ -36,9 +36,11 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   }
 }

--- a/packages/lsp23-contracts/hardhat.config.ts
+++ b/packages/lsp23-contracts/hardhat.config.ts
@@ -107,7 +107,13 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: ['LSP23LinkedContractsFactory', 'IPostDeploymentModule'],
+    contracts: [
+      'ILSP23LinkedContractsFactory',
+      'LSP23LinkedContractsFactory',
+      'IPostDeploymentModule',
+      'UniversalProfilePostDeploymentModule',
+      'UniversalProfileInitPostDeploymentModule',
+    ],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp23-contracts/package.json
+++ b/packages/lsp23-contracts/package.json
@@ -36,13 +36,13 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp25-contracts/hardhat.config.ts
+++ b/packages/lsp25-contracts/hardhat.config.ts
@@ -107,7 +107,7 @@ const config: HardhatUserConfig = {
   },
   packager: {
     // What contracts to keep the artifacts and the bindings for.
-    contracts: [],
+    contracts: ['ILSP25ExecuteRelayCall'],
     // Whether to include the TypeChain factories or not.
     // If this is enabled, you need to run the TypeChain files through the TypeScript compiler before shipping to the registry.
     includeFactories: true,

--- a/packages/lsp25-contracts/package.json
+++ b/packages/lsp25-contracts/package.json
@@ -36,12 +36,14 @@
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
-    "test:coverage": "hardhat coverage"
+    "test:coverage": "hardhat coverage",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.3"

--- a/packages/lsp4-contracts/package.json
+++ b/packages/lsp4-contracts/package.json
@@ -36,7 +36,6 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
@@ -45,7 +44,8 @@
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
-    "test:coverage": "hardhat coverage"
+    "test:coverage": "hardhat coverage",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp5-contracts/package.json
+++ b/packages/lsp5-contracts/package.json
@@ -39,7 +39,8 @@
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp6-contracts/constants.ts
+++ b/packages/lsp6-contracts/constants.ts
@@ -1,6 +1,6 @@
 import { LSP2ArrayKey } from '@lukso/lsp2-contracts';
 
-export const INTERFACE_ID_LSP6KEYMANAGER = '0x23f34c62';
+export const INTERFACE_ID_LSP6 = '0x23f34c62';
 
 /**
  * @dev values returned by the `isValidSignature` function of the ERC1271 standard.

--- a/packages/lsp6-contracts/hardhat.config.ts
+++ b/packages/lsp6-contracts/hardhat.config.ts
@@ -108,6 +108,7 @@ const config: HardhatUserConfig = {
   packager: {
     // What contracts to keep the artifacts and the bindings for.
     contracts: [
+      'ILSP6KeyManager',
       'LSP6KeyManager', // Standard version
       'LSP6KeyManagerInit', // Proxy version
     ],

--- a/packages/lsp6-contracts/package.json
+++ b/packages/lsp6-contracts/package.json
@@ -36,7 +36,6 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:foundry": "forge build",
     "build:js": "unbuild",
@@ -45,7 +44,8 @@
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
-    "test:foundry": "FOUNDRY_PROFILE=lsp6 forge test --no-match-test Skip -vvv"
+    "test:foundry": "FOUNDRY_PROFILE=lsp6 forge test --no-match-test Skip -vvv",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp7-contracts/hardhat.config.ts
+++ b/packages/lsp7-contracts/hardhat.config.ts
@@ -108,14 +108,17 @@ const config: HardhatUserConfig = {
   packager: {
     // What contracts to keep the artifacts and the bindings for.
     contracts: [
+      'ILSP7DigitalAsset',
       // Standard version
       // ------------------
       'LSP7DigitalAsset',
+      'LSP7Burnable',
       'LSP7CappedSupply',
       'LSP7Mintable',
       // Proxy version
       // ------------------
       'LSP7DigitalAssetInitAbstract',
+      'LSP7BurnableInitAbstract',
       'LSP7CappedSupplyInitAbstract',
       'LSP7MintableInit',
     ],

--- a/packages/lsp7-contracts/package.json
+++ b/packages/lsp7-contracts/package.json
@@ -36,14 +36,14 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp8-contracts/hardhat.config.ts
+++ b/packages/lsp8-contracts/hardhat.config.ts
@@ -108,15 +108,20 @@ const config: HardhatUserConfig = {
   packager: {
     // What contracts to keep the artifacts and the bindings for.
     contracts: [
+      'ILSP8IdentifiableDigitalAsset',
       // Standard version
       // ------------------
       'LSP8IdentifiableDigitalAsset',
+      'LSP8Burnable',
       'LSP8CappedSupply',
+      'LSP8Enumerable',
       'LSP8Mintable',
       // Proxy version
       // ------------------
       'LSP8IdentifiableDigitalAssetInitAbstract',
+      'LSP8BurnableInitAbstract',
       'LSP8CappedSupplyInitAbstract',
+      'LSP8EnumerableInitAbstract',
       'LSP8MintableInit',
     ],
     // Whether to include the TypeChain factories or not.

--- a/packages/lsp8-contracts/package.json
+++ b/packages/lsp8-contracts/package.json
@@ -36,14 +36,14 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp9-contracts/package.json
+++ b/packages/lsp9-contracts/package.json
@@ -36,14 +36,14 @@
     "Solidity"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:js": "unbuild",
     "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/packages/universalprofile-contracts/package.json
+++ b/packages/universalprofile-contracts/package.json
@@ -35,10 +35,12 @@
   ],
   "scripts": {
     "build": "hardhat compile --show-stack-traces",
+    "build:types": "npx wagmi generate",
     "clean": "hardhat clean && rm -Rf dist/",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
-    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'"
+    "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",

--- a/template/package.json
+++ b/template/package.json
@@ -36,7 +36,6 @@
     "./README.md"
   ],
   "scripts": {
-    "package": "hardhat prepare-package",
     "build": "hardhat compile --show-stack-traces",
     "build:foundry": "forge build",
     "build:js": "unbuild",
@@ -47,7 +46,8 @@
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
     "test:foundry": "FOUNDRY_PROFILE=lspN forge test --no-match-test Skip -vvv",
-    "test:coverage": "hardhat coverage"
+    "test:coverage": "hardhat coverage",
+    "package": "hardhat prepare-package"
   },
   "dependencies": {
     "@erc725/smart-contracts": "^7.0.0",


### PR DESCRIPTION
# What does this PR introduce?

- rename constants for the interface IDs of LSP0 and LSP6
- add missing JSON contract artifacts names for:
    - LSP1 package
    - LSP4 package
    - LSP17 contracts package
    - LSP20 package
    - LSP23 package
    - LSP25 package
    - Universal Profile package
    
- add missing `"package"` script to generate JSON artifacts for:
    - LSP1 package
    - LSP4 package
    - LSP14 package
    - LSP16 package
    - LSP1 Delegate package
    - LSP17 contract extension package
    - LSP20 package
    - LSP23 package
    - LSP25 package
    - Universal Profile package
    
 - add missing `"build:types"` script to generate WAGMI types for:
     - LSP1 package
     - LSP4 package
     - LSP14 package
     - LSP16 package
     - LSP1 Delegate package
     - LSP17 contract extension package
     - LSP20 package
     - LSP23 package
    - LSP25 package
    - Universal Profile package