### PR TITLE
docs: add security audit note about token votes extensions

### DIFF
--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -2,6 +2,8 @@
 
 Package for the LSP7 Digital Asset standard.
 
+> The contracts [`LSP7Votes`](contracts/extensions/LSP7Votes.sol) and [`LSP7VotesInitiAbstract`](contracts/extensions/LSP7VotesInitAbstract.sol) have not been formally audited by an external third party and are not recommended to be used in production without undergoing an independent security audit.
+
 ## Installation
 
 ```console

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Votes.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Votes.sol
@@ -24,6 +24,10 @@ import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
  *
  * By default, token balance does not account for voting power. This makes transfers cheaper. The downside is that it
  * requires users to delegate to themselves in order to activate checkpoints and have their voting power tracked.
+ *
+ * @custom:warning This extension contract is not formally audited.
+ * For any contract intended to be deployed in production that inherits from this extension, it is recommended to conduct
+ * an independent security audit, including this extension in the audit scope.
  */
 abstract contract LSP7Votes is LSP7DigitalAsset, EIP712, IERC5805 {
     using Counters for Counters.Counter;

--- a/packages/lsp7-contracts/contracts/extensions/LSP7VotesInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7VotesInitAbstract.sol
@@ -29,6 +29,10 @@ import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
  *
  * By default, token balance does not account for voting power. This makes transfers cheaper. The downside is that it
  * requires users to delegate to themselves in order to activate checkpoints and have their voting power tracked.
+ *
+ * @custom:warning This extension contract is not formally audited.
+ * For any contract intended to be deployed in production that inherits from this extension, it is recommended to conduct
+ * an independent security audit, including this extension in the audit scope.
  */
 abstract contract LSP7VotesInitAbstract is
     LSP7DigitalAssetInitAbstract,

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -2,6 +2,8 @@
 
 Package for the LSP8 Identifiable Digital Asset Standard.
 
+> The contracts [`LSP8Votes`](contracts/extensions/LSP8Votes.sol) and [`LSP8VotesInitiAbstract`](contracts/extensions/LSP8VotesInitAbstract.sol) have not been formally audited by an external third party and are not recommended to be used in production without undergoing an independent security audit.
+
 ## Installation
 
 ```console

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Votes.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Votes.sol
@@ -19,6 +19,10 @@ import {LSP1Utils} from "@lukso/lsp1-contracts/contracts/LSP1Utils.sol";
  * Tokens do not count as votes until they are delegated, because votes must be tracked which incurs an additional cost
  * on every transfer. Token holders can either delegate to a trusted representative who will decide how to make use of
  * the votes in governance decisions, or they can delegate to themselves to be their own representative.
+ *
+ * @custom:warning This extension contract is not formally audited.
+ * For any contract intended to be deployed in production that inherits from this extension, it is recommended to conduct
+ * an independent security audit, including this extension in the audit scope.
  */
 abstract contract LSP8Votes is LSP8IdentifiableDigitalAsset, Votes {
     /**

--- a/packages/lsp8-contracts/contracts/extensions/LSP8VotesInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8VotesInitAbstract.sol
@@ -20,6 +20,10 @@ import {LSP1Utils} from "@lukso/lsp1-contracts/contracts/LSP1Utils.sol";
  * Tokens do not count as votes until they are delegated, because votes must be tracked which incurs an additional cost
  * on every transfer. Token holders can either delegate to a trusted representative who will decide how to make use of
  * the votes in governance decisions, or they can delegate to themselves to be their own representative.
+ *
+ * @custom:warning This extension contract is not formally audited.
+ * For any contract intended to be deployed in production that inherits from this extension, it is recommended to conduct
+ * an independent security audit, including this extension in the audit scope.
  */
 abstract contract LSP8VotesInitAbstract is
     LSP8IdentifiableDigitalAssetInitAbstract,


### PR DESCRIPTION
The `LSP7Votes` and `LSP8Votes` extension contracts have never gone through an audit. Add small notice in Natspec comment + README of these two packages to warn users if used.