### PR TITLE
refactor: remove auxiliary data for roles, compilation via IR + change `AccessControlExtended` interface ID

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -37,7 +37,6 @@ test = 'packages/lsp7-contracts/foundry'
 out = 'packages/lsp7-contracts/contracts/foundry_artifacts'
 optimizer = true
 optimizer_runs = 20000
-via_ir = true
 solc = "0.8.28"
 evm_version = "prague"
 
@@ -47,7 +46,6 @@ test = 'packages/lsp8-contracts/foundry'
 out = 'packages/lsp8-contracts/contracts/foundry_artifacts'
 optimizer = true
 optimizer_runs = 20000
-via_ir = true
 solc = "0.8.28"
 evm_version = "prague"
 

--- a/packages/lsp-smart-contracts/hardhat.config.ts
+++ b/packages/lsp-smart-contracts/hardhat.config.ts
@@ -54,7 +54,6 @@ const LSP7_VIA_IR_SETTINGS: SolidityUserConfig = {
   version: '0.8.28',
   settings: {
     evmVersion: 'prague',
-    viaIR: true,
     optimizer: {
       enabled: true,
       /**
@@ -77,7 +76,6 @@ const LSP8_VIA_IR_SETTINGS: SolidityUserConfig = {
   version: '0.8.28',
   settings: {
     evmVersion: 'prague',
-    viaIR: true,
     optimizer: {
       enabled: true,
       /**

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -69,10 +69,6 @@ abstract contract AccessControlExtendedAbstract is
     mapping(address account => EnumerableSet.Bytes32Set rolesAssigned)
         private _addressRoles;
 
-    /// @dev Auxiliary data: role -> address -> bytes.
-    mapping(bytes32 role => mapping(address account => bytes roleData))
-        private _roleData;
-
     // --- Modifier
 
     /**
@@ -199,7 +195,14 @@ abstract contract AccessControlExtendedAbstract is
         return _roleMembers[role].length();
     }
 
-    // --- IAccessControlEnumerable (extended)
+    // --- IAccessControlExtended
+
+    /// @inheritdoc IAccessControlExtended
+    function rolesOf(
+        address account
+    ) public view virtual returns (bytes32[] memory) {
+        return _addressRoles[account].values();
+    }
 
     /**
      * @notice Returns all members that hold `role`.
@@ -218,56 +221,6 @@ abstract contract AccessControlExtendedAbstract is
         bytes32 role
     ) public view virtual returns (address[] memory) {
         return _roleMembers[role].values();
-    }
-
-    // --- IAccessControlExtended
-
-    /// @inheritdoc IAccessControlExtended
-    function rolesOf(
-        address account
-    ) public view virtual returns (bytes32[] memory) {
-        return _addressRoles[account].values();
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Atomically grants `role` to `account` and stores `data`.
-     * If `account` already holds the role (_grantRole is a no-op), the data
-     * is still updated if provided and {RoleDataChanged} is emitted.
-     */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _grantRole(role, account);
-        if (data.length > 0) {
-            _roleData[role][account] = data;
-            emit RoleDataChanged(role, account, data);
-        }
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Sets auxiliary data for a role-address pair. Does NOT revert if `account`
-     * does not hold the role (allows pre-configuration before granting).
-     * Requires the caller to have the admin role for `role`.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _roleData[role][account] = data;
-        emit RoleDataChanged(role, account, data);
-    }
-
-    /// @inheritdoc IAccessControlExtended
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) public view virtual returns (bytes memory) {
-        return _roleData[role][account];
     }
 
     // --- Internal functions
@@ -309,12 +262,6 @@ abstract contract AccessControlExtendedAbstract is
                 account: account,
                 sender: msg.sender
             });
-
-            // Auto-clear auxiliary data
-            if (_roleData[role][account].length > 0) {
-                delete _roleData[role][account];
-                emit RoleDataChanged({role: role, account: account, data: ""});
-            }
         }
     }
 
@@ -396,22 +343,12 @@ abstract contract AccessControlExtendedAbstract is
 
         for (uint256 ii = 0; ii < oldOwnerRoles.length; ++ii) {
             bytes32 role = oldOwnerRoles[ii];
-            bytes memory oldOwnerRoleData = _roleData[role][oldOwner];
 
             _revokeRole(role, oldOwner);
 
             // exclude case when renouncing ownership
             if (newOwner != address(0)) {
                 _grantRole(role, newOwner);
-
-                if (oldOwnerRoleData.length > 0) {
-                    _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged({
-                        role: role,
-                        account: newOwner,
-                        data: oldOwnerRoleData
-                    });
-                }
             }
         }
     }

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -245,9 +245,7 @@ abstract contract AccessControlExtendedAbstract is
      * @dev Revokes `role` from `account`. No-op if the account does not hold the role.
      * Auto-clears auxiliary data if any exists.
      *
-     * @custom:events
-     * - {RoleRevoked} if the role was revoked.
-     * - {RoleDataChanged} if auxiliary data was cleared.
+     * @custom:events Emits {RoleRevoked} if the role was revoked.
      */
     function _revokeRole(bytes32 role, address account) internal virtual {
         bool removed = _roleMembers[role].remove(account);

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -83,14 +83,11 @@ abstract contract AccessControlExtendedAbstract is
     // --- Constructor
 
     /**
-     * @dev Grants `DEFAULT_ADMIN_ROLE` to the initial owner so they appear in
-     * enumeration (getRoleMember, rolesOf) and can administer roles from deployment.
-     *
-     * @param initialOwner_ The initial owner who receives DEFAULT_ADMIN_ROLE.
+     * @dev Grants `DEFAULT_ADMIN_ROLE` to the contract owner so to allow it to administer roles to other addresses after deployment.
+     * This will also make it appear inside the enumerations (getRoleMember, rolesOf, getRoleMembers).
      */
-    constructor(address initialOwner_) {
-        Ownable._transferOwnership(initialOwner_);
-        _grantRole(DEFAULT_ADMIN_ROLE, initialOwner_);
+    constructor() {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner());
     }
 
     // --- ERC-165

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedConstants.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedConstants.sol
@@ -8,8 +8,5 @@ bytes4 constant _INTERFACEID_ACCESSCONTROL = 0x7965db0b;
 bytes4 constant _INTERFACEID_ACCESSCONTROLENUMERABLE = 0x5a05180f;
 
 /// @dev ERC-165 interface ID for IAccessControlExtended.
-///
-/// Computed as XOR of selectors:
-///   getRoleMembers(bytes32) ^ rolesOf(address) ^ grantRoleWithData(bytes32,address,bytes) ^
-///   setRoleData(bytes32,address,bytes) ^ getRoleData(bytes32,address)
-bytes4 constant _INTERFACEID_ACCESSCONTROLEXTENDED = 0xe8547543;
+/// Computed as XOR of selectors: getRoleMembers(bytes32) ^ rolesOf(address)
+bytes4 constant _INTERFACEID_ACCESSCONTROLEXTENDED = 0x8ecd22d4;

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -64,10 +64,6 @@ abstract contract AccessControlExtendedInitAbstract is
     mapping(address account => EnumerableSet.Bytes32Set rolesAssigned)
         private _addressRoles;
 
-    /// @dev Auxiliary data: role -> address -> bytes.
-    mapping(bytes32 role => mapping(address account => bytes roleData))
-        private _roleData;
-
     // --- Modifier
 
     /**
@@ -208,7 +204,14 @@ abstract contract AccessControlExtendedInitAbstract is
         return _roleMembers[role].length();
     }
 
-    // --- IAccessControlEnumerable (extended)
+    // --- IAccessControlExtended
+
+    /// @inheritdoc IAccessControlExtended
+    function rolesOf(
+        address account
+    ) public view virtual returns (bytes32[] memory) {
+        return _addressRoles[account].values();
+    }
 
     /**
      * @notice Returns all members that hold `role`.
@@ -227,56 +230,6 @@ abstract contract AccessControlExtendedInitAbstract is
         bytes32 role
     ) public view virtual returns (address[] memory) {
         return _roleMembers[role].values();
-    }
-
-    // --- IAccessControlExtended
-
-    /// @inheritdoc IAccessControlExtended
-    function rolesOf(
-        address account
-    ) public view virtual returns (bytes32[] memory) {
-        return _addressRoles[account].values();
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Atomically grants `role` to `account` and stores `data`.
-     * If `account` already holds the role (_grantRole is a no-op), the data
-     * is still updated if provided and {RoleDataChanged} is emitted.
-     */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _grantRole(role, account);
-        if (data.length > 0) {
-            _roleData[role][account] = data;
-            emit RoleDataChanged(role, account, data);
-        }
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Sets auxiliary data for a role-address pair. Does NOT revert if `account`
-     * does not hold the role (allows pre-configuration before granting).
-     * Requires the caller to have the admin role for `role`.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _roleData[role][account] = data;
-        emit RoleDataChanged(role, account, data);
-    }
-
-    /// @inheritdoc IAccessControlExtended
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) public view virtual returns (bytes memory) {
-        return _roleData[role][account];
     }
 
     // --- Internal functions
@@ -318,12 +271,6 @@ abstract contract AccessControlExtendedInitAbstract is
                 account: account,
                 sender: msg.sender
             });
-
-            // Auto-clear auxiliary data
-            if (_roleData[role][account].length > 0) {
-                delete _roleData[role][account];
-                emit RoleDataChanged({role: role, account: account, data: ""});
-            }
         }
     }
 
@@ -405,22 +352,12 @@ abstract contract AccessControlExtendedInitAbstract is
 
         for (uint256 ii = 0; ii < oldOwnerRoles.length; ++ii) {
             bytes32 role = oldOwnerRoles[ii];
-            bytes memory oldOwnerRoleData = _roleData[role][oldOwner];
 
             _revokeRole(role, oldOwner);
 
             // exclude case when renouncing ownership
             if (newOwner != address(0)) {
                 _grantRole(role, newOwner);
-
-                if (oldOwnerRoleData.length > 0) {
-                    _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged({
-                        role: role,
-                        account: newOwner,
-                        data: oldOwnerRoleData
-                    });
-                }
             }
         }
     }
@@ -433,5 +370,5 @@ abstract contract AccessControlExtendedInitAbstract is
      * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
      * always adds up to the same number (in this case 50 storage slots).
      */
-    uint256[46] private __gap;
+    uint256[47] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -80,26 +80,21 @@ abstract contract AccessControlExtendedInitAbstract is
     /**
      * @dev Chained initializer that grants DEFAULT_ADMIN_ROLE to the initial owner,
      * so they appear in enumeration (getRoleMember, rolesOf) and can administer roles from initialization.
-     *
-     * @param initialOwner_ Initial contract owner who also receives DEFAULT_ADMIN_ROLE.
      */
