### PR TITLE
fix: repair broken imports in publish.mjs and deploy-verify.mjs

### DIFF
--- a/deploy-verify.mjs
+++ b/deploy-verify.mjs
@@ -1,6 +1,18 @@
 #!/usr/bin/env node
-import { readFile } from 'fs/promises';
-import { $ } from 'zx';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+function run(cmd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, { shell: true, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      code === 0
+        ? resolve()
+        : reject(new Error(`Command failed (exit ${code}): ${cmd}`));
+    });
+  });
+}
 
 const outputs = JSON.parse(await readFile(process.argv[2], 'utf-8'));
 const network = process.argv[3];
@@ -8,11 +20,14 @@ for (const key in outputs) {
   const value = outputs[key];
   const match = key.match(/^(.*\/.*)--release_created$/);
 
-  // Skip if no release was created for this LSP package
   if (!match || !value) continue;
 
   const workspace = match[1];
 
-  await $`npm run verify-balance --workspace=./${workspace} -- --network ${network}`;
-  await $`npm run deploy:base --workspace=./${workspace} -- --network ${network}`;
+  await run(
+    `npm run verify-balance --workspace=./${workspace} -- --network ${network}`,
+  );
+  await run(
+    `npm run deploy:base --workspace=./${workspace} -- --network ${network}`,
+  );
 }

--- a/packages/lsp-smart-contracts/README.md
+++ b/packages/lsp-smart-contracts/README.md
@@ -1,6 +1,6 @@
 # `@lukso/lsp-smart-contracts`
 
-This is the _"umbrella"_ package for the LSP smart contracts. It contains all the individual `@lukso/lspN-contracts` packages (where `N` is an LSP number) as dependencies.
+This is the npm _"umbrella"_ package for the LSP smart contracts. It contains all the individual `@lukso/lspN-contracts` packages (where `N` is an LSP number) as dependencies.
 
 ## Installation
 

--- a/packages/lsp0-contracts/README.md
+++ b/packages/lsp0-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP0 ERC725Account &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp0-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp0-contracts)
 
-Package for the LSP0 ERC725Account standard.
+npm package for the LSP0 ERC725Account standard.
 
 ## Installation
 

--- a/packages/lsp1-contracts/README.md
+++ b/packages/lsp1-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP1 Universal Receiver &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp1-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp1-contracts)
 
-Package for the LSP1 Universal Receiver standard.
+npm package for the LSP1 Universal Receiver standard.
 
 ## Installation
 

--- a/packages/lsp10-contracts/README.md
+++ b/packages/lsp10-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP10 Received Vaults &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp10-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp10-contracts)
 
-Package for the LSP10 Received Vaults standard.
+npm package for the LSP10 Received Vaults standard.
 
 ## Installation
 

--- a/packages/lsp11-contracts/README.md
+++ b/packages/lsp11-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP11 Social Recovery
 
-Package for the [LSP11 Social Recovery](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-11-BasicSocialRecovery.md) standard.
+npm package for the [LSP11 Social Recovery](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-11-BasicSocialRecovery.md) standard.
 
 ## Installation
 

--- a/packages/lsp12-contracts/README.md
+++ b/packages/lsp12-contracts/README.md
@@ -1,6 +1,6 @@
-# &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp12-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp12-contracts)
+# LSP12 Issued Assets &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp12-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp12-contracts)
 
-Package for the LSP12 Issued Assets standard.
+npm package for the LSP12 Issued Assets standard.
 
 ## Installation
 

--- a/packages/lsp14-contracts/README.md
+++ b/packages/lsp14-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP14 Ownable 2 Step &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp14-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp14-contracts)
 
-Package for the LSP14 Ownable 2 Step standard.
+npm package for the LSP14 Ownable 2 Step standard.
 
 ## Installation
 

--- a/packages/lsp16-contracts/README.md
+++ b/packages/lsp16-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP16 Universal Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp16-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp16-contracts)
 
-Package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard, contains the `LSP16UniversalFactory` contract that allows deploying contracts at the same address on multiple chains.
+npm package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard, contains the `LSP16UniversalFactory` contract that allows deploying contracts at the same address on multiple chains.
 
 ## Installation
 

