### PR TITLE
fix: upgrade minimum dependencies in `@lukso/lsp-smart-contracts` to include security + build patch

### DIFF
--- a/packages/lsp-smart-contracts/package.json
+++ b/packages/lsp-smart-contracts/package.json
@@ -76,7 +76,7 @@
     "@lukso/lsp14-contracts": "~0.15.0",
     "@lukso/lsp16-contracts": "~0.15.0",
     "@lukso/lsp17-contracts": "~0.16.0",
-    "@lukso/lsp17contractextension-contracts": "~0.16.0",
+    "@lukso/lsp17contractextension-contracts": "~0.16.2",
     "@lukso/lsp1delegate-contracts": "~0.15.0",
     "@lukso/lsp2-contracts": "~0.15.0",
     "@lukso/lsp20-contracts": "~0.15.0",
@@ -84,11 +84,11 @@
     "@lukso/lsp25-contracts": "~0.15.0",
     "@lukso/lsp26-contracts": "~0.1.0",
     "@lukso/lsp3-contracts": "~0.16.0",
-    "@lukso/lsp4-contracts": "~0.16.0",
+    "@lukso/lsp4-contracts": "~0.16.2",
     "@lukso/lsp5-contracts": "~0.15.0",
     "@lukso/lsp6-contracts": "~0.15.0",
-    "@lukso/lsp7-contracts": "~0.16.0",
-    "@lukso/lsp8-contracts": "~0.16.0",
+    "@lukso/lsp7-contracts": "~0.16.3",
+    "@lukso/lsp8-contracts": "~0.16.2",
     "@lukso/lsp9-contracts": "~0.15.0",
     "@lukso/universalprofile-contracts": "~0.15.0"
   }


### PR DESCRIPTION
> Keeping open as draft. Need to update after latest patch release that fixes the typed ABIs missing in the build + audit fix on LSP7. Will merge and include within v0.17.0 (Need to change the conventional commit prefix probably)