### PR TITLE
test: adjust tests for support interface to assert with `to.be.true`

### DIFF
--- a/packages/lsp-smart-contracts/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP1UniversalReceiver/LSP1UniversalReceiverDelegateUP.behaviour.ts
@@ -3224,14 +3224,14 @@ export const shouldInitializeLikeLSP1Delegate = (
   });
 
   describe('when the contract was initialized', () => {
-    it('should have registered the ERC165 interface', async () => {
+    it('should support the ERC165 interface', async () => {
       const result = await context.lsp1universalReceiverDelegateUP.supportsInterface(
         INTERFACE_IDS.ERC165,
       );
       expect(result).to.be.true;
     });
 
-    it('should have registered the LSP1 interface', async () => {
+    it('should support the LSP1 interface', async () => {
       const result = await context.lsp1universalReceiverDelegateUP.supportsInterface(
         INTERFACE_IDS.LSP1UniversalReceiverDelegate,
       );

--- a/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/LSP7DigitalAsset.behaviour.ts
@@ -2615,20 +2615,24 @@ export const shouldInitializeLikeLSP7 = (
   });
 
   describe('when the contract was initialized', () => {
-    it('should have registered the ERC165 interface', async () => {
-      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC165));
+    it('should support the ERC165 interface', async () => {
+      const result = await context.lsp7.supportsInterface(INTERFACE_IDS.ERC165);
+      expect(result).to.be.true;
     });
 
-    it('should have registered the ERC725Y interface', async () => {
-      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.ERC725Y));
+    it('should support the ERC725Y interface', async () => {
+      const result = await context.lsp7.supportsInterface(INTERFACE_IDS.ERC725Y);
+      expect(result).to.be.true;
     });
 
-    it('should have registered the LSP7 interface', async () => {
-      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.LSP7DigitalAsset));
+    it('should support the LSP7 interface', async () => {
+      const result = await context.lsp7.supportsInterface(INTERFACE_IDS.LSP7DigitalAsset);
+      expect(result).to.be.true;
     });
 
-    it('should have registered the LSP17Extendable interface', async () => {
-      expect(await context.lsp7.supportsInterface(INTERFACE_IDS.LSP17Extendable));
+    it('should support the LSP17Extendable interface', async () => {
+      const result = await context.lsp7.supportsInterface(INTERFACE_IDS.LSP17Extendable);
+      expect(result).to.be.true;
     });
 
     it('should have set expected entries with ERC725Y.setData', async () => {

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8IdentifiableDigitalAsset.behaviour.ts
@@ -2211,20 +2211,26 @@ export const shouldInitializeLikeLSP8 = (
   });
 
   describe('when the contract was initialized', () => {
-    it('should have registered the ERC165 interface', async () => {
-      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC165));
+    it('should support the ERC165 interface', async () => {
+      const result = await context.lsp8.supportsInterface(INTERFACE_IDS.ERC165);
+      expect(result).to.be.true;
     });
 
-    it('should have registered the ERC725Y interface', async () => {
-      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.ERC725Y));
+    it('should support the ERC725Y interface', async () => {
+      const result = await context.lsp8.supportsInterface(INTERFACE_IDS.ERC725Y);
+      expect(result).to.be.true;
     });
 
-    it('should have registered the LSP8 interface', async () => {
-      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.LSP8IdentifiableDigitalAsset));
+    it('should support the LSP8 interface', async () => {
+      const result = await context.lsp8.supportsInterface(
+        INTERFACE_IDS.LSP8IdentifiableDigitalAsset,
+      );
+      expect(result).to.be.true;
     });
 
-    it('should have registered the LSP17Extendable interface', async () => {
-      expect(await context.lsp8.supportsInterface(INTERFACE_IDS.LSP17Extendable));
+    it('should support the LSP17Extendable interface', async () => {
+      const result = await context.lsp8.supportsInterface(INTERFACE_IDS.LSP17Extendable);
+      expect(result).to.be.true;
     });
 
     it('should have set expected entries with ERC725Y.setData', async () => {

--- a/packages/lsp-smart-contracts/tests/LSP9Vault/LSP9Vault.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP9Vault/LSP9Vault.behaviour.ts
@@ -849,27 +849,27 @@ export const shouldInitializeLikeLSP9 = (
   });
 
   describe('when the contract was initialized', () => {
-    it('should have registered the ERC165 interface', async () => {
+    it('should support the ERC165 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC165);
       expect(result).to.be.true;
     });
 
-    it('should have registered the ERC725X interface', async () => {
+    it('should support the ERC725X interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725X);
       expect(result).to.be.true;
     });
 
-    it('should have registered the ERC725Y interface', async () => {
+    it('should support the ERC725Y interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.ERC725Y);
       expect(result).to.be.true;
     });
 
-    it('should have registered the LSP9 interface', async () => {
+    it('should support the LSP9 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP9Vault);
       expect(result).to.be.true;
     });
 
-    it('should have registered the LSP1 interface', async () => {
+    it('should support the LSP1 interface', async () => {
       const result = await context.lsp9Vault.supportsInterface(INTERFACE_IDS.LSP1UniversalReceiver);
       expect(result).to.be.true;
     });


### PR DESCRIPTION
By missing the `.to.be.true` in the chai tests, we discovered that the issue addressed in PR #1008 actually fixed an interface ID check that was not passing. 

The incorrect inheritance of inheriting `LSP17Extendable` ❌ instead of `LSP7ExtendableInitAbstract` ✅ resulted in returning `false` when calling `supportsInterface(ERC725Y interface ID)`. See the tests output below when using the `.to.be.true` at commit [`b71b532`](https://github.com/lukso-network/lsp-smart-contracts/commits/main/)

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/b0dd6058-dc79-4cda-9b72-ad9e9e9a99cd" />
