### PR TITLE
feat: add force params to internal functions

### DIFF
--- a/packages/lsp-smart-contracts/contracts/Mocks/Tokens/LSP8TransferOwnerChange.sol
+++ b/packages/lsp-smart-contracts/contracts/Mocks/Tokens/LSP8TransferOwnerChange.sol
@@ -41,6 +41,7 @@ contract LSP8TransferOwnerChange is LSP8IdentifiableDigitalAsset, LSP8Burnable {
         address,
         address,
         bytes32 tokenId,
+        bool,
         bytes memory
     ) internal override {
         // if tokenID exist transfer token ownership to this contract

--- a/packages/lsp7-contracts/contracts/LSP7DigitalAsset.sol
+++ b/packages/lsp7-contracts/contracts/LSP7DigitalAsset.sol
@@ -600,11 +600,11 @@ abstract contract LSP7DigitalAsset is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(address(0), to, amount, data);
+        _beforeTokenTransfer(address(0), to, amount, force, data);
 
         _update(address(0), to, amount, force, data);
 
-        _afterTokenTransfer(address(0), to, amount, data);
+        _afterTokenTransfer(address(0), to, amount, force, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -650,11 +650,11 @@ abstract contract LSP7DigitalAsset is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(from, address(0), amount, data);
+        _beforeTokenTransfer(from, address(0), amount, false, data);
 
         _update(from, address(0), amount, false, data);
 
-        _afterTokenTransfer(from, address(0), amount, data);
+        _afterTokenTransfer(from, address(0), amount, false, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -745,11 +745,11 @@ abstract contract LSP7DigitalAsset is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(from, to, amount, data);
+        _beforeTokenTransfer(from, to, amount, force, data);
 
         _update(from, to, amount, force, data);
 
-        _afterTokenTransfer(from, to, amount, data);
+        _afterTokenTransfer(from, to, amount, force, data);
 
         bytes memory lsp1Data = abi.encode(msg.sender, from, to, amount, data);
 
@@ -814,12 +814,14 @@ abstract contract LSP7DigitalAsset is
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256 amount,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
@@ -830,12 +832,14 @@ abstract contract LSP7DigitalAsset is
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
         uint256 amount,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 

--- a/packages/lsp7-contracts/contracts/LSP7DigitalAssetInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/LSP7DigitalAssetInitAbstract.sol
@@ -613,11 +613,11 @@ abstract contract LSP7DigitalAssetInitAbstract is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(address(0), to, amount, data);
+        _beforeTokenTransfer(address(0), to, amount, force, data);
 
         _update(address(0), to, amount, force, data);
 
-        _afterTokenTransfer(address(0), to, amount, data);
+        _afterTokenTransfer(address(0), to, amount, force, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -663,11 +663,11 @@ abstract contract LSP7DigitalAssetInitAbstract is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(from, address(0), amount, data);
+        _beforeTokenTransfer(from, address(0), amount, false, data);
 
         _update(from, address(0), amount, false, data);
 
-        _afterTokenTransfer(from, address(0), amount, data);
+        _afterTokenTransfer(from, address(0), amount, false, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -758,11 +758,11 @@ abstract contract LSP7DigitalAssetInitAbstract is
             revert LSP7CannotSendWithAddressZero();
         }
 
-        _beforeTokenTransfer(from, to, amount, data);
+        _beforeTokenTransfer(from, to, amount, force, data);
 
         _update(from, to, amount, force, data);
 
-        _afterTokenTransfer(from, to, amount, data);
+        _afterTokenTransfer(from, to, amount, force, data);
 
         bytes memory lsp1Data = abi.encode(msg.sender, from, to, amount, data);
 
@@ -827,12 +827,14 @@ abstract contract LSP7DigitalAssetInitAbstract is
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         uint256 amount,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
@@ -843,12 +845,14 @@ abstract contract LSP7DigitalAssetInitAbstract is
      * @param from The sender address
      * @param to The recipient address
      * @param amount The amount of token to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
         uint256 amount,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 

--- a/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAsset.sol
+++ b/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAsset.sol
@@ -711,7 +711,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
             revert LSP8TokenIdAlreadyMinted(tokenId);
         }
 
-        _beforeTokenTransfer(address(0), to, tokenId, data);
+        _beforeTokenTransfer(address(0), to, tokenId, force, data);
 
         // Check that `tokenId` was not minted inside the `_beforeTokenTransfer` hook
         if (_exists(tokenId)) {
@@ -726,7 +726,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
 
         emit Transfer(msg.sender, address(0), to, tokenId, force, data);
 
-        _afterTokenTransfer(address(0), to, tokenId, data);
+        _afterTokenTransfer(address(0), to, tokenId, force, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -763,7 +763,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        _beforeTokenTransfer(tokenOwner, address(0), tokenId, data);
+        _beforeTokenTransfer(tokenOwner, address(0), tokenId, false, data);
 
         // Re-fetch and update `tokenOwner` in case `tokenId`
         // was transferred inside the `_beforeTokenTransfer` hook
@@ -779,7 +779,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
 
         emit Transfer(msg.sender, tokenOwner, address(0), tokenId, false, data);
 
-        _afterTokenTransfer(tokenOwner, address(0), tokenId, data);
+        _afterTokenTransfer(tokenOwner, address(0), tokenId, false, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -833,7 +833,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
             revert LSP8CannotSendToAddressZero();
         }
 
-        _beforeTokenTransfer(from, to, tokenId, data);
+        _beforeTokenTransfer(from, to, tokenId, force, data);
 
         // Check that `tokenId`'s owner was not changed inside the `_beforeTokenTransfer` hook
         address currentTokenOwner = tokenOwnerOf(tokenId);
@@ -853,7 +853,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
 
         emit Transfer(msg.sender, from, to, tokenId, force, data);
 
-        _afterTokenTransfer(from, to, tokenId, data);
+        _afterTokenTransfer(from, to, tokenId, force, data);
 
         bytes memory lsp1Data = abi.encode(msg.sender, from, to, tokenId, data);
 
@@ -899,12 +899,14 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
@@ -915,12 +917,14 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 

--- a/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -728,7 +728,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
             revert LSP8TokenIdAlreadyMinted(tokenId);
         }
 
-        _beforeTokenTransfer(address(0), to, tokenId, data);
+        _beforeTokenTransfer(address(0), to, tokenId, force, data);
 
         // Check that `tokenId` was not minted inside the `_beforeTokenTransfer` hook
         if (_exists(tokenId)) {
@@ -743,7 +743,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
 
         emit Transfer(msg.sender, address(0), to, tokenId, force, data);
 
-        _afterTokenTransfer(address(0), to, tokenId, data);
+        _afterTokenTransfer(address(0), to, tokenId, force, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -780,7 +780,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
 
-        _beforeTokenTransfer(tokenOwner, address(0), tokenId, data);
+        _beforeTokenTransfer(tokenOwner, address(0), tokenId, false, data);
 
         // Re-fetch and update `tokenOwner` in case `tokenId`
         // was transferred inside the `_beforeTokenTransfer` hook
@@ -796,7 +796,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
 
         emit Transfer(msg.sender, tokenOwner, address(0), tokenId, false, data);
 
-        _afterTokenTransfer(tokenOwner, address(0), tokenId, data);
+        _afterTokenTransfer(tokenOwner, address(0), tokenId, false, data);
 
         bytes memory lsp1Data = abi.encode(
             msg.sender,
@@ -850,7 +850,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
             revert LSP8CannotSendToAddressZero();
         }
 
-        _beforeTokenTransfer(from, to, tokenId, data);
+        _beforeTokenTransfer(from, to, tokenId, force, data);
 
         // Check that `tokenId`'s owner was not changed inside the `_beforeTokenTransfer` hook
         address currentTokenOwner = tokenOwnerOf(tokenId);
@@ -870,7 +870,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
 
         emit Transfer(msg.sender, from, to, tokenId, force, data);
 
-        _afterTokenTransfer(from, to, tokenId, data);
+        _afterTokenTransfer(from, to, tokenId, force, data);
 
         bytes memory lsp1Data = abi.encode(msg.sender, from, to, tokenId, data);
 
@@ -916,12 +916,14 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 
@@ -932,12 +934,14 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * @param from The sender address
      * @param to The recipient address
      * @param tokenId The tokenId to transfer
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the transfer
      */
     function _afterTokenTransfer(
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data // solhint-disable-next-line no-empty-blocks
     ) internal virtual {}
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Enumerable.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Enumerable.sol
@@ -35,12 +35,14 @@ abstract contract LSP8Enumerable is LSP8IdentifiableDigitalAsset {
      * @param from The address sending the `tokenId` (`address(0)` when `tokenId` is being minted).
      * @param to The address receiving the `tokenId` (`address(0)` when `tokenId` is being burnt).
      * @param tokenId The bytes32 identifier of the token being transferred.
+     * @param force A boolean that describe if transfer to a `to` address that does not support LSP1 is allowed or not.
      * @param data The data sent alongside the the token transfer.
      */
     function _beforeTokenTransfer(
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data
     ) internal virtual override {
         // `tokenId` being minted
@@ -63,6 +65,6 @@ abstract contract LSP8Enumerable is LSP8IdentifiableDigitalAsset {
             delete _tokenIndex[tokenId];
         }
 
-        super._beforeTokenTransfer(from, to, tokenId, data);
+        super._beforeTokenTransfer(from, to, tokenId, force, data);
     }
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8EnumerableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8EnumerableInitAbstract.sol
@@ -41,6 +41,7 @@ abstract contract LSP8EnumerableInitAbstract is
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data
     ) internal virtual override {
         if (from == address(0)) {
@@ -58,6 +59,6 @@ abstract contract LSP8EnumerableInitAbstract is
             delete _indexToken[lastIndex];
             delete _tokenIndex[tokenId];
         }
-        super._beforeTokenTransfer(from, to, tokenId, data);
+        super._beforeTokenTransfer(from, to, tokenId, force, data);
     }
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Votes.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Votes.sol
@@ -32,10 +32,11 @@ abstract contract LSP8Votes is LSP8IdentifiableDigitalAsset, Votes {
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data
     ) internal virtual override {
         _transferVotingUnits(from, to, 1);
-        super._afterTokenTransfer(from, to, tokenId, data);
+        super._afterTokenTransfer(from, to, tokenId, force, data);
     }
 
     /**

--- a/packages/lsp8-contracts/contracts/extensions/LSP8VotesInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8VotesInitAbstract.sol
@@ -54,10 +54,11 @@ abstract contract LSP8VotesInitAbstract is
         address from,
         address to,
         bytes32 tokenId,
+        bool force,
         bytes memory data
     ) internal virtual override {
         _transferVotingUnits(from, to, 1);
-        super._afterTokenTransfer(from, to, tokenId, data);
+        super._afterTokenTransfer(from, to, tokenId, force, data);
     }
 
     /**


### PR DESCRIPTION
# What does this PR introduce? 

- [x] add force parameters to `_beforeTokenTransfer` and `_afterTokenTransfer` to LSP7
- [x] add force parameters to `_beforeTokenTransfer` and `_afterTokenTransfer` to LSP8