### PR TITLE
build: fix package-lock and remove `@erc725` in LSP7/8 package as already obtained from LSP4 package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "@lukso/lsp-smart-contracts-monorepo",
-      "version": "0.14.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -18257,7 +18256,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp25-contracts": "~0.15.0",
-        "@openzeppelin/contracts": "^4.9.6"
+        "@openzeppelin/contracts": "^4.9.3"
       }
     },
     "packages/lsp12-contracts": {
@@ -18297,6 +18296,7 @@
         "@lukso/lsp14-contracts": "~0.15.0",
         "@lukso/lsp17contractextension-contracts": "~0.15.0",
         "@lukso/lsp20-contracts": "~0.15.0",
+        "@lukso/lsp6-contracts": "~0.15.0",
         "@openzeppelin/contracts": "^4.9.3"
       }
     },
@@ -18473,21 +18473,11 @@
       "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^8.0.0",
         "@lukso/lsp1-contracts": "~0.15.0",
         "@lukso/lsp17contractextension-contracts": "~0.16.0",
         "@lukso/lsp2-contracts": "~0.15.0",
         "@lukso/lsp4-contracts": "~0.16.0",
         "@openzeppelin/contracts": "^4.9.6"
-      }
-    },
-    "packages/lsp7-contracts/node_modules/@erc725/smart-contracts": {
-      "version": "8.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openzeppelin/contracts": "^4.9.6",
-        "@openzeppelin/contracts-upgradeable": "^4.9.6",
-        "solidity-bytes-utils": "0.8.0"
       }
     },
     "packages/lsp8-contracts": {
@@ -18495,21 +18485,11 @@
       "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@erc725/smart-contracts": "^8.0.0",
         "@lukso/lsp1-contracts": "~0.15.0",
         "@lukso/lsp17contractextension-contracts": "~0.16.0",
         "@lukso/lsp2-contracts": "~0.15.0",
         "@lukso/lsp4-contracts": "~0.16.0",
         "@openzeppelin/contracts": "^4.9.6"
-      }
-    },
-    "packages/lsp8-contracts/node_modules/@erc725/smart-contracts": {
-      "version": "8.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openzeppelin/contracts": "^4.9.6",
-        "@openzeppelin/contracts-upgradeable": "^4.9.6",
-        "solidity-bytes-utils": "0.8.0"
       }
     },
     "packages/lsp9-contracts": {

--- a/packages/lsp7-contracts/package.json
+++ b/packages/lsp7-contracts/package.json
@@ -47,7 +47,6 @@
     "package": "hardhat prepare-package"
   },
   "dependencies": {
-    "@erc725/smart-contracts": "^8.0.0",
     "@openzeppelin/contracts": "^4.9.6",
     "@lukso/lsp1-contracts": "~0.15.0",
     "@lukso/lsp2-contracts": "~0.15.0",

--- a/packages/lsp8-contracts/package.json
+++ b/packages/lsp8-contracts/package.json
@@ -47,7 +47,6 @@
     "package": "hardhat prepare-package"
   },
   "dependencies": {
-    "@erc725/smart-contracts": "^8.0.0",
     "@openzeppelin/contracts": "^4.9.6",
     "@lukso/lsp1-contracts": "~0.15.0",
     "@lukso/lsp2-contracts": "~0.15.0",


### PR DESCRIPTION

# What does this PR introduce?

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 🤖 CI
---->

## 📦 Build

- Fix `package-lock.json` corrupted (after removing the version field from the root `package.json`) by re-generating it.
- Remove dependencies on `@erc725/smart-contracts` in LSP7 and LSP8 package to avoid confusion (ERC725 package is not used directly in LSP7/8 packages, but rather inherited as `@erc725/smart-contracts-v8` from the LSP4 dependency).

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [x] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [x] Ran `npm run test`