--- a/packages/lsp17-contracts/README.md
+++ b/packages/lsp17-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP17 Extensions Package &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp17-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp17-contracts)
 
-Package for the LSP17 Extensions, that includes the following extensions:
+npm package for the LSP17 Extensions, that includes the following extensions:
 
 - `Extension4337` extension, which contains the `validateUserOp` function from the [`ERC4337` standard](https://eips.ethereum.org/EIPS/eip-4337).
 - `OnERC721ReceivedExtension` extension that contains the `onERC721Received` function from the [`ERC721` standard](https://eips.ethereum.org/EIPS/eip-721).

--- a/packages/lsp17contractextension-contracts/README.md
+++ b/packages/lsp17contractextension-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP17 Contract Extension Package &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp17contractextension-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp17contractextension-contracts)
 
-Package for the LSP17 Contract Extension
+npm package for the LSP17 Contract Extension.
 
 ## Installation
 

--- a/packages/lsp1delegate-contracts/README.md
+++ b/packages/lsp1delegate-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP1 Universal Receiver Delegate &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp1delegate-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp1delegate-contracts)
 
-Smart contract implementations of [LSP1 Universal Receiver Delegate](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-1-UniversalReceiver.md#universalreceiver-delegation)
+npm package with smart contract implementations of [LSP1 Universal Receiver Delegate](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-1-UniversalReceiver.md#universalreceiver-delegation)
 to register and manage:
 
 - LSP5 Received Assets

--- a/packages/lsp2-contracts/README.md
+++ b/packages/lsp2-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP2 ERC725Y JSON Schema &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp2-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp2-contracts)
 
-Package for the LSP2 ERC725Y JSON Schema standard.
+npm package for the LSP2 ERC725Y JSON Schema standard.
 
 ## Installation
 

--- a/packages/lsp20-contracts/README.md
+++ b/packages/lsp20-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP20 Call Verification &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp20-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp20-contracts)
 
-Package for the LSP20 Call Verification standard.
+npm package for the LSP20 Call Verification standard.
 
 ## Installation
 

--- a/packages/lsp23-contracts/README.md
+++ b/packages/lsp23-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP23 Linked Contracts Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp23-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp23-contracts)
 
-Package for the LSP23 Linked Contracts Factory. Contains the JSON artifacts (ABI, bytecode...) and the `LSP23LinkedContractsFactory`.
+npm package for the LSP23 Linked Contracts Factory. Contains the JSON artifacts (ABI, bytecode...) and the `LSP23LinkedContractsFactory`.
 
 ## Installation
 

--- a/packages/lsp25-contracts/README.md
+++ b/packages/lsp25-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP25 Execute Relay Call &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp25-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp25-contracts)
 
-Package for the LSP25 Execute Relay Call standard.
+npm package for the LSP25 Execute Relay Call standard.
 
 ## Installation
 

--- a/packages/lsp26-contracts/README.md
+++ b/packages/lsp26-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP26 Follower System &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp26-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp26-contracts)
 
-Package for the LSP26 Follower System standard.
+npm package for the LSP26 Follower System standard.
 
 ## Installation
 

--- a/packages/lsp3-contracts/README.md
+++ b/packages/lsp3-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP3 Profile Metadata &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp3-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp3-contracts)
 
-Package for the LSP3 Profile Metadata standard.
+npm package for the LSP3 Profile Metadata standard.
 
 ## Installation
 

--- a/packages/lsp4-contracts/README.md
+++ b/packages/lsp4-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP4 Digital Asset Metadata &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp4-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp4-contracts)
 
-Package for the LSP4 Digital Asset Metadata standard.
+npm package for the LSP4 Digital Asset Metadata standard.
 
 ## Installation
 

--- a/packages/lsp5-contracts/README.md
+++ b/packages/lsp5-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP5 Received Assets &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp5-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp5-contracts)
 
-Package for the LSP5 Received Assets standard.
+npm package for the LSP5 Received Assets standard.
 
 ## Installation
 

--- a/packages/lsp6-contracts/README.md
+++ b/packages/lsp6-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP6 Key Manager &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp6-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp6-contracts)
 
