### PR TITLE
docs: add extra warning comment for tokenId authorization check in LSP8 internal `_burn` function

### DIFF
--- a/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAsset.sol
+++ b/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAsset.sol
@@ -759,6 +759,8 @@ abstract contract LSP8IdentifiableDigitalAsset is
      * - `tokenId` must exist.
      *
      * @custom:events {Transfer} event with `address(0)` as the `to` address.
+     *
+     * @custom:warning This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
      */
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
@@ -815,7 +817,7 @@ abstract contract LSP8IdentifiableDigitalAsset is
      *
      * @custom:events {Transfer} event.
      *
-     * @custom:danger This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
+     * @custom:warning This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
      */
     function _transfer(
         address from,

--- a/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAssetInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/LSP8IdentifiableDigitalAssetInitAbstract.sol
@@ -776,6 +776,8 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      * - `tokenId` must exist.
      *
      * @custom:events {Transfer} event with `address(0)` as the `to` address.
+     *
+     * @custom:warning This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
      */
     function _burn(bytes32 tokenId, bytes memory data) internal virtual {
         address tokenOwner = tokenOwnerOf(tokenId);
@@ -832,7 +834,7 @@ abstract contract LSP8IdentifiableDigitalAssetInitAbstract is
      *
      * @custom:events {Transfer} event.
      *
-     * @custom:danger This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
+     * @custom:warning This internal function does not check if the sender is authorized or not to operate on the `tokenId`.
      */
     function _transfer(
         address from,


### PR DESCRIPTION
The warning Natspec comment about if the caller is authorized on the `tokenId` is mentioned for the internal `_transfer(...)` function.

However, it is not present inside the internal `_burn` function. 

This PR fixes that to make it consistent (similar to [OpenZeppelin ERC721 comment](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/7be5dde82d5b7d03dc59e28c2e2744e95992fa5c/contracts/token/ERC721/ERC721.sol#L295C8-L295C109)).

Lower the callout from danger to warning to display in yellow.