### PR TITLE
chore: add repository field to all child package.json files

### DIFF
--- a/config/eslint-config-custom/package.json
+++ b/config/eslint-config-custom/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "config/eslint-config-custom"
   },
   "type": "module",
   "private": true,

--- a/config/eslint-config-custom/package.json
+++ b/config/eslint-config-custom/package.json
@@ -1,6 +1,10 @@
 {
   "name": "eslint-config-custom",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "private": true,
   "exports": {

--- a/config/hardhat-packager-v3/package.json
+++ b/config/hardhat-packager-v3/package.json
@@ -9,7 +9,8 @@
   "author": "LUKSO",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "config/hardhat-packager-v3"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/config/hardhat-packager-v3/package.json
+++ b/config/hardhat-packager-v3/package.json
@@ -7,6 +7,10 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "author": "LUKSO",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "license": "Apache-2.0",
   "keywords": [
     "hardhat",

--- a/config/hardhat-verify-balance/package.json
+++ b/config/hardhat-verify-balance/package.json
@@ -7,6 +7,10 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "author": "LUKSO",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "license": "Apache-2.0",
   "keywords": [
     "hardhat",

--- a/config/hardhat-verify-balance/package.json
+++ b/config/hardhat-verify-balance/package.json
@@ -9,7 +9,8 @@
   "author": "LUKSO",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "config/hardhat-verify-balance"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/config/solhint-config-lsp-solidity-linting-rules/package.json
+++ b/config/solhint-config-lsp-solidity-linting-rules/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "config/solhint-config-lsp-solidity-linting-rules"
   },
   "private": true,
   "exports": {

--- a/config/solhint-config-lsp-solidity-linting-rules/package.json
+++ b/config/solhint-config-lsp-solidity-linting-rules/package.json
@@ -1,6 +1,10 @@
 {
   "name": "solhint-config-lsp-solidity-linting-rules",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "private": true,
   "exports": {
     ".": "./index.js"

--- a/config/tsconfig/package.json
+++ b/config/tsconfig/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "files": [
     "contracts.json",
     "contracts.module.json"

--- a/config/tsconfig/package.json
+++ b/config/tsconfig/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "config/tsconfig"
   },
   "files": [
     "contracts.json",

--- a/packages/lsp-smart-contracts/README.md
+++ b/packages/lsp-smart-contracts/README.md
@@ -10,9 +10,9 @@ npm install @lukso/lsp-smart-contracts
 
 ## Usage
 
-### in Javascript
+### in JavaScript
 
-The JSON ABIs of the smart contracts can be imported as follow:
+The JSON ABIs of the smart contracts can be imported as follows:
 
 ```javascript
 import LSP0ERC725Account from "@lukso/lsp-smart-contracts/artifacts/LSP0ERC725Account.json";
@@ -72,23 +72,23 @@ It also includes constant values [Array data keys](https://github.com/lukso-netw
 },
 ```
 
-### Note for Hardhat Typescript projects
+### Note for Hardhat TypeScript projects
 
-If you are trying to import the constants in a Hardhat project that uses Typescript, you will need to import the constants from the `dist` folder directly, as shown in the code snippet:
+If you are trying to import the constants in a Hardhat project that uses TypeScript, you will need to import the constants from the `dist` folder directly, as shown in the code snippet:
 
 ```js
 import { INTERFACE_IDS } from "@lukso/lsp-smart-contracts/dist/constants.cjs.js";
 
 // This will raise an error if you have ES Lint enabled,
-// but will allow you to import the constants in a Hardhat + Typescript based project.
+// but will allow you to import the constants in a Hardhat + TypeScript based project.
 const LSP0InterfaceId = INTERFACE_IDS.LSP0ERC725Account;
 ```
 
-See the [issue related to Hardhat Typescript + ES Modules](https://hardhat.org/hardhat-runner/docs/advanced/using-esm#esm-and-typescript-projects) in the Hardhat docs for more infos.
+See the [issue related to Hardhat TypeScript + ES Modules](https://hardhat.org/hardhat-runner/docs/advanced/using-esm#esm-and-typescript-projects) in the Hardhat docs for more information.
 
-## Typescript types
+## TypeScript types
 
-The following additional typescript types are also available, including types for the JSON format of the LSP3 Profile and LSP4 Digital Asset metadata.
+The following additional TypeScript types are also available, including types for the JSON format of the LSP3 Profile and LSP4 Digital Asset metadata.
 
 ```ts
 import {
@@ -105,7 +105,7 @@ import {
 } from "@lukso/lsp-smart-contracts";
 ```
 
-You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contracts from the `/abi` path.
+You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contract from the `/abi` path.
 
 ```ts
 import {

--- a/packages/lsp-smart-contracts/package.json
+++ b/packages/lsp-smart-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "The reference smart contract implementation for the LUKSO LSP standards",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp-smart-contracts/package.json
+++ b/packages/lsp-smart-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp-smart-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp0-contracts/README.md
+++ b/packages/lsp0-contracts/README.md
@@ -12,7 +12,7 @@ npm install @lukso/lsp0-contracts
 
 The `@lukso/lsp0-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP0 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```js
 import {
@@ -39,9 +39,9 @@ import {
 } from "@lukso/lsp0-contracts/contracts/LSP0Constants.sol";
 ```
 
-## Typescript types
+## TypeScript types
 
-You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contracts from the `/abi` path.
+You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contract from the `/abi` path.
 
 ```ts
 import {

--- a/packages/lsp0-contracts/package.json
+++ b/packages/lsp0-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP0ERC725Account standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp0-contracts/package.json
+++ b/packages/lsp0-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp0-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp1-contracts/README.md
+++ b/packages/lsp1-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP1 Universal Receiver &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp1-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp1-contracts)
 
-npm package for the LSP1 Universal Receiver standard.
+npm package for the LSP1 Universal Receiver standard (notifications and delegate hooks).
 
 ## Installation
 
@@ -10,9 +10,9 @@ npm install @lukso/lsp1-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp1-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP1 Standard. You can import and access them as follow.
+The `@lukso/lsp1-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP1 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```js
 import { INTERFACE_ID_LSP1, LSP1DataKeys } from "@lukso/lsp1-contracts";

--- a/packages/lsp1-contracts/package.json
+++ b/packages/lsp1-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp1-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp1-contracts/package.json
+++ b/packages/lsp1-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP1 Universal Receiver standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp10-contracts/README.md
+++ b/packages/lsp10-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP10 Received Vaults &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp10-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp10-contracts)
 
-npm package for the LSP10 Received Vaults standard.
+npm package for the LSP10 Received Vaults standard (ERC725Y data keys).
 
 ## Installation
 
@@ -10,7 +10,7 @@ npm install @lukso/lsp10-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp10-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP10 Standard. You can import and access them as follow:
+The `@lukso/lsp10-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP10 Standard. You can import and access them as follows:
 
 ```javascript
 import { LSP10DataKeys } from "@lukso/lsp10-contracts";

--- a/packages/lsp10-contracts/package.json
+++ b/packages/lsp10-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp10-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp10-contracts/package.json
+++ b/packages/lsp10-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP10 Received Vaults standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp11-contracts/README.md
+++ b/packages/lsp11-contracts/README.md
@@ -10,9 +10,9 @@ npm install @lukso/lsp11-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp11-contracts` npm package contains useful constants such as interface IDs related to the LSP11 standard. You can import and access them as follows.
+The `@lukso/lsp11-contracts` npm package contains useful constants such as interface IDs related to the LSP11 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { INTERFACE_ID_LSP11 } from "@lukso/lsp11-contracts";

--- a/packages/lsp11-contracts/package.json
+++ b/packages/lsp11-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP11 Social Recovery standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp11-contracts/package.json
+++ b/packages/lsp11-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp11-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp12-contracts/README.md
+++ b/packages/lsp12-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP12 Issued Assets &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp12-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp12-contracts)
 
-npm package for the LSP12 Issued Assets standard.
+npm package for the LSP12 Issued Assets standard (ERC725Y data keys).
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp12-contracts
 
 The `@lukso/lsp12-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP12 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { LSP12DataKeys } from "@lukso/lsp12-contracts";

--- a/packages/lsp12-contracts/package.json
+++ b/packages/lsp12-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp12-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp12-contracts/package.json
+++ b/packages/lsp12-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP12 Issued Assets standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp14-contracts/README.md
+++ b/packages/lsp14-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP14 Ownable 2 Step &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp14-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp14-contracts)
 
-npm package for the LSP14 Ownable 2 Step standard.
+npm package for the LSP14 Ownable2Step standard.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp14-contracts
 
 The `@lukso/lsp14-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP14 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { LSP14_TYPE_IDS, INTERFACE_ID_LSP14 } from "@lukso/lsp14-contracts";

--- a/packages/lsp14-contracts/package.json
+++ b/packages/lsp14-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp14-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp14-contracts/package.json
+++ b/packages/lsp14-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP14 Ownable 2 Step standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp16-contracts/README.md
+++ b/packages/lsp16-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP16 Universal Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp16-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp16-contracts)
 
-npm package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard, contains the `LSP16UniversalFactory` contract that allows deploying contracts at the same address on multiple chains.
+npm package for the [LSP16-UniversalFactory](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-16-UniversalFactory.md) standard. It contains the `LSP16UniversalFactory` contract, a factory contract that enables to deploy smart contracts at the same address across multiple chains.
 
 ## Installation
 

--- a/packages/lsp16-contracts/package.json
+++ b/packages/lsp16-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP16 Universal Factory standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp16-contracts/package.json
+++ b/packages/lsp16-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp16-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp17-contracts/README.md
+++ b/packages/lsp17-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP17 Extensions Package &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp17-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp17-contracts)
 
-npm package for the LSP17 Extensions, that includes the following extensions:
+npm package for the LSP17 Extensions, which include the following extensions contracts:
 
 - `Extension4337` extension, which contains the `validateUserOp` function from the [`ERC4337` standard](https://eips.ethereum.org/EIPS/eip-4337).
 - `OnERC721ReceivedExtension` extension that contains the `onERC721Received` function from the [`ERC721` standard](https://eips.ethereum.org/EIPS/eip-721).

--- a/packages/lsp17-contracts/package.json
+++ b/packages/lsp17-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp17-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp17-contracts/package.json
+++ b/packages/lsp17-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP17 extensions",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp17contractextension-contracts/README.md
+++ b/packages/lsp17contractextension-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP17 Contract Extension Package &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp17contractextension-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp17contractextension-contracts)
 
-npm package for the LSP17 Contract Extension.
+npm package for the LSP17 Contract Extension standard.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp17contractextension-contracts
 
 The `@lukso/lsp17contractextension-contracts` npm package contains useful constants such as interface IDs, and ERC725Y data keys related to the LSP17 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {

--- a/packages/lsp17contractextension-contracts/package.json
+++ b/packages/lsp17contractextension-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp17contractextension-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp17contractextension-contracts/package.json
+++ b/packages/lsp17contractextension-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP17 Contract Extension standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp1delegate-contracts/README.md
+++ b/packages/lsp1delegate-contracts/README.md
@@ -1,7 +1,7 @@
 # LSP1 Universal Receiver Delegate &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp1delegate-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp1delegate-contracts)
 
-npm package with smart contract implementations of [LSP1 Universal Receiver Delegate](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-1-UniversalReceiver.md#universalreceiver-delegation)
-to register and manage:
+npm package with smart contract implementations of the [LSP1 Universal Receiver Delegate](https://github.com/lukso-network/LIPs/blob/main/LSPs/LSP-1-UniversalReceiver.md#universalreceiver-delegation),
+used to register and manage:
 
 - LSP5 Received Assets
 - LSP10 Vaults

--- a/packages/lsp1delegate-contracts/package.json
+++ b/packages/lsp1delegate-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP1 Universal Receiver Delegate standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp1delegate-contracts/package.json
+++ b/packages/lsp1delegate-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp1delegate-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp2-contracts/README.md
+++ b/packages/lsp2-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP2 ERC725Y JSON Schema &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp2-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp2-contracts)
 
-npm package for the LSP2 ERC725Y JSON Schema standard.
+npm package for the LSP2 ERC725Y JSON Schema standard (key encoding and verification helpers).
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp2-contracts
 
 The `@lukso/lsp2-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP2 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { LSP2ArrayKey, Verification } from "@lukso/lsp2-contracts";

--- a/packages/lsp2-contracts/package.json
+++ b/packages/lsp2-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP2 ERC725Y JSON Schema standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp2-contracts/package.json
+++ b/packages/lsp2-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp2-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp20-contracts/README.md
+++ b/packages/lsp20-contracts/README.md
@@ -5,14 +5,14 @@ npm package for the LSP20 Call Verification standard.
 ## Installation
 
 ```bash
-npm i @lukso/lsp20-contracts
+npm install @lukso/lsp20-contracts
 ```
 
 ## Available Constants & Types
 
 The `@lukso/lsp20-contracts` npm package contains useful constants such as interface IDs, and specific constants related to the LSP20 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {

--- a/packages/lsp20-contracts/package.json
+++ b/packages/lsp20-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP20 Call Verification standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp20-contracts/package.json
+++ b/packages/lsp20-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp20-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp23-contracts/README.md
+++ b/packages/lsp23-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP23 Linked Contracts Factory &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp23-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp23-contracts)
 
-npm package for the LSP23 Linked Contracts Factory. Contains the JSON artifacts (ABI, bytecode...) and the `LSP23LinkedContractsFactory`.
+npm package for the LSP23 Linked Contracts Factory. It contains the JSON artifacts (ABI, bytecode, and related metadata) and the `LSP23LinkedContractsFactory` contract.
 
 ## Installation
 

--- a/packages/lsp23-contracts/package.json
+++ b/packages/lsp23-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP23 Linked Contracts Factory standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp23-contracts/package.json
+++ b/packages/lsp23-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp23-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp25-contracts/README.md
+++ b/packages/lsp25-contracts/README.md
@@ -5,14 +5,14 @@ npm package for the LSP25 Execute Relay Call standard.
 ## Installation
 
 ```bash
-npm i @lukso/lsp25-contracts
+npm install @lukso/lsp25-contracts
 ```
 
 ## Available Constants & Types
 
 The `@lukso/lsp25-contracts` npm package contains useful constants such as interface IDs, and specific constants related to the LSP25 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { LSP25_VERSION, INTERFACE_ID_LSP25 } from "@lukso/lsp25-contracts";

--- a/packages/lsp25-contracts/package.json
+++ b/packages/lsp25-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP25 Execute Relay Call standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp25-contracts/package.json
+++ b/packages/lsp25-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp25-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp26-contracts/README.md
+++ b/packages/lsp26-contracts/README.md
@@ -5,14 +5,14 @@ npm package for the LSP26 Follower System standard.
 ## Installation
 
 ```console
-npm i @lukso/lsp26-contracts
+npm install @lukso/lsp26-contracts
 ```
 
 ## Available Constants & Types
 
 The `@lukso/lsp26-contracts` npm package contains useful constants such as interface IDs, and specific constants related to the LSP26 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { INTERFACE_ID_LSP26, LSP26_TYPE_IDS } from "@lukso/lsp26-contracts";

--- a/packages/lsp26-contracts/package.json
+++ b/packages/lsp26-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP26 Follower System standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "files": [
     "contracts/**/*.sol",

--- a/packages/lsp26-contracts/package.json
+++ b/packages/lsp26-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp26-contracts"
   },
   "type": "module",
   "files": [

--- a/packages/lsp3-contracts/README.md
+++ b/packages/lsp3-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP3 Profile Metadata &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp3-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp3-contracts)
 
-npm package for the LSP3 Profile Metadata standard.
+npm package for the LSP3 Profile Metadata standard (profile JSON schema and data keys).
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp3-contracts
 
 The `@lukso/lsp3-contracts` npm package contains useful constants such as ERC725Y data keys related to the LSP3 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {

--- a/packages/lsp3-contracts/package.json
+++ b/packages/lsp3-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP3 Profile Metadata standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp3-contracts/package.json
+++ b/packages/lsp3-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp3-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp4-contracts/README.md
+++ b/packages/lsp4-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP4 Digital Asset Metadata &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp4-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp4-contracts)
 
-npm package for the LSP4 Digital Asset Metadata standard.
+npm package for the LSP4 Digital Asset Metadata standard (token metadata schema and data keys).
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp4-contracts
 
 The `@lukso/lsp4-contracts` npm package contains useful constants such as ERC725Y data keys related to the LSP4 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {

--- a/packages/lsp4-contracts/package.json
+++ b/packages/lsp4-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP4 Digital Asset Metadata standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp4-contracts/package.json
+++ b/packages/lsp4-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp4-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp5-contracts/README.md
+++ b/packages/lsp5-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP5 Received Assets &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp5-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp5-contracts)
 
-npm package for the LSP5 Received Assets standard.
+npm package for the LSP5 Received Assets standard (ERC725Y data keys).
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp5-contracts
 
 The `@lukso/lsp5-contracts` npm package contains useful constants such as ERC725Y Data Keys related to the LSP5 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import { LSP5DataKeys } from "@lukso/lsp5-contracts";

--- a/packages/lsp5-contracts/package.json
+++ b/packages/lsp5-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp5-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp5-contracts/package.json
+++ b/packages/lsp5-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP5 Received Assets standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp6-contracts/README.md
+++ b/packages/lsp6-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP6 Key Manager &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp6-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp6-contracts)
 
-npm package for the LSP6 Key Manager standard, to enable granting multiple permissions to controllers.
+npm package for the LSP6 Key Manager standard. It can be used with a Universal Profile or an LSP7/8 Token contract to manage these contracts from multiple addresses (_"controllers"_), with multiple permissions and fine-grained access control.
 
 ## Installation
 
@@ -12,7 +12,7 @@ npm install @lukso/lsp6-contracts
 
 The `@lukso/lsp6-contracts` npm package contains useful constants such as interface IDs or ERC725Y Data Keys related to the LSP6 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {
@@ -37,7 +37,7 @@ import {
 } from "@lukso/lsp6-contracts/contracts/constants.sol";
 ```
 
-## Typescript types
+## TypeScript types
 
 You can also import the [type-safe ABI](https://abitype.dev/) from the `/abi` path.
 

--- a/packages/lsp6-contracts/package.json
+++ b/packages/lsp6-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP6 Key Manager standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp6-contracts/package.json
+++ b/packages/lsp6-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp6-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp7-contracts/README.md
+++ b/packages/lsp7-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP7 Digital Asset &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp7-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp7-contracts)
 
-npm package for the LSP7 Digital Asset standard.
+npm package for the LSP7 Digital Asset standard (fungible and similar tokens).
 
 ## Audits
 
@@ -34,7 +34,7 @@ npm install @lukso/lsp7-contracts
 
 The `@lukso/lsp7-contracts` npm package contains useful constants such as interface IDs or ERC725Y data keys related to the LSP7 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {
@@ -60,7 +60,7 @@ import {
 } from "@lukso/lsp7-contracts/contracts/LSP7Constants.sol";
 ```
 
-The `LSP7_TYPE_IDS` includes type IDs for the following type of notifications:
+The `LSP7_TYPE_IDS` object includes type IDs for the following types of notifications:
 
 ```console
 'LSP7Tokens_SenderNotification';
@@ -70,7 +70,7 @@ The `LSP7_TYPE_IDS` includes type IDs for the following type of notifications:
 'LSP7Tokens_VotesDelegateeNotification';
 ```
 
-## Typescript types
+## TypeScript types
 
 You can also import the [type-safe ABI](https://abitype.dev/) from the `/abi` path.
 
@@ -98,15 +98,15 @@ Set your deployer key first:
 export PRIVATE_KEY=0x...
 ```
 
-## Dry run against LUKSO Testnet
+## Dry run against LUKSO Testnet
 
 ```console
 FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
 ```
 
-## Broadcast the deployment
+## Broadcast the deployment
 
-> Use one of the method described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
+> Use one of the methods described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
 
 ```console
 FOUNDRY_PROFILE=lsp7 forge script packages/lsp7-contracts/scripts/DeployLSP7CustomizableTokenInit.s.sol:DeployLSP7CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast

--- a/packages/lsp7-contracts/package.json
+++ b/packages/lsp7-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP7 Digital Asset standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp7-contracts/package.json
+++ b/packages/lsp7-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp7-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp8-contracts/README.md
+++ b/packages/lsp8-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP8 Identifiable Digital Asset &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp8-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp8-contracts)
 
-npm package for the LSP8 Identifiable Digital Asset standard.
+npm package for the LSP8 Identifiable Digital Asset standard (NFTs and similar token IDs).
 
 ## Audits
 
@@ -34,7 +34,7 @@ npm install @lukso/lsp8-contracts
 
 The `@lukso/lsp8-contracts` npm package contains useful constants such as interface IDs or ERC725Y data keys related to the LSP8 Standard. You can import and access them as follows.
 
-In Javascript.
+In JavaScript.
 
 ```javascript
 import {
@@ -73,7 +73,7 @@ import {
 } from "@lukso/lsp8-contracts/contracts/LSP8Constants.sol";
 ```
 
-## Typescript types
+## TypeScript types
 
 You can also import the [type-safe ABI](https://abitype.dev/) from the `/abi` path.
 
@@ -101,7 +101,7 @@ Set your deployer key first:
 export PRIVATE_KEY=0x...
 ```
 
-## Dry run against LUKSO Testnet
+## Dry run against LUKSO Testnet
 
 ```console
 FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network
@@ -109,7 +109,7 @@ FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8Cust
 
 ## Broadcast the deployment
 
-> Use one of the method described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
+> Use one of the methods described in the [foundry docs](https://www.getfoundry.sh/forge/scripting#providing-a-private-key) to broadcast from a specific address
 
 ```console
 FOUNDRY_PROFILE=lsp8 forge script packages/lsp8-contracts/scripts/DeployLSP8CustomizableTokenInit.s.sol:DeployLSP8CustomizableTokenInitScript --rpc-url https://rpc.testnet.lukso.network --broadcast

--- a/packages/lsp8-contracts/package.json
+++ b/packages/lsp8-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp8-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp8-contracts/package.json
+++ b/packages/lsp8-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP8 Identifiable Digital Asset standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/lsp9-contracts/README.md
+++ b/packages/lsp9-contracts/README.md
@@ -1,6 +1,6 @@
 # LSP9 Vault &middot; [![npm version](https://img.shields.io/npm/v/@lukso/lsp9-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/lsp9-contracts)
 
-npm package for the LSP9 Vault standard.
+npm package for the LSP9 Vault standard (standalone vault accounts).
 
 ## Installation
 
@@ -10,7 +10,7 @@ npm install @lukso/lsp9-contracts
 
 ## Available Constants & Types
 
-The `@lukso/lsp9-contracts` npm package contains useful constants such as interface IDs, ERC725Y Data Keys related to the LSP9 Standard. You can import and access them as follows.
+The `@lukso/lsp9-contracts` npm package contains useful constants such as interface IDs and ERC725Y data keys related to the LSP9 Standard. You can import and access them as follows.
 
 ```javascript
 import {

--- a/packages/lsp9-contracts/package.json
+++ b/packages/lsp9-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/lsp9-contracts"
   },
   "type": "module",
   "keywords": [

--- a/packages/lsp9-contracts/package.json
+++ b/packages/lsp9-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for the LSP9 Vault standard",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/universalprofile-contracts/README.md
+++ b/packages/universalprofile-contracts/README.md
@@ -1,14 +1,14 @@
 # Universal Profile &middot; [![npm version](https://img.shields.io/npm/v/@lukso/universalprofile-contracts.svg?style=flat)](https://www.npmjs.com/package/@lukso/universalprofile-contracts)
 
-npm package: smart contract implementation for **Universal Profile**, a combination of LSP0 ERC725 Account and LSP3 Profile Metadata.
+npm package with the smart contract implementation for **Universal Profile**, combining LSP0 ERC725Account and LSP3 Profile Metadata.
 
 ## Installation
 
 ```bash
-npm i @lukso/universalprofile-contracts
+npm install @lukso/universalprofile-contracts
 ```
 
-## Solidity constants
+## Solidity constants
 
 The constants related to LSP3 Profile Metadata can be directly imported from the Solidity `Constants.sol` file.
 
@@ -21,9 +21,9 @@ import {
 } from "@lukso/universalprofile-contracts/contracts/Constants.sol";
 ```
 
-## Typescript types
+## TypeScript types
 
-You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contracts from the `/abi` path.
+You can also import the [type-safe ABI](https://abitype.dev/) of each LSP smart contract from the `/abi` path.
 
 ```typescript
 import {

--- a/packages/universalprofile-contracts/package.json
+++ b/packages/universalprofile-contracts/package.json
@@ -4,6 +4,10 @@
   "description": "Package for Universal Profile, an implementation of LSP0 ERC725 Account & LSP3 Profile Metadata standards combined together.",
   "license": "Apache-2.0",
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+  },
   "type": "module",
   "keywords": [
     "LUKSO",

--- a/packages/universalprofile-contracts/package.json
+++ b/packages/universalprofile-contracts/package.json
@@ -6,7 +6,8 @@
   "author": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
+    "url": "https://github.com/lukso-network/lsp-smart-contracts.git",
+    "directory": "packages/universalprofile-contracts"
   },
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- **Required for npm trusted publishing (OIDC).** npm validates each published package's `repository.url` against the GitHub OIDC token's repository claim; without this field the trusted-publishing flow set up in 5a3c48ec rejects the publish. Without this PR, the next release-please cycle would fail at the `npm publish` step.
- Adds the field to every package under `packages/` (24 publishable) and `config/` (5 private — kept consistent so future moves between dirs don't break).
- Root `package.json` already had it.
- Inserted after `author` (or `license` / `version` where `author` is absent) to keep the metadata block grouped at the top of each file. No other fields touched.

```json
"repository": {
  "type": "git",
  "url": "https://github.com/lukso-network/lsp-smart-contracts.git"
}
```

## Test plan
- [ ] CI passes (no behavior change, just metadata)
- [ ] Next release-please publish succeeds end-to-end via OIDC
- [ ] After publish, the `Repository` link appears on each `@lukso/*-contracts` page on npmjs.com