### PR TITLE
fix: repair build error to re-trigger previously failed release

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,10 +33,10 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
-      - name: Use Node.js v20
+      - name: Use Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: 📦 Install dependencies

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -12,10 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-      - name: Use Node.js v20
+      - name: Use Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: 📦 Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js v20.x
+      - name: Use Node.js v22.x
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js v20
+      - name: Use Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,11 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}
 
-      - name: Use Node.js v20
+      - name: Use Node.js v22
         uses: actions/setup-node@v4
         if: ${{ steps.release.outputs.releases_created }}
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           scope: "@lukso"
           cache: "npm"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 20
+nodejs 22.13.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -25272,7 +25272,7 @@
     },
     "packages/lsp-smart-contracts": {
       "name": "@lukso/lsp-smart-contracts",
-      "version": "0.16.3",
+      "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp0-contracts": "~0.15.0",
@@ -25283,7 +25283,7 @@
         "@lukso/lsp14-contracts": "~0.15.0",
         "@lukso/lsp16-contracts": "~0.15.0",
         "@lukso/lsp17-contracts": "~0.16.0",
-        "@lukso/lsp17contractextension-contracts": "~0.16.0",
+        "@lukso/lsp17contractextension-contracts": "~0.16.2",
         "@lukso/lsp1delegate-contracts": "~0.15.0",
         "@lukso/lsp2-contracts": "~0.15.0",
         "@lukso/lsp20-contracts": "~0.15.0",
@@ -25291,18 +25291,18 @@
         "@lukso/lsp25-contracts": "~0.15.0",
         "@lukso/lsp26-contracts": "~0.1.0",
         "@lukso/lsp3-contracts": "~0.16.0",
-        "@lukso/lsp4-contracts": "~0.16.0",
+        "@lukso/lsp4-contracts": "~0.16.2",
         "@lukso/lsp5-contracts": "~0.15.0",
         "@lukso/lsp6-contracts": "~0.15.0",
-        "@lukso/lsp7-contracts": "~0.16.0",
-        "@lukso/lsp8-contracts": "~0.16.0",
+        "@lukso/lsp7-contracts": "~0.16.3",
+        "@lukso/lsp8-contracts": "~0.16.2",
         "@lukso/lsp9-contracts": "~0.15.0",
         "@lukso/universalprofile-contracts": "~0.15.0"
       }
     },
     "packages/lsp0-contracts": {
       "name": "@lukso/lsp0-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25324,7 +25324,7 @@
     },
     "packages/lsp1-contracts": {
       "name": "@lukso/lsp1-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp2-contracts": "~0.15.0",
@@ -25333,7 +25333,7 @@
     },
     "packages/lsp10-contracts": {
       "name": "@lukso/lsp10-contracts",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^6.0.0",
@@ -25351,7 +25351,7 @@
     },
     "packages/lsp11-contracts": {
       "name": "@lukso/lsp11-contracts",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp25-contracts": "~0.15.0",
@@ -25360,7 +25360,7 @@
     },
     "packages/lsp12-contracts": {
       "name": "@lukso/lsp12-contracts",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp2-contracts": "~0.15.0"
@@ -25368,7 +25368,7 @@
     },
     "packages/lsp14-contracts": {
       "name": "@lukso/lsp14-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25377,7 +25377,7 @@
     },
     "packages/lsp16-contracts": {
       "name": "@lukso/lsp16-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25387,7 +25387,7 @@
     },
     "packages/lsp17-contracts": {
       "name": "@lukso/lsp17-contracts",
-      "version": "0.16.3",
+      "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@account-abstraction/contracts": "^0.6.0",
@@ -25409,7 +25409,7 @@
     },
     "packages/lsp17contractextension-contracts": {
       "name": "@lukso/lsp17contractextension-contracts",
-      "version": "0.16.3",
+      "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.6"
@@ -25417,7 +25417,7 @@
     },
     "packages/lsp1delegate-contracts": {
       "name": "@lukso/lsp1delegate-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25472,7 +25472,7 @@
     },
     "packages/lsp2-contracts": {
       "name": "@lukso/lsp2-contracts",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25481,12 +25481,12 @@
     },
     "packages/lsp20-contracts": {
       "name": "@lukso/lsp20-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0"
     },
     "packages/lsp23-contracts": {
       "name": "@lukso/lsp23-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25496,7 +25496,7 @@
     },
     "packages/lsp25-contracts": {
       "name": "@lukso/lsp25-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^4.9.3"
@@ -25504,7 +25504,7 @@
     },
     "packages/lsp26-contracts": {
       "name": "@lukso/lsp26-contracts",
-      "version": "0.1.3",
+      "version": "0.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp0-contracts": "~0.15.0",
@@ -25514,7 +25514,7 @@
     },
     "packages/lsp3-contracts": {
       "name": "@lukso/lsp3-contracts",
-      "version": "0.16.3",
+      "version": "0.16.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp2-contracts": "~0.15.0"
@@ -25522,7 +25522,7 @@
     },
     "packages/lsp4-contracts": {
       "name": "@lukso/lsp4-contracts",
-      "version": "0.16.3",
+      "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts-v8": "npm:@erc725/smart-contracts@8.0.0",
@@ -25531,7 +25531,7 @@
     },
     "packages/lsp5-contracts": {
       "name": "@lukso/lsp5-contracts",
-      "version": "0.15.1",
+      "version": "0.15.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25540,7 +25540,7 @@
     },
     "packages/lsp6-contracts": {
       "name": "@lukso/lsp6-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25563,7 +25563,7 @@
     },
     "packages/lsp7-contracts": {
       "name": "@lukso/lsp7-contracts",
-      "version": "0.16.4",
+      "version": "0.16.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp1-contracts": "~0.15.0",
@@ -25575,7 +25575,7 @@
     },
     "packages/lsp8-contracts": {
       "name": "@lukso/lsp8-contracts",
-      "version": "0.16.3",
+      "version": "0.16.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@lukso/lsp1-contracts": "~0.15.0",
@@ -25587,7 +25587,7 @@
     },
     "packages/lsp9-contracts": {
       "name": "@lukso/lsp9-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",
@@ -25598,7 +25598,7 @@
     },
     "packages/universalprofile-contracts": {
       "name": "@lukso/universalprofile-contracts",
-      "version": "0.15.1",
+      "version": "0.15.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@erc725/smart-contracts": "^7.0.0",

--- a/packages/lsp-smart-contracts/README.md
+++ b/packages/lsp-smart-contracts/README.md
@@ -12,7 +12,7 @@ npm install @lukso/lsp-smart-contracts
 
 ### in Javascript
 
-You can use the contracts JSON ABI by importing them as follow:
+The JSON ABIs of the smart contracts can be imported as follow:
 
 ```javascript
 import LSP0ERC725Account from "@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json";

--- a/packages/lsp0-contracts/README.md
+++ b/packages/lsp0-contracts/README.md
@@ -10,7 +10,7 @@ npm install @lukso/lsp0-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp0-contracts` npm package contains useful constants such as interface Ids, and ERC725Y data keys related to the LSP0 Standard. You can import and access them as follows.
+The `@lukso/lsp0-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP0 Standard. You can import and access them as follows.
 
 In Javascript.
 

--- a/packages/lsp1-contracts/README.md
+++ b/packages/lsp1-contracts/README.md
@@ -10,7 +10,7 @@ npm install @lukso/lsp1-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp1-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP1 Standard. You can import and access them as follows.
+The `@lukso/lsp1-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP1 Standard. You can import and access them as follow.
 
 In Javascript.
 

--- a/packages/lsp10-contracts/README.md
+++ b/packages/lsp10-contracts/README.md
@@ -12,6 +12,6 @@ npm install @lukso/lsp10-contracts
 
 The `@lukso/lsp10-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP10 Standard. You can import and access them as follow:
 
-```js
+```javascript
 import { LSP10DataKeys } from "@lukso/lsp10-contracts";
 ```

--- a/packages/lsp11-contracts/README.md
+++ b/packages/lsp11-contracts/README.md
@@ -10,11 +10,11 @@ npm install @lukso/lsp11-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp11-contracts` npm package contains useful constants such as interface ID related to the LSP11 standard. You can import and access them as follows.
+The `@lukso/lsp11-contracts` npm package contains useful constants such as interface IDs related to the LSP11 standard. You can import and access them as follows.
 
 In Javascript.
 
-```js
+```javascript
 import { INTERFACE_ID_LSP11 } from "@lukso/lsp11-contracts";
 ```
 

--- a/packages/lsp12-contracts/README.md
+++ b/packages/lsp12-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp12-contracts` npm package contains useful constants such as ERC72
 
 In Javascript.
 
-```js
+```javascript
 import { LSP12DataKeys } from "@lukso/lsp12-contracts";
 ```
 

--- a/packages/lsp14-contracts/README.md
+++ b/packages/lsp14-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp14-contracts` npm package contains useful constants such as inter
 
 In Javascript.
 
-```js
+```javascript
 import { LSP14_TYPE_IDS, INTERFACE_ID_LSP14 } from "@lukso/lsp14-contracts";
 ```
 

--- a/packages/lsp16-contracts/README.md
+++ b/packages/lsp16-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP16 Universal Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp16-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp16-contracts)
 
