### PR TITLE
refactor: adjustments on Token Gen v2 contracts

### DIFF
--- a/packages/lsp-smart-contracts/tests/Benchmark.test.ts
+++ b/packages/lsp-smart-contracts/tests/Benchmark.test.ts
@@ -136,10 +136,18 @@ async function deployLsp8MintableProxy(
   owner: HardhatEthersSigner,
   tokenType: number,
   tokenIdFormat: number,
+  isMintable: boolean,
 ) {
   const lsp8MintableAddress = await deployProxy(await lsp8MintableInit.getAddress(), owner);
   const lsp8Mintable = LSP8MintableInit__factory.connect(lsp8MintableAddress, owner);
-  await lsp8Mintable.initialize(tokenName, tokenSymbol, owner.address, tokenType, tokenIdFormat);
+  await lsp8Mintable.initialize(
+    tokenName,
+    tokenSymbol,
+    owner.address,
+    tokenType,
+    tokenIdFormat,
+    isMintable,
+  );
 
   return lsp8Mintable;
 }
@@ -681,6 +689,7 @@ describe('⛽📊 Gas Benchmark', () => {
           context.mainController,
           LSP4_TOKEN_TYPES.NFT,
           LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+          true,
         );
 
         universalProfile1 = await deployUniversalProfileProxy(
@@ -858,6 +867,7 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+            true,
           );
 
           // mint some tokens to the UP
@@ -1070,6 +1080,7 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+            true,
           );
 
           lsp8LyxPunks = await deployLsp8MintableProxy(
@@ -1079,6 +1090,7 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+            true,
           );
 
           [

--- a/packages/lsp-smart-contracts/tests/Benchmark.test.ts
+++ b/packages/lsp-smart-contracts/tests/Benchmark.test.ts
@@ -113,7 +113,6 @@ async function deployLsp7MintableProxy(
   owner: HardhatEthersSigner,
   tokenType: number,
   isNonDivisible: boolean,
-  isMintable: boolean,
 ) {
   const lsp7MintableAddress = await deployProxy(await lsp7MintableInit.getAddress(), owner);
   const lsp7Mintable = LSP7MintableInit__factory.connect(lsp7MintableAddress, owner);
@@ -123,7 +122,6 @@ async function deployLsp7MintableProxy(
     owner.address,
     tokenType,
     isNonDivisible,
-    isMintable,
   );
 
   return lsp7Mintable;
@@ -136,7 +134,6 @@ async function deployLsp8MintableProxy(
   owner: HardhatEthersSigner,
   tokenType: number,
   tokenIdFormat: number,
-  isMintable: boolean,
 ) {
   const lsp8MintableAddress = await deployProxy(await lsp8MintableInit.getAddress(), owner);
   const lsp8Mintable = LSP8MintableInit__factory.connect(lsp8MintableAddress, owner);
@@ -146,7 +143,6 @@ async function deployLsp8MintableProxy(
     owner.address,
     tokenType,
     tokenIdFormat,
-    isMintable,
   );
 
   return lsp8Mintable;
@@ -678,7 +674,6 @@ describe('⛽📊 Gas Benchmark', () => {
           context.mainController,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         // deploy a LSP8 token
@@ -689,7 +684,6 @@ describe('⛽📊 Gas Benchmark', () => {
           context.mainController,
           LSP4_TOKEN_TYPES.NFT,
           LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-          true,
         );
 
         universalProfile1 = await deployUniversalProfileProxy(
@@ -856,7 +850,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.TOKEN,
             false,
-            true,
           );
 
           // deploy a LSP8 NFT
@@ -867,7 +860,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-            true,
           );
 
           // mint some tokens to the UP
@@ -1053,7 +1045,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.TOKEN,
             false,
-            true,
           );
 
           lsp7LyxDai = await deployLsp7MintableProxy(
@@ -1063,7 +1054,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.TOKEN,
             false,
-            true,
           );
 
           [lsp7MetaCoin, lsp7LyxDai].forEach(async (token) => {
@@ -1080,7 +1070,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-            true,
           );
 
           lsp8LyxPunks = await deployLsp8MintableProxy(
@@ -1090,7 +1079,6 @@ describe('⛽📊 Gas Benchmark', () => {
             context.mainController,
             LSP4_TOKEN_TYPES.NFT,
             LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-            true,
           );
 
           [

--- a/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
@@ -221,6 +221,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.NFT,
         LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+        true,
       );
 
       await lsp7Contract

--- a/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedFunctions.test.ts
@@ -212,7 +212,6 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       );
 
       lsp8Contract = await new LSP8Mintable__factory(context.accounts[0]).deploy(
@@ -221,7 +220,6 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.NFT,
         LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-        true,
       );
 
       await lsp7Contract

--- a/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/AllowedStandards.test.ts
@@ -268,7 +268,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         lsp7TokenB = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -277,7 +276,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         lsp7TokenC = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -286,7 +284,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         await lsp7TokenA

--- a/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/ERC725XExecuteBatch.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/ERC725XExecuteBatch.test.ts
@@ -44,7 +44,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     metaCoin = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -53,7 +52,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     rLyxToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -62,7 +60,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     await lyxDaiToken.mint(await context.universalProfile.getAddress(), 100, false, '0x');
@@ -243,7 +240,6 @@ export const shouldBehaveLikeBatchExecute = (
         await context.universalProfile.getAddress(),
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       ]);
 
       // use interface of an existing token contract
@@ -293,14 +289,13 @@ export const shouldBehaveLikeBatchExecute = (
     it('should 1) deploy a LSP7 token, 2) mint some tokens, 3) `transferBatch(...)` to multiple recipients', async () => {
       // step 1 - deploy token contract
       const lsp7ConstructorArguments = abiCoder.encode(
-        ['string', 'string', 'address', 'uint256', 'bool', 'bool'],
+        ['string', 'string', 'address', 'uint256', 'bool'],
         [
           'My UP LSP7 Token',
           'UPLSP7',
           await context.universalProfile.getAddress(),
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         ],
       );
 

--- a/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP20CallVerification/LSP6/Interactions/PermissionTransferValue.test.ts
@@ -655,7 +655,6 @@ export const shouldBehaveLikePermissionTransferValue = (
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       );
 
       targetContract = await new TargetPayableContract__factory(context.accounts[0]).deploy();
@@ -811,7 +810,6 @@ export const shouldBehaveLikePermissionTransferValue = (
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         const lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData('transfer', [
@@ -1063,7 +1061,6 @@ export const shouldBehaveLikePermissionTransferValue = (
               context.accounts[0].address,
               LSP4_TOKEN_TYPES.TOKEN,
               false,
-              true,
             );
 
             // give some tokens to the UP
@@ -1243,7 +1240,6 @@ export const shouldBehaveLikePermissionTransferValue = (
               context.accounts[0].address,
               LSP4_TOKEN_TYPES.TOKEN,
               false,
-              true,
             );
 
             // give some tokens to the UP

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
@@ -348,7 +348,6 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       );
 
       lsp8Contract = await new LSP8Mintable__factory(context.accounts[0]).deploy(
@@ -357,7 +356,6 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.NFT,
         LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
-        true,
       );
 
       await lsp7Contract

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedFunctions.test.ts
@@ -357,6 +357,7 @@ export const shouldBehaveLikeAllowedFunctions = (buildContext: () => Promise<LSP
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.NFT,
         LSP8_TOKEN_ID_FORMAT.UNIQUE_ID,
+        true,
       );
 
       await lsp7Contract

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/AllowedStandards.test.ts
@@ -295,7 +295,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         lsp7TokenB = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -304,7 +303,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         lsp7TokenC = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -313,7 +311,6 @@ export const shouldBehaveLikeAllowedStandards = (buildContext: () => Promise<LSP
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         await lsp7TokenA

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/BatchExecute.test.ts
@@ -62,7 +62,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     metaCoin = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -71,7 +70,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     rLyxToken = await new LSP7Mintable__factory(context.accounts[0]).deploy(
@@ -80,7 +78,6 @@ export const shouldBehaveLikeBatchExecute = (
       context.accounts[0].address,
       LSP4_TOKEN_TYPES.TOKEN,
       false,
-      true,
     );
 
     await lyxDaiToken.mint(await context.universalProfile.getAddress(), 100, false, '0x');
@@ -255,7 +252,6 @@ export const shouldBehaveLikeBatchExecute = (
         await context.universalProfile.getAddress(),
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       ]);
 
       // use interface of an existing token contract
@@ -321,14 +317,13 @@ export const shouldBehaveLikeBatchExecute = (
     it('should 1) deploy a LSP7 token, 2) mint some tokens, 3) `transferBatch(...)` to multiple recipients', async () => {
       // step 1 - deploy token contract
       const lsp7ConstructorArguments = abiCoder.encode(
-        ['string', 'string', 'address', 'uint256', 'bool', 'bool'],
+        ['string', 'string', 'address', 'uint256', 'bool'],
         [
           'My UP LSP7 Token',
           'UPLSP7',
           await context.universalProfile.getAddress(),
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         ],
       );
 

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Interactions/PermissionTransferValue.test.ts
@@ -1001,7 +1001,6 @@ export const shouldBehaveLikePermissionTransferValue = (
         context.accounts[0].address,
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       );
 
       targetContract = await new TargetPayableContract__factory(context.accounts[0]).deploy();
@@ -1183,7 +1182,6 @@ export const shouldBehaveLikePermissionTransferValue = (
           context.accounts[0].address,
           LSP4_TOKEN_TYPES.TOKEN,
           false,
-          true,
         );
 
         const lsp7TransferPayload = newLSP7Token.interface.encodeFunctionData('transfer', [
@@ -1464,7 +1462,6 @@ export const shouldBehaveLikePermissionTransferValue = (
               context.accounts[0].address,
               LSP4_TOKEN_TYPES.TOKEN,
               false,
-              true,
             );
 
             // give some tokens to the UP
@@ -1653,7 +1650,6 @@ export const shouldBehaveLikePermissionTransferValue = (
               context.accounts[0].address,
               LSP4_TOKEN_TYPES.TOKEN,
               false,
-              true,
             );
 
             // give some tokens to the UP

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/LSP6ControlledToken.test.ts
@@ -40,7 +40,6 @@ const buildContext = async () => {
     accounts[0].address,
     LSP4_TOKEN_TYPES.TOKEN,
     true,
-    true,
   );
 
   const keyManager = await new LSP6KeyManager__factory(accounts[0]).deploy(lsp7.target);

--- a/packages/lsp-smart-contracts/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP6KeyManager/Relay/ExecuteRelayCall.test.ts
@@ -1383,7 +1383,6 @@ export const shouldBehaveLikeExecuteRelayCall = (
         await context.universalProfile.getAddress(),
         LSP4_TOKEN_TYPES.TOKEN,
         false,
-        true,
       );
 
       const permissionKeys = [

--- a/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/LSP7Mintable.behaviour.ts
@@ -36,7 +36,6 @@ export type LSP7MintableDeployParams = {
   newOwner: string;
   isNFT: boolean;
   lsp4TokenType: number;
-  mintable: boolean;
 };
 
 export type LSP7MintableTestContext = {

--- a/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/proxy/LSP7MintableInit.test.ts
@@ -30,7 +30,6 @@ describe('LSP7MintableInit with proxy', () => {
       newOwner: accounts.owner.address,
       isNFT: false,
       lsp4TokenType: LSP4_TOKEN_TYPES.TOKEN,
-      mintable: true,
     };
 
     const LSP7MintableInit: LSP7MintableInit = await new LSP7MintableInit__factory(
@@ -49,13 +48,12 @@ describe('LSP7MintableInit with proxy', () => {
   };
 
   const initializeProxy = async (context: LSP7MintableTestContext) => {
-    return context.lsp7Mintable['initialize(string,string,address,uint256,bool,bool)'](
+    return context.lsp7Mintable['initialize(string,string,address,uint256,bool)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
       context.deployParams.lsp4TokenType,
       context.deployParams.isNFT,
-      context.deployParams.mintable,
     );
   };
 
@@ -88,7 +86,7 @@ describe('LSP7MintableInit with proxy', () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp7MintableInit.initialize('XXXXXXXXXXX', 'XXX', randomCaller.address, 12345, false, true),
+        lsp7MintableInit.initialize('XXXXXXXXXXX', 'XXX', randomCaller.address, 12345, false),
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });

--- a/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/standard/LSP7Mintable.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP7DigitalAsset/standard/LSP7Mintable.test.ts
@@ -24,7 +24,6 @@ describe('LSP7Mintable with constructor', () => {
       newOwner: accounts.owner.address,
       isNFT: false,
       lsp4TokenType: LSP4_TOKEN_TYPES.TOKEN,
-      mintable: true,
     };
 
     const lsp7Mintable: LSP7Mintable = await new LSP7Mintable__factory(accounts.owner).deploy(
@@ -33,7 +32,6 @@ describe('LSP7Mintable with constructor', () => {
       deployParams.newOwner,
       deployParams.lsp4TokenType,
       deployParams.isNFT,
-      deployParams.mintable,
     );
 
     return { ethers, accounts, lsp7Mintable, deployParams };

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
@@ -35,6 +35,7 @@ export type LSP8MintableDeployParams = {
   newOwner: string;
   lsp4TokenType: number;
   lsp8TokenIdFormat: number;
+  mintable: boolean;
 };
 
 export type LSP8MintableTestContext = {

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/LSP8Mintable.behaviour.ts
@@ -35,7 +35,6 @@ export type LSP8MintableDeployParams = {
   newOwner: string;
   lsp4TokenType: number;
   lsp8TokenIdFormat: number;
-  mintable: boolean;
 };
 
 export type LSP8MintableTestContext = {

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
@@ -27,7 +27,6 @@ describe('LSP8MintableInit with proxy', () => {
       newOwner: accounts.owner.address,
       lsp4TokenType: LSP4_TOKEN_TYPES.NFT,
       lsp8TokenIdFormat: LSP8_TOKEN_ID_FORMAT.NUMBER,
-      mintable: true,
     };
 
     const LSP8MintableInit: LSP8MintableInit = await new LSP8MintableInit__factory(
@@ -46,13 +45,12 @@ describe('LSP8MintableInit with proxy', () => {
   };
 
   const initializeProxy = async (context: LSP8MintableTestContext) => {
-    return context.lsp8Mintable['initialize(string,string,address,uint256,uint256,bool)'](
+    return context.lsp8Mintable['initialize(string,string,address,uint256,uint256)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
       context.deployParams.lsp4TokenType,
       context.deployParams.lsp8TokenIdFormat,
-      context.deployParams.mintable,
     );
   };
 
@@ -83,7 +81,7 @@ describe('LSP8MintableInit with proxy', () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp8Mintable.initialize('XXXXXXXXXXX', 'XXX', randomCaller.address, 0, 12345, true),
+        lsp8Mintable.initialize('XXXXXXXXXXX', 'XXX', randomCaller.address, 0, 12345),
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/proxy/LSP8MintableInit.test.ts
@@ -27,6 +27,7 @@ describe('LSP8MintableInit with proxy', () => {
       newOwner: accounts.owner.address,
       lsp4TokenType: LSP4_TOKEN_TYPES.NFT,
       lsp8TokenIdFormat: LSP8_TOKEN_ID_FORMAT.NUMBER,
+      mintable: true,
     };
 
     const LSP8MintableInit: LSP8MintableInit = await new LSP8MintableInit__factory(
@@ -45,12 +46,13 @@ describe('LSP8MintableInit with proxy', () => {
   };
 
   const initializeProxy = async (context: LSP8MintableTestContext) => {
-    return context.lsp8Mintable['initialize(string,string,address,uint256,uint256)'](
+    return context.lsp8Mintable['initialize(string,string,address,uint256,uint256,bool)'](
       context.deployParams.name,
       context.deployParams.symbol,
       context.deployParams.newOwner,
       context.deployParams.lsp4TokenType,
       context.deployParams.lsp8TokenIdFormat,
+      context.deployParams.mintable,
     );
   };
 
@@ -81,13 +83,7 @@ describe('LSP8MintableInit with proxy', () => {
       const randomCaller = accounts[1];
 
       await expect(
-        lsp8Mintable['initialize(string,string,address,uint256,uint256)'](
-          'XXXXXXXXXXX',
-          'XXX',
-          randomCaller.address,
-          0,
-          12345,
-        ),
+        lsp8Mintable.initialize('XXXXXXXXXXX', 'XXX', randomCaller.address, 0, 12345, true),
       ).to.be.revertedWith('Initializable: contract is already initialized');
     });
   });

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
@@ -24,6 +24,7 @@ describe('LSP8Mintable with constructor', () => {
       newOwner: accounts.owner.address,
       lsp4TokenType: LSP4_TOKEN_TYPES.NFT,
       lsp8TokenIdFormat: LSP8_TOKEN_ID_FORMAT.NUMBER,
+      mintable: true,
     };
 
     const lsp8Mintable: LSP8Mintable = await new LSP8Mintable__factory(accounts.owner).deploy(
@@ -32,6 +33,7 @@ describe('LSP8Mintable with constructor', () => {
       deployParams.newOwner,
       deployParams.lsp4TokenType,
       deployParams.lsp8TokenIdFormat,
+      deployParams.mintable,
     );
 
     return { ethers, accounts, lsp8Mintable, deployParams };

--- a/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
+++ b/packages/lsp-smart-contracts/tests/LSP8IdentifiableDigitalAsset/standard/LSP8Mintable.test.ts
@@ -24,7 +24,6 @@ describe('LSP8Mintable with constructor', () => {
       newOwner: accounts.owner.address,
       lsp4TokenType: LSP4_TOKEN_TYPES.NFT,
       lsp8TokenIdFormat: LSP8_TOKEN_ID_FORMAT.NUMBER,
-      mintable: true,
     };
 
     const lsp8Mintable: LSP8Mintable = await new LSP8Mintable__factory(accounts.owner).deploy(
@@ -33,7 +32,6 @@ describe('LSP8Mintable with constructor', () => {
       deployParams.newOwner,
       deployParams.lsp4TokenType,
       deployParams.lsp8TokenIdFormat,
-      deployParams.mintable,
     );
 
     return { ethers, accounts, lsp8Mintable, deployParams };

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -40,7 +40,7 @@ import {
  * Provides:
  * - Standard OZ {IAccessControl} functions: hasRole, grantRole, revokeRole, renounceRole, getRoleAdmin
  * - Standard OZ {IAccessControlEnumerable} functions: getRoleMember, getRoleMemberCount
- * - Extended functions: rolesOf, grantRoleWithData, setRoleData, getRoleData
+ * - Extended functions: rolesOf, getRoleMembers
  * - Explicit role checks for every role-gated function
  * - DEFAULT_ADMIN_ROLE as root admin for granting and revoking roles
  * - Automatic transfer of all roles (and their auxiliary data, if any) between old and new on ownership transfer
@@ -252,7 +252,6 @@ abstract contract AccessControlExtendedAbstract is
 
     /**
      * @dev Revokes `role` from `account`. No-op if the account does not hold the role.
-     * Auto-clears auxiliary data if any exists.
      *
      * @custom:events Emits {RoleRevoked} if the role was revoked.
      */
@@ -337,15 +336,13 @@ abstract contract AccessControlExtendedAbstract is
      * custom roles the old owner was assigned.
      *
      * For each role held by the old owner:
-     * 1. The role is revoked from the old owner (including clearing auxiliary data).
+     * 1. The role is revoked from the old owner.
      * 2. The role is granted to the new owner (if not already held).
      *
      * @custom:info When renouncing ownership, roles are only removed from the old owner. Roles are not passed to `address(0)` (being the `newOwner` in the case of renounce ownership).
      *
      * @custom:warning
      * - Gas cost scales linearly with the number of roles the old owner holds.
-     * - Auxiliary role data set on the old owner is transferred to the new owner if ownership is transferred.
-     * - Transferring ownership to self will still clear then restore the old owner's auxiliary role data.
      * - If the old owner holds a large number of roles, the transaction may approach or exceed
      *   the block gas limit and fail. Avoid assigning too many roles to the owner to ensure
      *   ownership transfers remain callable.

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -120,7 +120,21 @@ abstract contract AccessControlExtendedAbstract is
         return _roleAdmins[role];
     }
 
-    /// @inheritdoc IAccessControlExtended
+    /**
+     * @inheritdoc IAccessControlExtended
+     *
+     * @dev Sets `adminRole` as the admin of `role`. Available for extensions to configure custom admin hierarchies.
+     *
+     * @custom:warning
+     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
+     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
+     *
+     * @custom:requirements
+     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
+     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
+     *
+     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
+     */
     function setRoleAdmin(
         bytes32 role,
         bytes32 adminRole
@@ -298,20 +312,6 @@ abstract contract AccessControlExtendedAbstract is
         return _roleMembers[role].contains(account);
     }
 
-    /**
-     * @dev Sets `adminRole` as the admin of `role`. Available for extensions
-     * to configure custom admin hierarchies.
-     *
-     * @custom:warning
-     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
-     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
-     *
-     * @custom:requirements
-     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
-     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
-     *
-     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
-     */
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         require(
             role != DEFAULT_ADMIN_ROLE,

--- a/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -127,7 +127,22 @@ abstract contract AccessControlExtendedInitAbstract is
         return _roleAdmins[role];
     }
 
-    /// @inheritdoc IAccessControlExtended
+    /**
+     * @inheritdoc IAccessControlExtended
+     *
+     * @dev Sets `adminRole` as the admin of `role`. Available for extensions
+     * to configure custom admin hierarchies.
+     *
+     * @custom:warning
+     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
+     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
+     *
+     * @custom:requirements
+     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
+     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
+     *
+     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
+     */
     function setRoleAdmin(
         bytes32 role,
         bytes32 adminRole
@@ -306,20 +321,6 @@ abstract contract AccessControlExtendedInitAbstract is
         return _roleMembers[role].contains(account);
     }
 
-    /**
-     * @dev Sets `adminRole` as the admin of `role`. Available for extensions
-     * to configure custom admin hierarchies.
-     *
-     * @custom:warning
-     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
-     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
-     *
-     * @custom:requirements
-     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
-     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
-     *
-     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
-     */
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         require(
             role != DEFAULT_ADMIN_ROLE,

--- a/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7CappedBalance/LSP7CappedBalanceInitAbstract.sol
@@ -163,4 +163,14 @@ abstract contract LSP7CappedBalanceInitAbstract is
         _setRoleAdmin(UNCAPPED_BALANCE_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7CappedSupply/LSP7CappedSupplyInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7CappedSupply/LSP7CappedSupplyInitAbstract.sol
@@ -13,6 +13,7 @@ import {LSP7CappedSupplyCannotMintOverCap} from "./LSP7CappedSupplyErrors.sol";
  * @dev LSP7 token extension to add a max token supply cap (proxy version).
  */
 abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInitAbstract {
+    /// @notice The maximum token supply.
     uint256 private _tokenSupplyCap;
 
     /// @notice Initializes the LSP7CappedSupply contract with base token params and supply cap.
@@ -82,4 +83,14 @@ abstract contract LSP7CappedSupplyInitAbstract is LSP7DigitalAssetInitAbstract {
         _tokenSupplyCapCheck(to, amount, force, data);
         super._mint(to, amount, force, data);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableAbstract.sol
@@ -44,6 +44,7 @@ abstract contract LSP7MintableAbstract is
 
     /// @inheritdoc ILSP7Mintable
     /// @custom:warning Once this function is called, any address holding the `MINTER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `MINTER_ROLE` remains populated after the minting feature is switched off.
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP7MintDisabled());
         isMintable = false;

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
@@ -143,4 +143,14 @@ abstract contract LSP7MintableInitAbstract is
         _setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Mintable/LSP7MintableInitAbstract.sol
@@ -78,6 +78,7 @@ abstract contract LSP7MintableInitAbstract is
 
     /// @inheritdoc ILSP7Mintable
     /// @custom:warning Once this function is called, any address holding the `MINTER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `MINTER_ROLE` remains populated after the minting feature is switched off.
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP7MintDisabled());
         isMintable = false;

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableAbstract.sol
@@ -98,6 +98,7 @@ abstract contract LSP7NonTransferableAbstract is
     }
 
     /// @inheritdoc ILSP7NonTransferable
+    /// @custom:info The list of addresses holding the `NON_TRANSFERABLE_BYPASS_ROLE` remains populated after the non-transferable feature is switched off.
     function makeTransferable() public virtual override onlyOwner {
         require(transferLockEnabled, LSP7TokenAlreadyTransferable());
 

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
@@ -141,6 +141,7 @@ abstract contract LSP7NonTransferableInitAbstract is
     }
 
     /// @inheritdoc ILSP7NonTransferable
+    /// @custom:info The list of addresses holding the `NON_TRANSFERABLE_BYPASS_ROLE` remains populated after the non-transferable feature is switched off.
     function makeTransferable() public virtual override onlyOwner {
         require(transferLockEnabled, LSP7TokenAlreadyTransferable());
 

--- a/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7NonTransferable/LSP7NonTransferableInitAbstract.sol
@@ -227,4 +227,14 @@ abstract contract LSP7NonTransferableInitAbstract is
         _setRoleAdmin(NON_TRANSFERABLE_BYPASS_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[47] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
@@ -52,6 +52,8 @@ abstract contract LSP7RevokableAbstract is
     }
 
     /// @inheritdoc ILSP7Revokable
+    /// @custom:warning Once this function is called, any address holding the `REVOKER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `REVOKER_ROLE` remains populated after the revokable feature is switched off.
     function disableRevokable() public virtual override onlyOwner {
         require(isRevokable(), LSP7RevokableFeatureDisabled());
         _isRevokable = false;
@@ -97,19 +99,32 @@ abstract contract LSP7RevokableAbstract is
     }
 
     /// @dev Overridden function to ensure previous revokers do not persist after contract ownership has been transferred.
+    /// The only exception is if the old contract owner had the `REVOKER_ROLE`. This role will be given to the new owner.
+    ///
+    /// @custom:warning This function clears the entire `REVOKER_ROLE` member set.
+    /// - Gas cost scales linearly with the number of addresses with the `REVOKER_ROLE`.
+    /// - If the number of addresses with the `REVOKER_ROLE` is large, it might consume a lot of gas,
+    /// leading the transaction to approach or exceed the block gas limit and fail.
+    /// Consider revoking addresses with the `REVOKER_ROLE` in batches in separate transactions to mitigate this.
     function _transferOwnership(
         address newOwner
     ) internal virtual override(AccessControlExtendedAbstract, Ownable) {
         // restore default admin hierarchy so a previously-installed custom admin
         // cannot grant REVOKER_ROLE to new accounts post-transfer
         _setRoleAdmin(REVOKER_ROLE, DEFAULT_ADMIN_ROLE);
-        _clearRevokers();
-        super._transferOwnership(newOwner);
-    }
 
-    function _clearRevokers() internal virtual {
-        while (getRoleMemberCount(REVOKER_ROLE) != 0) {
-            _revokeRole(REVOKER_ROLE, getRoleMember(REVOKER_ROLE, 0));
+        // Transfer all roles from old owner to new owner first (including the `REVOKER_ROLE`)
+        // before clearing the list of revokers.
+        super._transferOwnership(newOwner);
+
+        address[] memory revokers = getRoleMembers(REVOKER_ROLE);
+
+        for (uint256 ii = 0; ii < revokers.length; ++ii) {
+            // Exclude the new owner from the list of revokers to delete.
+            address revoker = revokers[ii];
+            if (revoker == newOwner) continue;
+
+            _revokeRole(REVOKER_ROLE, revoker);
         }
     }
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableAbstract.sol
@@ -4,13 +4,17 @@ pragma solidity ^0.8.27;
 // modules
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {LSP7DigitalAsset} from "../../LSP7DigitalAsset.sol";
-import {AccessControlExtendedAbstract} from "../AccessControlExtended/AccessControlExtendedAbstract.sol";
+import {
+    AccessControlExtendedAbstract
+} from "../AccessControlExtended/AccessControlExtendedAbstract.sol";
 
 // interfaces
 import {ILSP7Revokable} from "./ILSP7Revokable.sol";
 
 // errors
-import {AccessControlUnauthorizedAccount} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
+import {
+    AccessControlUnauthorizedAccount
+} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
 import {LSP7RevokableFeatureDisabled} from "./LSP7RevokableErrors.sol";
 
 /// @title LSP7RevokableAbstract
@@ -23,11 +27,16 @@ import {LSP7RevokableFeatureDisabled} from "./LSP7RevokableErrors.sol";
 /// - Role badges: Remove role badges from community members
 /// - Compliance: Freeze or reverse tokens for regulatory requirements
 /// - Vesting: Revoke unvested tokens if conditions are not met
-abstract contract LSP7RevokableAbstract is ILSP7Revokable, LSP7DigitalAsset, AccessControlExtendedAbstract {
+abstract contract LSP7RevokableAbstract is
+    ILSP7Revokable,
+    LSP7DigitalAsset,
+    AccessControlExtendedAbstract
+{
     bool internal _isRevokable;
 
     /// @dev keccak256("REVOKER_ROLE")
-    bytes32 public constant REVOKER_ROLE = 0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
+    bytes32 public constant REVOKER_ROLE =
+        0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
 
     constructor(bool isRevokable_) {
         _isRevokable = isRevokable_;
@@ -50,33 +59,47 @@ abstract contract LSP7RevokableAbstract is ILSP7Revokable, LSP7DigitalAsset, Acc
     }
 
     /// @inheritdoc ILSP7Revokable
-    function revoke(address from, address to, uint256 amount, bytes memory data)
-        public
-        virtual
-        override
-        onlyRole(REVOKER_ROLE)
-    {
+    function revoke(
+        address from,
+        address to,
+        uint256 amount,
+        bytes memory data
+    ) public virtual override onlyRole(REVOKER_ROLE) {
         require(isRevokable(), LSP7RevokableFeatureDisabled());
-        require(to == owner() || hasRole(REVOKER_ROLE, to), AccessControlUnauthorizedAccount(to, REVOKER_ROLE));
+        require(
+            to == owner() || hasRole(REVOKER_ROLE, to),
+            AccessControlUnauthorizedAccount(to, REVOKER_ROLE)
+        );
 
         // We assume revokers are trusted when specifying revocation destinations.
         // Therefore, we bypass LSP1 receiver checks.
-        _transfer({from: from, to: to, amount: amount, force: true, data: data});
+        _transfer({
+            from: from,
+            to: to,
+            amount: amount,
+            force: true,
+            data: data
+        });
     }
 
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
         override(AccessControlExtendedAbstract, LSP7DigitalAsset)
         returns (bool)
     {
-        return AccessControlExtendedAbstract.supportsInterface(interfaceId)
-            || LSP7DigitalAsset.supportsInterface(interfaceId);
+        return
+            AccessControlExtendedAbstract.supportsInterface(interfaceId) ||
+            LSP7DigitalAsset.supportsInterface(interfaceId);
     }
 
     /// @dev Overridden function to ensure previous revokers do not persist after contract ownership has been transferred.
-    function _transferOwnership(address newOwner) internal virtual override(AccessControlExtendedAbstract, Ownable) {
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual override(AccessControlExtendedAbstract, Ownable) {
         // restore default admin hierarchy so a previously-installed custom admin
         // cannot grant REVOKER_ROLE to new accounts post-transfer
         _setRoleAdmin(REVOKER_ROLE, DEFAULT_ADMIN_ROLE);

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
@@ -170,4 +170,14 @@ abstract contract LSP7RevokableInitAbstract is
             _revokeRole(REVOKER_ROLE, revoker);
         }
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
+++ b/packages/lsp7-contracts/contracts/extensions/LSP7Revokable/LSP7RevokableInitAbstract.sol
@@ -2,15 +2,23 @@
 pragma solidity ^0.8.27;
 
 // modules
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {LSP7DigitalAssetInitAbstract} from "../../LSP7DigitalAssetInitAbstract.sol";
-import {AccessControlExtendedInitAbstract} from "../AccessControlExtended/AccessControlExtendedInitAbstract.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    LSP7DigitalAssetInitAbstract
+} from "../../LSP7DigitalAssetInitAbstract.sol";
+import {
+    AccessControlExtendedInitAbstract
+} from "../AccessControlExtended/AccessControlExtendedInitAbstract.sol";
 
 // interfaces
 import {ILSP7Revokable} from "./ILSP7Revokable.sol";
 
 // errors
-import {AccessControlUnauthorizedAccount} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
+import {
+    AccessControlUnauthorizedAccount
+} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
 import {LSP7RevokableFeatureDisabled} from "./LSP7RevokableErrors.sol";
 
 /// @title LSP7RevokableInitAbstract
@@ -33,7 +41,8 @@ abstract contract LSP7RevokableInitAbstract is
     bool internal _isRevokable;
 
     /// @dev keccak256("REVOKER_ROLE")
-    bytes32 public constant REVOKER_ROLE = 0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
+    bytes32 public constant REVOKER_ROLE =
+        0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
 
     /// @notice Initializes the LSP7Revokable contract with base token params.
     /// @dev Initializes the LSP7DigitalAsset base contract.
@@ -51,13 +60,21 @@ abstract contract LSP7RevokableInitAbstract is
         bool isNonDivisible_,
         bool isRevokable_
     ) internal virtual onlyInitializing {
-        LSP7DigitalAssetInitAbstract._initialize(name_, symbol_, newOwner_, lsp4TokenType_, isNonDivisible_);
+        LSP7DigitalAssetInitAbstract._initialize(
+            name_,
+            symbol_,
+            newOwner_,
+            lsp4TokenType_,
+            isNonDivisible_
+        );
         __AccessControlExtended_init();
         __LSP7Revokable_init_unchained(isRevokable_);
     }
 
     /// @notice Unchained initializer for LSP7Revokable.
-    function __LSP7Revokable_init_unchained(bool isRevokable_) internal virtual onlyInitializing {
+    function __LSP7Revokable_init_unchained(
+        bool isRevokable_
+    ) internal virtual onlyInitializing {
         _isRevokable = isRevokable_;
 
         if (isRevokable_) {
@@ -71,6 +88,8 @@ abstract contract LSP7RevokableInitAbstract is
     }
 
     /// @inheritdoc ILSP7Revokable
+    /// @custom:warning Once this function is called, any address holding the `REVOKER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `REVOKER_ROLE` remains populated after the revokable feature is switched off.
     function disableRevokable() public virtual override onlyOwner {
         require(isRevokable(), LSP7RevokableFeatureDisabled());
         _isRevokable = false;
@@ -78,47 +97,77 @@ abstract contract LSP7RevokableInitAbstract is
     }
 
     /// @inheritdoc ILSP7Revokable
-    function revoke(address from, address to, uint256 amount, bytes memory data)
-        public
-        virtual
-        override
-        onlyRole(REVOKER_ROLE)
-    {
+    function revoke(
+        address from,
+        address to,
+        uint256 amount,
+        bytes memory data
+    ) public virtual override onlyRole(REVOKER_ROLE) {
         require(isRevokable(), LSP7RevokableFeatureDisabled());
-        require(to == owner() || hasRole(REVOKER_ROLE, to), AccessControlUnauthorizedAccount(to, REVOKER_ROLE));
+        require(
+            to == owner() || hasRole(REVOKER_ROLE, to),
+            AccessControlUnauthorizedAccount(to, REVOKER_ROLE)
+        );
 
         // We assume revokers are trusted when specifying revocation destinations.
         // Therefore, we bypass LSP1 receiver checks.
-        _transfer({from: from, to: to, amount: amount, force: true, data: data});
+        _transfer({
+            from: from,
+            to: to,
+            amount: amount,
+            force: true,
+            data: data
+        });
     }
 
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
-        override(AccessControlExtendedInitAbstract, LSP7DigitalAssetInitAbstract)
+        override(
+            AccessControlExtendedInitAbstract,
+            LSP7DigitalAssetInitAbstract
+        )
         returns (bool)
     {
-        return AccessControlExtendedInitAbstract.supportsInterface(interfaceId)
-            || LSP7DigitalAssetInitAbstract.supportsInterface(interfaceId);
+        return
+            AccessControlExtendedInitAbstract.supportsInterface(interfaceId) ||
+            LSP7DigitalAssetInitAbstract.supportsInterface(interfaceId);
     }
 
     /// @dev Overridden function to ensure previous revokers do not persist after contract ownership has been transferred.
-    function _transferOwnership(address newOwner)
+    /// The only exception is if the old contract owner had the `REVOKER_ROLE`. This role will be given to the new owner.
+    ///
+    /// @custom:warning This function clears the entire `REVOKER_ROLE` member set.
+    /// - Gas cost scales linearly with the number of addresses with the `REVOKER_ROLE`.
+    /// - If the number of addresses with the `REVOKER_ROLE` is large, it might consume a lot of gas,
+    /// leading the transaction to approach or exceed the block gas limit and fail.
+    /// Consider revoking addresses with the `REVOKER_ROLE` in batches in separate transactions to mitigate this.
+    function _transferOwnership(
+        address newOwner
+    )
         internal
         virtual
         override(AccessControlExtendedInitAbstract, OwnableUpgradeable)
     {
-        _clearRevokers();
-        super._transferOwnership(newOwner);
-    }
-
-    function _clearRevokers() internal virtual {
-        while (getRoleMemberCount(REVOKER_ROLE) != 0) {
-            _revokeRole(REVOKER_ROLE, getRoleMember(REVOKER_ROLE, 0));
-        }
         // restore default admin hierarchy so a previously-installed custom admin
         // cannot grant REVOKER_ROLE to new accounts post-transfer
         _setRoleAdmin(REVOKER_ROLE, DEFAULT_ADMIN_ROLE);
+
+        // Transfer all roles from old owner to new owner first (including the `REVOKER_ROLE`)
+        // before clearing the list of revokers.
+        super._transferOwnership(newOwner);
+
+        address[] memory revokers = getRoleMembers(REVOKER_ROLE);
+
+        for (uint256 ii = 0; ii < revokers.length; ++ii) {
+            // Exclude the new owner from the list of revokers to delete.
+            address revoker = revokers[ii];
+            if (revoker == newOwner) continue;
+
+            _revokeRole(REVOKER_ROLE, revoker);
+        }
     }
 }

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -43,7 +43,7 @@ import {
 } from "../extensions/LSP7CappedSupply/LSP7CappedSupplyErrors.sol";
 
 /// @title LSP7CustomizableToken
-/// @dev A customizable LSP7 token (proxy version) implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
+/// @dev A customizable LSP7 token that implements multiple features and uses role-based exemptions.
 /// Implements {LSP7Burnable} to allow burning.
 /// Implements {LSP7Mintable} to allow minting.
 /// Implements {LSP7CappedSupply} to set total supply cap.

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableToken.sol
@@ -59,10 +59,10 @@ contract LSP7CustomizableToken is
     LSP7RevokableAbstract
 {
     /// @notice Initializes the token with name, symbol, owner, and customizable features.
-    /// @dev Sets up minting, balance cap, transfer restrictions, allowlist, and supply cap. Mints initial tokens if specified. Reverts if initialMintAmount_ exceeds tokenSupplyCap. Inherits constructor logic from parent contracts.
+    /// @dev Sets up minting, balance cap, total supply caps, transfer restrictions, and revoking feature. Mints initial tokens if specified. Reverts if initialMintAmount_ exceeds tokenSupplyCap. Inherits constructor logic from parent contracts.
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
-    /// @param newOwner_ The initial owner of the token, added to the allowlist.
+    /// @param newOwner_ The initial owner of the token.
     /// @param lsp4TokenType_ The LSP4 token type (e.g., 0 for token).
     /// @param isNonDivisible_ True if the token is non-divisible (e.g., for NDTs).
     /// @param mintableParams Deployment configuration for minting feature (see above).
@@ -154,7 +154,10 @@ contract LSP7CustomizableToken is
     }
 
     /// @notice Hook called before a token transfer to enforce restrictions.
-    /// @dev Combines checks from {LSP7CappedBalance} and {LSP7NonTransferable}. Bypasses all checks for allowlisted senders (from {LSP7NonTransferable}) or recipients (from {LSP7CappedBalance}). Allows burning to address(0) regardless of restrictions.
+    /// @dev Combines checks from {LSP7CappedBalance} and {LSP7NonTransferable}.
+    /// - Bypasses {LSP7NonTransferable} checks for senders (`from`) holding the `NON_TRANSFERABLE_BYPASS_ROLE` role.
+    /// - Bypasses {LSP7CappedBalance} checks for recipients (`to`) holding the `UNCAPPED_BALANCE_ROLE` role.
+    /// - Allows minting (from address(0)) and burning to address(0) regardless of restrictions.
     /// @param from The address sending the tokens.
     /// @param to The address receiving the tokens.
     /// @param amount The amount of tokens being transferred.

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -186,7 +186,10 @@ contract LSP7CustomizableTokenInit is
     }
 
     /// @notice Hook called before a token transfer to enforce restrictions.
-    /// @dev Combines checks from {LSP7CappedBalanceInitAbstract} and {LSP7NonTransferableInitAbstract}. Bypasses all checks for allowlisted senders (from {LSP7NonTransferableInitAbstract}) or recipients (from {LSP7CappedBalanceInitAbstract}). Allows burning to address(0) regardless of restrictions.
+    /// @dev Combines checks from {LSP7CappedBalanceInitAbstract} and {LSP7NonTransferableInitAbstract}. 
+    /// - Bypasses {LSP7NonTransferableInitAbstract} checks for senders (`from`) holding the `NON_TRANSFERABLE_BYPASS_ROLE` role. 
+    /// - Bypasses {LSP7CappedBalanceInitAbstract} checks for recipients (`to`) holding the `UNCAPPED_BALANCE_ROLE` role. 
+    /// - Allows minting (from address(0)) and burning to address(0) regardless of restrictions.
     /// @param from The address sending the tokens.
     /// @param to The address receiving the tokens.
     /// @param amount The amount of tokens being transferred.

--- a/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7CustomizableTokenInit.sol
@@ -46,7 +46,7 @@ import {
 } from "../extensions/LSP7CappedSupply/LSP7CappedSupplyErrors.sol";
 
 /// @title LSP7CustomizableTokenInit
-/// @dev A customizable LSP7 token implementing minting, balance caps, transfer restrictions, total supply cap and burning with role-based access control exemptions.
+/// @dev A customizable LSP7 token that implements multiple features and uses role-based exemptions. This version of the contract is the implementation to use behind proxies.
 /// Implements {LSP7BurnableInitAbstract} to allow burning.
 /// Implements {LSP7MintableInitAbstract} to allow minting.
 /// Implements {LSP7CappedSupplyInitAbstract} to set balance caps.

--- a/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
@@ -11,14 +11,15 @@ import {
 } from "../extensions/AccessControlExtended/AccessControlExtendedAbstract.sol";
 
 /**
- * @title LSP7DigitalAsset deployable preset contract with a public {mint} function callable only by the contract {owner}.
+ * @title LSP7DigitalAsset deployable preset contract with a public {mint} function callable by addresses holding `MINTER_ROLE`.
  */
 contract LSP7Mintable is LSP7MintableAbstract {
     /// @notice Deploying a `LSP7Mintable` token contract.
+    /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param newOwner_ The owner of the token contract.
     /// @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
-    /// @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
+    /// @param isNonDivisible_ Specify if the LSP7 token is divisible (decimals = 18) or non-divisible (decimals = 0).
     /// @param mintable_ True to enable minting initially, false to disable it.
     constructor(
         string memory name_,

--- a/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7Mintable.sol
@@ -14,20 +14,21 @@ import {
  * @title LSP7DigitalAsset deployable preset contract with a public {mint} function callable by addresses holding `MINTER_ROLE`.
  */
 contract LSP7Mintable is LSP7MintableAbstract {
-    /// @notice Deploying a `LSP7Mintable` token contract.
-    /// @param name_ The name of the token.
-    /// @param symbol_ The symbol of the token.
-    /// @param newOwner_ The owner of the token contract.
-    /// @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
-    /// @param isNonDivisible_ Specify if the LSP7 token is divisible (decimals = 18) or non-divisible (decimals = 0).
-    /// @param mintable_ True to enable minting initially, false to disable it.
+    /**
+     * @notice Deploying a `LSP7Mintable` token contract.
+     * @dev Set the token to be mintable to allow minting more tokens after deployment.
+     * @param name_ The name of the token.
+     * @param symbol_ The symbol of the token.
+     * @param newOwner_ The owner of the token contract.
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
+     * @param isNonDivisible_ Specify if the LSP7 token is divisible (decimals = 18) or non-divisible (decimals = 0).
+     */
     constructor(
         string memory name_,
         string memory symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        bool isNonDivisible_,
-        bool mintable_
+        bool isNonDivisible_
     )
         LSP7DigitalAsset(
             name_,
@@ -37,6 +38,6 @@ contract LSP7Mintable is LSP7MintableAbstract {
             isNonDivisible_
         )
         AccessControlExtendedAbstract()
-        LSP7MintableAbstract(mintable_)
+        LSP7MintableAbstract(true)
     {}
 }

--- a/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
@@ -10,7 +10,7 @@ import {
 } from "../extensions/LSP7Mintable/LSP7MintableInitAbstract.sol";
 
 /**
- * @dev LSP7DigitalAsset deployable preset contract (proxy version) with a public {mint} function callable only by the contract {owner}.
+ * @dev LSP7DigitalAsset deployable preset contract (proxy version) with a public {mint} function callable by addresses holding `MINTER_ROLE`.
  */
 contract LSP7MintableInit is LSP7MintableInitAbstract {
     /// @dev initialize (= lock) base implementation contract on deployment
@@ -23,7 +23,7 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
     /// @param symbol_ The symbol of the token.
     /// @param newOwner_ The owner of the token contract.
     /// @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
-    /// @param isNonDivisible_ Specify if the LSP7 token is a fungible or non-fungible token.
+    /// @param isNonDivisible_ Specify if the LSP7 token is is divisible (decimals = 18) or non-divisible (decimals = 0).
     /// @param mintable_ True to enable minting initially, false to disable it.
     function initialize(
         string calldata name_,

--- a/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
+++ b/packages/lsp7-contracts/contracts/presets/LSP7MintableInit.sol
@@ -13,25 +13,28 @@ import {
  * @dev LSP7DigitalAsset deployable preset contract (proxy version) with a public {mint} function callable by addresses holding `MINTER_ROLE`.
  */
 contract LSP7MintableInit is LSP7MintableInitAbstract {
-    /// @dev initialize (= lock) base implementation contract on deployment
+    /**
+     * @dev initialize (= lock) base implementation contract on deployment
+     */
     constructor() {
         _disableInitializers();
     }
 
-    /// @notice Initializing a `LSP7MintableInit` token contract.
-    /// @param name_ The name of the token.
-    /// @param symbol_ The symbol of the token.
-    /// @param newOwner_ The owner of the token contract.
-    /// @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
-    /// @param isNonDivisible_ Specify if the LSP7 token is is divisible (decimals = 18) or non-divisible (decimals = 0).
-    /// @param mintable_ True to enable minting initially, false to disable it.
+    /**
+     * @notice Initializing a `LSP7MintableInit` token contract.
+     * @dev Set the token to be mintable to allow minting more tokens after deployment.
+     * @param name_ The name of the token.
+     * @param symbol_ The symbol of the token.
+     * @param newOwner_ The owner of the token contract.
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
+     * @param isNonDivisible_ Specify if the LSP7 token is divisible (decimals = 18) or non-divisible (decimals = 0)
+     */
     function initialize(
         string calldata name_,
         string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        bool isNonDivisible_,
-        bool mintable_
+        bool isNonDivisible_
     ) external virtual initializer {
         LSP7DigitalAssetInitAbstract._initialize(
             name_,
@@ -41,6 +44,6 @@ contract LSP7MintableInit is LSP7MintableInitAbstract {
             isNonDivisible_
         );
         __AccessControlExtended_init();
-        __LSP7Mintable_init_unchained(mintable_);
+        __LSP7Mintable_init_unchained(true);
     }
 }

--- a/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7CustomizableToken.t.sol
@@ -400,7 +400,10 @@ contract LSP7CustomizableTokenTest is Test {
         assertTrue(lockedToken.transferLockEnabled());
     }
 
-    function test_ConstructorNonMintableInitialMintOverSupplyCapReverts(uint256 supplyCap, uint256 preMintAmount) public {
+    function test_ConstructorNonMintableInitialMintOverSupplyCapReverts(
+        uint256 supplyCap,
+        uint256 preMintAmount
+    ) public {
         vm.assume(supplyCap > 0);
         vm.assume(preMintAmount > supplyCap);
 
@@ -727,17 +730,16 @@ contract LSP7CustomizableTokenTest is Test {
 
         token.grantRole(revokerRole, revoker1);
         token.grantRole(revokerRole, revoker2);
-        token.grantRole(revokerRole, newOwner);
 
-        assertEq(token.getRoleMemberCount(revokerRole), 4);
+        assertEq(token.getRoleMemberCount(revokerRole), 3);
 
         token.transferOwnership(newOwner);
 
         assertEq(token.owner(), newOwner);
-        assertEq(token.getRoleMemberCount(revokerRole), 0);
+        assertEq(token.getRoleMemberCount(revokerRole), 1);
+        assertTrue(token.hasRole(revokerRole, newOwner));
 
         assertFalse(token.hasRole(revokerRole, owner));
-        assertFalse(token.hasRole(revokerRole, newOwner));
         assertFalse(token.hasRole(revokerRole, revoker1));
         assertFalse(token.hasRole(revokerRole, revoker2));
 

--- a/packages/lsp7-contracts/foundry/LSP7CustomizableTokenInit.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7CustomizableTokenInit.t.sol
@@ -28,7 +28,9 @@ contract LSP7CustomizableTokenInitTest is Test {
     address internal owner = address(this);
     address internal user1 = vm.addr(101);
     address internal user2 = vm.addr(102);
+    address internal newOwner = vm.addr(103);
     address internal revoker1 = vm.addr(104);
+    address internal revoker2 = vm.addr(105);
 
     function test_InitImplementationCannotBeInitializedAfterDeployment()
         public
@@ -84,16 +86,16 @@ contract LSP7CustomizableTokenInitTest is Test {
             initialMintAmount: preMintAmount
         });
 
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: supplyCap
+        });
+
         LSP7NonTransferableParams
             memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: 0
             });
-
-        LSP7CappedParams memory cappedParams = LSP7CappedParams({
-            tokenBalanceCap: 0,
-            tokenSupplyCap: supplyCap
-        });
 
         LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: false
@@ -148,15 +150,16 @@ contract LSP7CustomizableTokenInitTest is Test {
             isMintable: true,
             initialMintAmount: supplyCap + 1
         });
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
+            tokenBalanceCap: 2_000,
+            tokenSupplyCap: supplyCap
+        });
         LSP7NonTransferableParams
             memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: 0
             });
-        LSP7CappedParams memory cappedParams = LSP7CappedParams({
-            tokenBalanceCap: 2_000,
-            tokenSupplyCap: supplyCap
-        });
+
         LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: true
         });
@@ -183,16 +186,16 @@ contract LSP7CustomizableTokenInitTest is Test {
             initialMintAmount: preMintAmount
         });
 
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+
         LSP7NonTransferableParams
             memory nonTransferableParams = LSP7NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: 0
             });
-
-        LSP7CappedParams memory cappedParams = LSP7CappedParams({
-            tokenBalanceCap: 0,
-            tokenSupplyCap: 0
-        });
 
         LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
             isRevokable: false
@@ -365,5 +368,66 @@ contract LSP7CustomizableTokenInitTest is Test {
 
         assertEq(token.balanceOf(revoker1), 90);
         assertEq(token.balanceOf(user2), 10);
+    }
+
+    function test_TransferOwnershipClearsRevokersAndMigratesOwnerRolesViaEip1167Clone()
+        public
+    {
+        LSP7MintableParams memory mintableParams = LSP7MintableParams({
+            isMintable: true,
+            initialMintAmount: 1_000
+        });
+        LSP7CappedParams memory cappedParams = LSP7CappedParams({
+            tokenBalanceCap: 2_000,
+            tokenSupplyCap: 5_000
+        });
+        LSP7NonTransferableParams
+            memory nonTransferableParams = LSP7NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP7RevokableParams memory revokableParams = LSP7RevokableParams({
+            isRevokable: true
+        });
+
+        LSP7CustomizableTokenInit token = _deployClone(
+            mintableParams,
+            nonTransferableParams,
+            cappedParams,
+            revokableParams
+        );
+
+        bytes32 revokerRole = token.REVOKER_ROLE();
+
+        assertTrue(token.hasRole(revokerRole, owner));
+
+        token.grantRole(revokerRole, revoker1);
+        token.grantRole(revokerRole, revoker2);
+
+        // Owner is granted the REVOKER_ROLE on initialize, so we expect 3 holders
+        assertEq(token.getRoleMemberCount(revokerRole), 3);
+
+        token.transferOwnership(newOwner);
+
+        // CHECK new owner was passed the REVOKER_ROLE
+        assertEq(token.owner(), newOwner);
+        assertTrue(token.hasRole(revokerRole, newOwner));
+        assertEq(token.getRoleMemberCount(revokerRole), 1);
+
+        assertFalse(token.hasRole(revokerRole, owner));
+        assertFalse(token.hasRole(revokerRole, revoker1));
+        assertFalse(token.hasRole(revokerRole, revoker2));
+
+        assertFalse(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner));
+        assertFalse(token.hasRole(token.MINTER_ROLE(), owner));
+        assertFalse(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), owner));
+        assertFalse(token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), owner));
+
+        assertTrue(token.hasRole(token.DEFAULT_ADMIN_ROLE(), newOwner));
+        assertTrue(token.hasRole(token.MINTER_ROLE(), newOwner));
+        assertTrue(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), newOwner));
+        assertTrue(
+            token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), newOwner)
+        );
     }
 }

--- a/packages/lsp7-contracts/foundry/LSP7Revokable.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7Revokable.t.sol
@@ -577,8 +577,12 @@ contract LSP7RevokableTest is Test {
         // CHECK old owner + revokers have been removed their roles
         assertEq(
             lsp7Revokable.getRoleMemberCount(revokerRole),
-            0,
-            "All revokers should be cleared on ownership transfer"
+            1,
+            "All revokers should be cleared on ownership transfer (except the new owner should have REVOKER_ROLE)"
+        );
+        assertTrue(
+            lsp7Revokable.hasRole(revokerRole, newOwner),
+            "New owner should have REVOKER_ROLE after ownership transfer"
         );
         assertFalse(
             lsp7Revokable.hasRole(revokerRole, owner),
@@ -591,10 +595,6 @@ contract LSP7RevokableTest is Test {
         assertFalse(
             lsp7Revokable.hasRole(revokerRole, revoker2),
             "All delegated revokers should be cleared"
-        );
-        assertFalse(
-            lsp7Revokable.hasRole(revokerRole, newOwner),
-            "New owner should not implicitly keep REVOKER_ROLE after clear"
         );
 
         // CHECK previous revokers cannot revoke tokens anymore

--- a/packages/lsp7-contracts/foundry/LSP7RevokableInit.t.sol
+++ b/packages/lsp7-contracts/foundry/LSP7RevokableInit.t.sol
@@ -297,14 +297,15 @@ contract LSP7RevokableInitTest is Test {
 
         assertEq(
             token.getRoleMemberCount(revokerRole),
-            0,
-            "All revokers should be cleared on ownership transfer"
+            1,
+            "All revokers should be cleared on ownership transfer (except the new owner should have REVOKER_ROLE)"
         );
+        assertTrue(token.hasRole(revokerRole, newOwner));
+        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, newOwner));
+
         assertFalse(token.hasRole(revokerRole, owner));
         assertFalse(token.hasRole(revokerRole, revoker1));
         assertFalse(token.hasRole(revokerRole, revoker2));
-        assertFalse(token.hasRole(revokerRole, newOwner));
-        assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, newOwner));
 
         vm.prank(revoker1);
         vm.expectRevert(

--- a/packages/lsp7-contracts/tests/CustomizableTokenGasComparison.test.ts
+++ b/packages/lsp7-contracts/tests/CustomizableTokenGasComparison.test.ts
@@ -69,7 +69,6 @@ describe('Gas Comparison: LSP7MintableInit vs CustomizableTokenInit', () => {
         owner.address,
         LSP4_TOKEN_TYPES.TOKEN,
         false, // isNonDivisible
-        true, // mintable
       );
       const lsp7InitReceipt = await lsp7InitTx.wait();
       const lsp7InitGasUsed = lsp7InitReceipt?.gasUsed || 0n;

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedAbstract.sol
@@ -126,6 +126,18 @@ abstract contract AccessControlExtendedAbstract is
 
     /**
      * @inheritdoc IAccessControlExtended
+     *
+     * @dev Sets `adminRole` as the admin of `role`. Available for extensions to configure custom admin hierarchies.
+     *
+     * @custom:warning
+     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
+     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
+     *
+     * @custom:requirements
+     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
+     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
+     *
+     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
      */
     function setRoleAdmin(
         bytes32 role,
@@ -310,20 +322,6 @@ abstract contract AccessControlExtendedAbstract is
         return _roleMembers[role].contains(account);
     }
 
-    /**
-     * @dev Sets `adminRole` as the admin of `role`. Available for extensions
-     * to configure custom admin hierarchies.
-     *
-     * @custom:warning
-     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
-     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
-     *
-     * @custom:requirements
-     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
-     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
-     *
-     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
-     */
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         require(
             role != DEFAULT_ADMIN_ROLE,

--- a/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/AccessControlExtended/AccessControlExtendedInitAbstract.sol
@@ -133,6 +133,18 @@ abstract contract AccessControlExtendedInitAbstract is
 
     /**
      * @inheritdoc IAccessControlExtended
+     *
+     * @dev Sets `adminRole` as the admin of `role`. Available for extensions to configure custom admin hierarchies.
+     *
+     * @custom:warning
+     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
+     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
+     *
+     * @custom:requirements
+     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
+     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
+     *
+     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
      */
     function setRoleAdmin(
         bytes32 role,
@@ -310,20 +322,6 @@ abstract contract AccessControlExtendedInitAbstract is
         return _roleMembers[role].contains(account);
     }
 
-    /**
-     * @dev Sets `adminRole` as the admin of `role`. Available for extensions
-     * to configure custom admin hierarchies.
-     *
-     * @custom:warning
-     * - DO NOT expose this function without `onlyOwner` or `onlyRole(DEFAULT_ADMIN_ROLE)` access control.
-     * - Be aware that calling `setRoleAdmin(X, X)` creates a self-admin where nobody can grant role `X` unless someone already holds role `X`.
-     *
-     * @custom:requirements
-     * - `role` cannot be the `DEFAULT_ADMIN_ROLE`.
-     * - The caller must hold the `DEFAULT_ADMIN_ROLE`.
-     *
-     * @custom:events {RoleAdminChanged} with the previous and new admin roles.
-     */
     function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
         require(
             role != DEFAULT_ADMIN_ROLE,

--- a/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceInitAbstract.sol
@@ -157,4 +157,14 @@ abstract contract LSP8CappedBalanceInitAbstract is
         _setRoleAdmin(UNCAPPED_BALANCE_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8CappedSupply/LSP8CappedSupplyInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8CappedSupply/LSP8CappedSupplyInitAbstract.sol
@@ -84,4 +84,14 @@ abstract contract LSP8CappedSupplyInitAbstract is
         _tokenSupplyCapCheck(to, tokenId, force, data);
         super._mint(to, tokenId, force, data);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableAbstract.sol
@@ -45,6 +45,8 @@ abstract contract LSP8MintableAbstract is
     }
 
     /// @inheritdoc ILSP8Mintable
+    /// @custom:warning Once this function is called, any address holding the `MINTER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `MINTER_ROLE` remains populated after the minting feature is switched off.
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP8MintDisabled());
         isMintable = false;

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
@@ -142,4 +142,14 @@ abstract contract LSP8MintableInitAbstract is
         _setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Mintable/LSP8MintableInitAbstract.sol
@@ -76,6 +76,8 @@ abstract contract LSP8MintableInitAbstract is
     }
 
     /// @inheritdoc ILSP8Mintable
+    /// @custom:warning Once this function is called, any address holding the `MINTER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `MINTER_ROLE` remains populated after the minting feature is switched off.
     function disableMinting() public virtual override onlyOwner {
         require(isMintable, LSP8MintDisabled());
         isMintable = false;

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableAbstract.sol
@@ -100,6 +100,7 @@ abstract contract LSP8NonTransferableAbstract is
     }
 
     /// @inheritdoc ILSP8NonTransferable
+    /// @custom:info The list of addresses holding the `NON_TRANSFERABLE_BYPASS_ROLE` remains populated after the non-transferable feature is switched off.
     function makeTransferable() public virtual override onlyOwner {
         require(transferLockEnabled, LSP8TokenAlreadyTransferable());
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
@@ -24,7 +24,8 @@ import {
 } from "./LSP8NonTransferableErrors.sol";
 
 /// @title LSP8NonTransferableInitAbstract
-/// @dev Abstract contract implementing non-transferable LSP8 token functionality with transfer lock periods and role-based bypass support.
+/// @dev Abstract contract implementing non-transferable LSP8 token functionality with transfer lock periods
+/// and support to bypass non-transferable checks through a role.
 abstract contract LSP8NonTransferableInitAbstract is
     ILSP8NonTransferable,
     LSP8IdentifiableDigitalAssetInitAbstract,
@@ -229,4 +230,14 @@ abstract contract LSP8NonTransferableInitAbstract is
         _setRoleAdmin(NON_TRANSFERABLE_BYPASS_ROLE, DEFAULT_ADMIN_ROLE);
         super._transferOwnership(newOwner);
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[47] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8NonTransferable/LSP8NonTransferableInitAbstract.sol
@@ -143,6 +143,7 @@ abstract contract LSP8NonTransferableInitAbstract is
     }
 
     /// @inheritdoc ILSP8NonTransferable
+    /// @custom:info The list of addresses holding the `NON_TRANSFERABLE_BYPASS_ROLE` remains populated after the non-transferable feature is switched off.
     function makeTransferable() public virtual override onlyOwner {
         require(transferLockEnabled, LSP8TokenAlreadyTransferable());
 

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableAbstract.sol
@@ -3,14 +3,20 @@ pragma solidity ^0.8.27;
 
 // modules
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {LSP8IdentifiableDigitalAsset} from "../../LSP8IdentifiableDigitalAsset.sol";
-import {AccessControlExtendedAbstract} from "../AccessControlExtended/AccessControlExtendedAbstract.sol";
+import {
+    LSP8IdentifiableDigitalAsset
+} from "../../LSP8IdentifiableDigitalAsset.sol";
+import {
+    AccessControlExtendedAbstract
+} from "../AccessControlExtended/AccessControlExtendedAbstract.sol";
 
 // interfaces
 import {ILSP8Revokable} from "./ILSP8Revokable.sol";
 
 // errors
-import {AccessControlUnauthorizedAccount} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
+import {
+    AccessControlUnauthorizedAccount
+} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
 import {LSP8RevokableFeatureDisabled} from "./LSP8RevokableErrors.sol";
 
 /// @title LSP8RevokableAbstract
@@ -23,11 +29,16 @@ import {LSP8RevokableFeatureDisabled} from "./LSP8RevokableErrors.sol";
 /// - Role badges: Remove role badge NFTs from community members
 /// - Compliance: Freeze or reverse NFTs for regulatory requirements
 /// - Ticketing: Reclaim tickets or access NFTs when conditions are no longer met
-abstract contract LSP8RevokableAbstract is ILSP8Revokable, LSP8IdentifiableDigitalAsset, AccessControlExtendedAbstract {
+abstract contract LSP8RevokableAbstract is
+    ILSP8Revokable,
+    LSP8IdentifiableDigitalAsset,
+    AccessControlExtendedAbstract
+{
     bool internal _isRevokable;
 
     /// @dev keccak256("REVOKER_ROLE")
-    bytes32 public constant REVOKER_ROLE = 0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
+    bytes32 public constant REVOKER_ROLE =
+        0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
 
     constructor(bool isRevokable_) {
         _isRevokable = isRevokable_;
@@ -43,6 +54,8 @@ abstract contract LSP8RevokableAbstract is ILSP8Revokable, LSP8IdentifiableDigit
     }
 
     /// @inheritdoc ILSP8Revokable
+    /// @custom:warning Once this function is called, any address holding the `REVOKER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `REVOKER_ROLE` remains populated after the revokable feature is switched off.
     function disableRevokable() public virtual override onlyOwner {
         require(isRevokable(), LSP8RevokableFeatureDisabled());
         _isRevokable = false;
@@ -50,43 +63,70 @@ abstract contract LSP8RevokableAbstract is ILSP8Revokable, LSP8IdentifiableDigit
     }
 
     /// @inheritdoc ILSP8Revokable
-    function revoke(address from, address to, bytes32 tokenId, bytes memory data)
-        public
-        virtual
-        override
-        onlyRole(REVOKER_ROLE)
-    {
+    function revoke(
+        address from,
+        address to,
+        bytes32 tokenId,
+        bytes memory data
+    ) public virtual override onlyRole(REVOKER_ROLE) {
         require(isRevokable(), LSP8RevokableFeatureDisabled());
-        require(to == owner() || hasRole(REVOKER_ROLE, to), AccessControlUnauthorizedAccount(to, REVOKER_ROLE));
+        require(
+            to == owner() || hasRole(REVOKER_ROLE, to),
+            AccessControlUnauthorizedAccount(to, REVOKER_ROLE)
+        );
 
         // We assume revokers are trusted when specifying revocation destinations.
         // Therefore, we bypass LSP1 receiver checks.
-        _transfer({from: from, to: to, tokenId: tokenId, force: true, data: data});
+        _transfer({
+            from: from,
+            to: to,
+            tokenId: tokenId,
+            force: true,
+            data: data
+        });
     }
 
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
         override(AccessControlExtendedAbstract, LSP8IdentifiableDigitalAsset)
         returns (bool)
     {
-        return AccessControlExtendedAbstract.supportsInterface(interfaceId)
-            || LSP8IdentifiableDigitalAsset.supportsInterface(interfaceId);
+        return
+            AccessControlExtendedAbstract.supportsInterface(interfaceId) ||
+            LSP8IdentifiableDigitalAsset.supportsInterface(interfaceId);
     }
 
     /// @dev Overridden function to ensure previous revokers do not persist after contract ownership has been transferred.
-    function _transferOwnership(address newOwner) internal virtual override(AccessControlExtendedAbstract, Ownable) {
+    /// The only exception is if the old contract owner had the `REVOKER_ROLE`. This role will be given to the new owner.
+    ///
+    /// @custom:warning This function clears the entire `REVOKER_ROLE` member set.
+    /// - Gas cost scales linearly with the number of addresses with the `REVOKER_ROLE`.
+    /// - If the number of addresses with the `REVOKER_ROLE` is large, it might consume a lot of gas,
+    /// leading the transaction to approach or exceed the block gas limit and fail.
+    /// Consider revoking addresses with the `REVOKER_ROLE` in batches in separate transactions to mitigate this.
+    function _transferOwnership(
+        address newOwner
+    ) internal virtual override(AccessControlExtendedAbstract, Ownable) {
         // restore default admin hierarchy so a previously-installed custom admin
         // cannot grant REVOKER_ROLE to new accounts post-transfer
         _setRoleAdmin(REVOKER_ROLE, DEFAULT_ADMIN_ROLE);
-        _clearRevokers();
-        super._transferOwnership(newOwner);
-    }
 
-    function _clearRevokers() internal virtual {
-        while (getRoleMemberCount(REVOKER_ROLE) != 0) {
-            _revokeRole(REVOKER_ROLE, getRoleMember(REVOKER_ROLE, 0));
+        // Transfer all roles from old owner to new owner first (including the `REVOKER_ROLE`)
+        // before clearing the list of revokers.
+        super._transferOwnership(newOwner);
+
+        address[] memory revokers = getRoleMembers(REVOKER_ROLE);
+
+        for (uint256 ii = 0; ii < revokers.length; ++ii) {
+            // Exclude the new owner from the list of revokers to delete.
+            address revoker = revokers[ii];
+            if (revoker == newOwner) continue;
+
+            _revokeRole(REVOKER_ROLE, revoker);
         }
     }
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
@@ -165,4 +165,14 @@ abstract contract LSP8RevokableInitAbstract is
             _revokeRole(REVOKER_ROLE, revoker);
         }
     }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     *
+     * @custom:info The size of the `__gap` array is calculated so that the amount of storage used by the contract
+     * always adds up to the same number (in this case 50 storage slots).
+     */
+    uint256[49] private __gap;
 }

--- a/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
+++ b/packages/lsp8-contracts/contracts/extensions/LSP8Revokable/LSP8RevokableInitAbstract.sol
@@ -2,15 +2,23 @@
 pragma solidity ^0.8.27;
 
 // modules
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import {LSP8IdentifiableDigitalAssetInitAbstract} from "../../LSP8IdentifiableDigitalAssetInitAbstract.sol";
-import {AccessControlExtendedInitAbstract} from "../AccessControlExtended/AccessControlExtendedInitAbstract.sol";
+import {
+    OwnableUpgradeable
+} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {
+    LSP8IdentifiableDigitalAssetInitAbstract
+} from "../../LSP8IdentifiableDigitalAssetInitAbstract.sol";
+import {
+    AccessControlExtendedInitAbstract
+} from "../AccessControlExtended/AccessControlExtendedInitAbstract.sol";
 
 // interfaces
 import {ILSP8Revokable} from "./ILSP8Revokable.sol";
 
 // errors
-import {AccessControlUnauthorizedAccount} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
+import {
+    AccessControlUnauthorizedAccount
+} from "../AccessControlExtended/AccessControlExtendedErrors.sol";
 import {LSP8RevokableFeatureDisabled} from "./LSP8RevokableErrors.sol";
 
 /// @title LSP8RevokableInitAbstract
@@ -33,7 +41,8 @@ abstract contract LSP8RevokableInitAbstract is
     bool internal _isRevokable;
 
     /// @dev keccak256("REVOKER_ROLE")
-    bytes32 public constant REVOKER_ROLE = 0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
+    bytes32 public constant REVOKER_ROLE =
+        0xce3f34913921da558f105cefb578d87278debbbd073a8d552b5de0d168deee30;
 
     /// @notice Initializes the LSP8Revokable contract with base token params.
     /// @dev Initializes the LSP8IdentifiableDigitalAsset base contract.
@@ -52,14 +61,20 @@ abstract contract LSP8RevokableInitAbstract is
         bool isRevokable_
     ) internal virtual onlyInitializing {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(
-            name_, symbol_, newOwner_, lsp4TokenType_, lsp8TokenIdFormat_
+            name_,
+            symbol_,
+            newOwner_,
+            lsp4TokenType_,
+            lsp8TokenIdFormat_
         );
         __AccessControlExtended_init();
         __LSP8Revokable_init_unchained(isRevokable_);
     }
 
     /// @notice Unchained initializer for LSP8Revokable.
-    function __LSP8Revokable_init_unchained(bool isRevokable_) internal virtual onlyInitializing {
+    function __LSP8Revokable_init_unchained(
+        bool isRevokable_
+    ) internal virtual onlyInitializing {
         _isRevokable = isRevokable_;
 
         if (isRevokable_) {
@@ -73,6 +88,8 @@ abstract contract LSP8RevokableInitAbstract is
     }
 
     /// @inheritdoc ILSP8Revokable
+    /// @custom:warning Once this function is called, any address holding the `REVOKER_ROLE` will be inoperable.
+    /// @custom:info The list of addresses holding the `REVOKER_ROLE` remains populated after the revokable feature is switched off.
     function disableRevokable() public virtual override onlyOwner {
         require(isRevokable(), LSP8RevokableFeatureDisabled());
         _isRevokable = false;
@@ -80,33 +97,53 @@ abstract contract LSP8RevokableInitAbstract is
     }
 
     /// @inheritdoc ILSP8Revokable
-    function revoke(address from, address to, bytes32 tokenId, bytes memory data)
-        public
-        virtual
-        override
-        onlyRole(REVOKER_ROLE)
-    {
+    function revoke(
+        address from,
+        address to,
+        bytes32 tokenId,
+        bytes memory data
+    ) public virtual override onlyRole(REVOKER_ROLE) {
         require(isRevokable(), LSP8RevokableFeatureDisabled());
-        require(to == owner() || hasRole(REVOKER_ROLE, to), AccessControlUnauthorizedAccount(to, REVOKER_ROLE));
+        require(
+            to == owner() || hasRole(REVOKER_ROLE, to),
+            AccessControlUnauthorizedAccount(to, REVOKER_ROLE)
+        );
 
         // We assume revokers are trusted when specifying revocation destinations.
         // Therefore, we bypass LSP1 receiver checks.
         _transfer(from, to, tokenId, true, data);
     }
 
-    function supportsInterface(bytes4 interfaceId)
+    function supportsInterface(
+        bytes4 interfaceId
+    )
         public
         view
         virtual
-        override(AccessControlExtendedInitAbstract, LSP8IdentifiableDigitalAssetInitAbstract)
+        override(
+            AccessControlExtendedInitAbstract,
+            LSP8IdentifiableDigitalAssetInitAbstract
+        )
         returns (bool)
     {
-        return AccessControlExtendedInitAbstract.supportsInterface(interfaceId)
-            || LSP8IdentifiableDigitalAssetInitAbstract.supportsInterface(interfaceId);
+        return
+            AccessControlExtendedInitAbstract.supportsInterface(interfaceId) ||
+            LSP8IdentifiableDigitalAssetInitAbstract.supportsInterface(
+                interfaceId
+            );
     }
 
     /// @dev Overridden function to ensure previous revokers do not persist after contract ownership has been transferred.
-    function _transferOwnership(address newOwner)
+    /// The only exception is if the old contract owner had the `REVOKER_ROLE`. This role will be given to the new owner.
+    ///
+    /// @custom:warning This function clears the entire `REVOKER_ROLE` member set.
+    /// - Gas cost scales linearly with the number of addresses with the `REVOKER_ROLE`.
+    /// - If the number of addresses with the `REVOKER_ROLE` is large, it might consume a lot of gas,
+    /// leading the transaction to approach or exceed the block gas limit and fail.
+    /// Consider revoking addresses with the `REVOKER_ROLE` in batches in separate transactions to mitigate this.
+    function _transferOwnership(
+        address newOwner
+    )
         internal
         virtual
         override(AccessControlExtendedInitAbstract, OwnableUpgradeable)
@@ -114,13 +151,18 @@ abstract contract LSP8RevokableInitAbstract is
         // restore default admin hierarchy so a previously-installed custom admin
         // cannot grant REVOKER_ROLE to new accounts post-transfer
         _setRoleAdmin(REVOKER_ROLE, DEFAULT_ADMIN_ROLE);
-        _clearRevokers();
-        super._transferOwnership(newOwner);
-    }
 
-    function _clearRevokers() internal virtual {
-        while (getRoleMemberCount(REVOKER_ROLE) != 0) {
-            _revokeRole(REVOKER_ROLE, getRoleMember(REVOKER_ROLE, 0));
+        // Transfer all roles from old owner to new owner first (including the `REVOKER_ROLE`)
+        // before clearing the list of revokers.
+        super._transferOwnership(newOwner);
+
+        address[] memory revokers = getRoleMembers(REVOKER_ROLE);
+
+        // Exclude the new owner from the list of revokers to delete.
+        for (uint256 ii = 0; ii < revokers.length; ++ii) {
+            address revoker = revokers[ii];
+            if (revoker == newOwner) continue;
+            _revokeRole(REVOKER_ROLE, revoker);
         }
     }
 }

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -45,7 +45,7 @@ import {
 } from "../extensions/LSP8CappedSupply/LSP8CappedSupplyErrors.sol";
 
 /// @title LSP8CustomizableToken
-/// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions.
+/// @dev A customizable LSP8 token that implements multiple features and uses role-based exemptions.
 /// Implements {LSP8Burnable} to allow burning.
 /// Implements {LSP8Mintable} to allow minting.
 /// Implements {LSP8CappedSupply} to set total supply cap.

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableToken.sol
@@ -154,7 +154,10 @@ contract LSP8CustomizableToken is
     }
 
     /// @notice Hook called before a token transfer to enforce restrictions.
-    /// @dev Combines checks from {LSP8CappedBalance} and {LSP8NonTransferable}. Bypasses all checks for role holders configured by those extensions. Allows burning to address(0) regardless of restrictions.
+    /// @dev Combines checks from {LSP8CappedBalance} and {LSP8NonTransferable}. 
+    /// - Bypasses {LSP8NonTransferable} checks for senders (`from`) holding the `NON_TRANSFERABLE_BYPASS_ROLE` role. 
+    /// - Bypasses {LSP8CappedBalance} checks for recipients (`to`) holding the `UNCAPPED_BALANCE_ROLE` role. 
+    /// - Allows minting (from address(0)) and burning to address(0) regardless of restrictions.
     /// @param from The address sending the token.
     /// @param to The address receiving the token.
     /// @param tokenId The unique identifier of the token being transferred.

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -46,13 +46,13 @@ import {
 } from "../extensions/LSP8CappedSupply/LSP8CappedSupplyErrors.sol";
 
 /// @title LSP8CustomizableTokenInit
-/// @dev A customizable LSP8 token implementing minting, balance caps, transfer restrictions, total supply cap, burning and role-based exemptions. This is the proxy-deployable version.
-/// Implements {LSP8Burnable} to allow burning.
-/// Implements {LSP8Mintable} to allow minting.
-/// Implements {LSP8CappedSupply} to set total supply cap.
-/// Implements {LSP8CappedBalance} to set balance caps.
-/// Implements {LSP8NonTransferable} to restrict transfers.
-/// Implements {LSP8Revokable} to allow revoking tokens.
+/// @dev A customizable LSP8 token that implements multiple features and uses role-based exemptions. This version of the contract is the implementation to use behind proxies.
+/// Implements {LSP8BurnableInitAbstract} to allow burning.
+/// Implements {LSP8MintableInitAbstract} to allow minting.
+/// Implements {LSP8CappedSupplyInitAbstract} to set total supply cap.
+/// Implements {LSP8CappedBalanceInitAbstract} to set balance caps.
+/// Implements {LSP8NonTransferableInitAbstract} to restrict transfers.
+/// Implements {LSP8RevokableInitAbstract} to allow revoking tokens.
 contract LSP8CustomizableTokenInit is
     LSP8BurnableInitAbstract,
     LSP8MintableInitAbstract,
@@ -83,8 +83,8 @@ contract LSP8CustomizableTokenInit is
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
         LSP8MintableParams calldata mintableParams,
-        LSP8NonTransferableParams calldata nonTransferableParams,
         LSP8CappedParams calldata cappedParams,
+        LSP8NonTransferableParams calldata nonTransferableParams,
         LSP8RevokableParams calldata revokableParams
     ) external virtual initializer {
         __LSP8CustomizableToken_init(
@@ -94,8 +94,8 @@ contract LSP8CustomizableTokenInit is
             lsp4TokenType_,
             lsp8TokenIdFormat_,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
@@ -108,8 +108,8 @@ contract LSP8CustomizableTokenInit is
         uint256 lsp4TokenType_,
         uint256 lsp8TokenIdFormat_,
         LSP8MintableParams calldata mintableParams,
-        LSP8NonTransferableParams calldata nonTransferableParams,
         LSP8CappedParams calldata cappedParams,
+        LSP8NonTransferableParams calldata nonTransferableParams,
         LSP8RevokableParams calldata revokableParams
     ) internal virtual onlyInitializing {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(

--- a/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8CustomizableTokenInit.sol
@@ -184,7 +184,10 @@ contract LSP8CustomizableTokenInit is
     }
 
     /// @notice Hook called before a token transfer to enforce restrictions.
-    /// @dev Combines checks from {LSP8CappedBalance} and {LSP8NonTransferable}. Bypasses all checks for role holders configured by those extensions. Allows burning to address(0) regardless of restrictions.
+    /// @dev Combines checks from {LSP8CappedBalanceInitAbstract} and {LSP8NonTransferableInitAbstract}. 
+    /// - Bypasses {LSP8NonTransferableInitAbstract} checks for senders (`from`) holding the `NON_TRANSFERABLE_BYPASS_ROLE` role. 
+    /// - Bypasses {LSP8CappedBalanceInitAbstract} checks for recipients (`to`) holding the `UNCAPPED_BALANCE_ROLE` role. 
+    /// - Allows minting (from address(0)) and burning to address(0) regardless of restrictions.
     /// @param from The address sending the token.
     /// @param to The address receiving the token.
     /// @param tokenId The unique identifier of the token being transferred.

--- a/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
@@ -21,7 +21,8 @@ contract LSP8Mintable is LSP8MintableAbstract {
         string memory symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        uint256 lsp8TokenIdFormat_
+        uint256 lsp8TokenIdFormat_,
+        bool mintable_
     )
         LSP8IdentifiableDigitalAsset(
             name_,
@@ -31,6 +32,6 @@ contract LSP8Mintable is LSP8MintableAbstract {
             lsp8TokenIdFormat_
         )
         AccessControlExtendedAbstract()
-        LSP8MintableAbstract(true)
+        LSP8MintableAbstract(mintable_)
     {}
 }

--- a/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8Mintable.sol
@@ -16,13 +16,21 @@ import {
  * @title LSP8IdentifiableDigitalAsset deployable preset contract with a public {mint} function callable by addresses holding `MINTER_ROLE`.
  */
 contract LSP8Mintable is LSP8MintableAbstract {
+    /**
+     * @notice Deploying a `LSP8Mintable` token contract.
+     * @dev Set the token to be mintable to allow minting more tokens after deployment.
+     * @param name_ The name of the token.
+     * @param symbol_ The symbol of the token.
+     * @param newOwner_ The owner of the token contract.
+     * @param lsp4TokenType_ The type of token this digital asset contract represents (`0` = Token, `1` = NFT, `2` = Collection).
+     * @param lsp8TokenIdFormat_ The format of tokenIds (= NFTs) that this contract will create.
+     */
     constructor(
         string memory name_,
         string memory symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        uint256 lsp8TokenIdFormat_,
-        bool mintable_
+        uint256 lsp8TokenIdFormat_
     )
         LSP8IdentifiableDigitalAsset(
             name_,
@@ -32,6 +40,6 @@ contract LSP8Mintable is LSP8MintableAbstract {
             lsp8TokenIdFormat_
         )
         AccessControlExtendedAbstract()
-        LSP8MintableAbstract(mintable_)
+        LSP8MintableAbstract(true)
     {}
 }

--- a/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
@@ -35,8 +35,7 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
         string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        uint256 lsp8TokenIdFormat_,
-        bool mintable_
+        uint256 lsp8TokenIdFormat_
     ) external virtual initializer {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(
             name_,
@@ -46,6 +45,6 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
             lsp8TokenIdFormat_
         );
         __AccessControlExtended_init();
-        __LSP8Mintable_init_unchained(mintable_);
+        __LSP8Mintable_init_unchained(true);
     }
 }

--- a/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
+++ b/packages/lsp8-contracts/contracts/presets/LSP8MintableInit.sol
@@ -35,7 +35,8 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
         string calldata symbol_,
         address newOwner_,
         uint256 lsp4TokenType_,
-        uint256 lsp8TokenIdFormat_
+        uint256 lsp8TokenIdFormat_,
+        bool mintable_
     ) external virtual initializer {
         LSP8IdentifiableDigitalAssetInitAbstract._initialize(
             name_,
@@ -45,6 +46,6 @@ contract LSP8MintableInit is LSP8MintableInitAbstract {
             lsp8TokenIdFormat_
         );
         __AccessControlExtended_init();
-        __LSP8Mintable_init_unchained(true);
+        __LSP8Mintable_init_unchained(mintable_);
     }
 }

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableToken.t.sol
@@ -17,19 +17,29 @@ import {
 import {
     AccessControlUnauthorizedAccount
 } from "../contracts/extensions/AccessControlExtended/AccessControlExtendedErrors.sol";
-import {LSP8MintDisabled} from "../contracts/extensions/LSP8Mintable/LSP8MintableErrors.sol";
-import {LSP8CappedBalanceExceeded} from "../contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceErrors.sol";
+import {
+    LSP8MintDisabled
+} from "../contracts/extensions/LSP8Mintable/LSP8MintableErrors.sol";
+import {
+    LSP8CappedBalanceExceeded
+} from "../contracts/extensions/LSP8CappedBalance/LSP8CappedBalanceErrors.sol";
 import {
     LSP8TransferDisabled,
     LSP8CannotUpdateTransferLockPeriod,
     LSP8TokenAlreadyTransferable,
     LSP8InvalidTransferLockPeriod
 } from "../contracts/extensions/LSP8NonTransferable/LSP8NonTransferableErrors.sol";
-import {LSP8CappedSupplyCannotMintOverCap} from "../contracts/extensions/LSP8CappedSupply/LSP8CappedSupplyErrors.sol";
-import {LSP8RevokableFeatureDisabled} from "../contracts/extensions/LSP8Revokable/LSP8RevokableErrors.sol";
+import {
+    LSP8CappedSupplyCannotMintOverCap
+} from "../contracts/extensions/LSP8CappedSupply/LSP8CappedSupplyErrors.sol";
+import {
+    LSP8RevokableFeatureDisabled
+} from "../contracts/extensions/LSP8Revokable/LSP8RevokableErrors.sol";
 
 // constants
-import {_LSP4_TOKEN_TYPE_NFT} from "@lukso/lsp4-contracts/contracts/LSP4Constants.sol";
+import {
+    _LSP4_TOKEN_TYPE_NFT
+} from "@lukso/lsp4-contracts/contracts/LSP4Constants.sol";
 
 contract LSP8CustomizableTokenTest is Test {
     string name = "Custom NFT";
@@ -64,15 +74,24 @@ contract LSP8CustomizableTokenTest is Test {
         initialTokenIds[1] = bytes32(uint256(2));
         initialTokenIds[2] = bytes32(uint256(3));
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: initialTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: initialTokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap, tokenSupplyCap: tokenSupplyCap});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap,
+            tokenSupplyCap: tokenSupplyCap
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         token = new LSP8CustomizableToken(
             name,
@@ -96,16 +115,25 @@ contract LSP8CustomizableTokenTest is Test {
         uint256 transferLockEnd_,
         bool revokable_
     ) internal returns (LSP8CustomizableToken deployedToken) {
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: mintable_, initialMintTokenIds: initialTokenIds_});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: mintable_,
+            initialMintTokenIds: initialTokenIds_
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart_, transferLockEnd: transferLockEnd_});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart_,
+                transferLockEnd: transferLockEnd_
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap_, tokenSupplyCap: tokenSupplyCap_});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap_,
+            tokenSupplyCap: tokenSupplyCap_
+        });
 
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: revokable_});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: revokable_
+        });
 
         deployedToken = new LSP8CustomizableToken(
             name,
@@ -128,37 +156,85 @@ contract LSP8CustomizableTokenTest is Test {
         bool shouldHaveNonTransferableBypassRole,
         bool shouldHaveRevokerRole
     ) internal {
-        assertTrue(deployedToken.hasRole(deployedToken.DEFAULT_ADMIN_ROLE(), contractOwner));
+        assertTrue(
+            deployedToken.hasRole(
+                deployedToken.DEFAULT_ADMIN_ROLE(),
+                contractOwner
+            )
+        );
 
         shouldHaveMinterRole
-            ? assertTrue(deployedToken.hasRole(deployedToken.MINTER_ROLE(), contractOwner))
-            : assertFalse(deployedToken.hasRole(deployedToken.MINTER_ROLE(), contractOwner));
+            ? assertTrue(
+                deployedToken.hasRole(
+                    deployedToken.MINTER_ROLE(),
+                    contractOwner
+                )
+            )
+            : assertFalse(
+                deployedToken.hasRole(
+                    deployedToken.MINTER_ROLE(),
+                    contractOwner
+                )
+            );
 
         shouldHaveUncappedBalanceRole
-            ? assertTrue(deployedToken.hasRole(deployedToken.UNCAPPED_BALANCE_ROLE(), contractOwner))
-            : assertFalse(deployedToken.hasRole(deployedToken.UNCAPPED_BALANCE_ROLE(), contractOwner));
+            ? assertTrue(
+                deployedToken.hasRole(
+                    deployedToken.UNCAPPED_BALANCE_ROLE(),
+                    contractOwner
+                )
+            )
+            : assertFalse(
+                deployedToken.hasRole(
+                    deployedToken.UNCAPPED_BALANCE_ROLE(),
+                    contractOwner
+                )
+            );
 
         shouldHaveNonTransferableBypassRole
-            ? assertTrue(deployedToken.hasRole(deployedToken.NON_TRANSFERABLE_BYPASS_ROLE(), contractOwner))
-            : assertFalse(deployedToken.hasRole(deployedToken.NON_TRANSFERABLE_BYPASS_ROLE(), contractOwner));
+            ? assertTrue(
+                deployedToken.hasRole(
+                    deployedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+                    contractOwner
+                )
+            )
+            : assertFalse(
+                deployedToken.hasRole(
+                    deployedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+                    contractOwner
+                )
+            );
 
         shouldHaveRevokerRole
-            ? assertTrue(deployedToken.hasRole(deployedToken.REVOKER_ROLE(), contractOwner))
-            : assertFalse(deployedToken.hasRole(deployedToken.REVOKER_ROLE(), contractOwner));
+            ? assertTrue(
+                deployedToken.hasRole(
+                    deployedToken.REVOKER_ROLE(),
+                    contractOwner
+                )
+            )
+            : assertFalse(
+                deployedToken.hasRole(
+                    deployedToken.REVOKER_ROLE(),
+                    contractOwner
+                )
+            );
     }
 
-    function _mintTokenIds(LSP8CustomizableToken deployedToken, address to, uint256 startTokenId, uint256 count)
-        internal
-    {
+    function _mintTokenIds(
+        LSP8CustomizableToken deployedToken,
+        address to,
+        uint256 startTokenId,
+        uint256 count
+    ) internal {
         for (uint256 i = 0; i < count; i++) {
             deployedToken.mint(to, bytes32(startTokenId + i), true, "");
         }
     }
 
-    function _deployRevokableNonTransferableToken(uint256 lockStart, uint256 lockEnd)
-        internal
-        returns (LSP8CustomizableToken deployedToken)
-    {
+    function _deployRevokableNonTransferableToken(
+        uint256 lockStart,
+        uint256 lockEnd
+    ) internal returns (LSP8CustomizableToken deployedToken) {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
 
         deployedToken = _deployToken({
@@ -191,23 +267,68 @@ contract LSP8CustomizableTokenTest is Test {
 
     // Constructor Tests
     function test_ConstructorInitializesCorrectly() public {
-        assertEq(token.balanceOf(owner), 3, "Owner should have 3 initial tokens");
-        assertEq(token.totalSupply(), 3, "Total supply should match initial mint count");
-        assertEq(token.tokenBalanceCap(), tokenBalanceCap, "Balance cap should be set");
-        assertEq(token.isMintable(), isMintable, "Mintable status should be set");
+        assertEq(
+            token.balanceOf(owner),
+            3,
+            "Owner should have 3 initial tokens"
+        );
+        assertEq(
+            token.totalSupply(),
+            3,
+            "Total supply should match initial mint count"
+        );
+        assertEq(
+            token.tokenBalanceCap(),
+            tokenBalanceCap,
+            "Balance cap should be set"
+        );
+        assertEq(
+            token.isMintable(),
+            isMintable,
+            "Mintable status should be set"
+        );
         assertTrue(token.isRevokable(), "Revokable status should be set");
         assertTrue(token.isTransferable(), "Token should be transferable");
-        assertEq(token.transferLockStart(), transferLockStart, "Lock start should be set");
-        assertEq(token.transferLockEnd(), transferLockEnd, "Lock end should be set");
-        assertEq(token.tokenSupplyCap(), tokenSupplyCap, "Supply cap should be set");
-        assertTrue(token.hasRole(token.MINTER_ROLE(), owner), "Owner should have MINTER_ROLE");
-        assertTrue(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner), "Owner should have DEFAULT_ADMIN_ROLE");
-        assertTrue(token.hasRole(token.REVOKER_ROLE(), owner), "Owner should have REVOKER_ROLE");
-        assertTrue(token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), owner), "Owner should have bypass role");
-        assertTrue(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), owner), "Owner should have UNCAPPED_BALANCE_ROLE");
+        assertEq(
+            token.transferLockStart(),
+            transferLockStart,
+            "Lock start should be set"
+        );
+        assertEq(
+            token.transferLockEnd(),
+            transferLockEnd,
+            "Lock end should be set"
+        );
+        assertEq(
+            token.tokenSupplyCap(),
+            tokenSupplyCap,
+            "Supply cap should be set"
+        );
+        assertTrue(
+            token.hasRole(token.MINTER_ROLE(), owner),
+            "Owner should have MINTER_ROLE"
+        );
+        assertTrue(
+            token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner),
+            "Owner should have DEFAULT_ADMIN_ROLE"
+        );
+        assertTrue(
+            token.hasRole(token.REVOKER_ROLE(), owner),
+            "Owner should have REVOKER_ROLE"
+        );
+        assertTrue(
+            token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), owner),
+            "Owner should have bypass role"
+        );
+        assertTrue(
+            token.hasRole(token.UNCAPPED_BALANCE_ROLE(), owner),
+            "Owner should have UNCAPPED_BALANCE_ROLE"
+        );
     }
 
-    function test_ConstructorAssignsOwnerRolesAcrossFeatureCombinations() public {
+    function test_ConstructorAssignsOwnerRolesAcrossFeatureCombinations()
+        public
+    {
         _assertOwnerFeatureRoles({
             deployedToken: token,
             contractOwner: owner,
@@ -237,7 +358,9 @@ contract LSP8CustomizableTokenTest is Test {
         });
 
         assertEq(
-            nonRevokableToken.totalSupply(), 0, "Total supply should be 0 since we passed an empty array of token IDs"
+            nonRevokableToken.totalSupply(),
+            0,
+            "Total supply should be 0 since we passed an empty array of token IDs"
         );
 
         LSP8CustomizableToken lockedToken = _deployToken({
@@ -260,9 +383,10 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     /// @dev LSP8 premints one NFT per id; bound counts so fuzzing stays within practical gas.
-    function test_ConstructorNonMintableInitialMintOverSupplyCapReverts(uint256 supplyCap, uint256 preMintCount)
-        public
-    {
+    function test_ConstructorNonMintableInitialMintOverSupplyCapReverts(
+        uint256 supplyCap,
+        uint256 preMintCount
+    ) public {
         supplyCap = bound(supplyCap, 1, 128);
         preMintCount = bound(preMintCount, supplyCap + 1, supplyCap + 64);
 
@@ -271,13 +395,20 @@ contract LSP8CustomizableTokenTest is Test {
             initialMintTokenIds: _preMintTokenIds(preMintCount)
         });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: supplyCap});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: supplyCap
+        });
 
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: false});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: false
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         new LSP8CustomizableToken(
@@ -294,7 +425,9 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     /// @dev Same revert as `test_ConstructorNonMintableInitialMintOverSupplyCapReverts` but with an explicit `bytes32[]` (not only sequential ids).
-    function test_ConstructorNonMintableInitialMintOverSupplyCapRevertsWithExplicitTokenIds() public {
+    function test_ConstructorNonMintableInitialMintOverSupplyCapRevertsWithExplicitTokenIds()
+        public
+    {
         uint256 supplyCap = 4;
         bytes32[] memory tokenIds = new bytes32[](5);
         tokenIds[0] = keccak256("id-a");
@@ -303,16 +436,25 @@ contract LSP8CustomizableTokenTest is Test {
         tokenIds[3] = keccak256("id-d");
         tokenIds[4] = keccak256("id-e");
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: false, initialMintTokenIds: tokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: false,
+            initialMintTokenIds: tokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: supplyCap});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: supplyCap
+        });
 
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: false});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: false
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         new LSP8CustomizableToken(
@@ -335,15 +477,24 @@ contract LSP8CustomizableTokenTest is Test {
             tooManyTokenIds[i] = bytes32(uint256(i + 1));
         }
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: tooManyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: tooManyTokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap, tokenSupplyCap: tokenSupplyCap});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap,
+            tokenSupplyCap: tokenSupplyCap
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         new LSP8CustomizableToken(
@@ -361,15 +512,24 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_ConstructorSucceedsWithZeroInitialMint() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap, tokenSupplyCap: tokenSupplyCap});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap,
+            tokenSupplyCap: tokenSupplyCap
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken zeroMintToken = new LSP8CustomizableToken(
             name,
@@ -382,12 +542,18 @@ contract LSP8CustomizableTokenTest is Test {
             nonTransferableParams,
             revokableParams
         );
-        assertEq(zeroMintToken.balanceOf(owner), 0, "Owner should have no tokens");
+        assertEq(
+            zeroMintToken.balanceOf(owner),
+            0,
+            "Owner should have no tokens"
+        );
         assertEq(zeroMintToken.totalSupply(), 0, "Total supply should be zero");
     }
 
     /// @dev LSP8 mints one NFT per id; use a moderate count so the test stays within practical gas (LSP7 uses one _mint of 1_000_000).
-    function _preMintTokenIds(uint256 count) internal pure returns (bytes32[] memory ids) {
+    function _preMintTokenIds(
+        uint256 count
+    ) internal pure returns (bytes32[] memory ids) {
         ids = new bytes32[](count);
         for (uint256 i = 0; i < count; ++i) {
             ids[i] = bytes32(i + 1);
@@ -413,16 +579,23 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     function test_ConstructorRevertsWithInvalidLockPeriod() public {
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: initialTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams = LSP8NonTransferableParams({
-            transferLockStart: 200,
-            transferLockEnd: 100 // End before start - invalid
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: initialTokenIds
         });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 200,
+                transferLockEnd: 100 // End before start - invalid
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap, tokenSupplyCap: tokenSupplyCap});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap,
+            tokenSupplyCap: tokenSupplyCap
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         vm.expectRevert(LSP8InvalidTransferLockPeriod.selector);
         new LSP8CustomizableToken(
@@ -440,7 +613,11 @@ contract LSP8CustomizableTokenTest is Test {
 
     // Supply Cap Tests
     function test_TokenSupplyCapReturnsCorrectValue() public {
-        assertEq(token.tokenSupplyCap(), tokenSupplyCap, "Should return supply cap when isMintable");
+        assertEq(
+            token.tokenSupplyCap(),
+            tokenSupplyCap,
+            "Should return supply cap when isMintable"
+        );
         token.disableMinting();
         assertEq(
             token.tokenSupplyCap(),
@@ -454,7 +631,11 @@ contract LSP8CustomizableTokenTest is Test {
         for (uint256 i = 4; i <= tokenSupplyCap; i++) {
             token.mint(owner, bytes32(uint256(i)), true, "");
         }
-        assertEq(token.totalSupply(), tokenSupplyCap, "Total supply should reach cap");
+        assertEq(
+            token.totalSupply(),
+            tokenSupplyCap,
+            "Total supply should reach cap"
+        );
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         token.mint(owner, bytes32(uint256(tokenSupplyCap + 1)), true, "");
@@ -465,20 +646,34 @@ contract LSP8CustomizableTokenTest is Test {
         for (uint256 i = 4; i <= tokenSupplyCap; i++) {
             token.mint(owner, bytes32(uint256(i)), true, "");
         }
-        assertEq(token.totalSupply(), tokenSupplyCap, "Total supply should match cap");
+        assertEq(
+            token.totalSupply(),
+            tokenSupplyCap,
+            "Total supply should match cap"
+        );
     }
 
     function test_MintWithMaxSupplyCapAllowsUnlimitedMinting() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
         // Both caps disabled
-        LSP8CappedParams memory cappedParams = LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: 0});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken unlimitedToken = new LSP8CustomizableToken(
             name,
@@ -496,7 +691,11 @@ contract LSP8CustomizableTokenTest is Test {
         for (uint256 i = 1; i <= 1000; i++) {
             unlimitedToken.mint(owner, bytes32(uint256(i)), true, "");
         }
-        assertEq(unlimitedToken.totalSupply(), 1000, "Should allow minting many tokens");
+        assertEq(
+            unlimitedToken.totalSupply(),
+            1000,
+            "Should allow minting many tokens"
+        );
     }
 
     // Balance Cap Tests
@@ -512,7 +711,11 @@ contract LSP8CustomizableTokenTest is Test {
         token.mint(owner, bytes32(uint256(5)), true, "");
         token.transfer(owner, user1, bytes32(uint256(4)), true, "");
         token.transfer(owner, user1, bytes32(uint256(5)), true, "");
-        assertEq(token.balanceOf(user1), 5, "User1 should have 5 NFTs (at cap)");
+        assertEq(
+            token.balanceOf(user1),
+            5,
+            "User1 should have 5 NFTs (at cap)"
+        );
 
         // Mint one more and try to transfer - should fail
         token.mint(owner, bytes32(uint256(6)), true, "");
@@ -529,29 +732,36 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_BalanceCapDisabledWhenZero() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
 
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
         LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken tokenWithoutBalanceCap = new LSP8CustomizableToken(
-            name,
-            symbol,
-            owner,
-            tokenType,
-            tokenIdFormat,
-            mintableParams,
-            cappedParams,
-            nonTransferableParams,
-            revokableParams
-        );
+                name,
+                symbol,
+                owner,
+                tokenType,
+                tokenIdFormat,
+                mintableParams,
+                cappedParams,
+                nonTransferableParams,
+                revokableParams
+            );
 
         // Should be able to hold many NFTs when balance cap is disabled
         for (uint256 i = 1; i <= 100; i++) {
@@ -564,7 +774,11 @@ contract LSP8CustomizableTokenTest is Test {
     function test_OwnerCanMintToRegularAddress() public {
         token.mint(user1, bytes32(uint256(100)), true, "");
         assertEq(token.balanceOf(user1), 1, "User1 should have 1 token");
-        assertEq(token.tokenOwnerOf(bytes32(uint256(100))), user1, "User1 should own token 100");
+        assertEq(
+            token.tokenOwnerOf(bytes32(uint256(100))),
+            user1,
+            "User1 should own token 100"
+        );
     }
 
     function test_MintFailsWhenDisabled() public {
@@ -575,7 +789,11 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_NonOwnerCannotMint() public {
         vm.expectRevert(
-            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, nonOwner, token.MINTER_ROLE())
+            abi.encodeWithSelector(
+                AccessControlUnauthorizedAccount.selector,
+                nonOwner,
+                token.MINTER_ROLE()
+            )
         );
         vm.prank(nonOwner);
         token.mint(user1, bytes32(uint256(100)), true, "");
@@ -584,19 +802,24 @@ contract LSP8CustomizableTokenTest is Test {
     // Transfer Tests
     function test_TransferDisabledWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
-
-        LSP8NonTransferableParams memory nonTransferableParams = LSP8NonTransferableParams({
-            transferLockStart: 0,
-            transferLockEnd: type(uint256).max // non-transferable
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
         });
+
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: type(uint256).max // non-transferable
+            });
 
         LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken nonTransferableToken = new LSP8CustomizableToken(
             name,
@@ -616,23 +839,38 @@ contract LSP8CustomizableTokenTest is Test {
         // user1 trying to transfer should fail
         vm.prank(user1);
         vm.expectRevert(LSP8TransferDisabled.selector);
-        nonTransferableToken.transfer(user1, user2, bytes32(uint256(1)), true, "");
+        nonTransferableToken.transfer(
+            user1,
+            user2,
+            bytes32(uint256(1)),
+            true,
+            ""
+        );
     }
 
-    function test_nonTransferableBypassRoleCanTransferWhenNonTransferable() public {
+    function test_nonTransferableBypassRoleCanTransferWhenNonTransferable()
+        public
+    {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
 
         // ALWAYS non-transferable
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: type(uint256).max});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: type(uint256).max
+            });
 
         LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken nonTransferableToken = new LSP8CustomizableToken(
             name,
@@ -650,30 +888,49 @@ contract LSP8CustomizableTokenTest is Test {
         nonTransferableToken.mint(owner, bytes32(uint256(1)), true, "");
 
         // Owner should be able to transfer
-        nonTransferableToken.transfer(owner, user1, bytes32(uint256(1)), true, "");
+        nonTransferableToken.transfer(
+            owner,
+            user1,
+            bytes32(uint256(1)),
+            true,
+            ""
+        );
         assertEq(nonTransferableToken.balanceOf(user1), 1);
 
         // user1 should NOT be able to transfer
         vm.prank(user1);
         vm.expectRevert(LSP8TransferDisabled.selector);
-        nonTransferableToken.transfer(user1, user2, bytes32(uint256(1)), true, "");
+        nonTransferableToken.transfer(
+            user1,
+            user2,
+            bytes32(uint256(1)),
+            true,
+            ""
+        );
     }
 
     // Burning Tests
     function test_BurningAllowedWhenNonTransferable() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
 
         // ALWAYS non-transferable
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: type(uint256).max});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: type(uint256).max
+            });
 
         LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 0, // tokenBalanceCap = 0 (disabled)
             tokenSupplyCap: 0 // tokenSupplyCap = 0 (disabled)
         });
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: isRevokable});
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: isRevokable
+        });
 
         LSP8CustomizableToken nonTransferableToken = new LSP8CustomizableToken(
             name,
@@ -723,22 +980,23 @@ contract LSP8CustomizableTokenTest is Test {
         assertEq(token.balanceOf(user1), 11);
     }
 
-    function test_TransferOwnershipClearsRevokersAndMigratesOwnerRoles() public {
+    function test_TransferOwnershipClearsRevokersAndMigratesOwnerRoles()
+        public
+    {
         bytes32 revokerRole = token.REVOKER_ROLE();
 
         token.grantRole(revokerRole, revoker1);
         token.grantRole(revokerRole, revoker2);
-        token.grantRole(revokerRole, newOwner);
 
-        assertEq(token.getRoleMemberCount(revokerRole), 4);
+        assertEq(token.getRoleMemberCount(revokerRole), 3);
 
         token.transferOwnership(newOwner);
 
         assertEq(token.owner(), newOwner);
-        assertEq(token.getRoleMemberCount(revokerRole), 0);
+        assertEq(token.getRoleMemberCount(revokerRole), 1);
+        assertTrue(token.hasRole(revokerRole, newOwner));
 
         assertFalse(token.hasRole(revokerRole, owner));
-        assertFalse(token.hasRole(revokerRole, newOwner));
         assertFalse(token.hasRole(revokerRole, revoker1));
         assertFalse(token.hasRole(revokerRole, revoker2));
 
@@ -750,14 +1008,19 @@ contract LSP8CustomizableTokenTest is Test {
         assertTrue(token.hasRole(token.DEFAULT_ADMIN_ROLE(), newOwner));
         assertTrue(token.hasRole(token.MINTER_ROLE(), newOwner));
         assertTrue(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), newOwner));
-        assertTrue(token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), newOwner));
+        assertTrue(
+            token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), newOwner)
+        );
     }
 
-    function test_TransferOwnershipClearsSpecificRoleAdminsOnMultiFeatureToken() public {
+    function test_TransferOwnershipClearsSpecificRoleAdminsOnMultiFeatureToken()
+        public
+    {
         bytes32 minterRole = token.MINTER_ROLE();
         bytes32 revokerRole = token.REVOKER_ROLE();
         bytes32 uncappedRole = token.UNCAPPED_BALANCE_ROLE();
-        bytes32 nonTransferableBypassRole = token.NON_TRANSFERABLE_BYPASS_ROLE();
+        bytes32 nonTransferableBypassRole = token
+            .NON_TRANSFERABLE_BYPASS_ROLE();
 
         bytes32 minterAdminRole = keccak256("MINTER_ADMIN_ROLE");
         bytes32 revokerAdminRole = keccak256("REVOKER_ADMIN_ROLE");
@@ -767,27 +1030,43 @@ contract LSP8CustomizableTokenTest is Test {
         token.setRoleAdmin(minterRole, minterAdminRole);
         token.setRoleAdmin(revokerRole, revokerAdminRole);
         token.setRoleAdmin(uncappedRole, uncappedAdminRole);
-        token.setRoleAdmin(nonTransferableBypassRole, nonTransferableBypassAdminRole);
+        token.setRoleAdmin(
+            nonTransferableBypassRole,
+            nonTransferableBypassAdminRole
+        );
 
         address minterAdmin = makeAddr("a minter admin");
         address revokerAdmin = makeAddr("a revoker admin");
         address uncappedAdmin = makeAddr("a uncapped admin");
-        address nonTransferableBypassAdmin = makeAddr("a non transferable bypass admin");
+        address nonTransferableBypassAdmin = makeAddr(
+            "a non transferable bypass admin"
+        );
 
         assertEq(token.getRoleAdmin(minterRole), minterAdminRole);
         assertEq(token.getRoleAdmin(revokerRole), revokerAdminRole);
         assertEq(token.getRoleAdmin(uncappedRole), uncappedAdminRole);
-        assertEq(token.getRoleAdmin(nonTransferableBypassRole), nonTransferableBypassAdminRole);
+        assertEq(
+            token.getRoleAdmin(nonTransferableBypassRole),
+            nonTransferableBypassAdminRole
+        );
 
         token.grantRole(minterAdminRole, minterAdmin);
         token.grantRole(revokerAdminRole, revokerAdmin);
         token.grantRole(uncappedAdminRole, uncappedAdmin);
-        token.grantRole(nonTransferableBypassAdminRole, nonTransferableBypassAdmin);
+        token.grantRole(
+            nonTransferableBypassAdminRole,
+            nonTransferableBypassAdmin
+        );
 
         assertTrue(token.hasRole(minterAdminRole, minterAdmin));
         assertTrue(token.hasRole(revokerAdminRole, revokerAdmin));
         assertTrue(token.hasRole(uncappedAdminRole, uncappedAdmin));
-        assertTrue(token.hasRole(nonTransferableBypassAdminRole, nonTransferableBypassAdmin));
+        assertTrue(
+            token.hasRole(
+                nonTransferableBypassAdminRole,
+                nonTransferableBypassAdmin
+            )
+        );
 
         vm.prank(minterAdmin);
         token.grantRole(minterRole, address(11111));
@@ -811,37 +1090,59 @@ contract LSP8CustomizableTokenTest is Test {
         assertEq(token.getRoleAdmin(minterRole), token.DEFAULT_ADMIN_ROLE());
         assertEq(token.getRoleAdmin(revokerRole), token.DEFAULT_ADMIN_ROLE());
         assertEq(token.getRoleAdmin(uncappedRole), token.DEFAULT_ADMIN_ROLE());
-        assertEq(token.getRoleAdmin(nonTransferableBypassRole), token.DEFAULT_ADMIN_ROLE());
+        assertEq(
+            token.getRoleAdmin(nonTransferableBypassRole),
+            token.DEFAULT_ADMIN_ROLE()
+        );
 
         // The previous addresses should still have their former Admin roles
         assertTrue(token.hasRole(minterAdminRole, minterAdmin));
         assertTrue(token.hasRole(revokerAdminRole, revokerAdmin));
         assertTrue(token.hasRole(uncappedAdminRole, uncappedAdmin));
-        assertTrue(token.hasRole(nonTransferableBypassAdminRole, nonTransferableBypassAdmin));
+        assertTrue(
+            token.hasRole(
+                nonTransferableBypassAdminRole,
+                nonTransferableBypassAdmin
+            )
+        );
 
         // But they shouldn't be able to use them, it MUST revert if they try to-reuse these admin roles
         // to grant roles, as all the admin roles for these roles have been reset to DEFAULT_ADMIN_ROLE
         vm.expectRevert(
-            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, minterAdmin, token.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(
+                AccessControlUnauthorizedAccount.selector,
+                minterAdmin,
+                token.DEFAULT_ADMIN_ROLE()
+            )
         );
         vm.prank(minterAdmin);
         token.grantRole(minterRole, address(33333));
 
         vm.expectRevert(
-            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, revokerAdmin, token.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(
+                AccessControlUnauthorizedAccount.selector,
+                revokerAdmin,
+                token.DEFAULT_ADMIN_ROLE()
+            )
         );
         vm.prank(revokerAdmin);
         token.grantRole(revokerRole, address(44444));
 
         vm.expectRevert(
-            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, uncappedAdmin, token.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(
+                AccessControlUnauthorizedAccount.selector,
+                uncappedAdmin,
+                token.DEFAULT_ADMIN_ROLE()
+            )
         );
         vm.prank(uncappedAdmin);
         token.grantRole(uncappedRole, address(55555));
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                AccessControlUnauthorizedAccount.selector, nonTransferableBypassAdmin, token.DEFAULT_ADMIN_ROLE()
+                AccessControlUnauthorizedAccount.selector,
+                nonTransferableBypassAdmin,
+                token.DEFAULT_ADMIN_ROLE()
             )
         );
         vm.prank(nonTransferableBypassAdmin);
@@ -879,7 +1180,11 @@ contract LSP8CustomizableTokenTest is Test {
             shouldHaveRevokerRole: true
         });
 
-        assertEq(lockedToken.totalSupply(), 0, "Total supply should be 0 when initialTokenIds_ is empty");
+        assertEq(
+            lockedToken.totalSupply(),
+            0,
+            "Total supply should be 0 when initialTokenIds_ is empty"
+        );
 
         assertTrue(lockedToken.isTransferable());
 
@@ -890,7 +1195,9 @@ contract LSP8CustomizableTokenTest is Test {
         assertTrue(lockedToken.isTransferable());
     }
 
-    function test_MakeTransferableClearsLockAndPreventsFurtherLockUpdates() public {
+    function test_MakeTransferableClearsLockAndPreventsFurtherLockUpdates()
+        public
+    {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
 
         LSP8CustomizableToken lockedToken = _deployToken({
@@ -919,43 +1226,73 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     function test_OwnerCanRevokeFromNonBypassHolderDuringTransferLock() public {
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
 
         _assertRevokeSucceeds(lockedToken, owner, user1, owner);
     }
 
-    function test_RevokerCanRevokeFromNonBypassHolderDuringTransferLock() public {
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
+    function test_RevokerCanRevokeFromNonBypassHolderDuringTransferLock()
+        public
+    {
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
         lockedToken.grantRole(lockedToken.REVOKER_ROLE(), revoker1);
 
         _assertRevokeSucceeds(lockedToken, revoker1, user1, revoker1);
     }
 
     function test_OwnerCanRevokeFromBypassHolderDuringTransferLock() public {
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
-        lockedToken.grantRole(lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(), user1);
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
+        lockedToken.grantRole(
+            lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+            user1
+        );
 
         _assertRevokeSucceeds(lockedToken, owner, user1, owner);
     }
 
     function test_RevokerCanRevokeFromBypassHolderDuringTransferLock() public {
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
         lockedToken.grantRole(lockedToken.REVOKER_ROLE(), revoker1);
-        lockedToken.grantRole(lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(), user1);
+        lockedToken.grantRole(
+            lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+            user1
+        );
 
         _assertRevokeSucceeds(lockedToken, revoker1, user1, revoker1);
     }
 
-    function test_OwnerCanRevokeFromNonBypassHolderOutsideTransferLock() public {
+    function test_OwnerCanRevokeFromNonBypassHolderOutsideTransferLock()
+        public
+    {
         uint256 lockStart = block.timestamp + 1 days;
-        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(lockStart, lockStart + 1 days);
+        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(
+                lockStart,
+                lockStart + 1 days
+            );
 
         _assertRevokeSucceeds(unlockedToken, owner, user1, owner);
     }
 
-    function test_RevokerCanRevokeFromNonBypassHolderOutsideTransferLock() public {
+    function test_RevokerCanRevokeFromNonBypassHolderOutsideTransferLock()
+        public
+    {
         uint256 lockStart = block.timestamp + 1 days;
-        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(lockStart, lockStart + 1 days);
+        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(
+                lockStart,
+                lockStart + 1 days
+            );
         unlockedToken.grantRole(unlockedToken.REVOKER_ROLE(), revoker1);
 
         _assertRevokeSucceeds(unlockedToken, revoker1, user1, revoker1);
@@ -963,24 +1300,41 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_OwnerCanRevokeFromBypassHolderOutsideTransferLock() public {
         uint256 lockStart = block.timestamp + 1 days;
-        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(lockStart, lockStart + 1 days);
-        unlockedToken.grantRole(unlockedToken.NON_TRANSFERABLE_BYPASS_ROLE(), user1);
+        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(
+                lockStart,
+                lockStart + 1 days
+            );
+        unlockedToken.grantRole(
+            unlockedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+            user1
+        );
 
         _assertRevokeSucceeds(unlockedToken, owner, user1, owner);
     }
 
     function test_RevokerCanRevokeFromBypassHolderOutsideTransferLock() public {
         uint256 lockStart = block.timestamp + 1 days;
-        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(lockStart, lockStart + 1 days);
+        LSP8CustomizableToken unlockedToken = _deployRevokableNonTransferableToken(
+                lockStart,
+                lockStart + 1 days
+            );
         unlockedToken.grantRole(unlockedToken.REVOKER_ROLE(), revoker1);
-        unlockedToken.grantRole(unlockedToken.NON_TRANSFERABLE_BYPASS_ROLE(), user1);
+        unlockedToken.grantRole(
+            unlockedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+            user1
+        );
 
         _assertRevokeSucceeds(unlockedToken, revoker1, user1, revoker1);
     }
 
-    function test_RevokerCannotTransferDuringTransferLockWithoutBypassRole() public {
+    function test_RevokerCannotTransferDuringTransferLockWithoutBypassRole()
+        public
+    {
         bytes32 tokenId = bytes32(uint256(1));
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
         lockedToken.grantRole(lockedToken.REVOKER_ROLE(), revoker1);
         lockedToken.mint(revoker1, tokenId, true, "");
 
@@ -988,7 +1342,10 @@ contract LSP8CustomizableTokenTest is Test {
         vm.expectRevert(LSP8TransferDisabled.selector);
         lockedToken.transfer(revoker1, user2, tokenId, true, "");
 
-        lockedToken.grantRole(lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(), revoker1);
+        lockedToken.grantRole(
+            lockedToken.NON_TRANSFERABLE_BYPASS_ROLE(),
+            revoker1
+        );
 
         vm.prank(revoker1);
         lockedToken.transfer(revoker1, user2, tokenId, true, "");
@@ -999,18 +1356,27 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_RevokeToNonOwnerOrNonRevokerRecipientStillReverts() public {
         bytes32 tokenId = bytes32(uint256(1));
-        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(0, type(uint256).max);
+        LSP8CustomizableToken lockedToken = _deployRevokableNonTransferableToken(
+                0,
+                type(uint256).max
+            );
         lockedToken.grantRole(lockedToken.REVOKER_ROLE(), revoker1);
         lockedToken.mint(user1, tokenId, true, "");
 
         vm.expectRevert(
-            abi.encodeWithSelector(AccessControlUnauthorizedAccount.selector, user2, lockedToken.REVOKER_ROLE())
+            abi.encodeWithSelector(
+                AccessControlUnauthorizedAccount.selector,
+                user2,
+                lockedToken.REVOKER_ROLE()
+            )
         );
         vm.prank(revoker1);
         lockedToken.revoke(user1, user2, tokenId, "");
     }
 
-    function test_RevokeDuringTransferLockFailsWhenRevocationIsDisabledEvenIfRoleGranted() public {
+    function test_RevokeDuringTransferLockFailsWhenRevocationIsDisabledEvenIfRoleGranted()
+        public
+    {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
         bytes32 tokenId = bytes32(uint256(1));
         LSP8CustomizableToken nonRevokableToken = _deployToken({
@@ -1032,9 +1398,17 @@ contract LSP8CustomizableTokenTest is Test {
     }
 
     // Fuzzing Tests
-    function testFuzz_MintAmountRespectsBalanceCap(uint8 cap, uint8 currentBalance, uint8 mintAmount) public {
+    function testFuzz_MintAmountRespectsBalanceCap(
+        uint8 cap,
+        uint8 currentBalance,
+        uint8 mintAmount
+    ) public {
         uint256 boundedCap = bound(uint256(cap), 1, 50);
-        uint256 boundedCurrentBalance = bound(uint256(currentBalance), 0, boundedCap);
+        uint256 boundedCurrentBalance = bound(
+            uint256(currentBalance),
+            0,
+            boundedCap
+        );
         uint256 boundedMintAmount = bound(uint256(mintAmount), 1, 50);
         bytes32[] memory emptyTokenIds = new bytes32[](0);
 
@@ -1055,20 +1429,43 @@ contract LSP8CustomizableTokenTest is Test {
         if (boundedMintAmount > availableCapacity) {
             _mintTokenIds(cappedToken, user1, 1_000, availableCapacity);
 
-            vm.expectRevert(abi.encodeWithSelector(LSP8CappedBalanceExceeded.selector, user1, boundedCap, boundedCap));
-            cappedToken.mint(user1, bytes32(1_000 + availableCapacity), true, "");
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    LSP8CappedBalanceExceeded.selector,
+                    user1,
+                    boundedCap,
+                    boundedCap
+                )
+            );
+            cappedToken.mint(
+                user1,
+                bytes32(1_000 + availableCapacity),
+                true,
+                ""
+            );
 
             assertEq(cappedToken.balanceOf(user1), boundedCap);
             return;
         }
 
         _mintTokenIds(cappedToken, user1, 1_000, boundedMintAmount);
-        assertEq(cappedToken.balanceOf(user1), boundedCurrentBalance + boundedMintAmount);
+        assertEq(
+            cappedToken.balanceOf(user1),
+            boundedCurrentBalance + boundedMintAmount
+        );
     }
 
-    function testFuzz_TransferAmountRespectsBalanceCap(uint8 cap, uint8 currentBalance, uint8 transferAmount) public {
+    function testFuzz_TransferAmountRespectsBalanceCap(
+        uint8 cap,
+        uint8 currentBalance,
+        uint8 transferAmount
+    ) public {
         uint256 boundedCap = bound(uint256(cap), 1, 50);
-        uint256 boundedCurrentBalance = bound(uint256(currentBalance), 0, boundedCap);
+        uint256 boundedCurrentBalance = bound(
+            uint256(currentBalance),
+            0,
+            boundedCap
+        );
         uint256 boundedTransferAmount = bound(uint256(transferAmount), 1, 50);
         bytes32[] memory emptyTokenIds = new bytes32[](0);
 
@@ -1089,11 +1486,30 @@ contract LSP8CustomizableTokenTest is Test {
 
         if (boundedTransferAmount > availableCapacity) {
             for (uint256 i = 0; i < availableCapacity; i++) {
-                cappedToken.transfer(owner, user1, bytes32(10_000 + i), true, "");
+                cappedToken.transfer(
+                    owner,
+                    user1,
+                    bytes32(10_000 + i),
+                    true,
+                    ""
+                );
             }
 
-            vm.expectRevert(abi.encodeWithSelector(LSP8CappedBalanceExceeded.selector, user1, boundedCap, boundedCap));
-            cappedToken.transfer(owner, user1, bytes32(10_000 + availableCapacity), true, "");
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    LSP8CappedBalanceExceeded.selector,
+                    user1,
+                    boundedCap,
+                    boundedCap
+                )
+            );
+            cappedToken.transfer(
+                owner,
+                user1,
+                bytes32(10_000 + availableCapacity),
+                true,
+                ""
+            );
 
             assertEq(cappedToken.balanceOf(user1), boundedCap);
             return;
@@ -1103,10 +1519,16 @@ contract LSP8CustomizableTokenTest is Test {
             cappedToken.transfer(owner, user1, bytes32(10_000 + i), true, "");
         }
 
-        assertEq(cappedToken.balanceOf(user1), boundedCurrentBalance + boundedTransferAmount);
+        assertEq(
+            cappedToken.balanceOf(user1),
+            boundedCurrentBalance + boundedTransferAmount
+        );
     }
 
-    function testFuzz_MintAmountRespectsSupplyCap(uint8 cap, uint8 amountToMint) public {
+    function testFuzz_MintAmountRespectsSupplyCap(
+        uint8 cap,
+        uint8 amountToMint
+    ) public {
         uint256 boundedCap = bound(uint256(cap), 1, 100);
         uint256 boundedAmountToMint = bound(uint256(amountToMint), 1, 150);
         bytes32[] memory emptyTokenIds = new bytes32[](0);
@@ -1138,9 +1560,15 @@ contract LSP8CustomizableTokenTest is Test {
 
     function test_ConstructorInitializesCorrectlyWithSomeTokenIds() public {
         bytes32[] memory someTokenIds = new bytes32[](3);
-        someTokenIds[0] = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
-        someTokenIds[1] = 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
-        someTokenIds[2] = 0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc;
+        someTokenIds[
+            0
+        ] = 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+        someTokenIds[
+            1
+        ] = 0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+        someTokenIds[
+            2
+        ] = 0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc;
 
         LSP8CustomizableToken customToken = _deployToken({
             mintable_: true,
@@ -1170,14 +1598,23 @@ contract LSP8CustomizableTokenTest is Test {
     function test_RevokeFailsWhenRevocationIsDisabled() public {
         bytes32 revokerRole = token.REVOKER_ROLE();
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: isMintable, initialMintTokenIds: emptyTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: transferLockStart, transferLockEnd: transferLockEnd});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: isMintable,
+            initialMintTokenIds: emptyTokenIds
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: transferLockStart,
+                transferLockEnd: transferLockEnd
+            });
 
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: tokenBalanceCap, tokenSupplyCap: tokenSupplyCap});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: false});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: tokenBalanceCap,
+            tokenSupplyCap: tokenSupplyCap
+        });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: false
+        });
 
         LSP8CustomizableToken nonRevokableToken = new LSP8CustomizableToken(
             name,

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
@@ -14,7 +14,9 @@ import {
     LSP8CappedParams,
     LSP8RevokableParams
 } from "../contracts/presets/LSP8CustomizableTokenConstants.sol";
-import {LSP8TransferDisabled} from "../contracts/extensions/LSP8NonTransferable/LSP8NonTransferableErrors.sol";
+import {
+    LSP8TransferDisabled
+} from "../contracts/extensions/LSP8NonTransferable/LSP8NonTransferableErrors.sol";
 import {
     LSP8CappedSupplyCannotMintOverCap
 } from "../contracts/extensions/LSP8CappedSupply/LSP8CappedSupplyErrors.sol";
@@ -44,15 +46,15 @@ contract LSP8CustomizableTokenInitTest is Test {
             isMintable: true,
             initialMintTokenIds: initialTokenIds
         });
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 5,
+            tokenSupplyCap: 100
+        });
         LSP8NonTransferableParams
             memory nonTransferableParams = LSP8NonTransferableParams({
                 transferLockStart: 0,
                 transferLockEnd: 0
             });
-        LSP8CappedParams memory cappedParams = LSP8CappedParams({
-            tokenBalanceCap: 5,
-            tokenSupplyCap: 100
-        });
         LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
             isRevokable: true
         });
@@ -65,8 +67,8 @@ contract LSP8CustomizableTokenInitTest is Test {
             _LSP4_TOKEN_TYPE_NFT,
             0,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
@@ -81,17 +83,26 @@ contract LSP8CustomizableTokenInitTest is Test {
 
         LSP8CustomizableTokenInit implementation = new LSP8CustomizableTokenInit();
         address instance = Clones.clone(address(implementation));
-        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(payable(instance));
+        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(
+            payable(instance)
+        );
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: true, initialMintTokenIds: tooManyTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: tooManyTokenIds
+        });
         LSP8CappedParams memory cappedParams = LSP8CappedParams({
             tokenBalanceCap: 5,
             tokenSupplyCap: supplyCap
         });
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: true});
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         token.initialize(
@@ -101,35 +112,42 @@ contract LSP8CustomizableTokenInitTest is Test {
             _LSP4_TOKEN_TYPE_NFT,
             tokenIdFormat,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
 
     /// @dev LSP8 premints one NFT per id; bound counts so fuzzing stays within practical gas.
-    function test_InitializeNonMintableInitialMintOverSupplyCapReverts(uint256 supplyCap, uint256 preMintCount)
-        public
-    {
+    function test_InitializeNonMintableInitialMintOverSupplyCapReverts(
+        uint256 supplyCap,
+        uint256 preMintCount
+    ) public {
         supplyCap = bound(supplyCap, 1, 128);
         preMintCount = bound(preMintCount, supplyCap + 1, supplyCap + 64);
 
         LSP8CustomizableTokenInit implementation = new LSP8CustomizableTokenInit();
         address instance = Clones.clone(address(implementation));
-        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(payable(instance));
+        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(
+            payable(instance)
+        );
 
         LSP8MintableParams memory mintableParams = LSP8MintableParams({
             isMintable: false,
             initialMintTokenIds: _preMintTokenIds(preMintCount)
         });
-
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
-
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: supplyCap});
-
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: false});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: supplyCap
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: false
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         token.initialize(
@@ -139,14 +157,16 @@ contract LSP8CustomizableTokenInitTest is Test {
             _LSP4_TOKEN_TYPE_NFT,
             tokenIdFormat,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
 
     /// @dev Same revert as `test_InitializeNonMintableInitialMintOverSupplyCapReverts` but with an explicit `bytes32[]` (not only sequential ids).
-    function test_InitializeNonMintableInitialMintOverSupplyCapRevertsWithExplicitTokenIds() public {
+    function test_InitializeNonMintableInitialMintOverSupplyCapRevertsWithExplicitTokenIds()
+        public
+    {
         uint256 supplyCap = 4;
         bytes32[] memory tokenIds = new bytes32[](5);
         tokenIds[0] = keccak256("id-a");
@@ -157,18 +177,26 @@ contract LSP8CustomizableTokenInitTest is Test {
 
         LSP8CustomizableTokenInit implementation = new LSP8CustomizableTokenInit();
         address instance = Clones.clone(address(implementation));
-        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(payable(instance));
+        LSP8CustomizableTokenInit token = LSP8CustomizableTokenInit(
+            payable(instance)
+        );
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: false, initialMintTokenIds: tokenIds});
-
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
-
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: supplyCap});
-
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: false});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: false,
+            initialMintTokenIds: tokenIds
+        });
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: supplyCap
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: false
+        });
 
         vm.expectRevert(LSP8CappedSupplyCannotMintOverCap.selector);
         token.initialize(
@@ -178,14 +206,16 @@ contract LSP8CustomizableTokenInitTest is Test {
             _LSP4_TOKEN_TYPE_NFT,
             tokenIdFormat,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
 
     /// @dev LSP8 mints one NFT per id; use a moderate count so the test stays within practical gas (LSP7 uses one _mint of 1_000_000).
-    function _preMintTokenIds(uint256 count) internal pure returns (bytes32[] memory ids) {
+    function _preMintTokenIds(
+        uint256 count
+    ) internal pure returns (bytes32[] memory ids) {
         ids = new bytes32[](count);
         for (uint256 i = 0; i < count; ++i) {
             ids[i] = bytes32(i + 1);
@@ -217,8 +247,8 @@ contract LSP8CustomizableTokenInitTest is Test {
 
         LSP8CustomizableTokenInit nonMintableToken = _deployClone(
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
 
@@ -229,8 +259,8 @@ contract LSP8CustomizableTokenInitTest is Test {
 
     function _deployClone(
         LSP8MintableParams memory mintableParams,
-        LSP8NonTransferableParams memory nonTransferableParams,
         LSP8CappedParams memory cappedParams,
+        LSP8NonTransferableParams memory nonTransferableParams,
         LSP8RevokableParams memory revokableParams
     ) internal returns (LSP8CustomizableTokenInit token) {
         LSP8CustomizableTokenInit implementation = new LSP8CustomizableTokenInit();
@@ -243,8 +273,8 @@ contract LSP8CustomizableTokenInitTest is Test {
             _LSP4_TOKEN_TYPE_NFT,
             tokenIdFormat,
             mintableParams,
-            nonTransferableParams,
             cappedParams,
+            nonTransferableParams,
             revokableParams
         );
     }
@@ -255,16 +285,28 @@ contract LSP8CustomizableTokenInitTest is Test {
         bytes32[] memory initialTokenIds = new bytes32[](1);
         initialTokenIds[0] = bytes32(uint256(1));
 
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: true, initialMintTokenIds: initialTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams =
-            LSP8NonTransferableParams({transferLockStart: 0, transferLockEnd: 0});
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: 0});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: true});
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: initialTokenIds
+        });
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
 
         LSP8CustomizableTokenInit token = _deployClone(
-            mintableParams, nonTransferableParams, cappedParams, revokableParams
+            mintableParams,
+            cappedParams,
+            nonTransferableParams,
+            revokableParams
         );
 
         bytes32 tokenId = bytes32(uint256(1));
@@ -279,18 +321,28 @@ contract LSP8CustomizableTokenInitTest is Test {
 
     function test_TransferDisabledWhenNonTransferableViaEip1167Clone() public {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: true, initialMintTokenIds: emptyTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams = LSP8NonTransferableParams({
-            transferLockStart: 0,
-            transferLockEnd: type(uint256).max
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: emptyTokenIds
         });
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: 0});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: true});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: type(uint256).max
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
 
         LSP8CustomizableTokenInit token = _deployClone(
-            mintableParams, nonTransferableParams, cappedParams, revokableParams
+            mintableParams,
+            cappedParams,
+            nonTransferableParams,
+            revokableParams
         );
 
         bytes32 tokenId = bytes32(uint256(1));
@@ -301,23 +353,35 @@ contract LSP8CustomizableTokenInitTest is Test {
         token.transfer(user1, user2, tokenId, true, "");
     }
 
-    function test_TransferRevertsDuringBoundedLockWindowViaEip1167Clone() public {
+    function test_TransferRevertsDuringBoundedLockWindowViaEip1167Clone()
+        public
+    {
         uint256 lockStart = block.timestamp + 1 days;
         uint256 lockEnd = lockStart + 1 days;
 
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: true, initialMintTokenIds: emptyTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams = LSP8NonTransferableParams({
-            transferLockStart: lockStart,
-            transferLockEnd: lockEnd
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: emptyTokenIds
         });
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: 0});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: true});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: lockStart,
+                transferLockEnd: lockEnd
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
 
         LSP8CustomizableTokenInit token = _deployClone(
-            mintableParams, nonTransferableParams, cappedParams, revokableParams
+            mintableParams,
+            cappedParams,
+            nonTransferableParams,
+            revokableParams
         );
 
         bytes32 tokenId = bytes32(uint256(1));
@@ -343,18 +407,28 @@ contract LSP8CustomizableTokenInitTest is Test {
         public
     {
         bytes32[] memory emptyTokenIds = new bytes32[](0);
-        LSP8MintableParams memory mintableParams =
-            LSP8MintableParams({isMintable: true, initialMintTokenIds: emptyTokenIds});
-        LSP8NonTransferableParams memory nonTransferableParams = LSP8NonTransferableParams({
-            transferLockStart: 0,
-            transferLockEnd: type(uint256).max
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: emptyTokenIds
         });
-        LSP8CappedParams memory cappedParams =
-            LSP8CappedParams({tokenBalanceCap: 0, tokenSupplyCap: 0});
-        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({isRevokable: true});
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 0,
+            tokenSupplyCap: 0
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: type(uint256).max
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
 
         LSP8CustomizableTokenInit token = _deployClone(
-            mintableParams, nonTransferableParams, cappedParams, revokableParams
+            mintableParams,
+            cappedParams,
+            nonTransferableParams,
+            revokableParams
         );
 
         bytes32 tokenId = bytes32(uint256(1));

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
@@ -487,7 +487,7 @@ contract LSP8CustomizableTokenInitTest is Test {
         token.grantRole(revokerRole, revoker1);
         token.grantRole(revokerRole, revoker2);
 
-        // Owner is granted the REVOKER_ROLE on initialize, so we expect 4 holders
+        // Owner is granted the REVOKER_ROLE on initialize, so we expect 3 holders
         assertEq(token.getRoleMemberCount(revokerRole), 3);
 
         token.transferOwnership(newOwner);

--- a/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
+++ b/packages/lsp8-contracts/foundry/LSP8CustomizableTokenInit.t.sol
@@ -30,7 +30,9 @@ contract LSP8CustomizableTokenInitTest is Test {
     address internal owner = address(this);
     address internal user1 = vm.addr(101);
     address internal user2 = vm.addr(102);
+    address internal newOwner = vm.addr(103);
     address internal revoker1 = vm.addr(104);
+    address internal revoker2 = vm.addr(105);
 
     function test_InitImplementationCannotBeInitializedAfterDeployment()
         public
@@ -446,5 +448,68 @@ contract LSP8CustomizableTokenInitTest is Test {
 
         assertEq(token.balanceOf(revoker1), 0);
         assertEq(token.tokenOwnerOf(tokenId), user2);
+    }
+
+    function test_TransferOwnershipClearsRevokersAndMigratesOwnerRolesViaEip1167Clone()
+        public
+    {
+        bytes32[] memory initialTokenIds = new bytes32[](3);
+        initialTokenIds[0] = bytes32(uint256(1));
+        initialTokenIds[1] = bytes32(uint256(2));
+        initialTokenIds[2] = bytes32(uint256(3));
+
+        LSP8MintableParams memory mintableParams = LSP8MintableParams({
+            isMintable: true,
+            initialMintTokenIds: initialTokenIds
+        });
+        LSP8CappedParams memory cappedParams = LSP8CappedParams({
+            tokenBalanceCap: 5,
+            tokenSupplyCap: 100
+        });
+        LSP8NonTransferableParams
+            memory nonTransferableParams = LSP8NonTransferableParams({
+                transferLockStart: 0,
+                transferLockEnd: 0
+            });
+        LSP8RevokableParams memory revokableParams = LSP8RevokableParams({
+            isRevokable: true
+        });
+
+        LSP8CustomizableTokenInit token = _deployClone(
+            mintableParams,
+            cappedParams,
+            nonTransferableParams,
+            revokableParams
+        );
+
+        bytes32 revokerRole = token.REVOKER_ROLE();
+
+        token.grantRole(revokerRole, revoker1);
+        token.grantRole(revokerRole, revoker2);
+
+        // Owner is granted the REVOKER_ROLE on initialize, so we expect 4 holders
+        assertEq(token.getRoleMemberCount(revokerRole), 3);
+
+        token.transferOwnership(newOwner);
+
+        assertEq(token.owner(), newOwner);
+        assertEq(token.getRoleMemberCount(revokerRole), 1);
+        assertTrue(token.hasRole(revokerRole, newOwner));
+
+        assertFalse(token.hasRole(revokerRole, owner));
+        assertFalse(token.hasRole(revokerRole, revoker1));
+        assertFalse(token.hasRole(revokerRole, revoker2));
+
+        assertFalse(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner));
+        assertFalse(token.hasRole(token.MINTER_ROLE(), owner));
+        assertFalse(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), owner));
+        assertFalse(token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), owner));
+
+        assertTrue(token.hasRole(token.DEFAULT_ADMIN_ROLE(), newOwner));
+        assertTrue(token.hasRole(token.MINTER_ROLE(), newOwner));
+        assertTrue(token.hasRole(token.UNCAPPED_BALANCE_ROLE(), newOwner));
+        assertTrue(
+            token.hasRole(token.NON_TRANSFERABLE_BYPASS_ROLE(), newOwner)
+        );
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to LUKSO! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- Consider checking CONTRIBUTING.md before contributing. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

# What does this PR introduce?

- Adjust param order for LSP8 Customizable token
- Fix removing `REVOKER_ROLE` to new owner on transfer ownership
- Add storage gaps to every `*InitAbstract` contracts for new token extension contracts
- Set `mintable_` param to `true` for Mintable preset contracts in LSP7 and LSP8 packages
- Improve Natspec comments for unexpected behaviours, and documentation clarity

<!-- Keep the sub-header that suits the PR and remove the rest -->

<!-- Changes that potentially causes other components to fail (changes in interfaceIds, function signatures, behavior, etc ..) --->

<!---
## ⚠️ BREAKING CHANGES
## 🚀 Feature
## 🐛 Bug
## ♻️ Refactor
## 🧪 Tests
## ⚡️ Performance
## 🎨 Style
## 📄 Documentation
## 📦 Build
## 🤖 CI
---->

<!---
Fixes #<Fill in with issue number>
---->

<!-- Describe the changes introduced in this pull request here. -->

<!-- Include any context necessary for understanding the PR's purpose. (Images, links, etc ..) -->

### PR Checklist

<!-- Before merging the pull request, making sure you have run locally the following. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- (Some of the items may not apply.) -->

- [ ] Wrote Tests
- [ ] Wrote & Generated Documentation (readme/natspec/dodoc)
- [ ] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [ ] Ran `npm run format` (prettier)
- [ ] Ran `npm run build`
- [ ] Ran `npm run test`
