### PR TITLE
fix: Match node versions across dev, github actions so it works with mise, asdf and so on

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js v20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: "npm"
@@ -59,10 +59,10 @@ jobs:
         with:
           clean: false
 
-      - name: Use Node.js '16.15.0'
-        uses: actions/setup-node@v2
+      - name: Use Node.js '20.x'
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.15.0"
+          node-version: "20.x"
           cache: "npm"
 
       - name: 📦 Install dependencies

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -13,7 +13,7 @@ jobs:
 
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       - name: Use Node.js v20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: "npm"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js v16
-        uses: actions/setup-node@v2
+      - name: Use Node.js v20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Use Node.js v20
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           cache: "npm"

--- a/.github/workflows/mythx-analysis.yml
+++ b/.github/workflows/mythx-analysis.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Node.js '16.15.0'
-        uses: actions/setup-node@v2
+      - name: Setup Node.js '20.x'
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.15.0"
+          node-version: "20.x"
           cache: "npm"
 
       - name: Set up Python 3.8

--- a/.github/workflows/solc_version.yml
+++ b/.github/workflows/solc_version.yml
@@ -49,10 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js '16.15.0'
-        uses: actions/setup-node@v2
+      - name: Use Node.js '20.x'
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.15.0"
+          node-version: "20.x"
           cache: "npm"
 
       - name: 📦 Install dependencies

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 16.19.0
+nodejs 20


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

## 🐛 Bug

Currently the project will not work on a machine with mise or asdf
due to the fact that the .tool-versions points to node 16.x which is no
longer compatible with most of the npm modules.

Along the way I also found that a lot of the github actions were still using
the old actions/setup-node@v2 and actions/setup-node@v3 as well
as specifying node 16.x

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
