### PR TITLE
Sub - LSP26 follower system upgrade - private mode, remove follower, block/unblock

### DIFF
--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -129,7 +129,7 @@ interface ILSP26FollowerSystem {
 
     /// @notice Check if an address is following a specific address.
     /// @param follower The address of the follower to check.
-    /// @param addr The address being followed.
+    /// @param followee The address being followed.
     /// @return True if `follower` is following `addr`, false otherwise.
     function isFollowing(
         address follower,

--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -77,14 +77,14 @@ interface ILSP26FollowerSystem {
     /// @param isApproved True if follower is approved, false if rejected.
     /// @custom:events {FollowRequestApproved} event when a follow request is approved.
     /// @custom:events {FollowRequestRejected} event when a follow request is rejected.
-    function handleFollowRequest(address follower, bool isApproved) external;
+    function respondToFollowRequest(address follower, bool isApproved) external;
 
     /// @notice Handles multiple follow requests in a batch operation.
     /// @param followers An array of addresses that sent follow requests.
     /// @param approvals An array of booleans indicating whether each corresponding follow request is approved (true) or rejected (false).
     /// @custom:events {FollowRequestApproved} event when a follow request is approved.
     /// @custom:events {FollowRequestRejected} event when a follow request is rejected.
-    function handleFollowRequestBatch(address[] calldata followers, bool[] calldata approvals) external;
+    function respondToFollowRequestBatch(address[] calldata followers, bool[] calldata approvals) external;
 
     /// @notice Removes specific follower from follower's list.
     /// @param follower The address to be removed.

--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -109,7 +109,7 @@ interface ILSP26FollowerSystem {
     /// @notice Unblock a specific address.
     /// @param addr The address to unblock.
     /// @custom:events {Unblock} event when unblocking an address.
-    function unblock(address addr) external;
+    function unblockAddress(address addr) external;
 
     /// @notice Unblock an array of addresses.
     /// @param addresses The addresses to unblock.
@@ -133,7 +133,7 @@ interface ILSP26FollowerSystem {
     /// @return True if `follower` is following `addr`, false otherwise.
     function isFollowing(
         address follower,
-        address addr
+        address followee
     ) external view returns (bool);
 
     /// @notice Get the number of followers for an address.
@@ -168,6 +168,11 @@ interface ILSP26FollowerSystem {
         uint256 endIndex
     ) external view returns (address[] memory);
 
+    /// @notice Get the number of pending requests for an address.
+    /// @param addr The address whose pending requests count is requested.
+    /// @return The number of pending requests for `addr`.
+    function pendingRequestCount(address addr) external view returns (uint256);
+
     /// @notice Get the list of pending follow requests for an address within a specified range.
     /// @param addr The address whose pending follow requests are requested.
     /// @param startIndex The start index of the range (inclusive).
@@ -178,6 +183,11 @@ interface ILSP26FollowerSystem {
         uint256 startIndex,
         uint256 endIndex
     ) external view returns (address[] memory);
+
+    /// @notice Get the number of blocked addresses for an address.
+    /// @param addr The address whose blocked addresses count is requested.
+    /// @return The number of blocked addresses for `addr`.
+    function blockedCount(address addr) external view returns (uint256);
 
     /// @notice Get the list of blocked addresses for an address within a specified range.
     /// @param addr The address whose blocked addresses are requested.

--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -92,14 +92,14 @@ interface ILSP26FollowerSystem {
     function remove(address follower) external;
 
     /// @notice Removes an array of followers from follower's list.
-    /// @param folowers The addresses to be removed.
+    /// @param followers The addresses to be removed.
     /// @custom:events {RemoveFollower} event when removing a follower in the list.
     function removeBatch(address[] memory followers) external;
 
     /// @notice Block a specific address. If the address is a follower, remove first, then block.
     /// @param addr The address to block.
     /// @custom:events {Block} event when blocking an address.
-    function block(address addr) external;
+    function blockAddress(address addr) external;
 
     /// @notice Block an array of addresses.
     /// @param addresses The addresses to block.
@@ -120,6 +120,12 @@ interface ILSP26FollowerSystem {
     /// @param addr The address to check.
     /// @return True if the address requires approval for following, false otherwise.
     function isApprovalRequired(address addr) external view returns (bool);
+
+    /// @notice Check if an address is blocked.
+    /// @param blocker The address that might have blocked the other address.
+    /// @param blocked The address that might be blocked.
+    /// @return True if the address is blocked, false otherwise.
+    function isBlocked(address blocker, address blocked) external view returns (bool);
 
     /// @notice Check if an address is following a specific address.
     /// @param follower The address of the follower to check.
@@ -157,6 +163,28 @@ interface ILSP26FollowerSystem {
     /// @param endIndex The end index of the range (exclusive).
     /// @return An array of addresses that are following an addresses.
     function getFollowersByIndex(
+        address addr,
+        uint256 startIndex,
+        uint256 endIndex
+    ) external view returns (address[] memory);
+
+    /// @notice Get the list of pending follow requests for an address within a specified range.
+    /// @param addr The address whose pending follow requests are requested.
+    /// @param startIndex The start index of the range (inclusive).
+    /// @param endIndex The end index of the range (exclusive).
+    /// @return An array of addresses that have sent follow requests to `addr`.
+    function getPendingFollowRequests(
+        address addr,
+        uint256 startIndex,
+        uint256 endIndex
+    ) external view returns (address[] memory);
+
+    /// @notice Get the list of blocked addresses for an address within a specified range.
+    /// @param addr The address whose blocked addresses are requested.
+    /// @param startIndex The start index of the range (inclusive).
+    /// @param endIndex The end index of the range (exclusive).
+    /// @return An array of addresses that are blocked by `addr`.
+    function getBlockedAddresses(
         address addr,
         uint256 startIndex,
         uint256 endIndex

--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -5,12 +5,52 @@ interface ILSP26FollowerSystem {
     /// @notice Emitted when following an address.
     /// @param follower The address that follows `addr`
     /// @param addr The address that is followed by `follower`
-    event Follow(address follower, address addr);
+    event Follow(address indexed follower, address indexed addr);
 
     /// @notice Emitted when unfollowing an address.
     /// @param unfollower The address that unfollows `addr`
     /// @param addr The address that is unfollowed by `follower`
-    event Unfollow(address unfollower, address addr);
+    event Unfollow(address indexed unfollower, address indexed addr);
+
+    /// @notice Emitted when a follower is removed.
+    /// @param followee The address that removed the follower.
+    /// @param follower The address that was removed.
+    event RemoveFollower(address indexed followee, address indexed follower);
+
+    /// @notice Emitted when an address is blocked.
+    /// @param initiator The address that blocked the other address.
+    /// @param addr The address that was blocked.
+    event Block(address indexed initiator, address indexed addr);
+
+    /// @notice Emitted when an address is unblocked.
+    /// @param initiator The address that unblocked the other address.
+    /// @param addr The address that was unblocked.
+    event Unblock(address indexed initiator, address indexed addr);
+
+    /// @notice Emitted when the `requiresApproval` setting is toggled.
+    /// @param owner The address that toggled the approval setting.
+    /// @param requiresApproval The new state of the `requiresApproval` setting.
+    event RequiresApprovalSet(address indexed owner, bool requiresApproval);
+
+    /// @notice Emitted when a follow request is sent.
+    /// @param requester The address that sent the follow request.
+    /// @param target The address that received the follow request.
+    event FollowRequestSent(address indexed requester, address indexed target);
+
+    /// @notice Emitted when a follow request is approved.
+    /// @param approver The address that approved the follow request.
+    /// @param follower The address that sent the follow request.
+    event FollowRequestApproved(address indexed approver, address indexed follower);
+
+    /// @notice Emitted when a follow request is rejected.
+    /// @param rejector The address that rejected the follow request.
+    /// @param follower The address that sent the follow request.
+    event FollowRequestRejected(address indexed rejector, address indexed follower);
+
+    /// @notice Set whether following requires approval from the followee.
+    /// @param requiresApproval True if following requires approval from the followee, false otherwise.
+    /// @custom:events {RequiresApprovalSet} event when toggling the approval setting.
+    function setRequiresApproval(bool requiresApproval) external;
 
     /// @notice Follow an specific address.
     /// @param addr The address to start following.
@@ -29,8 +69,57 @@ interface ILSP26FollowerSystem {
 
     /// @notice Unfollow a list of addresses.
     /// @param addresses The list of addresses to unfollow.
-    /// @custom:events {Follow} event when unfollowing each address in the list.
+    /// @custom:events {Unfollow} event when unfollowing each address in the list.
     function unfollowBatch(address[] memory addresses) external;
+
+    /// @notice Handles follow request pending approval/rejection.
+    /// @param follower Address that requested follow, pending approval/rejection.
+    /// @param isApproved True if follower is approved, false if rejected.
+    /// @custom:events {FollowRequestApproved} event when a follow request is approved.
+    /// @custom:events {FollowRequestRejected} event when a follow request is rejected.
+    function handleFollowRequest(address follower, bool isApproved) external;
+
+    /// @notice Handles multiple follow requests in a batch operation.
+    /// @param followers An array of addresses that sent follow requests.
+    /// @param approvals An array of booleans indicating whether each corresponding follow request is approved (true) or rejected (false).
+    /// @custom:events {FollowRequestApproved} event when a follow request is approved.
+    /// @custom:events {FollowRequestRejected} event when a follow request is rejected.
+    function handleFollowRequestBatch(address[] calldata followers, bool[] calldata approvals) external;
+
+    /// @notice Removes specific follower from follower's list.
+    /// @param follower The address to be removed.
+    /// @custom:events {RemoveFollower} event when removing a follower.
+    function remove(address follower) external;
+
+    /// @notice Removes an array of followers from follower's list.
+    /// @param folowers The addresses to be removed.
+    /// @custom:events {RemoveFollower} event when removing a follower in the list.
+    function removeBatch(address[] memory followers) external;
+
+    /// @notice Block a specific address. If the address is a follower, remove first, then block.
+    /// @param addr The address to block.
+    /// @custom:events {Block} event when blocking an address.
+    function block(address addr) external;
+
+    /// @notice Block an array of addresses.
+    /// @param addresses The addresses to block.
+    /// @custom:events {Block} event when blocking an address in the list.
+    function blockBatch(address[] memory addresses) external;
+
+    /// @notice Unblock a specific address.
+    /// @param addr The address to unblock.
+    /// @custom:events {Unblock} event when unblocking an address.
+    function unblock(address addr) external;
+
+    /// @notice Unblock an array of addresses.
+    /// @param addresses The addresses to unblock.
+    /// @custom:events {Unblock} event when unblocking an address in the list.
+    function unblockBatch(address[] memory addresses) external;
+
+    /// @notice Get if the following requires approval from the followee.
+    /// @param addr The address to check.
+    /// @return True if the address requires approval for following, false otherwise.
+    function isApprovalRequired(address addr) external view returns (bool);
 
     /// @notice Check if an address is following a specific address.
     /// @param follower The address of the follower to check.

--- a/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/ILSP26FollowerSystem.sol
@@ -15,7 +15,7 @@ interface ILSP26FollowerSystem {
     /// @notice Emitted when a follower is removed.
     /// @param followee The address that removed the follower.
     /// @param follower The address that was removed.
-    event RemoveFollower(address indexed followee, address indexed follower);
+    event RemovedFollower(address indexed followee, address indexed follower);
 
     /// @notice Emitted when an address is blocked.
     /// @param initiator The address that blocked the other address.
@@ -89,12 +89,12 @@ interface ILSP26FollowerSystem {
     /// @notice Removes specific follower from follower's list.
     /// @param follower The address to be removed.
     /// @custom:events {RemoveFollower} event when removing a follower.
-    function remove(address follower) external;
+    function removeFollower(address follower) external;
 
     /// @notice Removes an array of followers from follower's list.
     /// @param followers The addresses to be removed.
     /// @custom:events {RemoveFollower} event when removing a follower in the list.
-    function removeBatch(address[] memory followers) external;
+    function removeFollowerBatch(address[] memory followers) external;
 
     /// @notice Block a specific address. If the address is a follower, remove first, then block.
     /// @param addr The address to block.

--- a/packages/lsp26-contracts/contracts/LSP26Constants.sol
+++ b/packages/lsp26-contracts/contracts/LSP26Constants.sol
@@ -8,3 +8,24 @@ bytes32 constant _TYPEID_LSP26_FOLLOW = 0x71e02f9f05bcd5816ec4f3134aa2e5a9166695
 
 // keccak256('LSP26FollowerSystem_UnfollowNotification')
 bytes32 constant _TYPEID_LSP26_UNFOLLOW = 0x9d3c0b4012b69658977b099bdaa51eff0f0460f421fba96d15669506c00d1c4f;
+
+// keccak256('LSP26FollowerSystem_RemoveFollowerNotification')
+bytes32 constant _TYPEID_LSP26_REMOVE_FOLLOWER = 0x1e4d1b7dbb4a5a9e7a5a4a91a1e26a24e4c04e6bfa3b823b896f3d5d6d4d72f2;
+
+// keccak256('LSP26FollowerSystem_BlockNotification')
+bytes32 constant _TYPEID_LSP26_BLOCK = 0x8f7b879cb22d038f5c5f5c5cba1b055021c1f6c3a4d2c0716f20d8a8d9e3d93a;
+
+// keccak256('LSP26FollowerSystem_UnblockNotification')
+bytes32 constant _TYPEID_LSP26_UNBLOCK = 0x07d26bcb0de905f78b6f3cdd1e1c09c0a5c6c4e1c9b1b37990fdc8ef4b0c6e2b;
+
+// keccak256('LSP26FollowerSystem_RequiresApprovalSetNotification')
+bytes32 constant _TYPEID_LSP26_REQUIRES_APPROVAL_SET = 0x4f8f55ae0e5f905057cf0069e0f4c0b556f7d291a7b6e4a4cbbdbd7b0c3a1f2a;
+
+// keccak256('LSP26FollowerSystem_FollowRequestSent')
+bytes32 constant _TYPEID_LSP26_FOLLOW_REQUEST_SENT = 0x4f8f55ae0e5f905057cf0069e0f4c0b556f7d291a7b6e4a4cbbdbd7b0c3a1f2a;
+
+// keccak256('LSP26FollowerSystem_FollowRequestApproved')
+bytes32 constant _TYPEID_LSP26_FOLLOW_REQUEST_APPROVED = 0x4f8f55ae0e5f905057cf0069e0f4c0b556f7d291a7b6e4a4cbbdbd7b0c3a1f2a;
+
+// keccak256('LSP26FollowerSystem_FollowRequestRejected')
+bytes32 constant _TYPEID_LSP26_FOLLOW_REQUEST_REJECTED = 0x4f8f55ae0e5f905057cf0069e0f4c0b556f7d291a7b6e4a4cbbdbd7b0c3a1f2a;

--- a/packages/lsp26-contracts/contracts/LSP26Errors.sol
+++ b/packages/lsp26-contracts/contracts/LSP26Errors.sol
@@ -6,3 +6,19 @@ error LSP26CannotSelfFollow();
 error LSP26AlreadyFollowing(address addr);
 
 error LSP26NotFollowing(address addr);
+
+error LSP26CannotRemoveNonFollower(address addr);
+
+error LSP26CannotRemoveSelf();
+
+error LSP26CannotBlockSelf();
+
+error LSP26CannotUnblockSelf();
+
+error LSP26AlreadyBlocked(address addr);
+
+error LSP26NotBlocked(address addr);
+
+error LSP26NoFollowRequestPending(address follower);
+
+error LSP26FollowRequestAlreadyPending(address addr);

--- a/packages/lsp26-contracts/contracts/LSP26Errors.sol
+++ b/packages/lsp26-contracts/contracts/LSP26Errors.sol
@@ -11,6 +11,8 @@ error LSP26CannotRemoveNonFollower(address addr);
 
 error LSP26CannotRemoveSelf();
 
+error LSP26BlockedFromFollowing(address addr);
+
 error LSP26CannotBlockSelf();
 
 error LSP26CannotUnblockSelf();

--- a/packages/lsp26-contracts/contracts/LSP26Errors.sol
+++ b/packages/lsp26-contracts/contracts/LSP26Errors.sol
@@ -17,6 +17,8 @@ error LSP26CannotBlockSelf();
 
 error LSP26CannotUnblockSelf();
 
+error LSP26UserBlocked(address addr);
+
 error LSP26AlreadyBlocked(address addr);
 
 error LSP26NotBlocked(address addr);

--- a/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
@@ -299,6 +299,10 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
             revert LSP26BlockedFromFollowing(addr);
         }
 
+        if(_blockedAddresses[msg.sender].contains(addr)) {
+            revert LSP26UserBlocked(addr);
+        }
+
         if (_requiresApproval[addr]) {
             _createFollowRequest(addr);
         } else {
@@ -391,7 +395,7 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
             revert LSP26AlreadyBlocked(addr);
         }
 
-        // If the address is a follower, remove it first
+        // If the address is a follower, remove it
         if (_followersOf[msg.sender].contains(addr)) {
             _removeFollower(addr);
         }

--- a/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
@@ -40,6 +40,7 @@ import {
     LSP26CannotBlockSelf,
     LSP26BlockedFromFollowing,
     LSP26CannotUnblockSelf,
+    LSP26UserBlocked,
     LSP26AlreadyBlocked,
     LSP26NotBlocked,
     LSP26NoFollowRequestPending,

--- a/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
@@ -150,12 +150,12 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
     }
 
     // @inheritdoc ILSP26FollowerSystem
-    function remove(address follower) external {
+    function removeFollower(address follower) external {
         _removeFollower(follower);
     }
 
     // @inheritdoc ILSP26FollowerSystem
-    function removeBatch(address[] memory followers) external {
+    function removeFollowerBatch(address[] memory followers) external {
         for (uint256 i = 0; i < followers.length; i++) {
             _removeFollower(followers[i]);
         }
@@ -360,7 +360,7 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
 
         _followingsOf[follower].remove(msg.sender);
 
-        emit RemoveFollower(msg.sender, follower);
+        emit RemovedFollower(msg.sender, follower);
     }
 
     function _unfollow(address addr) internal {

--- a/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
+++ b/packages/lsp26-contracts/contracts/LSP26FollowerSystem.sol
@@ -146,6 +146,18 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
     }
 
     // @inheritdoc ILSP26FollowerSystem
+    function remove(address follower) external {
+        _removeFollower(follower);
+    }
+
+    // @inheritdoc ILSP26FollowerSystem
+    function removeBatch(address[] memory followers) external {
+        for (uint256 i = 0; i < followers.length; i++) {
+            _removeFollower(followers[i]);
+        }
+    }
+
+    // @inheritdoc ILSP26FollowerSystem
     function isApprovalRequired(address addr) external view returns (bool) {
         return _requiresApproval[addr];
     }
@@ -248,6 +260,22 @@ contract LSP26FollowerSystem is ILSP26FollowerSystem {
                 )
             {} catch {}
         }
+    }
+
+    function _removeFollower(address follower) internal {
+        if (follower == msg.sender) {
+            revert LSP26CannotRemoveSelf();
+        }
+
+        bool isRemoved = _followersOf[msg.sender].remove(follower);
+
+        if (!isRemoved) {
+            revert LSP26NotFollowing(follower);
+        }
+
+        _followingsOf[follower].remove(msg.sender);
+
+        emit RemoveFollower(msg.sender, follower);
     }
 
     function _unfollow(address addr) internal {


### PR DESCRIPTION
# Enhanced LSP26 Follower System

This PR introduces several new features to the LSP26 Follower System, providing users with greater control over their Universal Profile and social interactions. These enhancements aim to address common issues in social networks and create a more user-controlled environment.

## New Features

### 1. Private Account Mode

Users can now set their account to private, requiring approval for new follow requests.

**Example:**


```
// Set account to private
followerSystem.setRequiresApproval(true);

// Approve a follow request
followerSystem.respondToFollowRequest(requesterAddress, true);

// Reject a follow request
followerSystem.respondToFollowRequest(requesterAddress, false);
```


### 2. Follower Removal

Account owners can now remove followers from their list.

**Example:**

```
// Remove a single follower
followerSystem.removeFollower(followerAddress);

// Remove multiple followers
followerSystem.removeFollowerBatch([follower1, follower2, follower3]);
```

### 3. Blocking

Users can block other accounts, preventing them from following and potentially interacting in other ways.

**Example:**

```
// Block a single address
followerSystem.blockAddress(addressToBlock);

// Block multiple addresses
followerSystem.blockBatch([address1, address2, address3]);
```

### 4. Unblocking

Blocked accounts can be unblocked, allowing normal interactions to resume.

**Example:**

```
// Unblock a single address
followerSystem.unblockAddress(addressToUnblock);

// Unblock multiple addresses
followerSystem.unblockBatch([address1, address2, address3]);
```

## What was changed?

Here's list of new functions, internal functions, errors, constants, events and state variables introduced in this PR.

**New functions introduced in the LSP26 interface & contract:**

```
setRequiresApproval
respondToFollowRequest
respondToFollowRequestBatch
removeFollower
removeFollowerBatch
blockAddress
blockBatch
unblockAddress
unblockBatch
isApprovalRequired
isBlocked
pendingRequestCount
getPendingFollowRequests
blockedCount
getBlockedAddresses
```

**New internal functions in the LSP26 contract:**

```
_createFollowRequest
_addFollower
_removeFollower
_block
_unblock
```

**New errors:**

```
LSP26CannotRemoveSelf
LSP26CannotBlockSelf
LSP26BlockedFromFollowing
LSP26CannotUnblockSelf
LSP26UserBlocked
LSP26AlreadyBlocked
LSP26NotBlocked
LSP26NoFollowRequestPending
LSP26FollowRequestAlreadyPending
```

**New constants:**

```
_TYPEID_LSP26_REMOVE_FOLLOWER
_TYPEID_LSP26_BLOCK
_TYPEID_LSP26_UNBLOCK
_TYPEID_LSP26_REQUIRES_APPROVAL_SET
_TYPEID_LSP26_FOLLOW_REQUEST_SENT
_TYPEID_LSP26_FOLLOW_REQUEST_APPROVED
_TYPEID_LSP26_FOLLOW_REQUEST_REJECTED
```

**New events:**

```
RemovedFollower
Block
Unblock
RequiresApprovalSet
FollowRequestSent
FollowRequestApproved
FollowRequestRejected
```

**New state variables:**

```
_requiresApproval
_pendingFollowRequests
_blockedAddresses
```

## Testing and Quality Assurance

We've run our new features through Remix. So far, everything's working as intended, which is great news. But we know how crucial thorough testing is in smart contract development.

Moving forward:

1. LSP26FollowerSystem.test.ts needs to be updated to test new functionalities.
2. There might be edge cases - or use cases - that we haven't thought of before. Needs more investigating.
3. We need to ensure smooth integration with other LSP standards, particularly LSP1 to make sure nothing reverts.

We'd really appreciate input from the community on additional test scenarios. Fresh perspectives often uncover things we might have missed.

## Rationale

These new features address several key issues:

1. **Spam Prevention**: By allowing users to remove followers and block accounts, we reduce the impact of bot accounts and spam followers.

2. **Privacy Control**: Private account mode gives users the ability to curate their follower list, ensuring that only approved accounts can follow them.

3. **Content Filtering**: Blocking functionality can be used by dApps to filter content, allowing users to avoid seeing posts or interactions from blocked accounts.

4. **Enhanced Security**: These features provide a foundation for more secure interactions. For example, blocking could be integrated with LSP1 to prevent unwanted token transfers or contract interactions from blocked Universal Profiles.

5. **Flexible Implementation**: While these features provide powerful tools for user control, they are implemented in a way that allows dApps to utilize them flexibly, potentially creating more nuanced social experiences.

## Impact

I believe these new features make the LSP26 Follower System more robust and open up possibilities for more nuanced use cases. The idea for these enhancements came from looking at the current implementation of LSP26 and seeing the issues that users faced with botted accounts or otherwise.

For example - as mentioned earlier - the blocking feature could be used in conjunction with token transfers. Imagine a scenario where you don't want to receive tokens from a specific Universal Profile - blocking could be integrated with LSP1 to prevent such unwanted transfers.

These additions give users more control over their social interactions within the LUKSO ecosystem. They're not just abstract concepts; they address practical concerns like spam followers, unwanted interactions, and privacy control.

While there's always room for further improvements, I think these changes represent a solid step towards a more user-centric and flexible follower system for Universal Profiles. They provide a foundation that developers can build upon to create safer and more customizable social experiences in their dApps.

Thanks for reading! Let me know your thoughts