-    function __AccessControlExtended_init(
-        address initialOwner_
-    ) internal virtual onlyInitializing {
-        __AccessControlExtended_init_unchained(initialOwner_);
+    function __AccessControlExtended_init() internal virtual onlyInitializing {
+        __AccessControlExtended_init_unchained();
     }
 
     /**
      * @dev Standalone initializer. Only grants DEFAULT_ADMIN_ROLE to the owner.
      * Use when the LSP7 base is already initialized through another path.
-     *
-     * @param initialOwner_ The initial contract owner who also receives DEFAULT_ADMIN_ROLE.
      */
-    function __AccessControlExtended_init_unchained(
-        address initialOwner_
-    ) internal virtual onlyInitializing {
-        OwnableUpgradeable._transferOwnership(initialOwner_);
-        _grantRole(DEFAULT_ADMIN_ROLE, initialOwner_);
+    function __AccessControlExtended_init_unchained()
+        internal
+        virtual
+        onlyInitializing
+    {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner());
     }
 
     // --- ERC-165

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -252,9 +252,7 @@ abstract contract AccessControlExtendedInitAbstract is
      * @dev Revokes `role` from `account`. No-op if the account does not hold the role.
      * Auto-clears auxiliary data if any exists.
      *
-     * @custom:events
-     * - {RoleRevoked} if the role was revoked.
-     * - {RoleDataChanged} if auxiliary data was cleared.
+     * @custom:events Emits {RoleRevoked} if the role was revoked.
      */
     function _revokeRole(bytes32 role, address account) internal virtual {
         bool removed = _roleMembers[role].remove(account);

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/IAccessControlExtended.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/IAccessControlExtended.sol
@@ -15,18 +15,6 @@ import {
  */
 interface IAccessControlExtended is IAccessControlEnumerable {
     /**
-     * @dev Emitted when auxiliary data is set or cleared for a role-address pair.
-     * @param role The role identifier.
-     * @param account The account address whose data was changed.
-     * @param data The new data (empty bytes when data is cleared).
-     */
-    event RoleDataChanged(
-        bytes32 indexed role,
-        address indexed account,
-        bytes data
-    );
-
-    /**
      * @notice Returns all members that hold `role`.
      *
      * @dev Convenience function that returns the full membership array in a single call.
@@ -51,53 +39,4 @@ interface IAccessControlExtended is IAccessControlEnumerable {
      * @return An array of role identifiers assigned to the account.
      */
     function rolesOf(address account) external view returns (bytes32[] memory);
-
-    /**
-     * @notice Grants `role` to `account` and stores auxiliary `data` associated with the role-address pair.
-     * @dev If `account` already holds the role, only the data is updated.
-     *
-     * @custom:requirements Caller must have the admin role for `role`.
-     *
-     * @param role The role identifier to grant.
-     * @param account The address to grant the role to.
-     * @param data Auxiliary data to store for this role-address pair.
-     *
-     * @custom:events
-     * - {RoleGranted} if the role was newly granted.
-     * - {RoleDataChanged} if `data` is non-empty or if data was updated.
-     */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) external;
-
-    /**
-     * @notice Sets auxiliary `data` for a `role` assigned to an `account` address.
-     * @dev Does NOT revert if `account` does not hold the role (allows pre-configuration).
-     *
-     * @custom:requirements Caller must have the admin role for `role`.
-     *
-     * @param role The role identifier.
-     * @param account The address to set data for.
-     * @param data The auxiliary data to store.
-     *
-     * @custom:events {RoleDataChanged} event.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) external;
-
-    /**
-     * @notice Returns the auxiliary data stored for a role-address pair.
-     * @param role The role identifier.
-     * @param account The address to query data for.
-     * @return The stored data, or empty bytes if none exists.
-     */
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) external view returns (bytes memory);
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceAbstract.sol
@@ -19,8 +19,8 @@ import {LSP7CappedBalanceExceeded} from "./LSP7CappedBalanceErrors.sol";
 /// Inherits from LSP7AllowlistAbstract to integrate allowlist functionality.
 abstract contract LSP7CappedBalanceAbstract is
     ILSP7CappedBalance,
-    AccessControlExtendedAbstract,
-    LSP7DigitalAsset
+    LSP7DigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @notice The dead address is also commonly used for burning tokens as an alternative to address(0).
     address internal constant _DEAD_ADDRESS =

--- a/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceInitAbstract.sol
@@ -22,8 +22,8 @@ import {LSP7CappedBalanceExceeded} from "./LSP7CappedBalanceErrors.sol";
 /// @dev Abstract contract implementing a per-address balance cap for LSP7 tokens, with exemptions for allowlisted addresses. Inherits from LSP7AllowlistAbstract to integrate allowlist functionality.
 abstract contract LSP7CappedBalanceInitAbstract is
     ILSP7CappedBalance,
-    AccessControlExtendedInitAbstract,
-    LSP7DigitalAssetInitAbstract
+    LSP7DigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @notice The dead address is also commonly used for burning tokens as an alternative to address(0).
     address internal constant _DEAD_ADDRESS =
@@ -59,7 +59,7 @@ abstract contract LSP7CappedBalanceInitAbstract is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP7CappedBalance_init_unchained(tokenBalanceCap_);
     }
 

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
@@ -19,8 +19,8 @@ import {LSP7MintDisabled} from "./LSP7MintableErrors.sol";
 /// Inherits from LSP7DigitalAsset to provide core token functionality.
 abstract contract LSP7MintableAbstract is
     ILSP7Mintable,
-    AccessControlExtendedAbstract,
-    LSP7DigitalAsset
+    LSP7DigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @notice Indicates whether minting is currently enabled or not.
     bool public isMintable;

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
@@ -24,8 +24,8 @@ import {LSP7MintDisabled} from "./LSP7MintableErrors.sol";
 /// Inherits from LSP7DigitalAsset to provide core token functionality.
 abstract contract LSP7MintableInitAbstract is
     ILSP7Mintable,
-    AccessControlExtendedInitAbstract,
-    LSP7DigitalAssetInitAbstract
+    LSP7DigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @notice Indicates whether minting is currently enabled or not.
     bool public isMintable;
@@ -58,7 +58,7 @@ abstract contract LSP7MintableInitAbstract is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP7Mintable_init_unchained(mintable_);
     }
 

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
@@ -23,8 +23,8 @@ import {
 /// @dev Abstract contract implementing non-transferable LSP7 token functionality with transfer lock periods and allowlist support.
 abstract contract LSP7NonTransferableAbstract is
     ILSP7NonTransferable,
-    AccessControlExtendedAbstract,
-    LSP7DigitalAsset
+    LSP7DigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @dev `"NON_TRANSFERABLE_BYPASS_ROLE"` as utf8 hex (zero padded on the right to 32 bytes)
     bytes32 public constant NON_TRANSFERABLE_BYPASS_ROLE =

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
@@ -27,8 +27,8 @@ import {
 /// @dev Abstract contract implementing non-transferable LSP7 token functionality with transfer lock periods and allowlist support.
 abstract contract LSP7NonTransferableInitAbstract is
     ILSP7NonTransferable,
-    AccessControlExtendedInitAbstract,
-    LSP7DigitalAssetInitAbstract
+    LSP7DigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @dev `"NON_TRANSFERABLE_BYPASS_ROLE"` as utf8 hex (zero padded on the right to 32 bytes)
     bytes32 public constant NON_TRANSFERABLE_BYPASS_ROLE =
@@ -68,7 +68,7 @@ abstract contract LSP7NonTransferableInitAbstract is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP7NonTransferable_init_unchained(
             transferLockStart_,
             transferLockEnd_

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
@@ -29,8 +29,8 @@ import {LSP7RevokableFeatureDisabled} from "./LSP7RevokableErrors.sol";
 /// - Vesting: Revoke unvested tokens if conditions are not met
 abstract contract LSP7RevokableAbstract is
     ILSP7Revokable,
-    AccessControlExtendedAbstract,
-    LSP7DigitalAsset
+    LSP7DigitalAsset,
+    AccessControlExtendedAbstract
 {
     bool internal immutable _IS_REVOKABLE;
 
@@ -38,11 +38,11 @@ abstract contract LSP7RevokableAbstract is
     bytes32 public constant REVOKER_ROLE =
         0x5245564f4b45525f524f4c450000000000000000000000000000000000000000;
 
-    constructor(address newOwner_, bool isRevokable_) {
+    constructor(bool isRevokable_) {
         _IS_REVOKABLE = isRevokable_;
 
         if (isRevokable_) {
-            _grantRole(REVOKER_ROLE, newOwner_);
+            _grantRole(REVOKER_ROLE, owner());
         }
     }
 

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
@@ -35,8 +35,8 @@ import {LSP7RevokableFeatureDisabled} from "./LSP7RevokableErrors.sol";
 /// - Vesting: Revoke unvested tokens if conditions are not met
 abstract contract LSP7RevokableInitAbstract is
     ILSP7Revokable,
-    AccessControlExtendedInitAbstract,
-    LSP7DigitalAssetInitAbstract
+    LSP7DigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     bool internal _isRevokable;
 
@@ -67,19 +67,18 @@ abstract contract LSP7RevokableInitAbstract is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
-        __LSP7Revokable_init_unchained(newOwner_, isRevokable_);
+        __AccessControlExtended_init();
+        __LSP7Revokable_init_unchained(isRevokable_);
     }
 
     /// @notice Unchained initializer for LSP7Revokable.
     function __LSP7Revokable_init_unchained(
-        address newOwner_,
         bool isRevokable_
     ) internal virtual onlyInitializing {
         _isRevokable = isRevokable_;
 
         if (isRevokable_) {
-            _grantRole(REVOKER_ROLE, newOwner_);
+            _grantRole(REVOKER_ROLE, owner());
         }
     }
 

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -42,10 +42,11 @@ import {
 /// @title LSP7CustomizableToken
 /// @dev A customizable LSP7 token (proxy version) implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
 /// Implements {LSP7Mintable} to allow minting.
-/// Implements {LSP7Burnable} to allow burning
+/// Implements {LSP7Burnable} to allow burning.
 /// Implements {LSP7CappedBalance} to set balance caps.
-/// Implements {LSP7NonTransferable} to restrict transfers.
 /// Implements {LSP7CappedSupply} to set total supply cap.
+/// Implements {LSP7NonTransferable} to restrict transfers.
+/// Implements {LSP7Revokable} to allow revoking tokens.
 contract LSP7CustomizableToken is
     LSP7Burnable,
     LSP7MintableAbstract,
@@ -83,7 +84,7 @@ contract LSP7CustomizableToken is
             lsp4TokenType_,
             isNonDivisible_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP7MintableAbstract(mintableParams.isMintable)
         LSP7CappedSupplyAbstract(cappedParams.tokenSupplyCap)
         LSP7CappedBalanceAbstract(cappedParams.tokenBalanceCap)
@@ -91,7 +92,7 @@ contract LSP7CustomizableToken is
             nonTransferableParams.transferLockStart,
             nonTransferableParams.transferLockEnd
         )
-        LSP7RevokableAbstract(newOwner_, revokableParams.isRevokable)
+        LSP7RevokableAbstract(revokableParams.isRevokable)
     {
         if (mintableParams.initialMintAmount > 0) {
             _mint(newOwner_, mintableParams.initialMintAmount, true, "");

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -41,10 +41,10 @@ import {
 
 /// @title LSP7CustomizableToken
 /// @dev A customizable LSP7 token (proxy version) implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
-/// Implements {LSP7Mintable} to allow minting.
 /// Implements {LSP7Burnable} to allow burning.
-/// Implements {LSP7CappedBalance} to set balance caps.
+/// Implements {LSP7Mintable} to allow minting.
 /// Implements {LSP7CappedSupply} to set total supply cap.
+/// Implements {LSP7CappedBalance} to set balance caps.
 /// Implements {LSP7NonTransferable} to restrict transfers.
 /// Implements {LSP7Revokable} to allow revoking tokens.
 contract LSP7CustomizableToken is

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -44,11 +44,12 @@ import {
 
 /// @title LSP7CustomizableTokenInit
 /// @dev A customizable LSP7 token implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
+/// Implements {LSP7BurnableInitAbstract} to allow burning.
 /// Implements {LSP7MintableInitAbstract} to allow minting.
-/// Implements {LSP7BurnableInitAbstract} to allow burning
 /// Implements {LSP7CappedBalanceInitAbstract} to restrict transfers.
 /// Implements {LSP7CappedSupplyInitAbstract} to set balance caps.
 /// Implements {LSP7BurnableInitAbstract} to set total supply cap.
+/// Implement {LSP7RevokableInitAbstract} to allow revoking tokens.
 contract LSP7CustomizableTokenInit is
     LSP7BurnableInitAbstract,
     LSP7MintableInitAbstract,
@@ -110,7 +111,7 @@ contract LSP7CustomizableTokenInit is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init_unchained(newOwner_);
+        __AccessControlExtended_init_unchained();
         __LSP7Mintable_init_unchained(mintableParams.isMintable);
         __LSP7CappedSupply_init_unchained(cappedParams.tokenSupplyCap);
         __LSP7CappedBalance_init_unchained(cappedParams.tokenBalanceCap);
@@ -118,7 +119,7 @@ contract LSP7CustomizableTokenInit is
             nonTransferableParams.transferLockStart,
             nonTransferableParams.transferLockEnd
         );
-        __LSP7Revokable_init_unchained(newOwner_, revokableParams.isRevokable);
+        __LSP7Revokable_init_unchained(revokableParams.isRevokable);
 
         if (mintableParams.initialMintAmount > 0) {
             _mint(newOwner_, mintableParams.initialMintAmount, true, "");

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -46,9 +46,9 @@ import {
 /// @dev A customizable LSP7 token implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
 /// Implements {LSP7BurnableInitAbstract} to allow burning.
 /// Implements {LSP7MintableInitAbstract} to allow minting.
-/// Implements {LSP7CappedBalanceInitAbstract} to restrict transfers.
 /// Implements {LSP7CappedSupplyInitAbstract} to set balance caps.
-/// Implements {LSP7BurnableInitAbstract} to set total supply cap.
+/// Implements {LSP7CappedBalanceInitAbstract} to set balance caps.
+/// Implements {LSP7NonTransferableInitAbstract} to restrict transfers.
 /// Implement {LSP7RevokableInitAbstract} to allow revoking tokens.
 contract LSP7CustomizableTokenInit is
     LSP7BurnableInitAbstract,

--- a/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
@@ -35,7 +35,7 @@ contract LSP7Mintable is LSP7MintableAbstract {
             lsp4TokenType_,
             isNonDivisible_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP7MintableAbstract(mintable_)
     {}
 }

--- a/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
@@ -40,7 +40,7 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP7Mintable_init_unchained(mintable_);
     }
 }

--- a/packages/lsp7-contracts/foundry/AccessControlExtended.t.sol
+++ b/packages/lsp7-contracts/foundry/AccessControlExtended.t.sol
@@ -1327,7 +1327,7 @@ contract AccessControlExtendedTest is Test {
         address newOwner = account1;
         token.transferOwnership(newOwner);
 
-        // Old owner's rolesshould be cleared
+        // Old owner's roles should be cleared
         bytes32[] memory rolesAfter = token.rolesOf(owner);
         assertEq(
             rolesAfter.length,

--- a/packages/lsp7-contracts/foundry/AccessControlExtended.t.sol
+++ b/packages/lsp7-contracts/foundry/AccessControlExtended.t.sol
@@ -63,7 +63,7 @@ contract MockTokenWithAccessControlExtended is
             lsp4TokenType_,
             isNonDivisible_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
     {}
 
     function mint(
@@ -168,7 +168,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 1: Constructor initialization (TEST-01)
+    // Section 1: Constructor initialization
     // ============================================================
 
     function test_ConstructorGrantsDefaultAdminRoleToOwner() public {
@@ -242,7 +242,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 2: grantRole / revokeRole (TEST-01)
+    // Section 2: grantRole / revokeRole
     // ============================================================
 
     function test_OwnerCanGrantRole() public {
@@ -259,6 +259,12 @@ contract AccessControlExtendedTest is Test {
             token.hasRole(TEST_ROLE, account1),
             "Account1 should have TEST_ROLE"
         );
+    }
+
+    function testFuzz_GrantRole(bytes32 newRole) public {
+        vm.assume(newRole != DEFAULT_ADMIN_ROLE);
+        token.grantRole(newRole, account1);
+        assertTrue(token.hasRole(newRole, account1));
     }
 
     function test_NonOwnerCannotGrantRole() public {
@@ -521,7 +527,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 3: renounceRole (TEST-01)
+    // Section 3: renounceRole
     // ============================================================
 
     function test_AccountCanRenounceOwnRole() public {
@@ -579,28 +585,30 @@ contract AccessControlExtendedTest is Test {
         );
     }
 
-    function test_RenounceRoleClearsData() public {
-        bytes memory data = abi.encodePacked(uint256(42));
-        token.grantRoleWithData(TEST_ROLE, account1, data);
+    function test_RenounceRoleRemovesRole() public {
+        token.grantRole(TEST_ROLE, account1);
+        assertTrue(token.hasRole(TEST_ROLE, account1));
 
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored"
-        );
+        bytes32[] memory expectedRoles = token.rolesOf(account1);
+
+        assertEq(expectedRoles.length, 1, "Account1 should have 1 role");
+        assertEq(expectedRoles[0], TEST_ROLE);
 
         vm.prank(account1);
         token.renounceRole(TEST_ROLE, account1);
 
+        assertFalse(token.hasRole(TEST_ROLE, account1));
+
+        bytes32[] memory rolesAfterRenounce = token.rolesOf(account1);
         assertEq(
-            token.getRoleData(TEST_ROLE, account1).length,
+            rolesAfterRenounce.length,
             0,
-            "Data should be cleared after renounce"
+            "Account1 should have 0 roles after renounce"
         );
     }
 
     // ============================================================
-    // Section 4: hasRole (TEST-01)
+    // Section 4: hasRole
     // ============================================================
 
     function test_HasRoleReturnsTrueForGrantedRole() public {
@@ -640,7 +648,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 5: Enumeration - forward lookup (TEST-01)
+    // Section 5: Enumeration - forward lookup
     // ============================================================
 
     function test_GetRoleMemberReturnsCorrectAddress() public {
@@ -741,7 +749,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 6: Reverse lookup (TEST-01)
+    // Section 6: Reverse lookup
     // ============================================================
 
     function test_RolesOfReturnsAllRoles() public {
@@ -798,208 +806,41 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 7: Auxiliary data - setRoleData / getRoleData / grantRoleWithData (TEST-01)
+    // Section 7: Data cleanup on revoke
     // ============================================================
 
-    function test_SetRoleDataStoresData() public {
+    function test_RevokeRole() public {
         token.grantRole(TEST_ROLE, account1);
         assertTrue(token.hasRole(TEST_ROLE, account1));
-        assertEq(token.getRoleData(TEST_ROLE, account1).length, 0);
 
-        bytes memory data = bytes("some role data");
-        token.setRoleData(TEST_ROLE, account1, data);
+        bytes32[] memory roles = token.rolesOf(account1);
+        assertEq(roles.length, 1, "Account1 should have 1 role");
+        assertEq(roles[0], TEST_ROLE);
 
-        assertTrue(token.hasRole(TEST_ROLE, account1));
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Stored data should match"
-        );
-    }
-
-    function test_SetRoleDataEmitsEvent() public {
-        bytes memory data = abi.encodePacked(uint256(200));
-
-        vm.expectEmit(true, true, false, true, address(token));
-        emit IAccessControlExtended.RoleDataChanged(TEST_ROLE, account1, data);
-        token.setRoleData(TEST_ROLE, account1, data);
-    }
-
-    function test_SetRoleDataAllowedWithoutRole() public {
-        // setRoleData does NOT revert if account lacks role
-        assertFalse(token.hasRole(TEST_ROLE, account1));
-        assertEq(token.getRoleData(TEST_ROLE, account1).length, 0);
-
-        bytes memory data = bytes("some role data");
-        token.setRoleData(TEST_ROLE, account1, data);
+        token.revokeRole(TEST_ROLE, account1);
 
         assertFalse(token.hasRole(TEST_ROLE, account1));
+
+        bytes32[] memory rolesAfter = token.rolesOf(account1);
         assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored even without role"
+            rolesAfter.length,
+            0,
+            "Account1 should have 0 roles after revoke"
         );
     }
 
-    function test_SetRoleDataOnlyCallableByOwnerOrRoleAdmin() public {
-        bytes memory data = bytes("some role data");
+    function test_RevokeRoleEmitsRoleRevokedEvent() public {
+        token.grantRole(TEST_ROLE, account1);
 
-        vm.prank(nonOwner);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                AccessControlUnauthorizedAccount.selector,
-                nonOwner,
-                DEFAULT_ADMIN_ROLE
-            )
-        );
-        token.setRoleData(TEST_ROLE, account1, data);
-
-        // test with owner
-        vm.prank(owner);
-        token.setRoleData(TEST_ROLE, account1, data);
-
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored"
-        );
-
-        // test with role admin
-        bytes32 roleAdmin = keccak256("Test role admin");
-        token.setRoleAdmin(TEST_ROLE, roleAdmin);
-        token.grantRole(roleAdmin, account1);
-        assertTrue(token.hasRole(roleAdmin, account1));
-
-        vm.prank(account1);
-        token.setRoleData(TEST_ROLE, account2, data);
-
-        assertEq(
-            token.getRoleData(TEST_ROLE, account2),
-            data,
-            "Data should be stored"
-        );
-    }
-
-    function test_GetRoleDataReturnsEmptyForNoData() public {
-        bytes memory data = token.getRoleData(TEST_ROLE, account1);
-        assertEq(data.length, 0, "Should return empty bytes for no data");
-    }
-
-    function test_GrantRoleWithDataStoresRoleAndData() public {
-        bytes memory data = bytes("some role data");
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-
-        assertTrue(
-            token.hasRole(TEST_ROLE, account1),
-            "Account1 should have TEST_ROLE"
-        );
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored"
-        );
-    }
-
-    function test_GrantRoleWithDataEmitsBothEvents() public {
-        bytes memory data = bytes("some role data");
+        vm.recordLogs();
 
         vm.expectEmit(true, true, true, true, address(token));
-        emit IAccessControl.RoleGranted(TEST_ROLE, account1, owner);
-        vm.expectEmit(true, true, false, true, address(token));
-        emit IAccessControlExtended.RoleDataChanged(TEST_ROLE, account1, data);
-
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-    }
-
-    function test_GrantRoleWithDataUpdateDataOnlyIfRoleAlreadyHeld() public {
-        // First grant without data
-        token.grantRole(TEST_ROLE, account1);
-
-        bytes memory data = abi.encodePacked(uint256(700));
-
-        // grantRoleWithData when role already held: no RoleGranted, but RoleDataChanged
-        vm.recordLogs();
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        // Should have exactly 1 event: RoleDataChanged (no RoleGranted since role already held)
-        assertEq(entries.length, 1, "Should emit only RoleDataChanged");
-        assertEq(
-            entries[0].topics[0],
-            IAccessControlExtended.RoleDataChanged.selector
-        );
-
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be updated"
-        );
-    }
-
-    function test_GrantRoleWithDataEmptyDataNoDataEvent() public {
-        // grantRoleWithData with empty data -> only RoleGranted, no RoleDataChanged
-        vm.recordLogs();
-        token.grantRoleWithData(TEST_ROLE, account1, "");
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        // Should have exactly 1 event: RoleGranted (no RoleDataChanged since data is empty)
-        assertEq(entries.length, 1, "Should emit only RoleGranted");
-        assertEq(entries[0].topics[0], IAccessControl.RoleGranted.selector);
-
-        assertTrue(
-            token.hasRole(TEST_ROLE, account1),
-            "Account1 should have TEST_ROLE"
-        );
-    }
-
-    // ============================================================
-    // Section 8: Data cleanup on revoke (TEST-01)
-    // ============================================================
-
-    function test_RevokeRoleClearsAssociatedData() public {
-        bytes memory data = bytes("some data");
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-        assertTrue(token.hasRole(TEST_ROLE, account1));
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored"
-        );
-
-        token.revokeRole(TEST_ROLE, account1);
-
-        assertFalse(token.hasRole(TEST_ROLE, account1));
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1).length,
-            0,
-            "Data should be cleared after revocation"
-        );
-    }
-
-    function test_RevokeRoleEmitsRoleDataChangedWhenDataExists() public {
-        bytes memory data = bytes("some data");
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-
-        vm.expectEmit(true, true, false, true, address(token));
-        emit IAccessControlExtended.RoleDataChanged(TEST_ROLE, account1, "");
+        emit IAccessControl.RoleRevoked(TEST_ROLE, account1, address(this));
         token.revokeRole(TEST_ROLE, account1);
     }
 
-    function test_RevokeRoleNoDataEventWhenNoDataExists() public {
-        // Grant role without data
-        token.grantRole(TEST_ROLE, account1);
-
-        vm.recordLogs();
-        token.revokeRole(TEST_ROLE, account1);
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-
-        // Should have exactly 1 event: RoleRevoked (no RoleDataChanged since no data existed)
-        assertEq(entries.length, 1, "Should emit only RoleRevoked");
-        assertEq(entries[0].topics[0], IAccessControl.RoleRevoked.selector);
-    }
-
     // ============================================================
-    // Section 9: Role admin hierarchy (TEST-01)
+    // Section 8: Role admin hierarchy
     // ============================================================
 
     function test_DefaultAdminRoleIsDefaultAdmin() public {
@@ -1096,7 +937,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 10: supportsInterface (TEST-02)
+    // Section 9: supportsInterface
     // ============================================================
 
     function test_InterfaceIdConstantsMatchComputedSelectors() public {
@@ -1157,7 +998,7 @@ contract AccessControlExtendedTest is Test {
     // }
 
     // ============================================================
-    // Section 11: Ownership transfer sync (TEST-01)
+    // Section 10: Ownership transfer sync
     // ============================================================
 
     function test_TransferOwnershipSyncsDefaultAdminRole() public {
@@ -1269,7 +1110,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 12: onlyRole modifier (TEST-01)
+    // Section 11: onlyRole modifier
     // ============================================================
 
     function test_OnlyRoleAllowsRoleHolder() public {
@@ -1307,7 +1148,7 @@ contract AccessControlExtendedTest is Test {
     }
 
     // ============================================================
-    // Section 13: Fuzz tests (TEST-01)
+    // Section 12: Fuzz tests
     // ============================================================
 
     function testFuzz_GrantAndRevokeRoleConsistency(
@@ -1356,35 +1197,31 @@ contract AccessControlExtendedTest is Test {
         assertFalse(foundAfter, "rolesOf should not contain the revoked role");
     }
 
-    function testFuzz_RoleDataLifecycle(
-        address addr,
-        bytes calldata data
-    ) public {
+    function testFuzz_RoleLifecycle(address addr) public {
         vm.assume(addr != address(0));
         vm.assume(addr != owner);
         vm.assume(uint160(addr) > 9);
-        vm.assume(data.length > 0);
 
         // Grant with data
-        token.grantRoleWithData(TEST_ROLE, addr, data);
+        token.grantRole(TEST_ROLE, addr);
         assertTrue(token.hasRole(TEST_ROLE, addr), "Should have role");
-        assertEq(token.getRoleData(TEST_ROLE, addr), data, "Data should match");
 
-        // Revoke (should clear data)
+        bytes32[] memory roles = token.rolesOf(addr);
+        assertEq(roles.length, 1, "Should have 1 role");
+        assertEq(roles[0], TEST_ROLE);
+
         token.revokeRole(TEST_ROLE, addr);
         assertFalse(
             token.hasRole(TEST_ROLE, addr),
             "Should not have role after revoke"
         );
-        assertEq(
-            token.getRoleData(TEST_ROLE, addr).length,
-            0,
-            "Data should be cleared after revoke"
-        );
+
+        bytes32[] memory rolesAfter = token.rolesOf(addr);
+        assertEq(rolesAfter.length, 0, "Should have 0 roles after revoke");
     }
 
     // ============================================================
-    // Section 14: _transferOwnership transfers ALL roles (Enhancement 1)
+    // Section 13: _transferOwnership transfers ALL roles
     // ============================================================
 
     function test_TransferOwnershipTransfersAllRoles() public {
@@ -1473,36 +1310,49 @@ contract AccessControlExtendedTest is Test {
         );
     }
 
-    function test_TransferOwnershipTransfersOldOwnerRoleData() public {
-        // Grant role with data to owner
-        token.grantRoleWithData(MINTER_ROLE, owner, hex"cafebabe");
+    function test_TransferOwnershipTransfersOldOwnerRoles() public {
+        token.grantRole(MINTER_ROLE, owner);
 
-        assertEq(
-            token.getRoleData(MINTER_ROLE, owner),
-            hex"cafebabe",
-            "Owner should have role data"
+        assertTrue(
+            token.hasRole(MINTER_ROLE, owner),
+            "Owner should have MINTER_ROLE"
         );
+
+        bytes32[] memory ownerRoles = token.rolesOf(owner);
+
+        assertEq(ownerRoles.length, 2, "Owner should have 2 roles");
+        assertEq(ownerRoles[0], DEFAULT_ADMIN_ROLE);
+        assertEq(ownerRoles[1], MINTER_ROLE);
 
         address newOwner = account1;
         token.transferOwnership(newOwner);
 
-        // Old owner's role data should be cleared
+        // Old owner's rolesshould be cleared
+        bytes32[] memory rolesAfter = token.rolesOf(owner);
         assertEq(
-            token.getRoleData(MINTER_ROLE, owner).length,
+            rolesAfter.length,
             0,
-            "Old owner role data should be cleared"
+            "Old owner should have 0 roles after transfer"
         );
 
-        // New owner should inherit the old owner's auxiliary data for the transferred role
+        // New owner should inherit the old owner's roles
+        assertTrue(
+            token.hasRole(DEFAULT_ADMIN_ROLE, newOwner),
+            "New owner should have DEFAULT_ADMIN_ROLE"
+        );
         assertTrue(
             token.hasRole(MINTER_ROLE, newOwner),
             "New owner should have MINTER_ROLE"
         );
-        assertEq(
-            token.getRoleData(MINTER_ROLE, newOwner),
-            hex"cafebabe",
-            "New owner should inherit the transferred role data"
-        );
+
+        bytes32[] memory newOwnerRoles = token.rolesOf(newOwner);
+        assertEq(newOwnerRoles.length, 2, "New owner should have 2 roles");
+        assertEq(newOwnerRoles[0], DEFAULT_ADMIN_ROLE);
+        assertEq(newOwnerRoles[1], MINTER_ROLE);
+
+        assertEq(newOwnerRoles.length, ownerRoles.length);
+        assertEq(newOwnerRoles[0], ownerRoles[0]);
+        assertEq(newOwnerRoles[1], ownerRoles[1]);
     }
 
     function test_TransferOwnershipEmitsAllRoleEvents() public {

--- a/packages/lsp7-contracts/foundry/AccessControlExtendedInit.t.sol
+++ b/packages/lsp7-contracts/foundry/AccessControlExtendedInit.t.sol
@@ -286,7 +286,7 @@ contract AccessControlExtendedInitTest is Test {
         // forge-lint: disable-next-line(unsafe-typecast)
         bytes32 roleB = bytes32(bytes("RoleB"));
 
-        // Grant multiple rolesto multiple accounts through proxy
+        // Grant multiple roles to multiple accounts through proxy
         token.grantRole(roleA, account1);
         token.grantRole(roleA, account2);
         token.grantRole(roleB, account1);

--- a/packages/lsp7-contracts/foundry/AccessControlExtendedInit.t.sol
+++ b/packages/lsp7-contracts/foundry/AccessControlExtendedInit.t.sol
@@ -68,7 +68,7 @@ contract MockAccessControlExtendedInit is
             lsp4TokenType_,
             isNonDivisible_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
     }
 
     function mint(
@@ -213,43 +213,30 @@ contract AccessControlExtendedInitTest is Test {
         assertEq(roles[0], TEST_ROLE, "Role should be TEST_ROLE");
     }
 
-    function test_InitGrantRoleWithDataWorks() public {
-        bytes memory data = abi.encodePacked(uint256(42));
-        token.grantRoleWithData(TEST_ROLE, account1, data);
+    function test_InitGrantRole() public {
+        token.grantRole(TEST_ROLE, account1);
 
         assertTrue(
             token.hasRole(TEST_ROLE, account1),
             "Account1 should have TEST_ROLE"
         );
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored"
-        );
+        bytes32[] memory roles = token.rolesOf(account1);
+        assertEq(roles.length, 1, "Account1 should have 1 role");
+        assertEq(roles[0], TEST_ROLE, "Role should be TEST_ROLE");
     }
 
-    function test_InitSetRoleDataWorks() public {
-        bytes memory data = abi.encodePacked(uint256(100));
-        token.setRoleData(TEST_ROLE, account1, data);
+    function test_InitRevokeRole() public {
+        token.grantRole(TEST_ROLE, account1);
 
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1),
-            data,
-            "Data should be stored via setRoleData"
-        );
-    }
-
-    function test_InitRevokeRoleClearsData() public {
-        bytes memory data = abi.encodePacked(uint256(200));
-        token.grantRoleWithData(TEST_ROLE, account1, data);
+        bytes32[] memory roles = token.rolesOf(account1);
+        assertEq(roles.length, 1, "Account1 should have 1 role");
+        assertEq(roles[0], TEST_ROLE, "Role should be TEST_ROLE");
 
         token.revokeRole(TEST_ROLE, account1);
 
-        assertEq(
-            token.getRoleData(TEST_ROLE, account1).length,
-            0,
-            "Data should be cleared after revocation"
-        );
+        roles = token.rolesOf(account1);
+
+        assertEq(roles.length, 0, "Account1 should have 0 roles after revoke");
     }
 
     function test_InitRenounceRoleWorks() public {
@@ -299,14 +286,10 @@ contract AccessControlExtendedInitTest is Test {
         // forge-lint: disable-next-line(unsafe-typecast)
         bytes32 roleB = bytes32(bytes("RoleB"));
 
-        bytes memory dataA1 = abi.encodePacked(uint256(1000));
-        bytes memory dataA2 = abi.encodePacked(uint256(2000));
-        bytes memory dataB1 = abi.encodePacked(uint256(3000));
-
-        // Grant multiple roles with data to multiple accounts through proxy
-        token.grantRoleWithData(roleA, account1, dataA1);
-        token.grantRoleWithData(roleA, account2, dataA2);
-        token.grantRoleWithData(roleB, account1, dataB1);
+        // Grant multiple rolesto multiple accounts through proxy
+        token.grantRole(roleA, account1);
+        token.grantRole(roleA, account2);
+        token.grantRole(roleB, account1);
         token.grantRole(roleB, account3);
 
         // Read all state back through proxy and verify consistency
@@ -359,23 +342,6 @@ contract AccessControlExtendedInitTest is Test {
         // rolesOf (reverse lookup)
         bytes32[] memory account1Roles = token.rolesOf(account1);
         assertEq(account1Roles.length, 2, "account1 should have 2 roles");
-
-        // getRoleData
-        assertEq(
-            token.getRoleData(roleA, account1),
-            dataA1,
-            "account1 roleA data should match"
-        );
-        assertEq(
-            token.getRoleData(roleA, account2),
-            dataA2,
-            "account2 roleA data should match"
-        );
-        assertEq(
-            token.getRoleData(roleB, account1),
-            dataB1,
-            "account1 roleB data should match"
-        );
     }
 
     function test_InitStorageConsistentAcrossProxyCalls() public {

--- a/packages/lsp7-contracts/foundry/LSP7CappedBalance.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7CappedBalance.t.sol
@@ -40,8 +40,8 @@ contract MockLSP7CappedBalance is LSP7CappedBalanceAbstract {
             lsp4TokenType_,
             isNonDivisible_
         )
+        AccessControlExtendedAbstract()
         LSP7CappedBalanceAbstract(tokenBalanceCap_)
-        AccessControlExtendedAbstract(newOwner_)
     {}
 
     // Helper function to mint tokens for testing

--- a/packages/lsp7-contracts/foundry/LSP7Mintable.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7Mintable.t.sol
@@ -50,8 +50,8 @@ contract MockLSP7Mintable is LSP7MintableAbstract {
             lsp4TokenType_,
             isNonDivisible_
         )
+        AccessControlExtendedAbstract()
         LSP7MintableAbstract(mintable_)
-        AccessControlExtendedAbstract(newOwner_)
     {}
 }
 
@@ -175,10 +175,19 @@ contract LSP7MintableTest is Test {
         assertEq(lsp7NonMintable.owner(), owner);
     }
 
-    function test_OwnerStartsWithMinterRole() public {
+    function test_OwnerStartsWithDefaultAdminRoleAndMinterRole() public {
+        assertTrue(
+            lsp7Mintable.hasRole(DEFAULT_ADMIN_ROLE, owner),
+            "Owner should start with DEFAULT_ADMIN_ROLE"
+        );
         assertTrue(
             lsp7Mintable.hasRole(lsp7Mintable.MINTER_ROLE(), owner),
             "Owner should start with MINTER_ROLE"
+        );
+
+        assertTrue(
+            lsp7MintableRandomOwner.hasRole(DEFAULT_ADMIN_ROLE, randomOwner),
+            "Random owner should start with DEFAULT_ADMIN_ROLE"
         );
         assertTrue(
             lsp7MintableRandomOwner.hasRole(
@@ -243,6 +252,11 @@ contract LSP7MintableTest is Test {
     function test_DefaultAdminCanGrantItselfMinterRoleAndMint() public {
         bytes32 minterRole = lsp7MintableRandomOwner.MINTER_ROLE();
         address defaultAdmin = vm.addr(103);
+
+        assertEq(lsp7MintableRandomOwner.owner(), randomOwner);
+        assertTrue(
+            lsp7MintableRandomOwner.hasRole(DEFAULT_ADMIN_ROLE, randomOwner)
+        );
 
         vm.prank(randomOwner);
         lsp7MintableRandomOwner.grantRole(DEFAULT_ADMIN_ROLE, defaultAdmin);

--- a/packages/lsp7-contracts/foundry/LSP7NonTransferable.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7NonTransferable.t.sol
@@ -48,8 +48,8 @@ contract MockLSP7NonTransferable is LSP7NonTransferableAbstract {
             lsp4TokenType_,
             isNonDivisible_
         )
+        AccessControlExtendedAbstract()
         LSP7NonTransferableAbstract(transferLockStart_, transferLockEnd_)
-        AccessControlExtendedAbstract(newOwner_)
     {}
 
     function mint(

--- a/packages/lsp7-contracts/foundry/LSP7Revokable.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7Revokable.t.sol
@@ -49,8 +49,8 @@ contract MockLSP7Revokable is LSP7RevokableAbstract {
             lsp4TokenType_,
             isNonDivisible_
         )
-        AccessControlExtendedAbstract(newOwner_)
-        LSP7RevokableAbstract(newOwner_, isRevokable_)
+        AccessControlExtendedAbstract()
+        LSP7RevokableAbstract(isRevokable_)
     {}
 
     /// @dev Helper function to mint tokens for testing
@@ -150,16 +150,22 @@ contract LSP7RevokableTest is Test {
 
         Vm.Log[] memory recordedLogs = vm.getRecordedLogs();
 
+        uint256 lastLog = recordedLogs.length - 1;
+
         // First `RoleGranted` event MUST be for `DEFAULT_ADMIN_ROLE`
         assertEq(
-            recordedLogs[2].topics[0],
+            recordedLogs[lastLog - 1].topics[0],
             IAccessControl.RoleGranted.selector
         );
-        assertEq(recordedLogs[2].topics[1], DEFAULT_ADMIN_ROLE);
-        assertEq(recordedLogs[2].topics[2], bytes32(uint256(uint160(owner))));
-        assertEq(recordedLogs[2].topics[3], bytes32(uint256(uint160(owner))));
-
-        uint256 lastLog = recordedLogs.length - 1;
+        assertEq(recordedLogs[lastLog - 1].topics[1], DEFAULT_ADMIN_ROLE);
+        assertEq(
+            recordedLogs[lastLog - 1].topics[2],
+            bytes32(uint256(uint160(owner)))
+        );
+        assertEq(
+            recordedLogs[lastLog - 1].topics[3],
+            bytes32(uint256(uint160(owner)))
+        );
 
         // Another `RoleGranted` event MUST be for `REVOKER_ROLE`
         assertEq(

--- a/packages/lsp7-contracts/hardhat.config.ts
+++ b/packages/lsp7-contracts/hardhat.config.ts
@@ -116,7 +116,6 @@ const config: HardhatUserConfig = {
     version: '0.8.28',
     settings: {
       evmVersion: 'prague',
-      viaIR: true,
       optimizer: {
         enabled: true,
         /**

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -34,15 +34,15 @@ import {
 /**
  * @title AccessControlExtendedAbstract
  * @dev Abstract contract implementing OZ-compatible role management with reverse lookups
- * and auxiliary data storage. Uses EnumerableSet composition (NOT OZ AccessControl inheritance)
+ * Uses EnumerableSet composition (NOT OZ AccessControl inheritance)
  *
  * Provides:
  * - Standard OZ {IAccessControl} functions: hasRole, grantRole, revokeRole, renounceRole, getRoleAdmin
  * - Standard OZ {IAccessControlEnumerable} functions: getRoleMember, getRoleMemberCount
- * - Extended functions: rolesOf, grantRoleWithData, setRoleData, getRoleData
+ * - Extended functions: rolesOf, getRoleMembers
  * - Explicit role checks for every role-gated function
  * - DEFAULT_ADMIN_ROLE as root admin for granting and revoking roles
- * - Automatic transfer of all roles (and their auxiliary data, if any) between old and new on ownership transfer
+ * - Automatic transfer of all roles between old and new on ownership transfer
  */
 abstract contract AccessControlExtendedAbstract is
     IAccessControlExtended,
@@ -68,10 +68,6 @@ abstract contract AccessControlExtendedAbstract is
     /// @dev Reverse lookup: address -> set of roles held.
     mapping(address account => EnumerableSet.Bytes32Set rolesAssigned)
         private _addressRoles;
-
-    /// @dev Auxiliary data: role -> address -> bytes.
-    mapping(bytes32 role => mapping(address account => bytes roleData))
-        private _roleData;
 
     // --- Modifier
 
@@ -113,7 +109,9 @@ abstract contract AccessControlExtendedAbstract is
 
     // --- IAccessControl
 
-    /// @inheritdoc IAccessControl
+    /**
+     * @inheritdoc IAccessControl
+     */
     function hasRole(
         bytes32 role,
         address account
@@ -121,7 +119,9 @@ abstract contract AccessControlExtendedAbstract is
         return _hasRole(role, account);
     }
 
-    /// @inheritdoc IAccessControl
+    /**
+     * @inheritdoc IAccessControl
+     */
     function getRoleAdmin(bytes32 role) public view virtual returns (bytes32) {
         return _roleAdmins[role];
     }
@@ -160,7 +160,6 @@ abstract contract AccessControlExtendedAbstract is
      * @inheritdoc IAccessControl
      * @dev Allows `msg.sender` to renounce their own `role`. The `callerConfirmation`
      * parameter must equal `msg.sender` to prevent accidental renouncement (OZ pattern).
-     * Renouncing triggers data cleanup.
      *
      * @custom:warning The current owner cannot renounce `DEFAULT_ADMIN_ROLE`
      * to prevent locking the contract out of role administration.
@@ -184,7 +183,9 @@ abstract contract AccessControlExtendedAbstract is
 
     // --- IAccessControlEnumerable
 
-    /// @inheritdoc IAccessControlEnumerable
+    /**
+     * @inheritdoc IAccessControlEnumerable
+     */
     function getRoleMember(
         bytes32 role,
         uint256 index
@@ -192,14 +193,25 @@ abstract contract AccessControlExtendedAbstract is
         return _roleMembers[role].at(index);
     }
 
-    /// @inheritdoc IAccessControlEnumerable
+    /**
+     * @inheritdoc IAccessControlEnumerable
+     */
     function getRoleMemberCount(
         bytes32 role
     ) public view virtual returns (uint256) {
         return _roleMembers[role].length();
     }
 
-    // --- IAccessControlEnumerable (extended)
+    // --- IAccessControlExtended
+
+    /**
+     * @inheritdoc IAccessControlExtended
+     */
+    function rolesOf(
+        address account
+    ) public view virtual returns (bytes32[] memory) {
+        return _addressRoles[account].values();
+    }
 
     /**
      * @notice Returns all members that hold `role`.
@@ -210,7 +222,8 @@ abstract contract AccessControlExtendedAbstract is
      * @param role The role identifier to query members for.
      * @return An array of addresses that currently hold the specified role.
      *
-     * @custom:warning This function copies the entire role membership set into memory.
+     * @custom:warning This function copies the entire role members set from storage into memory.
+     * This is designed to mostly be used by view accessors that are queried without any gas fees.
      * For roles with a large number of members, this may consume a significant amount of gas. If calling this function on-chain, consider calling `{getRoleMember}` repeatedly, using `getRoleMemberCount` to know as max index.
      * This function is primarily intended for off-chain usage.
      */
@@ -218,56 +231,6 @@ abstract contract AccessControlExtendedAbstract is
         bytes32 role
     ) public view virtual returns (address[] memory) {
         return _roleMembers[role].values();
-    }
-
-    // --- IAccessControlExtended
-
-    /// @inheritdoc IAccessControlExtended
-    function rolesOf(
-        address account
-    ) public view virtual returns (bytes32[] memory) {
-        return _addressRoles[account].values();
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Atomically grants `role` to `account` and stores `data`.
-     * If `account` already holds the role (_grantRole is a no-op), the data
-     * is still updated if provided and {RoleDataChanged} is emitted.
-     */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _grantRole(role, account);
-        if (data.length > 0) {
-            _roleData[role][account] = data;
-            emit RoleDataChanged(role, account, data);
-        }
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Sets auxiliary data for a role-address pair. Does NOT revert if `account`
-     * does not hold the role (allows pre-configuration before granting).
-     * Requires the caller to have the admin role for `role`.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _roleData[role][account] = data;
-        emit RoleDataChanged(role, account, data);
-    }
-
-    /// @inheritdoc IAccessControlExtended
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) public view virtual returns (bytes memory) {
-        return _roleData[role][account];
     }
 
     // --- Internal functions
@@ -293,11 +256,8 @@ abstract contract AccessControlExtendedAbstract is
 
     /**
      * @dev Revokes `role` from `account`. No-op if the account does not hold the role.
-     * Auto-clears auxiliary data if any exists.
      *
-     * @custom:events
-     * - {RoleRevoked} if the role was revoked.
-     * - {RoleDataChanged} if auxiliary data was cleared.
+     * @custom:events Emits {RoleRevoked} if the role was revoked.
      */
     function _revokeRole(bytes32 role, address account) internal virtual {
         bool removed = _roleMembers[role].remove(account);
@@ -309,12 +269,6 @@ abstract contract AccessControlExtendedAbstract is
                 account: account,
                 sender: msg.sender
             });
-
-            // Auto-clear auxiliary data (BASE-09)
-            if (_roleData[role][account].length > 0) {
-                delete _roleData[role][account];
-                emit RoleDataChanged({role: role, account: account, data: ""});
-            }
         }
     }
 
@@ -374,15 +328,13 @@ abstract contract AccessControlExtendedAbstract is
      * custom roles the old owner was assigned.
      *
      * For each role held by the old owner:
-     * 1. The role is revoked from the old owner (including clearing auxiliary data).
+     * 1. The role is revoked from the old owner.
      * 2. The role is granted to the new owner (if not already held).
      *
      * @custom:info When renouncing ownership, roles are only removed from the old owner. Roles are not passed to `address(0)` (being the `newOwner` in the case of renounce ownership).
      *
      * @custom:warning
      * - Gas cost scales linearly with the number of roles the old owner holds.
-     * - Auxiliary role data set on the old owner is transferred to the new owner if ownership is transferred.
-     * - Transferring ownership to self will still clear then restore the old owner's auxiliary role data.
      * - If the old owner holds a large number of roles, the transaction may approach or exceed
      *   the block gas limit and fail. Avoid assigning too many roles to the owner to ensure
      *   ownership transfers remain callable.
@@ -396,22 +348,12 @@ abstract contract AccessControlExtendedAbstract is
 
         for (uint256 ii = 0; ii < oldOwnerRoles.length; ++ii) {
             bytes32 role = oldOwnerRoles[ii];
-            bytes memory oldOwnerRoleData = _roleData[role][oldOwner];
 
             _revokeRole(role, oldOwner);
 
             // exclude case when renouncing ownership
             if (newOwner != address(0)) {
                 _grantRole(role, newOwner);
-
-                if (oldOwnerRoleData.length > 0) {
-                    _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged({
-                        role: role,
-                        account: newOwner,
-                        data: oldOwnerRoleData
-                    });
-                }
             }
         }
     }

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -236,7 +236,7 @@ abstract contract AccessControlExtendedAbstract is
      * @dev Grants `role` to `account`. No-op if the account already holds the role
      * (matching OZ behavior). Updates both forward and reverse lookups.
      *
-     * @custom:events {RoleGranted} if the role was newly granted.
+     * @custom:events Emits {RoleGranted} if the role was newly granted.
      */
     function _grantRole(bytes32 role, address account) internal virtual {
         bool added = _roleMembers[role].add(account);

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -83,14 +83,11 @@ abstract contract AccessControlExtendedAbstract is
     // --- Constructor
 
     /**
-     * @dev Grants `DEFAULT_ADMIN_ROLE` to the initial owner so they appear in
-     * enumeration (getRoleMember, rolesOf) and can administer roles from deployment.
-     *
-     * @param initialOwner_ The initial owner who receives DEFAULT_ADMIN_ROLE.
+     * @dev Grants `DEFAULT_ADMIN_ROLE` to the contract owner so to allow it to administer roles to other addresses after deployment.
+     * This will also make it appear inside the enumerations (getRoleMember, rolesOf, getRoleMembers).
      */
-    constructor(address initialOwner_) {
-        Ownable._transferOwnership(initialOwner_);
-        _grantRole(DEFAULT_ADMIN_ROLE, initialOwner_);
+    constructor() {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner());
     }
 
     // --- ERC-165

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedConstants.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedConstants.sol
@@ -8,8 +8,5 @@ bytes4 constant _INTERFACEID_ACCESSCONTROL = 0x7965db0b;
 bytes4 constant _INTERFACEID_ACCESSCONTROLENUMERABLE = 0x5a05180f;
 
 /// @dev ERC-165 interface ID for IAccessControlExtended.
-///
-/// Computed as XOR of selectors:
-///   getRoleMembers(bytes32) ^ rolesOf(address) ^ grantRoleWithData(bytes32,address,bytes) ^
-///   setRoleData(bytes32,address,bytes) ^ getRoleData(bytes32,address)
-bytes4 constant _INTERFACEID_ACCESSCONTROLEXTENDED = 0xe8547543;
+/// Computed as XOR of selectors: getRoleMembers(bytes32) ^ rolesOf(address)
+bytes4 constant _INTERFACEID_ACCESSCONTROLEXTENDED = 0x8ecd22d4;

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -80,26 +80,21 @@ abstract contract AccessControlExtendedInitAbstract is
     /**
      * @dev Chained initializer that grants DEFAULT_ADMIN_ROLE to the initial owner,
      * so they appear in enumeration (getRoleMember, rolesOf) and can administer roles from initialization.
-     *
-     * @param initialOwner_ Initial contract owner who also receives DEFAULT_ADMIN_ROLE.
      */
-    function __AccessControlExtended_init(
-        address initialOwner_
-    ) internal virtual onlyInitializing {
-        __AccessControlExtended_init_unchained(initialOwner_);
+    function __AccessControlExtended_init() internal virtual onlyInitializing {
+        __AccessControlExtended_init_unchained();
     }
 
     /**
      * @dev Standalone initializer. Only grants DEFAULT_ADMIN_ROLE to the owner.
      * Use when the LSP8 base is already initialized through another path.
-     *
-     * @param initialOwner_ The initial contract owner who also receives DEFAULT_ADMIN_ROLE.
      */
-    function __AccessControlExtended_init_unchained(
-        address initialOwner_
-    ) internal virtual onlyInitializing {
-        OwnableUpgradeable._transferOwnership(initialOwner_);
-        _grantRole(DEFAULT_ADMIN_ROLE, initialOwner_);
+    function __AccessControlExtended_init_unchained()
+        internal
+        virtual
+        onlyInitializing
+    {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner());
     }
 
     // --- ERC-165

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -86,7 +86,7 @@ abstract contract AccessControlExtendedInitAbstract is
     }
 
     /**
-     * @dev Standalone initializer. Only grants DEFAULT_ADMIN_ROLE to the owner.
+     * @dev Standalone initializer. Only grants DEFAULT_ADMIN_ROLE to the contract owner.
      * Use when the LSP8 base is already initialized through another path.
      */
     function __AccessControlExtended_init_unchained()
@@ -254,9 +254,7 @@ abstract contract AccessControlExtendedInitAbstract is
      * @dev Revokes `role` from `account`. No-op if the account does not hold the role.
      * Auto-clears auxiliary data if any exists.
      *
-     * @custom:events
-     * - {RoleRevoked} if the role was revoked.
-     * - {RoleDataChanged} if auxiliary data was cleared.
+     * @custom:events Emits {RoleRevoked} if the role was revoked.
      */
     function _revokeRole(bytes32 role, address account) internal virtual {
         bool removed = _roleMembers[role].remove(account);

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -64,10 +64,6 @@ abstract contract AccessControlExtendedInitAbstract is
     mapping(address account => EnumerableSet.Bytes32Set rolesAssigned)
         private _addressRoles;
 
-    /// @dev Auxiliary data: role -> address -> bytes.
-    mapping(bytes32 role => mapping(address account => bytes roleData))
-        private _roleData;
-
     // --- Modifier
 
     /**
@@ -122,7 +118,9 @@ abstract contract AccessControlExtendedInitAbstract is
 
     // --- IAccessControl
 
-    /// @inheritdoc IAccessControl
+    /**
+     * @inheritdoc IAccessControl
+     */
     function hasRole(
         bytes32 role,
         address account
@@ -130,13 +128,16 @@ abstract contract AccessControlExtendedInitAbstract is
         return _hasRole(role, account);
     }
 
-    /// @inheritdoc IAccessControl
+    /**
+     * @inheritdoc IAccessControl
+     */
     function getRoleAdmin(bytes32 role) public view virtual returns (bytes32) {
         return _roleAdmins[role];
     }
 
     /**
      * @inheritdoc IAccessControl
+     *
      * @dev Grants `role` to `account`.
      *
      * @custom:requirements The caller must hold the admin role for `role`.
@@ -167,6 +168,7 @@ abstract contract AccessControlExtendedInitAbstract is
 
     /**
      * @inheritdoc IAccessControl
+     *
      * @dev Allows `msg.sender` to renounce their own `role`. The `callerConfirmation`
      * parameter must equal `msg.sender` to prevent accidental renouncement (OZ pattern).
      * Renouncing triggers data cleanup.
@@ -193,7 +195,9 @@ abstract contract AccessControlExtendedInitAbstract is
 
     // --- IAccessControlEnumerable
 
-    /// @inheritdoc IAccessControlEnumerable
+    /**
+     * @inheritdoc IAccessControlEnumerable
+     */
     function getRoleMember(
         bytes32 role,
         uint256 index
@@ -201,37 +205,20 @@ abstract contract AccessControlExtendedInitAbstract is
         return _roleMembers[role].at(index);
     }
 
-    /// @inheritdoc IAccessControlEnumerable
+    /**
+     * @inheritdoc IAccessControlEnumerable
+     */
     function getRoleMemberCount(
         bytes32 role
     ) public view virtual returns (uint256) {
         return _roleMembers[role].length();
     }
 
-    // --- IAccessControlEnumerable (extended)
-
-    /**
-     * @notice Returns all members that hold `role`.
-     *
-     * @dev Convenience function that returns the full membership array in a single call.
-     * Equivalent to calling {getRoleMember} for each index from `0` to `getRoleMemberCount(role) - 1`.
-     *
-     * @param role The role identifier to query members for.
-     * @return An array of addresses that currently hold the specified role.
-     *
-     * @custom:warning This function copies the entire role membership set into memory.
-     * For roles with a large number of members, this may consume a significant amount of gas. If calling this function on-chain, consider calling `{getRoleMember}` repeatedly, using `getRoleMemberCount` to know as max index.
-     * This function is primarily intended for off-chain usage.
-     */
-    function getRoleMembers(
-        bytes32 role
-    ) public view virtual returns (address[] memory) {
-        return _roleMembers[role].values();
-    }
-
     // --- IAccessControlExtended
 
-    /// @inheritdoc IAccessControlExtended
+    /**
+     * @inheritdoc IAccessControlExtended
+     */
     function rolesOf(
         address account
     ) public view virtual returns (bytes32[] memory) {
@@ -240,43 +227,11 @@ abstract contract AccessControlExtendedInitAbstract is
 
     /**
      * @inheritdoc IAccessControlExtended
-     * @dev Atomically grants `role` to `account` and stores `data`.
-     * If `account` already holds the role (_grantRole is a no-op), the data
-     * is still updated if provided and {RoleDataChanged} is emitted.
      */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _grantRole(role, account);
-        if (data.length > 0) {
-            _roleData[role][account] = data;
-            emit RoleDataChanged(role, account, data);
-        }
-    }
-
-    /**
-     * @inheritdoc IAccessControlExtended
-     * @dev Sets auxiliary data for a role-address pair. Does NOT revert if `account`
-     * does not hold the role (allows pre-configuration before granting).
-     * Requires the caller to have the admin role for `role`.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) public virtual onlyRole(getRoleAdmin(role)) {
-        _roleData[role][account] = data;
-        emit RoleDataChanged(role, account, data);
-    }
-
-    /// @inheritdoc IAccessControlExtended
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) public view virtual returns (bytes memory) {
-        return _roleData[role][account];
+    function getRoleMembers(
+        bytes32 role
+    ) public view virtual returns (address[] memory) {
+        return _roleMembers[role].values();
     }
 
     // --- Internal functions
@@ -318,12 +273,6 @@ abstract contract AccessControlExtendedInitAbstract is
                 account: account,
                 sender: msg.sender
             });
-
-            // Auto-clear auxiliary data
-            if (_roleData[role][account].length > 0) {
-                delete _roleData[role][account];
-                emit RoleDataChanged({role: role, account: account, data: ""});
-            }
         }
     }
 
@@ -405,22 +354,12 @@ abstract contract AccessControlExtendedInitAbstract is
 
         for (uint256 ii = 0; ii < oldOwnerRoles.length; ++ii) {
             bytes32 role = oldOwnerRoles[ii];
-            bytes memory oldOwnerRoleData = _roleData[role][oldOwner];
 
             _revokeRole(role, oldOwner);
 
             // exclude case when renouncing ownership
             if (newOwner != address(0)) {
                 _grantRole(role, newOwner);
-
-                if (oldOwnerRoleData.length > 0) {
-                    _roleData[role][newOwner] = oldOwnerRoleData;
-                    emit RoleDataChanged({
-                        role: role,
-                        account: newOwner,
-                        data: oldOwnerRoleData
-                    });
-                }
             }
         }
     }
@@ -433,5 +372,5 @@ abstract contract AccessControlExtendedInitAbstract is
      * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
      * always adds up to the same number (in this case 50 storage slots).
      */
-    uint256[46] private __gap;
+    uint256[47] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/IAccessControlExtended.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/IAccessControlExtended.sol
@@ -8,36 +8,22 @@ import {
 
 /**
  * @title IAccessControlExtended
- * @dev Interface extending IAccessControlEnumerable with reverse role lookups
- * and auxiliary data storage per role-address pair.
- *
+ * @dev Interface extending IAccessControlEnumerable with reverse role lookups.
  * Inherits all functions from {IAccessControl} and {IAccessControlEnumerable}:
  */
 interface IAccessControlExtended is IAccessControlEnumerable {
     /**
-     * @dev Emitted when auxiliary data is set or cleared for a role-address pair.
-     * @param role The role identifier.
-     * @param account The account address whose data was changed.
-     * @param data The new data (empty bytes when data is cleared).
-     */
-    event RoleDataChanged(
-        bytes32 indexed role,
-        address indexed account,
-        bytes data
-    );
-
-    /**
      * @notice Returns all members that hold `role`.
      *
      * @dev Convenience function that returns the full membership array in a single call.
-     * Equivalent to calling {getRoleMember} for each index from `0` to
-     * `getRoleMemberCount(role) - 1`.
+     * Equivalent to calling {getRoleMember} for each index from `0` to `getRoleMemberCount(role) - 1`.
      *
      * @param role The role identifier to query members for.
      * @return An array of addresses that currently hold the specified role.
      *
      * @custom:warning This function copies the entire role membership set into memory.
-     * For roles with a large number of members, this may consume a significant amount of gas. If calling this function on-chain, consider calling `{getRoleMember}` repeatedly, using `getRoleMemberCount` to know as max index.
+     * For roles with a large number of members, this may consume a significant amount of gas. If calling this function on-chain,
+     * consider calling `{getRoleMember}` repeatedly, using `getRoleMemberCount` to know as max index.
      * This function is primarily intended for off-chain usage.
      */
     function getRoleMembers(
@@ -51,53 +37,4 @@ interface IAccessControlExtended is IAccessControlEnumerable {
      * @return An array of role identifiers assigned to the account.
      */
     function rolesOf(address account) external view returns (bytes32[] memory);
-
-    /**
-     * @notice Grants `role` to `account` and stores auxiliary `data` associated with the role-address pair.
-     * @dev If `account` already holds the role, only the data is updated.
-     *
-     * @custom:requirements Caller must have the admin role for `role`.
-     *
-     * @param role The role identifier to grant.
-     * @param account The address to grant the role to.
-     * @param data Auxiliary data to store for this role-address pair.
-     *
-     * @custom:events
-     * - {RoleGranted} if the role was newly granted.
-     * - {RoleDataChanged} if `data` is non-empty or if data was updated.
-     */
-    function grantRoleWithData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) external;
-
-    /**
-     * @notice Sets auxiliary `data` for a `role` assigned to an `account` address.
-     * @dev Does NOT revert if `account` does not hold the role (allows pre-configuration).
-     *
-     * @custom:requirements Caller must have the admin role for `role`.
-     *
-     * @param role The role identifier.
-     * @param account The address to set data for.
-     * @param data The auxiliary data to store.
-     *
-     * @custom:events {RoleDataChanged} event.
-     */
-    function setRoleData(
-        bytes32 role,
-        address account,
-        bytes calldata data
-    ) external;
-
-    /**
-     * @notice Returns the auxiliary data stored for a role-address pair.
-     * @param role The role identifier.
-     * @param account The address to query data for.
-     * @return The stored data, or empty bytes if none exists.
-     */
-    function getRoleData(
-        bytes32 role,
-        address account
-    ) external view returns (bytes memory);
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceAbstract.sol
@@ -20,8 +20,8 @@ import {LSP8CappedBalanceExceeded} from "./LSP8CappedBalanceErrors.sol";
 /// @dev Abstract contract implementing a per-address NFT count cap for LSP8 tokens, with role-based exemptions.
 abstract contract LSP8CappedBalanceAbstract is
     ILSP8CappedBalance,
-    AccessControlExtendedAbstract,
-    LSP8IdentifiableDigitalAsset
+    LSP8IdentifiableDigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @notice The dead address is also commonly used for burning tokens as an alternative to address(0).
     address internal constant _DEAD_ADDRESS =

--- a/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceInitAbstract.sol
@@ -22,8 +22,8 @@ import {LSP8CappedBalanceExceeded} from "./LSP8CappedBalanceErrors.sol";
 /// @dev Abstract contract implementing a per-address NFT count cap for LSP8 tokens, with role-based exemptions.
 abstract contract LSP8CappedBalanceInitAbstract is
     ILSP8CappedBalance,
-    AccessControlExtendedInitAbstract,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @notice The dead address is also commonly used for burning tokens as an alternative to address(0).
     address internal constant _DEAD_ADDRESS =
@@ -59,7 +59,7 @@ abstract contract LSP8CappedBalanceInitAbstract is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP8CappedBalance_init_unchained(tokenBalanceCap_);
     }
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
@@ -21,8 +21,8 @@ import {LSP8MintDisabled} from "./LSP8MintableErrors.sol";
 /// Inherits from LSP8IdentifiableDigitalAsset to provide core token functionality.
 abstract contract LSP8MintableAbstract is
     ILSP8Mintable,
-    AccessControlExtendedAbstract,
-    LSP8IdentifiableDigitalAsset
+    LSP8IdentifiableDigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @notice Indicates whether minting is currently enabled.
     bool public isMintable;

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
@@ -23,8 +23,8 @@ import {LSP8MintDisabled} from "./LSP8MintableErrors.sol";
 /// Inherits from LSP8IdentifiableDigitalAssetInitAbstract to provide core token functionality.
 abstract contract LSP8MintableInitAbstract is
     ILSP8Mintable,
-    AccessControlExtendedInitAbstract,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @notice Indicates whether minting is currently enabled.
     bool public isMintable;
@@ -57,7 +57,7 @@ abstract contract LSP8MintableInitAbstract is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP8Mintable_init_unchained(mintable_);
     }
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
@@ -25,8 +25,8 @@ import {
 /// @dev Abstract contract implementing non-transferable LSP8 token functionality with transfer lock periods and role-based bypass support.
 abstract contract LSP8NonTransferableAbstract is
     ILSP8NonTransferable,
-    AccessControlExtendedAbstract,
-    LSP8IdentifiableDigitalAsset
+    LSP8IdentifiableDigitalAsset,
+    AccessControlExtendedAbstract
 {
     /// @dev `"NON_TRANSFERABLE_BYPASS_ROLE"` as utf8 hex (zero padded on the right to 32 bytes)
     bytes32 public constant NON_TRANSFERABLE_BYPASS_ROLE =

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
@@ -27,8 +27,8 @@ import {
 /// @dev Abstract contract implementing non-transferable LSP8 token functionality with transfer lock periods and role-based bypass support.
 abstract contract LSP8NonTransferableInitAbstract is
     ILSP8NonTransferable,
-    AccessControlExtendedInitAbstract,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     /// @dev `"NON_TRANSFERABLE_BYPASS_ROLE"` as utf8 hex (zero padded on the right to 32 bytes)
     bytes32 public constant NON_TRANSFERABLE_BYPASS_ROLE =
@@ -65,7 +65,7 @@ abstract contract LSP8NonTransferableInitAbstract is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP8NonTransferable_init_unchained(
             transferLockStart_,
             transferLockEnd_

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
@@ -31,8 +31,8 @@ import {LSP8RevokableFeatureDisabled} from "./LSP8RevokableErrors.sol";
 /// - Ticketing: Reclaim tickets or access NFTs when conditions are no longer met
 abstract contract LSP8RevokableAbstract is
     ILSP8Revokable,
-    AccessControlExtendedAbstract,
-    LSP8IdentifiableDigitalAsset
+    LSP8IdentifiableDigitalAsset,
+    AccessControlExtendedAbstract
 {
     bool internal immutable _IS_REVOKABLE;
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
@@ -40,11 +40,11 @@ abstract contract LSP8RevokableAbstract is
     bytes32 public constant REVOKER_ROLE =
         0x5245564f4b45525f524f4c450000000000000000000000000000000000000000;
 
-    constructor(address newOwner_, bool isRevokable_) {
+    constructor(bool isRevokable_) {
         _IS_REVOKABLE = isRevokable_;
 
         if (isRevokable_) {
-            _grantRole(REVOKER_ROLE, newOwner_);
+            _grantRole(REVOKER_ROLE, owner());
         }
     }
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
@@ -35,8 +35,8 @@ import {LSP8RevokableFeatureDisabled} from "./LSP8RevokableErrors.sol";
 /// - Ticketing: Reclaim tickets or access NFTs when conditions are no longer met
 abstract contract LSP8RevokableInitAbstract is
     ILSP8Revokable,
-    AccessControlExtendedInitAbstract,
-    LSP8IdentifiableDigitalAssetInitAbstract
+    LSP8IdentifiableDigitalAssetInitAbstract,
+    AccessControlExtendedInitAbstract
 {
     bool internal _isRevokable;
 
@@ -67,19 +67,18 @@ abstract contract LSP8RevokableInitAbstract is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init(newOwner_);
-        __LSP8Revokable_init_unchained(newOwner_, isRevokable_);
+        __AccessControlExtended_init();
+        __LSP8Revokable_init_unchained(isRevokable_);
     }
 
     /// @notice Unchained initializer for LSP8Revokable.
     function __LSP8Revokable_init_unchained(
-        address newOwner_,
         bool isRevokable_
     ) internal virtual onlyInitializing {
         _isRevokable = isRevokable_;
 
         if (isRevokable_) {
-            _grantRole(REVOKER_ROLE, newOwner_);
+            _grantRole(REVOKER_ROLE, owner());
         }
     }
 

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -43,11 +43,12 @@ import {
 
 /// @title LSP8CustomizableToken
 /// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions.
+/// Implements {LSP8Burnable} to allow burning.
 /// Implements {LSP8Mintable} to allow minting.
-/// Implements {LSP8Burnable} to allow burning
 /// Implements {LSP8CappedBalance} to set balance caps.
-/// Implements {LSP8NonTransferable} to restrict transfers.
 /// Implements {LSP8CappedSupply} to set total supply cap.
+/// Implements {LSP8NonTransferable} to restrict transfers.
+/// Implements {LSP8Revokable} to allow revoking tokens.
 contract LSP8CustomizableToken is
     LSP8Burnable,
     LSP8MintableAbstract,
@@ -85,7 +86,7 @@ contract LSP8CustomizableToken is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP8MintableAbstract(mintableParams.isMintable)
         LSP8CappedSupplyAbstract(cappedParams.tokenSupplyCap)
         LSP8CappedBalanceAbstract(cappedParams.tokenBalanceCap)
@@ -93,7 +94,7 @@ contract LSP8CustomizableToken is
             nonTransferableParams.transferLockStart,
             nonTransferableParams.transferLockEnd
         )
-        LSP8RevokableAbstract(newOwner_, revokableParams.isRevokable)
+        LSP8RevokableAbstract(revokableParams.isRevokable)
     {
         // Mint initial tokens
         for (

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -45,8 +45,8 @@ import {
 /// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions.
 /// Implements {LSP8Burnable} to allow burning.
 /// Implements {LSP8Mintable} to allow minting.
-/// Implements {LSP8CappedBalance} to set balance caps.
 /// Implements {LSP8CappedSupply} to set total supply cap.
+/// Implements {LSP8CappedBalance} to set balance caps.
 /// Implements {LSP8NonTransferable} to restrict transfers.
 /// Implements {LSP8Revokable} to allow revoking tokens.
 contract LSP8CustomizableToken is

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -115,7 +115,7 @@ contract LSP8CustomizableTokenInit is
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init_unchained(newOwner_);
+        __AccessControlExtended_init_unchained();
         __LSP8Mintable_init_unchained(mintableParams.isMintable);
         __LSP8CappedSupply_init_unchained(cappedParams.tokenSupplyCap);
         __LSP8CappedBalance_init_unchained(cappedParams.tokenBalanceCap);
@@ -123,7 +123,7 @@ contract LSP8CustomizableTokenInit is
             nonTransferableParams.transferLockStart,
             nonTransferableParams.transferLockEnd
         );
-        __LSP8Revokable_init_unchained(newOwner_, revokableParams.isRevokable);
+        __LSP8Revokable_init_unchained(revokableParams.isRevokable);
 
         // Mint initial tokens
         for (

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -44,11 +44,12 @@ import {
 
 /// @title LSP8CustomizableTokenInit
 /// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions. This is the proxy-deployable version.
+/// Implements {LSP8Burnable} to allow burning.
 /// Implements {LSP8Mintable} to allow minting.
-/// Implements {LSP8Burnable} to allow burning
+/// Implements {LSP8CappedSupply} to set total supply cap.
 /// Implements {LSP8CappedBalance} to set balance caps.
 /// Implements {LSP8NonTransferable} to restrict transfers.
-/// Implements {LSP8CappedSupply} to set total supply cap.
+/// Implements {LSP8Revokable} to allow revoking tokens.
 contract LSP8CustomizableTokenInit is
     LSP8BurnableInitAbstract,
     LSP8MintableInitAbstract,

--- a/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
@@ -30,7 +30,7 @@ contract LSP8Mintable is LSP8MintableAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP8MintableAbstract(true)
     {}
 }

--- a/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
@@ -44,7 +44,7 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
         __LSP8Mintable_init_unchained(true);
     }
 }

--- a/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
+++ b/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
@@ -166,22 +166,17 @@ contract AccessControlExtendedTest is Test {
         assertTrue(token.hasRole(TEST_ROLE, account1));
     }
 
-    function test_GrantRoleWithDataStoresData() public {
-        bytes memory data = abi.encodePacked(uint256(42));
-
-        token.grantRoleWithData(TEST_ROLE, account1, data);
-
+    function test_GrantRoleStoresRole() public {
+        token.grantRole(TEST_ROLE, account1);
         assertTrue(token.hasRole(TEST_ROLE, account1));
-        assertEq(token.getRoleData(TEST_ROLE, account1), data);
     }
 
-    function test_RevokeRoleClearsData() public {
-        token.grantRoleWithData(TEST_ROLE, account1, bytes("hello"));
+    function test_RevokeRoleClearsRole() public {
+        token.grantRole(TEST_ROLE, account1);
+        assertTrue(token.hasRole(TEST_ROLE, account1));
 
         token.revokeRole(TEST_ROLE, account1);
-
         assertFalse(token.hasRole(TEST_ROLE, account1));
-        assertEq(token.getRoleData(TEST_ROLE, account1).length, 0);
     }
 
     function test_RenounceRoleRequiresConfirmation() public {
@@ -239,7 +234,6 @@ contract AccessControlExtendedTest is Test {
         bytes32 burnerRole = keccak256("BURNER_ROLE");
 
         token.grantRole(minterRole, owner);
-        token.grantRoleWithData(burnerRole, owner, hex"cafe");
 
         token.transferOwnership(account1);
 
@@ -247,13 +241,11 @@ contract AccessControlExtendedTest is Test {
         assertFalse(token.hasRole(minterRole, owner));
         assertFalse(token.hasRole(burnerRole, owner));
         assertEq(token.rolesOf(owner).length, 0);
-        assertEq(token.getRoleData(burnerRole, owner).length, 0);
 
         assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, account1));
         assertTrue(token.hasRole(minterRole, account1));
         assertTrue(token.hasRole(burnerRole, account1));
         assertEq(token.rolesOf(account1).length, 3);
-        assertEq(token.getRoleData(burnerRole, account1), hex"cafe");
     }
 
     function test_RenounceOwnershipRevokesAllRoles() public {

--- a/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
+++ b/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
@@ -207,14 +207,20 @@ contract AccessControlExtendedTest is Test {
     }
 
     function test_InterfaceIdConstantsMatchComputedSelectors() public {
-        assertEq(_INTERFACEID_ACCESSCONTROL, type(IAccessControl).interfaceId);
+        assertEq(
+            _INTERFACEID_ACCESSCONTROL,
+            type(IAccessControl).interfaceId,
+            "AccessControl interfaceId constant mismatch"
+        );
         assertEq(
             _INTERFACEID_ACCESSCONTROLENUMERABLE,
-            type(IAccessControlEnumerable).interfaceId
+            type(IAccessControlEnumerable).interfaceId,
+            "AccessControlEnumerable interfaceId constant mismatch"
         );
         assertEq(
             _INTERFACEID_ACCESSCONTROLEXTENDED,
-            type(IAccessControlExtended).interfaceId
+            type(IAccessControlExtended).interfaceId,
+            "AccessControlExtended interfaceId constant mismatch"
         );
     }
 
@@ -234,6 +240,7 @@ contract AccessControlExtendedTest is Test {
         bytes32 burnerRole = keccak256("BURNER_ROLE");
 
         token.grantRole(minterRole, owner);
+        token.grantRole(burnerRole, owner);
 
         token.transferOwnership(account1);
 

--- a/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
+++ b/packages/lsp8-contracts/foundry/AccessControlExtended.t.sol
@@ -59,7 +59,7 @@ contract MockLSP8WithAccessControlExtended is
             _LSP4_TOKEN_TYPE_NFT,
             _LSP8_TOKENID_FORMAT_NUMBER
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
     {}
 
     function setRoleAdmin(bytes32 role, bytes32 adminRole) public {

--- a/packages/lsp8-contracts/foundry/AccessControlExtendedInit.t.sol
+++ b/packages/lsp8-contracts/foundry/AccessControlExtendedInit.t.sol
@@ -100,14 +100,14 @@ contract AccessControlExtendedInitTest is Test {
     function setUp() public {
         implementation = new MockAccessControlExtendedInit();
 
-        bytes memory initData = abi.encodeCall(
+        bytes memory initializeCalldata = abi.encodeCall(
             MockAccessControlExtendedInit.initialize,
             (owner)
         );
 
         ERC1967Proxy proxy = new ERC1967Proxy(
             address(implementation),
-            initData
+            initializeCalldata
         );
         token = MockAccessControlExtendedInit(payable(address(proxy)));
     }
@@ -136,7 +136,6 @@ contract AccessControlExtendedInitTest is Test {
 
     function test_TransferOwnershipTransfersAllRolesThroughProxy() public {
         token.grantRole(EXTRA_ROLE, owner);
-        token.grantRoleWithData(TEST_ROLE, owner, hex"beef");
 
         token.transferOwnership(account1);
 
@@ -144,13 +143,11 @@ contract AccessControlExtendedInitTest is Test {
         assertFalse(token.hasRole(EXTRA_ROLE, owner));
         assertFalse(token.hasRole(TEST_ROLE, owner));
         assertEq(token.rolesOf(owner).length, 0);
-        assertEq(token.getRoleData(TEST_ROLE, owner).length, 0);
 
         assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, account1));
         assertTrue(token.hasRole(EXTRA_ROLE, account1));
         assertTrue(token.hasRole(TEST_ROLE, account1));
         assertEq(token.rolesOf(account1).length, 3);
-        assertEq(token.getRoleData(TEST_ROLE, account1), hex"beef");
     }
 
     function test_RenounceOwnershipRevokesAllRolesThroughProxy() public {

--- a/packages/lsp8-contracts/foundry/AccessControlExtendedInit.t.sol
+++ b/packages/lsp8-contracts/foundry/AccessControlExtendedInit.t.sol
@@ -47,7 +47,7 @@ contract MockAccessControlExtendedInit is
             _LSP4_TOKEN_TYPE_NFT,
             _LSP8_TOKENID_FORMAT_NUMBER
         );
-        __AccessControlExtended_init(newOwner_);
+        __AccessControlExtended_init();
     }
 
     function supportsInterface(
@@ -135,6 +135,7 @@ contract AccessControlExtendedInitTest is Test {
     }
 
     function test_TransferOwnershipTransfersAllRolesThroughProxy() public {
+        token.grantRole(TEST_ROLE, owner);
         token.grantRole(EXTRA_ROLE, owner);
 
         token.transferOwnership(account1);

--- a/packages/lsp8-contracts/foundry/LSP8CappedBalance.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CappedBalance.t.sol
@@ -43,7 +43,7 @@ contract MockLSP8CappedBalance is LSP8CappedBalanceAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP8CappedBalanceAbstract(tokenBalanceCap_)
     {}
 

--- a/packages/lsp8-contracts/foundry/LSP8Mintable.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8Mintable.t.sol
@@ -52,7 +52,7 @@ contract MockLSP8Mintable is LSP8MintableAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
-        AccessControlExtendedAbstract(newOwner_)
+        AccessControlExtendedAbstract()
         LSP8MintableAbstract(mintable_)
     {}
 }

--- a/packages/lsp8-contracts/foundry/LSP8NonTransferable.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8NonTransferable.t.sol
@@ -51,8 +51,8 @@ contract MockLSP8NonTransferable is LSP8NonTransferableAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
+        AccessControlExtendedAbstract()
         LSP8NonTransferableAbstract(transferLockStart_, transferLockEnd_)
-        AccessControlExtendedAbstract(newOwner_)
     {}
 
     function mint(

--- a/packages/lsp8-contracts/foundry/LSP8Revokable.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8Revokable.t.sol
@@ -54,8 +54,8 @@ contract MockLSP8Revokable is LSP8RevokableAbstract {
             lsp4TokenType_,
             lsp8TokenIdFormat_
         )
-        AccessControlExtendedAbstract(newOwner_)
-        LSP8RevokableAbstract(newOwner_, isRevokable_)
+        AccessControlExtendedAbstract()
+        LSP8RevokableAbstract(isRevokable_)
     {}
 
     function mint(
@@ -131,13 +131,13 @@ contract LSP8RevokableTest is Test {
         Vm.Log[] memory recordedLogs = vm.getRecordedLogs();
 
         // First `RoleGranted` event MUST be for `DEFAULT_ADMIN_ROLE`
-        assertEq(
-            recordedLogs[2].topics[0],
-            IAccessControl.RoleGranted.selector
-        );
-        assertEq(recordedLogs[2].topics[1], DEFAULT_ADMIN_ROLE);
-        assertEq(recordedLogs[2].topics[2], bytes32(uint256(uint160(owner))));
-        assertEq(recordedLogs[2].topics[3], bytes32(uint256(uint160(owner))));
+        // assertEq(
+        //     recordedLogs[2].topics[0],
+        //     IAccessControl.RoleGranted.selector
+        // );
+        // assertEq(recordedLogs[2].topics[1], DEFAULT_ADMIN_ROLE);
+        // assertEq(recordedLogs[2].topics[2], bytes32(uint256(uint160(owner))));
+        // assertEq(recordedLogs[2].topics[3], bytes32(uint256(uint160(owner))));
 
         uint256 lastLog = recordedLogs.length - 1;
 

--- a/packages/lsp8-contracts/foundry/LSP8Revokable.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8Revokable.t.sol
@@ -130,16 +130,22 @@ contract LSP8RevokableTest is Test {
 
         Vm.Log[] memory recordedLogs = vm.getRecordedLogs();
 
-        // First `RoleGranted` event MUST be for `DEFAULT_ADMIN_ROLE`
-        // assertEq(
-        //     recordedLogs[2].topics[0],
-        //     IAccessControl.RoleGranted.selector
-        // );
-        // assertEq(recordedLogs[2].topics[1], DEFAULT_ADMIN_ROLE);
-        // assertEq(recordedLogs[2].topics[2], bytes32(uint256(uint160(owner))));
-        // assertEq(recordedLogs[2].topics[3], bytes32(uint256(uint160(owner))));
-
         uint256 lastLog = recordedLogs.length - 1;
+
+        // First `RoleGranted` event MUST be for `DEFAULT_ADMIN_ROLE`
+        assertEq(
+            recordedLogs[lastLog - 1].topics[0],
+            IAccessControl.RoleGranted.selector
+        );
+        assertEq(recordedLogs[lastLog - 1].topics[1], DEFAULT_ADMIN_ROLE);
+        assertEq(
+            recordedLogs[lastLog - 1].topics[2],
+            bytes32(uint256(uint160(owner)))
+        );
+        assertEq(
+            recordedLogs[lastLog - 1].topics[3],
+            bytes32(uint256(uint160(owner)))
+        );
 
         // Another `RoleGranted` event MUST be for `REVOKER_ROLE`
         assertEq(

--- a/packages/lsp8-contracts/hardhat.config.ts
+++ b/packages/lsp8-contracts/hardhat.config.ts
@@ -118,7 +118,6 @@ const config: HardhatUserConfig = {
     version: '0.8.28',
     settings: {
       evmVersion: 'prague',
-      viaIR: true,
       optimizer: {
         enabled: true,
         /**


### PR DESCRIPTION
Compilation via IR was removed as it generated a Solidity compiler bug from the IR pipeline.
See comment in this issue for details on the Solidity GitHub repository for details: https://github.com/argotorg/solidity/issues/14358#issuecomment-4299015925