-Package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard, contains a contract that allows deploying contracts on multiple chains with the same address.
+Package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard, contains the `LSP16UniversalFactory` contract that allows deploying contracts at the same address on multiple chains.
 
 ## Installation
 

--- a/packages/lsp17-contracts/README.md
+++ b/packages/lsp17-contracts/README.md
@@ -16,6 +16,6 @@ npm install @lukso/lsp17-contracts
 
 The `@lukso/lsp17-contracts` npm package contains useful constants such as interface IDs related to the LSP17 Extensions. You can import and access them as follows.
 
-```js
+```javascript
 import { INTERFACE_ID_LSP17Extension } from "@lukso/lsp17-contracts";
 ```

--- a/packages/lsp17contractextension-contracts/README.md
+++ b/packages/lsp17contractextension-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp17contractextension-contracts` npm package contains useful consta
 
 In Javascript.
 
-```js
+```javascript
 import {
   INTERFACE_ID_LSP17Extendable,
   INTERFACE_ID_LSP17Extension,

--- a/packages/lsp1delegate-contracts/README.md
+++ b/packages/lsp1delegate-contracts/README.md
@@ -19,7 +19,7 @@ npm install @lukso/lsp1delegate-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp1delegate-contracts` npm package contains useful constants such as InterfaceIds related to the LSP1Delegate Standard. You can import and access them as follow:
+The `@lukso/lsp1delegate-contracts` npm package contains useful constants such as interface IDs related to the LSP1Delegate Standard. You can import and access them as follows.
 
 ```js
 import { INTERFACE_ID_LSP1DELEGATE } from "@lukso/lsp1delegate-contracts";

--- a/packages/lsp2-contracts/README.md
+++ b/packages/lsp2-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp2-contracts` npm package contains useful constants such as ERC725
 
 In Javascript.
 
-```js
+```javascript
 import { LSP2ArrayKey, Verification } from "@lukso/lsp2-contracts";
 ```
 

--- a/packages/lsp20-contracts/README.md
+++ b/packages/lsp20-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp20-contracts` npm package contains useful constants such as inter
 
 In Javascript.
 
-```js
+```javascript
 import {
   LSP20_SUCCESS_VALUES,
   INTERFACE_ID_LSP20CallVerifier,

--- a/packages/lsp23-contracts/README.md
+++ b/packages/lsp23-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP23 Linked Contracts Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp23-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp23-contracts)
 
-Package for the LSP23 Linked Contracts Factory.
+Package for the LSP23 Linked Contracts Factory. Contains the JSON artifacts (ABI, bytecode...) and the `LSP23LinkedContractsFactory`.
 
 ## Installation
 

--- a/packages/lsp25-contracts/README.md
+++ b/packages/lsp25-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp25-contracts` npm package contains useful constants such as inter
 
 In Javascript.
 
-```js
+```javascript
 import { LSP25_VERSION, INTERFACE_ID_LSP25 } from "@lukso/lsp25-contracts";
 ```
 

--- a/packages/lsp26-contracts/README.md
+++ b/packages/lsp26-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp26-contracts` npm package contains useful constants such as inter
 
 In Javascript.
 
-```js
+```javascript
 import { INTERFACE_ID_LSP26, LSP26_TYPE_IDS } from "@lukso/lsp26-contracts";
 ```
 

--- a/packages/lsp3-contracts/README.md
+++ b/packages/lsp3-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp3-contracts` npm package contains useful constants such as ERC725
 
 In Javascript.
 
-```js
+```javascript
 import {
   LSP3DataKeys,
   LSP3SupportedStandard,

--- a/packages/lsp4-contracts/README.md
+++ b/packages/lsp4-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp4-contracts` npm package contains useful constants such as ERC725
 
 In Javascript.
 
-```js
+```javascript
 import {
   LSP4_TOKEN_TYPES,
   LSP4SupportedStandard,

--- a/packages/lsp5-contracts/README.md
+++ b/packages/lsp5-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp5-contracts` npm package contains useful constants such as ERC725
 
 In Javascript.
 
-```js
+```javascript
 import { LSP5DataKeys } from "@lukso/lsp5-contracts";
 ```
 

--- a/packages/lsp6-contracts/README.md
+++ b/packages/lsp6-contracts/README.md
@@ -14,7 +14,7 @@ The `@lukso/lsp6-contracts` npm package contains useful constants such as interf
 
 In Javascript.
 
-```js
+```javascript
 import {
   INTERFACE_ID_LSP6,
   LSP6DataKeys,

--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -16,7 +16,7 @@ The `@lukso/lsp7-contracts` npm package contains useful constants such as interf
 
 In Javascript.
 
-```js
+```javascript
 import {
   INTERFACE_ID_LSP7,
   INTERFACE_ID_LSP7_PREVIOUS,

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -16,7 +16,7 @@ The `@lukso/lsp8-contracts` npm package contains useful constants such as interf
 
 In Javascript.
 
-```js
+```javascript
 import {
   INTERFACE_ID_LSP8,
   INTERFACE_ID_LSP8_PREVIOUS,

--- a/packages/lsp9-contracts/README.md
+++ b/packages/lsp9-contracts/README.md
@@ -10,9 +10,9 @@ npm install @lukso/lsp9-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp9-contracts` npm package contains useful constants such as InterfaceIds, ERC725Y Data Keys related to the LSP9 Standard. You can import and access them as follows.
+The `@lukso/lsp9-contracts` npm package contains useful constants such as interface IDs, ERC725Y Data Keys related to the LSP9 Standard. You can import and access them as follows.
 
-```js
+```javascript
 import {
   OPERATION_TYPES,
   INTERFACE_ID_LSP9,

--- a/packages/universalprofile-contracts/README.md
+++ b/packages/universalprofile-contracts/README.md
@@ -25,7 +25,7 @@ import {
 
 You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contracts from the `/abi` path.
 
-```ts
+```typescript
 import {
   universalProfileAbi,
   universalProfileInitAbi,


### PR DESCRIPTION
The CI of the previous release failed due to a heap memory error. It seems to be an issue related to node js v20.
Upgrading to node v22 to fix the error and re-trigger the release