### PR TITLE
refactor: reduce Customizable contracts bytecode size, improve code clarity, adjust `__gap[...]` storage size and deployment scripts for Customizable Tokens

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -36,18 +36,20 @@ src = 'packages/lsp7-contracts/contracts'
 test = 'packages/lsp7-contracts/foundry'
 out = 'packages/lsp7-contracts/contracts/foundry_artifacts'
 optimizer = true
-optimizer_runs = 1000
+optimizer_runs = 20000
 via_ir = true
-solc = "0.8.27"
+solc = "0.8.28"
+evm_version = "prague"
 
 [profile.lsp8]
 src = 'packages/lsp8-contracts/contracts'
 test = 'packages/lsp8-contracts/foundry'
 out = 'packages/lsp8-contracts/contracts/foundry_artifacts'
 optimizer = true
-optimizer_runs = 1000
+optimizer_runs = 20000
 via_ir = true
-solc = "0.8.27"
+solc = "0.8.28"
+evm_version = "prague"
 
 [profile.lsp11]
 src = 'packages/lsp11-contracts/contracts'

--- a/packages/lsp-smart-contracts/hardhat.config.ts
+++ b/packages/lsp-smart-contracts/hardhat.config.ts
@@ -63,7 +63,7 @@ const LSP7_VIA_IR_SETTINGS: SolidityUserConfig = {
        * values will optimize more for high-frequency usage.
        * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
        */
-      runs: 25000,
+      runs: 20000,
     },
     outputSelection: {
       '*': {
@@ -86,7 +86,7 @@ const LSP8_VIA_IR_SETTINGS: SolidityUserConfig = {
        * values will optimize more for high-frequency usage.
        * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
        */
-      runs: 25000,
+      runs: 20000,
     },
     outputSelection: {
       '*': {

--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -78,13 +78,15 @@ Set your deployer key first:
 export PRIVATE_KEY=0x...
 ```
 
-Dry run against LUKSO Testnet:
+## Dry run against LUKSO Testnet
 
 ```console
 FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
 ```
 
-Broadcast the deployment:
+## Broadcast the deployment
+
+> Use one of the method described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
 
 ```console
 FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast
@@ -93,5 +95,5 @@ FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7Cust
 Broadcast and verify on the LUKSO Testnet Blockscout explorer:
 
 ```console
-FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://explorer.execution.testnet.lukso.network/api?
+FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://api.explorer.execution.testnet.lukso.network/api?
 ```

--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -67,3 +67,31 @@ import {
     lsp7MintableInitAbi,
  } from '@lukso/lsp7-contracts/abi';
 ```
+
+## Foundry deployment
+
+This package includes a Foundry script at `scripts/DeployLSP7CustomizableTokenInit.s.sol` to deploy the `LSP7CustomizableTokenInit` implementation contract.
+
+Set your deployer key first:
+
+```console
+export PRIVATE_KEY=0x...
+```
+
+Dry run against LUKSO Testnet:
+
+```console
+FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
+```
+
+Broadcast the deployment:
+
+```console
+FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast
+```
+
+Broadcast and verify on the LUKSO Testnet Blockscout explorer:
+
+```console
+FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://explorer.execution.testnet.lukso.network/api?
+```

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -287,7 +287,11 @@ abstract contract AccessControlExtendedAbstract is
 
         if (added) {
             _addressRoles[account].add(role);
-            emit RoleGranted(role, account, msg.sender);
+            emit RoleGranted({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
         }
     }
 
@@ -304,12 +308,16 @@ abstract contract AccessControlExtendedAbstract is
 
         if (removed) {
             _addressRoles[account].remove(role);
-            emit RoleRevoked(role, account, msg.sender);
+            emit RoleRevoked({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
 
             // Auto-clear auxiliary data (BASE-09)
             if (_roleData[role][account].length > 0) {
                 delete _roleData[role][account];
-                emit RoleDataChanged(role, account, "");
+                emit RoleDataChanged({role: role, account: account, data: ""});
             }
         }
     }
@@ -355,7 +363,11 @@ abstract contract AccessControlExtendedAbstract is
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         bytes32 previousAdminRole = getRoleAdmin(role);
         _roleAdmins[role] = adminRole;
-        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+        emit RoleAdminChanged({
+            role: role,
+            previousAdminRole: previousAdminRole,
+            newAdminRole: adminRole
+        });
     }
 
     // --- Ownership sync
@@ -398,7 +410,11 @@ abstract contract AccessControlExtendedAbstract is
 
                 if (oldOwnerRoleData.length > 0) {
                     _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged(role, newOwner, oldOwnerRoleData);
+                    emit RoleDataChanged({
+                        role: role,
+                        account: newOwner,
+                        data: oldOwnerRoleData
+                    });
                 }
             }
         }

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -296,7 +296,11 @@ abstract contract AccessControlExtendedInitAbstract is
 
         if (added) {
             _addressRoles[account].add(role);
-            emit RoleGranted(role, account, msg.sender);
+            emit RoleGranted({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
         }
     }
 
@@ -313,12 +317,16 @@ abstract contract AccessControlExtendedInitAbstract is
 
         if (removed) {
             _addressRoles[account].remove(role);
-            emit RoleRevoked(role, account, msg.sender);
+            emit RoleRevoked({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
 
             // Auto-clear auxiliary data (BASE-09)
             if (_roleData[role][account].length > 0) {
                 delete _roleData[role][account];
-                emit RoleDataChanged(role, account, "");
+                emit RoleDataChanged({role: role, account: account, data: ""});
             }
         }
     }
@@ -364,7 +372,11 @@ abstract contract AccessControlExtendedInitAbstract is
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         bytes32 previousAdminRole = getRoleAdmin(role);
         _roleAdmins[role] = adminRole;
-        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+        emit RoleAdminChanged({
+            role: role,
+            previousAdminRole: previousAdminRole,
+            newAdminRole: adminRole
+        });
     }
 
     // --- Ownership sync
@@ -407,7 +419,11 @@ abstract contract AccessControlExtendedInitAbstract is
 
                 if (oldOwnerRoleData.length > 0) {
                     _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged(role, newOwner, oldOwnerRoleData);
+                    emit RoleDataChanged({
+                        role: role,
+                        account: newOwner,
+                        data: oldOwnerRoleData
+                    });
                 }
             }
         }

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -433,6 +433,9 @@ abstract contract AccessControlExtendedInitAbstract is
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
      */
-    uint256[49] private __gap;
+    uint256[46] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
@@ -35,7 +35,7 @@ abstract contract LSP7MintableAbstract is
     /// @custom:info If `mintable_` is set to `true` then it can be disabled using `disableMinting()` function later on.
     constructor(bool mintable_) {
         isMintable = mintable_;
-        emit MintingStatusChanged(mintable_);
+        emit MintingStatusChanged({enabled: mintable_});
         _grantRole(MINTER_ROLE, owner());
     }
 
@@ -44,7 +44,7 @@ abstract contract LSP7MintableAbstract is
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP7MintDisabled());
         isMintable = false;
-        emit MintingStatusChanged(false);
+        emit MintingStatusChanged({enabled: false});
     }
 
     /// @inheritdoc ILSP7Mintable

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
@@ -69,7 +69,7 @@ abstract contract LSP7MintableInitAbstract is
         bool mintable_
     ) internal virtual onlyInitializing {
         isMintable = mintable_;
-        emit MintingStatusChanged(mintable_);
+        emit MintingStatusChanged({enabled: mintable_});
         _grantRole(MINTER_ROLE, owner());
     }
 
@@ -78,7 +78,7 @@ abstract contract LSP7MintableInitAbstract is
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP7MintDisabled());
         isMintable = false;
-        emit MintingStatusChanged(false);
+        emit MintingStatusChanged({enabled: false});
     }
 
     /// @inheritdoc ILSP7Mintable

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
@@ -105,7 +105,7 @@ abstract contract LSP7NonTransferableAbstract is
         transferLockStart = 0;
         transferLockEnd = 0;
 
-        emit TransferLockPeriodChanged(0, 0);
+        emit TransferLockPeriodChanged({start: 0, end: 0});
     }
 
     /// @inheritdoc ILSP7NonTransferable
@@ -127,10 +127,10 @@ abstract contract LSP7NonTransferableAbstract is
         transferLockStart = newTransferLockStart;
         transferLockEnd = newTransferLockEnd;
 
-        emit TransferLockPeriodChanged(
-            newTransferLockStart,
-            newTransferLockEnd
-        );
+        emit TransferLockPeriodChanged({
+            start: newTransferLockStart,
+            end: newTransferLockEnd
+        });
     }
 
     /// @notice Checks if a token transfer is allowed based on transferability status.

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
@@ -149,7 +149,7 @@ abstract contract LSP7NonTransferableInitAbstract is
         transferLockStart = 0;
         transferLockEnd = 0;
 
-        emit TransferLockPeriodChanged(0, 0);
+        emit TransferLockPeriodChanged({start: 0, end: 0});
     }
 
     /// @inheritdoc ILSP7NonTransferable
@@ -170,10 +170,10 @@ abstract contract LSP7NonTransferableInitAbstract is
         transferLockStart = newTransferLockStart;
         transferLockEnd = newTransferLockEnd;
 
-        emit TransferLockPeriodChanged(
-            newTransferLockStart,
-            newTransferLockEnd
-        );
+        emit TransferLockPeriodChanged({
+            start: newTransferLockStart,
+            end: newTransferLockEnd
+        });
     }
 
     /// @notice Checks if a token transfer is allowed based on transferability status.

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -26,40 +26,18 @@ import {
     LSP7RevokableAbstract
 } from "../extensions/LSP7Revokable/LSP7RevokableAbstract.sol";
 
+// constants
+import {
+    LSP7MintableParams,
+    LSP7CappedParams,
+    LSP7NonTransferableParams,
+    LSP7RevokableParams
+} from "./LSP7CustomizableTokenConstants.sol";
+
 // errors
 import {
     LSP7MintDisabled
 } from "../extensions/LSP7Mintable/LSP7MintableErrors.sol";
-
-/// @dev Deployment configuration for minting feature.
-/// @param mintable True to enable minting after deployment, false to disable it forever.
-/// @param initialMintAmount The amount of tokens to mint to `newOwner_` on deployment in wei.
-struct LSP7MintableParams {
-    bool mintable;
-    uint256 initialMintAmount;
-}
-
-/// @dev Deployment configuration for capped balance and capped supply features.
-/// @param tokenBalanceCap The maximum balance per address in wei, 0 to disable.
-/// @param tokenSupplyCap The maximum total supply in wei, 0 to disable.
-struct LSP7CappedParams {
-    uint256 tokenBalanceCap;
-    uint256 tokenSupplyCap;
-}
-
-/// @dev Deployment configuration for non-transferable feature.
-/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
-/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct LSP7NonTransferableParams {
-    uint256 transferLockStart;
-    uint256 transferLockEnd;
-}
-
-/// @dev Deployment configuration for revokable feature.
-/// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct LSP7RevokableParams {
-    bool isRevokable;
-}
 
 /// @title LSP7CustomizableToken
 /// @dev A customizable LSP7 token (proxy version) implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
@@ -106,7 +84,7 @@ contract LSP7CustomizableToken is
             isNonDivisible_
         )
         AccessControlExtendedAbstract(newOwner_)
-        LSP7MintableAbstract(mintableParams.mintable)
+        LSP7MintableAbstract(mintableParams.isMintable)
         LSP7CappedSupplyAbstract(cappedParams.tokenSupplyCap)
         LSP7CappedBalanceAbstract(cappedParams.tokenBalanceCap)
         LSP7NonTransferableAbstract(

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -34,7 +34,7 @@ import {
 /// @dev Deployment configuration for minting feature.
 /// @param mintable True to enable minting after deployment, false to disable it forever.
 /// @param initialMintAmount The amount of tokens to mint to `newOwner_` on deployment in wei.
-struct MintableParams {
+struct LSP7MintableParams {
     bool mintable;
     uint256 initialMintAmount;
 }
@@ -42,7 +42,7 @@ struct MintableParams {
 /// @dev Deployment configuration for capped balance and capped supply features.
 /// @param tokenBalanceCap The maximum balance per address in wei, 0 to disable.
 /// @param tokenSupplyCap The maximum total supply in wei, 0 to disable.
-struct CappedParams {
+struct LSP7CappedParams {
     uint256 tokenBalanceCap;
     uint256 tokenSupplyCap;
 }
@@ -50,14 +50,14 @@ struct CappedParams {
 /// @dev Deployment configuration for non-transferable feature.
 /// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
 /// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct NonTransferableParams {
+struct LSP7NonTransferableParams {
     uint256 transferLockStart;
     uint256 transferLockEnd;
 }
 
 /// @dev Deployment configuration for revokable feature.
 /// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct RevokableParams {
+struct LSP7RevokableParams {
     bool isRevokable;
 }
 
@@ -93,10 +93,10 @@ contract LSP7CustomizableToken is
         address newOwner_,
         uint256 lsp4TokenType_,
         bool isNonDivisible_,
-        MintableParams memory mintableParams,
-        CappedParams memory cappedParams,
-        NonTransferableParams memory nonTransferableParams,
-        RevokableParams memory revokableParams
+        LSP7MintableParams memory mintableParams,
+        LSP7CappedParams memory cappedParams,
+        LSP7NonTransferableParams memory nonTransferableParams,
+        LSP7RevokableParams memory revokableParams
     )
         LSP7DigitalAsset(
             name_,

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenConstants.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenConstants.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+/// @dev Deployment configuration for minting feature.
+/// @param isMintable True to enable minting after deployment, false to disable it forever.
+/// @param initialMintAmount The amount of tokens to mint to `newOwner_` on deployment in wei.
+struct LSP7MintableParams {
+    bool isMintable;
+    uint256 initialMintAmount;
+}
+
+/// @dev Deployment configuration for capped balance and capped supply features.
+/// @param tokenBalanceCap The maximum balance per address in wei, 0 to disable.
+/// @param tokenSupplyCap The maximum total supply in wei, 0 to disable.
+struct LSP7CappedParams {
+    uint256 tokenBalanceCap;
+    uint256 tokenSupplyCap;
+}
+
+/// @dev Deployment configuration for non-transferable feature.
+/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
+/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
+struct LSP7NonTransferableParams {
+    uint256 transferLockStart;
+    uint256 transferLockEnd;
+}
+
+/// @dev Deployment configuration for revokable feature.
+/// @param isRevokable True to enable token revocation after deployment, false to disable it.
+struct LSP7RevokableParams {
+    bool isRevokable;
+}

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -37,7 +37,7 @@ import {
 /// @dev Deployment configuration for minting feature.
 /// @param isMintable True to enable minting after deployment, false to disable it forever.
 /// @param initialMintAmount The amount of tokens to mint to `newOwner_` on deployment in wei.
-struct MintableParams {
+struct LSP7MintableParams {
     bool isMintable;
     uint256 initialMintAmount;
 }
@@ -45,7 +45,7 @@ struct MintableParams {
 /// @dev Deployment configuration for capped balance and capped supply features.
 /// @param tokenBalanceCap The maximum balance per address in wei, 0 to disable.
 /// @param tokenSupplyCap The maximum total supply in wei, 0 to disable.
-struct CappedParams {
+struct LSP7CappedParams {
     uint256 tokenBalanceCap;
     uint256 tokenSupplyCap;
 }
@@ -53,14 +53,14 @@ struct CappedParams {
 /// @dev Deployment configuration for non-transferable feature.
 /// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
 /// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct NonTransferableParams {
+struct LSP7NonTransferableParams {
     uint256 transferLockStart;
     uint256 transferLockEnd;
 }
 
 /// @dev Deployment configuration for revokable feature.
 /// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct RevokableParams {
+struct LSP7RevokableParams {
     bool isRevokable;
 }
 
@@ -85,10 +85,10 @@ contract LSP7CustomizableTokenInit is
         address newOwner_,
         uint256 lsp4TokenType_,
         bool isNonDivisible_,
-        MintableParams calldata mintableParams,
-        NonTransferableParams calldata nonTransferableParams,
-        CappedParams calldata cappedParams,
-        RevokableParams calldata revokableParams
+        LSP7MintableParams calldata mintableParams,
+        LSP7NonTransferableParams calldata nonTransferableParams,
+        LSP7CappedParams calldata cappedParams,
+        LSP7RevokableParams calldata revokableParams
     ) external virtual initializer {
         __LSP7CustomizableToken_init(
             name_,
@@ -120,10 +120,10 @@ contract LSP7CustomizableTokenInit is
         address newOwner_,
         uint256 lsp4TokenType_,
         bool isNonDivisible_,
-        MintableParams calldata mintableParams,
-        CappedParams calldata cappedParams,
-        NonTransferableParams calldata nonTransferableParams,
-        RevokableParams calldata revokableParams
+        LSP7MintableParams calldata mintableParams,
+        LSP7CappedParams calldata cappedParams,
+        LSP7NonTransferableParams calldata nonTransferableParams,
+        LSP7RevokableParams calldata revokableParams
     ) internal virtual onlyInitializing {
         LSP7DigitalAssetInitAbstract._initialize(
             name_,

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -80,15 +80,15 @@ contract LSP7CustomizableTokenInit is
     LSP7RevokableInitAbstract
 {
     function initialize(
-        string memory name_,
-        string memory symbol_,
+        string calldata name_,
+        string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
         bool isNonDivisible_,
-        MintableParams memory mintableParams,
-        NonTransferableParams memory nonTransferableParams,
-        CappedParams memory cappedParams,
-        RevokableParams memory revokableParams
+        MintableParams calldata mintableParams,
+        NonTransferableParams calldata nonTransferableParams,
+        CappedParams calldata cappedParams,
+        RevokableParams calldata revokableParams
     ) external virtual initializer {
         __LSP7CustomizableToken_init(
             name_,
@@ -115,15 +115,15 @@ contract LSP7CustomizableTokenInit is
     /// @param nonTransferableParams Deployment configuration for non-transferable feature (see above).
     /// @param revokableParams Deployment configuration for revokable feature (see above).
     function __LSP7CustomizableToken_init(
-        string memory name_,
-        string memory symbol_,
+        string calldata name_,
+        string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
         bool isNonDivisible_,
-        MintableParams memory mintableParams,
-        CappedParams memory cappedParams,
-        NonTransferableParams memory nonTransferableParams,
-        RevokableParams memory revokableParams
+        MintableParams calldata mintableParams,
+        CappedParams calldata cappedParams,
+        NonTransferableParams calldata nonTransferableParams,
+        RevokableParams calldata revokableParams
     ) internal virtual onlyInitializing {
         LSP7DigitalAssetInitAbstract._initialize(
             name_,

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -29,40 +29,18 @@ import {
     LSP7RevokableInitAbstract
 } from "../extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol";
 
+// constants
+import {
+    LSP7MintableParams,
+    LSP7NonTransferableParams,
+    LSP7CappedParams,
+    LSP7RevokableParams
+} from "./LSP7CustomizableTokenConstants.sol";
+
 // errors
 import {
     LSP7MintDisabled
 } from "../extensions/LSP7Mintable/LSP7MintableErrors.sol";
-
-/// @dev Deployment configuration for minting feature.
-/// @param isMintable True to enable minting after deployment, false to disable it forever.
-/// @param initialMintAmount The amount of tokens to mint to `newOwner_` on deployment in wei.
-struct LSP7MintableParams {
-    bool isMintable;
-    uint256 initialMintAmount;
-}
-
-/// @dev Deployment configuration for capped balance and capped supply features.
-/// @param tokenBalanceCap The maximum balance per address in wei, 0 to disable.
-/// @param tokenSupplyCap The maximum total supply in wei, 0 to disable.
-struct LSP7CappedParams {
-    uint256 tokenBalanceCap;
-    uint256 tokenSupplyCap;
-}
-
-/// @dev Deployment configuration for non-transferable feature.
-/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
-/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct LSP7NonTransferableParams {
-    uint256 transferLockStart;
-    uint256 transferLockEnd;
-}
-
-/// @dev Deployment configuration for revokable feature.
-/// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct LSP7RevokableParams {
-    bool isRevokable;
-}
 
 /// @title LSP7CustomizableTokenInit
 /// @dev A customizable LSP7 token implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.

--- a/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
@@ -7,10 +7,10 @@ import {Test} from "forge-std/Test.sol";
 // modules
 import {
     LSP7CustomizableToken,
-    MintableParams,
-    NonTransferableParams,
-    CappedParams,
-    RevokableParams
+    LSP7MintableParams,
+    LSP7NonTransferableParams,
+    LSP7CappedParams,
+    LSP7RevokableParams
 } from "../contracts/presets/LSP7CustomizableToken.sol";
 
 // errors
@@ -57,22 +57,22 @@ contract LSP7CustomizableTokenTest is Test {
     LSP7CustomizableToken token;
 
     function setUp() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: initialMintAmount
         });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -132,22 +132,22 @@ contract LSP7CustomizableTokenTest is Test {
     }
 
     function test_ConstructorRevertsIfInitialMintExceedsSupplyCap() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: tokenSupplyCap + 1
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -166,22 +166,22 @@ contract LSP7CustomizableTokenTest is Test {
     }
 
     function test_ConstructorSucceedsWithZeroInitialMint() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: 0
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -205,22 +205,22 @@ contract LSP7CustomizableTokenTest is Test {
     }
 
     function test_ConstructorRevertsWithInvalidLockPeriod() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: initialMintAmount
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: 200,
                 transferLockEnd: 100
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -276,22 +276,22 @@ contract LSP7CustomizableTokenTest is Test {
     }
 
     function test_MintWithMaxSupplyCapAllowsUnlimitedMinting() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: initialMintAmount
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: 0
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -316,22 +316,22 @@ contract LSP7CustomizableTokenTest is Test {
 
     // Balance Cap Tests
     function test_BalanceCapEnforcedCorrectly() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: 2000
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: 1500,
             tokenSupplyCap: 0
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -365,22 +365,22 @@ contract LSP7CustomizableTokenTest is Test {
     }
 
     function test_BalanceCapDisabledWhenZero() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: 1000000
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -420,20 +420,20 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_RevokeFailsWhenRevocationIsDisabled() public {
         bytes32 revokerRole = token.REVOKER_ROLE();
-        MintableParams memory mintableParams = MintableParams({
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
             mintable: mintable,
             initialMintAmount: 1000
         });
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
-        CappedParams memory cappedParams = CappedParams({
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: false
         });
 

--- a/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
@@ -40,7 +40,7 @@ contract LSP7CustomizableTokenTest is Test {
     string symbol = "CT";
     uint256 tokenType = _LSP4_TOKEN_TYPE_TOKEN;
     bool isNonDivisible = false;
-    bool mintable = true;
+    bool isMintable = true;
     bool isRevokable = true;
     uint256 initialMintAmount = 1000;
     uint256 transferLockStart = 0;
@@ -58,7 +58,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function setUp() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: initialMintAmount
         });
 
@@ -106,7 +106,11 @@ contract LSP7CustomizableTokenTest is Test {
             tokenBalanceCap,
             "Balance cap should be set"
         );
-        assertEq(token.isMintable(), mintable, "Mintable status should be set");
+        assertEq(
+            token.isMintable(),
+            isMintable,
+            "Mintable status should be set"
+        );
         assertTrue(token.isRevokable(), "Revokable status should be set");
         assertTrue(token.isTransferable(), "Token should be transferable");
         assertEq(
@@ -133,7 +137,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_ConstructorRevertsIfInitialMintExceedsSupplyCap() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: tokenSupplyCap + 1
         });
 
@@ -167,7 +171,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_ConstructorSucceedsWithZeroInitialMint() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: 0
         });
 
@@ -206,7 +210,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_ConstructorRevertsWithInvalidLockPeriod() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: initialMintAmount
         });
 
@@ -277,7 +281,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_MintWithMaxSupplyCapAllowsUnlimitedMinting() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: initialMintAmount
         });
 
@@ -317,7 +321,7 @@ contract LSP7CustomizableTokenTest is Test {
     // Balance Cap Tests
     function test_BalanceCapEnforcedCorrectly() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: 2000
         });
 
@@ -366,7 +370,7 @@ contract LSP7CustomizableTokenTest is Test {
 
     function test_BalanceCapDisabledWhenZero() public {
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: 1000000
         });
 
@@ -421,7 +425,7 @@ contract LSP7CustomizableTokenTest is Test {
     function test_RevokeFailsWhenRevocationIsDisabled() public {
         bytes32 revokerRole = token.REVOKER_ROLE();
         LSP7MintableParams memory mintableParams = LSP7MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintAmount: 1000
         });
         LSP7NonTransferableParams

--- a/packages/lsp7-contracts/hardhat.config.ts
+++ b/packages/lsp7-contracts/hardhat.config.ts
@@ -125,7 +125,7 @@ const config: HardhatUserConfig = {
          * values will optimize more for high-frequency usage.
          * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
          */
-        runs: 25000,
+        runs: 20000,
       },
       outputSelection: {
         '*': {

--- a/packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol
+++ b/packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {Script} from "../../../lib/forge-std/src/Script.sol";
+import {console2} from "../../../lib/forge-std/src/console2.sol";
+import {LSP7CustomizableTokenInit} from "../contracts/presets/LSP7CustomizableTokenInit.sol";
+
+contract DeployLSP7CustomizableTokenInitScript is Script {
+    function run() public returns (LSP7CustomizableTokenInit deployedContract) {
+        vm.startBroadcast();
+
+        deployedContract = new LSP7CustomizableTokenInit();
+
+        vm.stopBroadcast();
+
+        console2.log(
+            "LSP7CustomizableTokenInit deployed at:",
+            address(deployedContract)
+        );
+    }
+}

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -81,13 +81,15 @@ Set your deployer key first:
 export PRIVATE_KEY=0x...
 ```
 
-Dry run against LUKSO Testnet:
+## Dry run against LUKSO Testnet
 
 ```console
 FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
 ```
 
-Broadcast the deployment:
+## Broadcast the deployment
+
+> Use one of the method described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
 
 ```console
 FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast
@@ -96,5 +98,5 @@ FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8Cust
 Broadcast and verify on the LUKSO Testnet Blockscout explorer:
 
 ```console
-FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://explorer.execution.testnet.lukso.network/api?
+FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://api.explorer.execution.testnet.lukso.network/api?
 ```

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -70,3 +70,31 @@ import {
     lsp8MintableInitAbi,
  } from '@lukso/lsp8-contracts/abi';
 ```
+
+## Foundry deployment
+
+This package includes a Foundry script at `scripts/DeployLSP8CustomizableTokenInit.s.sol` to deploy the `LSP8CustomizableTokenInit` implementation contract.
+
+Set your deployer key first:
+
+```console
+export PRIVATE_KEY=0x...
+```
+
+Dry run against LUKSO Testnet:
+
+```console
+FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
+```
+
+Broadcast the deployment:
+
+```console
+FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast
+```
+
+Broadcast and verify on the LUKSO Testnet Blockscout explorer:
+
+```console
+FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast --verify --verifier blockscout --verifier-url https://explorer.execution.testnet.lukso.network/api?
+```

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -287,7 +287,11 @@ abstract contract AccessControlExtendedAbstract is
 
         if (added) {
             _addressRoles[account].add(role);
-            emit RoleGranted(role, account, msg.sender);
+            emit RoleGranted({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
         }
     }
 
@@ -304,12 +308,16 @@ abstract contract AccessControlExtendedAbstract is
 
         if (removed) {
             _addressRoles[account].remove(role);
-            emit RoleRevoked(role, account, msg.sender);
+            emit RoleRevoked({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
 
             // Auto-clear auxiliary data (BASE-09)
             if (_roleData[role][account].length > 0) {
                 delete _roleData[role][account];
-                emit RoleDataChanged(role, account, "");
+                emit RoleDataChanged({role: role, account: account, data: ""});
             }
         }
     }
@@ -355,7 +363,11 @@ abstract contract AccessControlExtendedAbstract is
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         bytes32 previousAdminRole = getRoleAdmin(role);
         _roleAdmins[role] = adminRole;
-        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+        emit RoleAdminChanged({
+            role: role,
+            previousAdminRole: previousAdminRole,
+            newAdminRole: adminRole
+        });
     }
 
     // --- Ownership sync
@@ -398,7 +410,11 @@ abstract contract AccessControlExtendedAbstract is
 
                 if (oldOwnerRoleData.length > 0) {
                     _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged(role, newOwner, oldOwnerRoleData);
+                    emit RoleDataChanged({
+                        role: role,
+                        account: newOwner,
+                        data: oldOwnerRoleData
+                    });
                 }
             }
         }

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -396,6 +396,9 @@ abstract contract AccessControlExtendedInitAbstract is
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
      */
-    uint256[49] private __gap;
+    uint256[46] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -284,7 +284,11 @@ abstract contract AccessControlExtendedInitAbstract is
 
         if (added) {
             _addressRoles[account].add(role);
-            emit RoleGranted(role, account, msg.sender);
+            emit RoleGranted({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
         }
     }
 
@@ -293,11 +297,15 @@ abstract contract AccessControlExtendedInitAbstract is
 
         if (removed) {
             _addressRoles[account].remove(role);
-            emit RoleRevoked(role, account, msg.sender);
+            emit RoleRevoked({
+                role: role,
+                account: account,
+                sender: msg.sender
+            });
 
             if (_roleData[role][account].length > 0) {
                 delete _roleData[role][account];
-                emit RoleDataChanged(role, account, "");
+                emit RoleDataChanged({role: role, account: account, data: ""});
             }
         }
     }
@@ -327,7 +335,11 @@ abstract contract AccessControlExtendedInitAbstract is
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         bytes32 previousAdminRole = getRoleAdmin(role);
         _roleAdmins[role] = adminRole;
-        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+        emit RoleAdminChanged({
+            role: role,
+            previousAdminRole: previousAdminRole,
+            newAdminRole: adminRole
+        });
     }
 
     // --- Ownership sync
@@ -370,7 +382,11 @@ abstract contract AccessControlExtendedInitAbstract is
 
                 if (oldOwnerRoleData.length > 0) {
                     _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged(role, newOwner, oldOwnerRoleData);
+                    emit RoleDataChanged({
+                        role: role,
+                        account: newOwner,
+                        data: oldOwnerRoleData
+                    });
                 }
             }
         }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
