### PR TITLE
docs: add info note in Natspec about zero transfer amounts from non operators

### DIFF
--- a/packages/lsp7-contracts/contracts/ILSP7DigitalAsset.sol
+++ b/packages/lsp7-contracts/contracts/ILSP7DigitalAsset.sol
@@ -250,6 +250,9 @@ interface ILSP7DigitalAsset {
      *
      * @custom:info if the `to` address is a contract that implements LSP1, it will always be notified via its `universalReceiver(...)` function, regardless if `force` is set to `true` or `false`.
      *
+     * @custom:info Note that token transfers revert when no allowance is given, including when the `amount` is `0`.
+     * This is to prevent this function from being used maliciously, such as performing zero-value token transfer phishing attacks.
+     *
      * @custom:warning Be aware that when either the sender or the recipient can have logic that revert in their `universalReceiver(...)` function when being notified.
      * This even if the `force` was set to `true`.
      */


### PR DESCRIPTION
# What does this PR introduce?

## 📄 Documentation

Zero value transfers are known to be used for phishing attacks. Document that in Natspec comments of the LSP7 function. See these articles for rationale:

- https://cryptorank.io/news/feed/3ff47-180067-zero-value-token-transfer-phishing
- https://tokenview.medium.com/understanding-zero-transferfrom-scams-and-using-tokenview-explorer-to-identify-them-889e1b9f4e7c
- https://www.coinbase.com/en-de/blog/zero-transfer-phishing-part-1-attack-analysis

