### PR TITLE
fix: use correct contract `LSP17ExtendableInitAbstract` in inheritance of LSP7 Init

### DIFF
--- a/packages/lsp-smart-contracts/package.json
+++ b/packages/lsp-smart-contracts/package.json
@@ -63,7 +63,7 @@
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "package": "hardhat prepare-package",
     "test": "hardhat test --no-compile tests/**/*.test.ts tests/LSP7DigitalAsset/**/*.ts tests/LSP8IdentifiableDigitalAsset/**/*.ts",
-    "test:foundry": "FOUNDRY_PROFILE=lsp_smart_contracts forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lsp_smart_contracts forge test -vvvv",
     "test:coverage": "hardhat coverage",
     "test:benchmark": "hardhat test --no-compile tests/Benchmark.test.ts"
   },

--- a/packages/lsp11-contracts/package.json
+++ b/packages/lsp11-contracts/package.json
@@ -42,7 +42,7 @@
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
-    "test:foundry": "FOUNDRY_PROFILE=lsp11 forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lsp11 forge test -vvvv",
     "test:coverage": "hardhat coverage",
     "package": "hardhat prepare-package"
   },

--- a/packages/lsp16-contracts/package.json
+++ b/packages/lsp16-contracts/package.json
@@ -41,7 +41,7 @@
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
-    "test:foundry": "FOUNDRY_PROFILE=lsp16 forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lsp16 forge test -vvvv",
     "test:coverage": "hardhat coverage",
     "package": "hardhat prepare-package"
   },