-Package for the LSP6 Key Manager standard, to enable granting multiple permissions to controllers.
+npm package for the LSP6 Key Manager standard, to enable granting multiple permissions to controllers.
 
 ## Installation
 

--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP7 Digital Asset &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp7-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp7-contracts)
 
-Package for the LSP7 Digital Asset standard.
+npm package for the LSP7 Digital Asset standard.
 
 ## Audits
 

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP8 Identifiable Digital Asset &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp8-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp8-contracts)
 
-Package for the LSP8 Identifiable Digital Asset Standard.
+npm package for the LSP8 Identifiable Digital Asset standard.
 
 ## Audits
 

--- a/packages/lsp9-contracts/README.md
+++ b/packages/lsp9-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP9 Vault &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp9-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp9-contracts)
 
-Package for the LSP9 Vault standard.
+npm package for the LSP9 Vault standard.
 
 ## Installation
 

--- a/packages/universalprofile-contracts/README.md
+++ b/packages/universalprofile-contracts/README.md
@@ -1,6 +1,6 @@
 # Universal Profile &middot; [![npm version](https://img.shields.io/npm/v/@lukso/universalprofile-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/universalprofile-contracts)
 
-Smart Contract implementation for **Universal Profile**, a combination of LSP0 ERC725 Account and LSP3 Profile Metadata.
+npm package: smart contract implementation for **Universal Profile**, a combination of LSP0 ERC725 Account and LSP3 Profile Metadata.
 
 ## Installation
 

--- a/publish.mjs
+++ b/publish.mjs
@@ -1,28 +1,35 @@
 #!/usr/bin/env node
-import { readFile } from 'fs/promises';
-import { exec } from 'node:child_process/promises';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+function run(cmd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, { shell: true, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      code === 0
+        ? resolve()
+        : reject(new Error(`Command failed (exit ${code}): ${cmd}`));
+    });
+  });
+}
 
 const outputs = JSON.parse(await readFile(process.argv[2], 'utf-8'));
 for (const key in outputs) {
   const value = outputs[key];
   const match = key.match(/^(.*\/.*)--release_created$/);
 
-  // Skip if no release was created for this LSP package
   if (!match || !value) continue;
 
   let tag = 'latest';
-
   const version = outputs[`${match[1]}--version`];
-
-  // Do not publish as latest on npm if we are doing a release candidate
-  if (version != null && version.includes('-rc')) {
+  if (version?.includes('-rc')) {
     tag = 'rc';
   }
 
   const workspace = match[1];
-  // log the files and folders include in each package
-  await exec(`npm pack --workspace=./${workspace}`);
-
-  // publish to npm registry
-  await exec(`npm publish --workspace=./${workspace} --tag ${tag} --no-git-checks --access public`);
+  await run(`npm pack --workspace=./${workspace}`);
+  await run(
+    `npm publish --workspace=./${workspace} --tag ${tag} --no-git-checks --access public`,
+  );
 }


### PR DESCRIPTION
## Summary
- `publish.mjs` imported from `node:child_process/promises`, which isn't a real built-in subpath — the module fails to load with `ERR_UNKNOWN_BUILTIN_MODULE`. Broken since 8ecf97e1d ("build: remove \`zx\` dependency and replace by \`exec\`").
- `deploy-verify.mjs` still imported \`\$\` from \`zx\` after \`zx\` was removed from \`package.json\` in the same commit — crashes at module load.
- Both run from the release workflow ([release.yml:83](.github/workflows/release.yml#L83), [release.yml:118](.github/workflows/release.yml#L118)), so the next release-please publish would have failed.
- Replace with a small inline \`run()\` helper using \`spawn\` with \`shell: true\` and \`stdio: 'inherit'\` so stdout/stderr stream live into the CI log (no buffering, no 1 MB \`maxBuffer\` ceiling).

## Test plan
- [x] \`node --check\` passes on both files
- [x] Smoke test of the \`run()\` helper confirms streaming output and non-zero exit propagation
- [ ] Real verification has to wait until the next release-please cycle actually fires the publish/deploy-verify jobs