@@ -37,7 +37,7 @@ abstract contract LSP8MintableAbstract is
     /// @custom:info If `mintable_` is set to `true` then it can be disabled using `disableMinting()` function later on.
     constructor(bool mintable_) {
         isMintable = mintable_;
-        emit MintingStatusChanged(mintable_);
+        emit MintingStatusChanged({enabled: mintable_});
         _grantRole(MINTER_ROLE, owner());
     }
 
@@ -45,7 +45,7 @@ abstract contract LSP8MintableAbstract is
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP8MintDisabled());
         isMintable = false;
-        emit MintingStatusChanged(false);
+        emit MintingStatusChanged({enabled: false});
     }
 
     /// @inheritdoc ILSP8Mintable

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
@@ -68,7 +68,7 @@ abstract contract LSP8MintableInitAbstract is
         bool mintable_
     ) internal virtual onlyInitializing {
         isMintable = mintable_;
-        emit MintingStatusChanged(mintable_);
+        emit MintingStatusChanged({enabled: mintable_});
         _grantRole(MINTER_ROLE, owner());
     }
 
@@ -76,7 +76,7 @@ abstract contract LSP8MintableInitAbstract is
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP8MintDisabled());
         isMintable = false;
-        emit MintingStatusChanged(false);
+        emit MintingStatusChanged({enabled: false});
     }
 
     /// @inheritdoc ILSP8Mintable

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
@@ -99,7 +99,7 @@ abstract contract LSP8NonTransferableAbstract is
         transferLockStart = 0;
         transferLockEnd = 0;
 
