### PR TITLE
refactor!: upgrade solc compiler + EVM version in LSP7 package to optimize runtime cost

### DIFF
--- a/packages/lsp-smart-contracts/hardhat.config.ts
+++ b/packages/lsp-smart-contracts/hardhat.config.ts
@@ -79,9 +79,10 @@ const VIA_IR_SETTINGS = {
 };
 
 const LSP7_VIA_IR_SETTINGS = {
-  version: '0.8.17',
+  version: '0.8.28',
   settings: {
     viaIR: true,
+    evmVersion: 'prague',
     optimizer: {
       enabled: true,
       /**
@@ -90,7 +91,7 @@ const LSP7_VIA_IR_SETTINGS = {
        * values will optimize more for high-frequency usage.
        * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
        */
-      runs: 1000,
+      runs: 25000,
     },
     outputSelection: {
       '*': {

--- a/packages/lsp7-contracts/hardhat.config.ts
+++ b/packages/lsp7-contracts/hardhat.config.ts
@@ -118,8 +118,9 @@ const config: HardhatUserConfig = {
     showMethodSig: true,
   },
   solidity: {
-    version: '0.8.17',
+    version: '0.8.28',
     settings: {
+      evmVersion: 'prague',
       viaIR: true,
       optimizer: {
         enabled: true,
@@ -129,7 +130,7 @@ const config: HardhatUserConfig = {
          * values will optimize more for high-frequency usage.
          * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
          */
-        runs: 1000,
+        runs: 25000,
       },
       outputSelection: {
         '*': {


### PR DESCRIPTION
# What does this PR introduce?

## ⚠️ BREAKING CHANGES

The LSP7 contracts from `@lukso/lsp7-contracts` (in particular the deployable ones listed under `presets/`) now are compiled using the following compiler settings

- compiler version = 0.8.27 
- EVM version = prague 
- Optimizer ON (nb of runs = 25,000)
- via IR ON

This enables gas optimisations at runtime, since LSP7 tokens main interations revolve around minting + transferring.

<img width="793" height="349" alt="image" src="https://github.com/user-attachments/assets/930ce76a-1a60-422f-91f7-9515ce2a93b4" />


