### PR TITLE
ci(main): switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
@@ -15,8 +16,6 @@ jobs:
       release_outputs: ${{ steps.release.outputs }}
     runs-on: ubuntu-latest
     environment: publish
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_KEY }}
 
     steps:
       - uses: google-github-actions/release-please-action@v3
@@ -44,6 +43,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           scope: "@lukso"
           cache: "npm"
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1.
+      # Node 24 ships with npm 11, but pin to latest to guarantee the version.
+      - name: Upgrade npm
+        if: ${{ steps.release.outputs.releases_created }}
+        run: npm install -g npm@latest
 
       - name: Install Dependencies
         if: ${{ steps.release.outputs.releases_created }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-registry=https://registry.npmjs.org/
-always-auth=true


### PR DESCRIPTION
> Replaces PR #1109 to target the `main` branch (PR #1109 targets `develop` and has merge conflicts when changing the target branch. I cherry picked the commit.

## Summary
- Replaces the long-lived `NPM_PUBLISH_KEY` secret with [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) via GitHub OIDC.
- Adds `id-token: write` permission, drops the `NODE_AUTH_TOKEN` env, bumps the release runner to Node 24, and force-upgrades to latest npm so the `>=11.5.1` trusted-publishing requirement is guaranteed.
- Removes the committed `.npmrc` (the `_authToken=${NODE_AUTH_TOKEN}` reference is no longer used; `actions/setup-node` writes a fresh project `.npmrc` at job time and OIDC supplies credentials at publish).

## Before merging — npmjs.com configuration required

Each `@lukso/*` package below must be configured on npmjs.com → Package settings → **Publishing access** → Add trusted publisher (GitHub Actions), with:
- Organization: `lukso-network`
- Repository: `lsp-smart-contracts`
- Workflow filename: `release.yml`
- Environment: `publish`

Packages (24):

- `@lukso/lsp-smart-contracts`
- `@lukso/lsp0-contracts`
- `@lukso/lsp1-contracts`
- `@lukso/lsp1delegate-contracts`
- `@lukso/lsp2-contracts`
- `@lukso/lsp3-contracts`
- `@lukso/lsp4-contracts`
- `@lukso/lsp5-contracts`
- `@lukso/lsp6-contracts`
- `@lukso/lsp7-contracts`
- `@lukso/lsp8-contracts`
- `@lukso/lsp9-contracts`
- `@lukso/lsp10-contracts`
- `@lukso/lsp11-contracts`
- `@lukso/lsp12-contracts`
- `@lukso/lsp14-contracts`
- `@lukso/lsp16-contracts`
- `@lukso/lsp17-contracts`
- `@lukso/lsp17contractextension-contracts`
- `@lukso/lsp20-contracts`
- `@lukso/lsp23-contracts`
- `@lukso/lsp25-contracts`
- `@lukso/lsp26-contracts`
- `@lukso/universalprofile-contracts`

## Notes
- `LUKSO_NPM_TOKEN` is **not** referenced anywhere in the repo, so this PR doesn't touch it. If a future build ever needs it for private modules, re-introduce it as a regular secret on the specific job.
- Once trusted publishing is configured on all packages, the `NPM_PUBLISH_KEY` repo secret can be deleted.
- Trusted publishing automatically attaches provenance attestations to published packages — no explicit `--provenance` flag needed in `publish.mjs`.

## Test plan
- [ ] All 24 packages configured on npmjs.com with the trusted publisher entry above
- [ ] Merge this PR into `develop`, then merge `develop` → `main` to trigger `release.yml`
- [ ] Confirm the `release-please` job's "Publish on NPM" step succeeds without `NODE_AUTH_TOKEN`
- [ ] Verify the new package versions show up on npmjs.com with provenance badges
- [ ] After a successful release, delete the `NPM_PUBLISH_KEY` repo secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)