-        emit TransferLockPeriodChanged(0, 0);
+        emit TransferLockPeriodChanged({start: 0, end: 0});
     }
 
     /// @inheritdoc ILSP8NonTransferable
@@ -128,10 +128,10 @@ abstract contract LSP8NonTransferableAbstract is
         transferLockStart = newTransferLockStart;
         transferLockEnd = newTransferLockEnd;
 
-        emit TransferLockPeriodChanged(
-            newTransferLockStart,
-            newTransferLockEnd
-        );
+        emit TransferLockPeriodChanged({
+            start: newTransferLockStart,
+            end: newTransferLockEnd
+        });
     }
 
     /// @notice Checks if a token transfer is allowed based on transferability status.

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
@@ -142,7 +142,7 @@ abstract contract LSP8NonTransferableInitAbstract is
         transferLockStart = 0;
         transferLockEnd = 0;
 
-        emit TransferLockPeriodChanged(0, 0);
+        emit TransferLockPeriodChanged({start: 0, end: 0});
     }
 
     /// @inheritdoc ILSP8NonTransferable
@@ -171,10 +171,10 @@ abstract contract LSP8NonTransferableInitAbstract is
         transferLockStart = newTransferLockStart;
         transferLockEnd = newTransferLockEnd;
 
-        emit TransferLockPeriodChanged(
-            newTransferLockStart,
-            newTransferLockEnd
-        );
+        emit TransferLockPeriodChanged({
+            start: newTransferLockStart,
+            end: newTransferLockEnd
+        });
     }
 
     /// @notice Checks if a token transfer is allowed based on transferability status.

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -36,7 +36,7 @@ import {
 /// @dev Deployment configuration for minting feature.
 /// @param mintable True to enable minting after deployment, false to disable it forever.
 /// @param initialMintTokenIds Array of tokenIds to mint to `newOwner_` on deployment.
-struct MintableParams {
+struct LSP8MintableParams {
     bool mintable;
     bytes32[] initialMintTokenIds;
 }
@@ -44,7 +44,7 @@ struct MintableParams {
 /// @dev Deployment configuration for capped balance and capped supply features.
 /// @param tokenBalanceCap The maximum number of NFTs per address, 0 to disable.
 /// @param tokenSupplyCap The maximum total supply of NFTs, 0 to disable.
-struct CappedParams {
+struct LSP8CappedParams {
     uint256 tokenBalanceCap;
     uint256 tokenSupplyCap;
 }
@@ -52,14 +52,14 @@ struct CappedParams {
 /// @dev Deployment configuration for non-transferable feature.
 /// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
 /// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct NonTransferableParams {
+struct LSP8NonTransferableParams {
     uint256 transferLockStart;
     uint256 transferLockEnd;
 }
 
 /// @dev Deployment configuration for revokable feature.
 /// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct RevokableParams {
+struct LSP8RevokableParams {
     bool isRevokable;
 }
 
@@ -95,10 +95,10 @@ contract LSP8CustomizableToken is
         address newOwner_,
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
-        MintableParams memory mintableParams,
-        CappedParams memory cappedParams,
-        NonTransferableParams memory nonTransferableParams,
-        RevokableParams memory revokableParams
+        LSP8MintableParams memory mintableParams,
+        LSP8CappedParams memory cappedParams,
+        LSP8NonTransferableParams memory nonTransferableParams,
+        LSP8RevokableParams memory revokableParams
     )
         LSP8IdentifiableDigitalAsset(
             name_,

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -28,40 +28,18 @@ import {
     LSP8RevokableAbstract
 } from "../extensions/LSP8Revokable/LSP8RevokableAbstract.sol";
 
+// constants
+import {
+    LSP8MintableParams,
+    LSP8NonTransferableParams,
+    LSP8CappedParams,
+    LSP8RevokableParams
+} from "./LSP8CustomizableTokenConstants.sol";
+
 // errors
 import {
     LSP8MintDisabled
 } from "../extensions/LSP8Mintable/LSP8MintableErrors.sol";
-
-/// @dev Deployment configuration for minting feature.
-/// @param mintable True to enable minting after deployment, false to disable it forever.
-/// @param initialMintTokenIds Array of tokenIds to mint to `newOwner_` on deployment.
-struct LSP8MintableParams {
-    bool mintable;
-    bytes32[] initialMintTokenIds;
-}
-
-/// @dev Deployment configuration for capped balance and capped supply features.
-/// @param tokenBalanceCap The maximum number of NFTs per address, 0 to disable.
-/// @param tokenSupplyCap The maximum total supply of NFTs, 0 to disable.
-struct LSP8CappedParams {
-    uint256 tokenBalanceCap;
-    uint256 tokenSupplyCap;
-}
-
-/// @dev Deployment configuration for non-transferable feature.
-/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
-/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct LSP8NonTransferableParams {
-    uint256 transferLockStart;
-    uint256 transferLockEnd;
-}
-
-/// @dev Deployment configuration for revokable feature.
-/// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct LSP8RevokableParams {
-    bool isRevokable;
-}
 
 /// @title LSP8CustomizableToken
 /// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions.
@@ -108,7 +86,7 @@ contract LSP8CustomizableToken is
             lsp8TokenIdFormat_
         )
         AccessControlExtendedAbstract(newOwner_)
-        LSP8MintableAbstract(mintableParams.mintable)
+        LSP8MintableAbstract(mintableParams.isMintable)
         LSP8CappedSupplyAbstract(cappedParams.tokenSupplyCap)
         LSP8CappedBalanceAbstract(cappedParams.tokenBalanceCap)
         LSP8NonTransferableAbstract(

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenConstants.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenConstants.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+/// @dev Deployment configuration for minting feature.
+/// @param isMintable True to enable minting after deployment, false to disable it forever.
+/// @param initialMintTokenIds Array of tokenIds to mint to `newOwner_` on deployment.
+struct LSP8MintableParams {
+    bool isMintable;
+    bytes32[] initialMintTokenIds;
+}
+
+/// @dev Deployment configuration for capped balance and capped supply features.
+/// @param tokenBalanceCap The maximum number of NFTs per address, 0 to disable.
+/// @param tokenSupplyCap The maximum total supply of NFTs, 0 to disable.
+struct LSP8CappedParams {
+    uint256 tokenBalanceCap;
+    uint256 tokenSupplyCap;
+}
+
+/// @dev Deployment configuration for non-transferable feature.
+/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
+/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
+struct LSP8NonTransferableParams {
+    uint256 transferLockStart;
+    uint256 transferLockEnd;
+}
+
+/// @dev Deployment configuration for revokable feature.
+/// @param isRevokable True to enable token revocation after deployment, false to disable it.
+struct LSP8RevokableParams {
+    bool isRevokable;
+}

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -37,7 +37,7 @@ import {
 /// @dev Deployment configuration for minting feature.
 /// @param mintable True to enable minting after deployment, false to disable it forever.
 /// @param initialMintTokenIds Array of tokenIds to mint to `newOwner_` on deployment.
-struct MintableParamsInit {
+struct LSP8MintableParams {
     bool mintable;
     bytes32[] initialMintTokenIds;
 }
@@ -45,7 +45,7 @@ struct MintableParamsInit {
 /// @dev Deployment configuration for capped balance and capped supply features.
 /// @param tokenBalanceCap The maximum number of NFTs per address, 0 to disable.
 /// @param tokenSupplyCap The maximum total supply of NFTs, 0 to disable.
-struct CappedParamsInit {
+struct LSP8CappedParams {
     uint256 tokenBalanceCap;
     uint256 tokenSupplyCap;
 }
@@ -53,14 +53,14 @@ struct CappedParamsInit {
 /// @dev Deployment configuration for non-transferable feature.
 /// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
 /// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct NonTransferableParamsInit {
+struct LSP8NonTransferableParams {
     uint256 transferLockStart;
     uint256 transferLockEnd;
 }
 
 /// @dev Deployment configuration for revokable feature.
 /// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct RevokableParamsInit {
+struct LSP8RevokableParams {
     bool isRevokable;
 }
 
@@ -100,10 +100,10 @@ contract LSP8CustomizableTokenInit is
         address newOwner_,
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
-        MintableParamsInit calldata mintableParams,
-        NonTransferableParamsInit calldata nonTransferableParams,
-        CappedParamsInit calldata cappedParams,
-        RevokableParamsInit calldata revokableParams
+        LSP8MintableParams calldata mintableParams,
+        LSP8NonTransferableParams calldata nonTransferableParams,
+        LSP8CappedParams calldata cappedParams,
+        LSP8RevokableParams calldata revokableParams
     ) external virtual initializer {
         __LSP8CustomizableToken_init(
             name_,
@@ -125,10 +125,10 @@ contract LSP8CustomizableTokenInit is
         address newOwner_,
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
-        MintableParamsInit calldata mintableParams,
-        NonTransferableParamsInit calldata nonTransferableParams,
-        CappedParamsInit calldata cappedParams,
-        RevokableParamsInit calldata revokableParams
+        LSP8MintableParams calldata mintableParams,
+        LSP8NonTransferableParams calldata nonTransferableParams,
+        LSP8CappedParams calldata cappedParams,
+        LSP8RevokableParams calldata revokableParams
     ) internal virtual onlyInitializing {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(
             name_,

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -95,15 +95,15 @@ contract LSP8CustomizableTokenInit is
     /// @param nonTransferableParams Deployment configuration for non-transferable feature (see above).
     /// @param cappedParams Deployment configuration for capped balance and capped supply features (see above).
     function initialize(
-        string memory name_,
-        string memory symbol_,
+        string calldata name_,
+        string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
-        MintableParamsInit memory mintableParams,
-        NonTransferableParamsInit memory nonTransferableParams,
-        CappedParamsInit memory cappedParams,
-        RevokableParamsInit memory revokableParams
+        MintableParamsInit calldata mintableParams,
+        NonTransferableParamsInit calldata nonTransferableParams,
+        CappedParamsInit calldata cappedParams,
+        RevokableParamsInit calldata revokableParams
     ) external virtual initializer {
         __LSP8CustomizableToken_init(
             name_,
@@ -120,15 +120,15 @@ contract LSP8CustomizableTokenInit is
 
     /// @dev Internal initialization function.
     function __LSP8CustomizableToken_init(
-        string memory name_,
-        string memory symbol_,
+        string calldata name_,
+        string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
-        MintableParamsInit memory mintableParams,
-        NonTransferableParamsInit memory nonTransferableParams,
-        CappedParamsInit memory cappedParams,
-        RevokableParamsInit memory revokableParams
+        MintableParamsInit calldata mintableParams,
+        NonTransferableParamsInit calldata nonTransferableParams,
+        CappedParamsInit calldata cappedParams,
+        RevokableParamsInit calldata revokableParams
     ) internal virtual onlyInitializing {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(
             name_,

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -29,40 +29,18 @@ import {
     LSP8RevokableInitAbstract
 } from "../extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol";
 
+// constants
+import {
+    LSP8MintableParams,
+    LSP8NonTransferableParams,
+    LSP8CappedParams,
+    LSP8RevokableParams
+} from "./LSP8CustomizableTokenConstants.sol";
+
 // errors
 import {
     LSP8MintDisabled
 } from "../extensions/LSP8Mintable/LSP8MintableErrors.sol";
-
-/// @dev Deployment configuration for minting feature.
-/// @param mintable True to enable minting after deployment, false to disable it forever.
-/// @param initialMintTokenIds Array of tokenIds to mint to `newOwner_` on deployment.
-struct LSP8MintableParams {
-    bool mintable;
-    bytes32[] initialMintTokenIds;
-}
-
-/// @dev Deployment configuration for capped balance and capped supply features.
-/// @param tokenBalanceCap The maximum number of NFTs per address, 0 to disable.
-/// @param tokenSupplyCap The maximum total supply of NFTs, 0 to disable.
-struct LSP8CappedParams {
-    uint256 tokenBalanceCap;
-    uint256 tokenSupplyCap;
-}
-
-/// @dev Deployment configuration for non-transferable feature.
-/// @param transferLockStart The start timestamp of the transfer lock period, 0 to disable.
-/// @param transferLockEnd The end timestamp of the transfer lock period, 0 to disable.
-struct LSP8NonTransferableParams {
-    uint256 transferLockStart;
-    uint256 transferLockEnd;
-}
-
-/// @dev Deployment configuration for revokable feature.
-/// @param isRevokable True to enable token revocation after deployment, false to disable it.
-struct LSP8RevokableParams {
-    bool isRevokable;
-}
 
 /// @title LSP8CustomizableTokenInit
 /// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions. This is the proxy-deployable version.
@@ -138,7 +116,7 @@ contract LSP8CustomizableTokenInit is
             lsp8TokenIdFormat_
         );
         __AccessControlExtended_init_unchained(newOwner_);
-        __LSP8Mintable_init_unchained(mintableParams.mintable);
+        __LSP8Mintable_init_unchained(mintableParams.isMintable);
         __LSP8CappedSupply_init_unchained(cappedParams.tokenSupplyCap);
         __LSP8CappedBalance_init_unchained(cappedParams.tokenBalanceCap);
         __LSP8NonTransferable_init_unchained(

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
@@ -44,7 +44,7 @@ contract LSP8CustomizableTokenTest is Test {
     string symbol = "CNFT";
     uint256 tokenType = _LSP4_TOKEN_TYPE_NFT;
     uint256 tokenIdFormat = 0; // NUMBER format
-    bool mintable = true;
+    bool isMintable = true;
     bool isRevokable = true;
     uint256 transferLockStart = 0;
     uint256 transferLockEnd = 0;
@@ -77,7 +77,7 @@ contract LSP8CustomizableTokenTest is Test {
         initialTokenIds[2] = bytes32(uint256(3));
 
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: initialTokenIds
         });
 
@@ -125,7 +125,11 @@ contract LSP8CustomizableTokenTest is Test {
             tokenBalanceCap,
             "Balance cap should be set"
         );
-        assertEq(token.isMintable(), mintable, "Mintable status should be set");
+        assertEq(
+            token.isMintable(),
+            isMintable,
+            "Mintable status should be set"
+        );
         assertTrue(token.isRevokable(), "Revokable status should be set");
         assertTrue(token.isTransferable(), "Token should be transferable");
         assertEq(
@@ -165,7 +169,7 @@ contract LSP8CustomizableTokenTest is Test {
         }
 
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: tooManyTokenIds
         });
 
@@ -200,7 +204,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_ConstructorSucceedsWithZeroInitialMint() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -239,7 +243,7 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_ConstructorRevertsWithInvalidLockPeriod() public {
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: initialTokenIds
         });
         LSP8NonTransferableParams
@@ -315,7 +319,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_MintWithMaxSupplyCapAllowsUnlimitedMinting() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -392,7 +396,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_BalanceCapDisabledWhenZero() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -462,7 +466,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_TransferDisabledWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -510,7 +514,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_BypassRoleCanTransferWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -570,7 +574,7 @@ contract LSP8CustomizableTokenTest is Test {
     function test_BurningAllowedWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
 
@@ -641,7 +645,7 @@ contract LSP8CustomizableTokenTest is Test {
         bytes32 revokerRole = token.REVOKER_ROLE();
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
-            mintable: mintable,
+            isMintable: isMintable,
             initialMintTokenIds: emptyTokenIds
         });
         LSP8NonTransferableParams

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
@@ -7,10 +7,10 @@ import {Test} from "forge-std/Test.sol";
 // modules
 import {
     LSP8CustomizableToken,
-    MintableParams,
-    NonTransferableParams,
-    CappedParams,
-    RevokableParams
+    LSP8MintableParams,
+    LSP8NonTransferableParams,
+    LSP8CappedParams,
+    LSP8RevokableParams
 } from "../contracts/presets/LSP8CustomizableToken.sol";
 
 // errors
@@ -76,22 +76,22 @@ contract LSP8CustomizableTokenTest is Test {
         initialTokenIds[1] = bytes32(uint256(2));
         initialTokenIds[2] = bytes32(uint256(3));
 
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: initialTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -164,22 +164,22 @@ contract LSP8CustomizableTokenTest is Test {
             tooManyTokenIds[i] = bytes32(uint256(i + 1));
         }
 
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: tooManyTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -199,22 +199,22 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_ConstructorSucceedsWithZeroInitialMint() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -238,21 +238,21 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     function test_ConstructorRevertsWithInvalidLockPeriod() public {
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: initialTokenIds
         });
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: 200,
                 transferLockEnd: 100 // End before start - invalid
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -314,23 +314,23 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_MintWithMaxSupplyCapAllowsUnlimitedMinting() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
         // Both caps disabled
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0,
             tokenSupplyCap: 0
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -391,22 +391,22 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_BalanceCapDisabledWhenZero() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -461,22 +461,22 @@ contract LSP8CustomizableTokenTest is Test {
     // Transfer Tests
     function test_TransferDisabledWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: type(uint256).max // non-transferable
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -509,23 +509,23 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_BypassRoleCanTransferWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
         // ALWAYS non-transferable
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: type(uint256).max
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -569,23 +569,23 @@ contract LSP8CustomizableTokenTest is Test {
     // Burning Tests
     function test_BurningAllowedWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
 
         // ALWAYS non-transferable
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: type(uint256).max
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: isRevokable
         });
 
@@ -640,21 +640,21 @@ contract LSP8CustomizableTokenTest is Test {
     function test_RevokeFailsWhenRevocationIsDisabled() public {
         bytes32 revokerRole = token.REVOKER_ROLE();
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        MintableParams memory mintableParams = MintableParams({
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
             mintable: mintable,
             initialMintTokenIds: emptyTokenIds
         });
-        NonTransferableParams
-            memory nonTransferableParams = NonTransferableParams({
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: transferLockStart,
                 transferLockEnd: transferLockEnd
             });
 
-        CappedParams memory cappedParams = CappedParams({
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: tokenBalanceCap,
             tokenSupplyCap: tokenSupplyCap
         });
-        RevokableParams memory revokableParams = RevokableParams({
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: false
         });
 

--- a/packages/lsp8-contracts/hardhat.config.ts
+++ b/packages/lsp8-contracts/hardhat.config.ts
@@ -127,7 +127,7 @@ const config: HardhatUserConfig = {
          * values will optimize more for high-frequency usage.
          * @see https://docs.soliditylang.org/en/v0.8.6/internals/optimizer.html#opcode-based-optimizer-module
          */
-        runs: 25000,
+        runs: 20000,
       },
       outputSelection: {
         '*': {

--- a/packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol
+++ b/packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.27;
+
+import {Script} from "../../../lib/forge-std/src/Script.sol";
+import {console2} from "../../../lib/forge-std/src/console2.sol";
+import {LSP8CustomizableTokenInit} from "../contracts/presets/LSP8CustomizableTokenInit.sol";
+
+contract DeployLSP8CustomizableTokenInitScript is Script {
+    function run() public returns (LSP8CustomizableTokenInit deployedContract) {
+        vm.startBroadcast();
+
+        deployedContract = new LSP8CustomizableTokenInit();
+
+        vm.stopBroadcast();
+
+        console2.log(
+            "LSP8CustomizableTokenInit deployed at:",
+            address(deployedContract)
+        );
+    }
+}


### PR DESCRIPTION
# What does this PR introduce?

- use named parameters for event emission to improve code clarity and visualize what each value correspond to when emitting events
- add Foundry deployment scripts for `LSP7CustomizableTokenInit` and `LSP8CuztomizableTokenInit`
- Adjust size of `_gap[...]` array in `AccessControlExtendedInitAbstract` contracts in LSP7 and LSP8 packages
- Rename `struct` of Customizable Token contracts to start with LSP7 and LSP8
- Use `calldata` as data location to reduce gas cost on initialization of Customizable Token contracts
- Move `struct` into separate file `LSP7CustomizableTokenConstants.sol` and `LSP8CustomizableTokenConstants.sol`