--- a/packages/lsp2-contracts/foundry/LSP2Utils.t.sol
+++ b/packages/lsp2-contracts/foundry/LSP2Utils.t.sol
@@ -8,6 +8,9 @@ import {BytesLib} from "solidity-bytes-utils/contracts/BytesLib.sol";
 import "../contracts/LSP2Utils.sol";
 
 contract LSP2UtilsTests is Test {
+    /// @dev Prevent error "FAIL: call didn't revert at a lower depth than cheatcode call depth;"
+    /// This is due to the new behaviour of Foundry
+    /// forge-config: default.allow_internal_expect_revert = true
     function testRevertsOnWrongLastBracket(string memory x) public {
         bytes memory dataKey = bytes(x);
         // check if x last char is not ]
@@ -18,6 +21,7 @@ contract LSP2UtilsTests is Test {
         }
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testRevertsOnWrongSecondToLastBracket(string memory x) public {
         bytes memory dataKey = bytes(x);
         // check if x sencond to last char is not [

--- a/packages/lsp2-contracts/package.json
+++ b/packages/lsp2-contracts/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
-    "test:foundry": "FOUNDRY_PROFILE=lsp2 forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lsp2 forge test -vvvv",
     "test:coverage": "hardhat coverage"
   },
   "dependencies": {

--- a/packages/lsp6-contracts/foundry/LSP6AllowedCallsTest.t.sol
+++ b/packages/lsp6-contracts/foundry/LSP6AllowedCallsTest.t.sol
@@ -119,7 +119,7 @@ contract LSP6AllowedCallsTest is Test {
         );
     }
 
-    function testFail_ShouldRevertForAnyMessageCallToTargetWithNoCallTypeAllowed(
+    function test_RevertForAnyMessageCallToTargetWithNoCallTypeAllowed(
         uint8 operationType,
         uint256 value,
         bytes memory callData
@@ -131,6 +131,14 @@ contract LSP6AllowedCallsTest is Test {
         // we should use a valid operation type
         vm.assume(operationType <= 4);
 
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NotAllowedCall.selector,
+                address(this),
+                targetContract,
+                bytes4(callData)
+            )
+        );
         keyManager.verifyAllowedCall(
             address(this),
             uint256(operationType),
@@ -140,7 +148,7 @@ contract LSP6AllowedCallsTest is Test {
         );
     }
 
-    function testFail_ShouldRevertWithEmptyCallNoValueWhenAssociatedCallTypeIsNotSet(
+    function test_RevertWithEmptyCallNoValueWhenAssociatedCallTypeIsNotSet(
         uint8 operationType,
         bytes4 callTypeToGrant
     ) public {
@@ -176,6 +184,7 @@ contract LSP6AllowedCallsTest is Test {
             bytes4(0xffffffff)
         ); // for any function
 
+        vm.expectRevert();
         keyManager.verifyAllowedCall(
             address(this),
             uint256(operationType),
@@ -278,7 +287,7 @@ contract LSP6AllowedCallsTest is Test {
         );
     }
 
-    function testFail_ShouldRevertWithCallDataAs0x00000000WhenCallTypeDoesNotAllowBytes4ZeroSelector(
+    function test_RevertWithCallDataAs0x00000000WhenCallTypeDoesNotAllowBytes4ZeroSelector(
         uint8 operationType,
         bytes4 callTypeToGrant,
         bytes4 randomFunctionSelectorToAllow
@@ -321,6 +330,7 @@ contract LSP6AllowedCallsTest is Test {
             randomFunctionSelectorToAllow
         );
 
+        vm.expectRevert();
         keyManager.verifyAllowedCall(
             address(this),
             uint256(operationType),

--- a/packages/lsp6-contracts/package.json
+++ b/packages/lsp6-contracts/package.json
@@ -44,7 +44,7 @@
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
-    "test:foundry": "FOUNDRY_PROFILE=lsp6 forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lsp6 forge test -vvvv",
     "package": "hardhat prepare-package"
   },
   "dependencies": {

--- a/packages/lsp7-contracts/contracts/LSP7DigitalAssetInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/LSP7DigitalAssetInitAbstract.sol
@@ -19,8 +19,8 @@ import {
     ERC725YInitAbstract
 } from "@lukso/lsp4-contracts/contracts/LSP4DigitalAssetMetadataInitAbstract.sol";
 import {
-    LSP17Extendable
-} from "@lukso/lsp17contractextension-contracts/contracts/LSP17Extendable.sol";
+    LSP17ExtendableInitAbstract
+} from "@lukso/lsp17contractextension-contracts/contracts/LSP17ExtendableInitAbstract.sol";
 
 // libraries
 import {LSP1Utils} from "@lukso/lsp1-contracts/contracts/LSP1Utils.sol";
@@ -77,7 +77,7 @@ import {
 abstract contract LSP7DigitalAssetInitAbstract is
     ILSP7DigitalAsset,
     LSP4DigitalAssetMetadataInitAbstract,
-    LSP17Extendable
+    LSP17ExtendableInitAbstract
 {
     using EnumerableSet for EnumerableSet.AddressSet;
 
@@ -236,13 +236,15 @@ abstract contract LSP7DigitalAssetInitAbstract is
         public
         view
         virtual
-        override(ERC725YInitAbstract, LSP17Extendable)
+        override(ERC725YInitAbstract, LSP17ExtendableInitAbstract)
         returns (bool)
     {
         return
             interfaceId == _INTERFACEID_LSP7 ||
             super.supportsInterface(interfaceId) ||
-            LSP17Extendable._supportsInterfaceInERC165Extension(interfaceId);
+            LSP17ExtendableInitAbstract._supportsInterfaceInERC165Extension(
+                interfaceId
+            );
     }
 
     // --- Token queries

--- a/template/package.json
+++ b/template/package.json
@@ -45,7 +45,7 @@
     "lint": "eslint . --ext .ts,.js",
     "lint:solidity": "solhint 'contracts/**/*.sol' && prettier --check 'contracts/**/*.sol'",
     "test": "hardhat test --no-compile tests/*.test.ts",
-    "test:foundry": "FOUNDRY_PROFILE=lspN forge test --no-match-test Skip -vvv",
+    "test:foundry": "FOUNDRY_PROFILE=lspN forge test -vvvv",
     "test:coverage": "hardhat coverage",
     "package": "hardhat prepare-package"
   },


### PR DESCRIPTION
# What does this PR introduce?

## 🐛 Bug

`LSP7DigitalAssetInitAbstract` inherits `LSP17Extendable`:

```solidity
abstract contract LSP7DigitalAssetInitAbstract is
    ILSP7DigitalAsset,
    LSP4DigitalAssetMetadataInitAbstract,
    LSP17Extendable
{
```

However, it should inherit `LSP17ExtendableInitAbstract` instead as it is an initializable contract.


